### PR TITLE
feat(review): #2323 cross-AI plan-review fan-out (Claude + Codex + Gemini)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ lib/
 !scripts/cron/lib/
 !scripts/improve/lib/
 !scripts/lib/
+!scripts/review/lib/
 !scripts/work-queue/lib/
 # GSD bin/lib — runtime libraries needed across machines
 !.claude/get-shit-done/bin/lib/

--- a/docs/plans/2026-04-17-issue-2323-cross-ai-review-fanout.md
+++ b/docs/plans/2026-04-17-issue-2323-cross-ai-review-fanout.md
@@ -1,6 +1,6 @@
 # Plan for #2323: Single-command cross-AI plan-review fan-out (Claude + Codex + Gemini)
 
-> **Status:** draft
+> **Status:** implemented (branch `issue-2323-cross-ai-review-fanout`)
 > **Complexity:** T2
 > **Date:** 2026-04-17
 > **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2323

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -81,6 +81,27 @@ Route the plan to at least 2 other AI providers. Each gives a verdict:
 
 Save review artifacts to `scripts/review/results/YYYY-MM-DD-plan-NNN-<agent>.md`.
 
+#### Canonical way to run the adversarial wave (#2323)
+
+```bash
+scripts/review/plan-review-fanout.sh docs/plans/YYYY-MM-DD-issue-NNN-slug.md
+```
+
+This wraps Claude + Codex + Gemini in parallel under the shared stance contract
+at `scripts/review/plan-review-prompt.md`. It writes one per-provider artifact
+plus a `-disagreement.md` summarizing verdict splits + per-provider unique
+findings. Per-provider invocation shape is tuned to each CLI's known quirks
+(Codex and Gemini get INLINE plan body; Claude gets an `@`-path reference;
+Gemini runs from `cwd=/tmp` to dodge the `.gemini/agents/*.md` permissionMode
+validation bug). Single-provider failure does not abort the other two — the
+failing provider's artifact records `UNAVAILABLE`.
+
+Flags:
+
+- `--providers=claude,codex,gemini` — subset of providers (comma-separated).
+- `--output-dir=<dir>` — override the default `scripts/review/results/` sink
+  (useful for batch / worktree / test runs).
+
 ### Step 5: Post and Label
 
 1. Post the completed plan as a GitHub issue comment

--- a/scripts/review/lib/disagreement-diff.sh
+++ b/scripts/review/lib/disagreement-diff.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# disagreement-diff.sh — summarize verdict + per-provider unique findings
+# across the per-provider artifacts produced by plan-review-fanout.sh.
+#
+# Usage: disagreement-diff.sh <results-dir> <date> <issue-num>
+# Reads files matching <results-dir>/<date>-plan-<issue-num>-<provider>.md and
+# writes a markdown report on stdout.
+
+set -euo pipefail
+
+RESULTS_DIR="${1:?results-dir required}"
+DATE="${2:?date required}"
+ISSUE="${3:?issue-num required}"
+
+# Extract the verdict line (first non-empty line under ## Verdict).
+extract_verdict() {
+  local file="$1"
+  awk '
+    /^## Verdict/ { in_verdict=1; next }
+    in_verdict && /^## / { exit }
+    in_verdict && NF { print; exit }
+  ' "$file"
+}
+
+# Extract the findings block (content between ## Findings and the next ## heading).
+extract_findings() {
+  local file="$1"
+  awk '
+    /^## Findings/ { in_findings=1; next }
+    in_findings && /^## / { in_findings=0 }
+    in_findings { print }
+  ' "$file"
+}
+
+# ── Collect artifacts ────────────────────────────────────────────────────
+declare -a PROVIDERS=()
+declare -A VERDICTS=()
+declare -A FINDINGS=()
+
+for file in "$RESULTS_DIR/$DATE-plan-$ISSUE-"*.md; do
+  [[ -e "$file" ]] || continue
+  local_base="$(basename "$file" .md)"
+  # Skip the disagreement file itself.
+  [[ "$local_base" == *-disagreement ]] && continue
+  # Extract the trailing <provider> token.
+  prov="${local_base##*-plan-$ISSUE-}"
+  PROVIDERS+=("$prov")
+  VERDICTS[$prov]="$(extract_verdict "$file")"
+  FINDINGS[$prov]="$(extract_findings "$file")"
+done
+
+# ── Emit markdown ────────────────────────────────────────────────────────
+echo "# Disagreement report — plan #${ISSUE} (${DATE})"
+echo ""
+echo "## Verdicts"
+echo ""
+echo "| Provider | Verdict |"
+echo "|---|---|"
+for prov in "${PROVIDERS[@]}"; do
+  echo "| $prov | ${VERDICTS[$prov]:-UNKNOWN} |"
+done
+echo ""
+
+echo "## Findings unique to each provider"
+echo ""
+echo "A finding is 'unique to X' if its text appears in X's artifact but not"
+echo "verbatim in any other provider's artifact."
+echo ""
+
+for prov in "${PROVIDERS[@]}"; do
+  echo "### ${prov}"
+  echo ""
+  # Build an \"others\" blob of concatenated findings excluding this provider.
+  others_blob=""
+  for other in "${PROVIDERS[@]}"; do
+    [[ "$other" == "$prov" ]] && continue
+    others_blob+="${FINDINGS[$other]}"$'\n'
+  done
+  # For each non-empty line in this provider's findings, check presence in others_blob.
+  found_any=0
+  while IFS= read -r line; do
+    [[ -z "${line// }" ]] && continue
+    # Strip leading list markers and surrounding whitespace for a lenient match.
+    stripped="$(echo "$line" | sed -E 's/^[[:space:]]*(-|[0-9]+\.)[[:space:]]*//')"
+    if [[ -z "${stripped// }" ]]; then continue; fi
+    if ! grep -qF -- "$stripped" <<<"$others_blob"; then
+      echo "- $stripped"
+      found_any=1
+    fi
+  done <<<"${FINDINGS[$prov]}"
+  (( found_any == 0 )) && echo "(no findings unique to this provider)"
+  echo ""
+done

--- a/scripts/review/lib/plan-file-parse.sh
+++ b/scripts/review/lib/plan-file-parse.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# plan-file-parse.sh — parse plan filenames into fields (issue number, date, slug).
+# Sourced by scripts/review/plan-review-fanout.sh and its tests.
+#
+# Conforming filename: YYYY-MM-DD-issue-NNNN-<slug>.md
+# (plus any directory prefix, e.g. docs/plans/...)
+
+extract_issue_num() {
+  local path="$1"
+  local base
+  base="$(basename "$path")"
+  if [[ "$base" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-issue-([0-9]+)- ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}

--- a/scripts/review/plan-review-fanout.sh
+++ b/scripts/review/plan-review-fanout.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# plan-review-fanout.sh — #2323
+# Run an adversarial plan review across Claude + Codex + Gemini in parallel and
+# write one canonical artifact per provider under scripts/review/results/ (or a
+# caller-supplied --output-dir).
+#
+# Usage:
+#   plan-review-fanout.sh <plan-file> [--providers=claude,codex,gemini] [--output-dir=<dir>]
+#
+# Per-provider invocation shape (empirically tuned, see docs/plans/...2323...md):
+#   claude  — path reference: `claude -p "@<prompt> — review plan at <path>..."`
+#             Claude resolves @-sigils natively; passing by path keeps token
+#             budget tight and the plan fresh on disk.
+#   codex   — INLINE: `codex exec --no-interactive "<prompt>\n--- PLAN ---\n<body>"`
+#             Codex drops context when given a path-only argument and falls
+#             back to GitHub MCP lookups, producing false MAJORs.
+#   gemini  — INLINE, and invoked from cwd=/tmp to dodge a local
+#             .gemini/agents/*.md permissionMode validation bug in the repo.
+#
+# Environment knobs (for tests):
+#   PLAN_REVIEW_RESULTS_DIR — overrides the default results dir (superseded by --output-dir).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/plan-file-parse.sh"
+
+PROMPT_FILE="$SCRIPT_DIR/plan-review-prompt.md"
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+PLAN_FILE=""
+OUTPUT_DIR="${PLAN_REVIEW_RESULTS_DIR:-$SCRIPT_DIR/results}"
+PROVIDERS="claude,codex,gemini"
+
+usage() {
+  sed -n '2,20p' "${BASH_SOURCE[0]}" >&2
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --providers=*)  PROVIDERS="${1#*=}"; shift ;;
+    --providers)    PROVIDERS="${2:?--providers requires a value}"; shift 2 ;;
+    --output-dir=*) OUTPUT_DIR="${1#*=}"; shift ;;
+    --output-dir)   OUTPUT_DIR="${2:?--output-dir requires a value}"; shift 2 ;;
+    -h|--help)      usage; exit 0 ;;
+    --)             shift; break ;;
+    -*)             echo "unknown flag: $1" >&2; usage; exit 2 ;;
+    *)              [[ -z "$PLAN_FILE" ]] && PLAN_FILE="$1" || { echo "unexpected positional arg: $1" >&2; exit 2; }; shift ;;
+  esac
+done
+
+[[ -n "$PLAN_FILE" ]] || { usage; exit 2; }
+[[ -f "$PLAN_FILE" ]] || { echo "plan file not found: $PLAN_FILE" >&2; exit 2; }
+
+ISSUE_NUM="$(extract_issue_num "$PLAN_FILE")" || {
+  echo "plan filename must match YYYY-MM-DD-issue-NNNN-<slug>.md; got: $PLAN_FILE" >&2
+  exit 2
+}
+TODAY="$(date +%Y-%m-%d)"
+mkdir -p "$OUTPUT_DIR"
+
+# ── Per-provider invocation ──────────────────────────────────────────────
+# Writes to $OUTPUT_DIR/$TODAY-plan-$ISSUE_NUM-<provider>.md. On CLI failure,
+# writes an UNAVAILABLE-verdict stub instead (graceful degradation).
+invoke_provider() {
+  local prov="$1"
+  local out="$OUTPUT_DIR/${TODAY}-plan-${ISSUE_NUM}-${prov}.md"
+  local err="${out}.err"
+  local rc=0
+
+  case "$prov" in
+    claude)
+      # Path reference — no inline body.
+      claude -p "@$PROMPT_FILE — review the plan at $PLAN_FILE. Return sections: VERDICT, RETRIEVAL, FINDINGS, BLOCKERS." \
+        > "$out" 2>"$err" || rc=$?
+      ;;
+    codex)
+      local combined
+      combined="$(printf '%s\n\n--- PLAN (%s) ---\n%s' \
+        "$(cat "$PROMPT_FILE")" "$PLAN_FILE" "$(cat "$PLAN_FILE")")"
+      codex exec --no-interactive "$combined" > "$out" 2>"$err" || rc=$?
+      ;;
+    gemini)
+      local combined
+      combined="$(printf '%s\n\n--- PLAN (%s) ---\n%s' \
+        "$(cat "$PROMPT_FILE")" "$PLAN_FILE" "$(cat "$PLAN_FILE")")"
+      # cwd=/tmp dodges the .gemini/agents/*.md permissionMode validation bug.
+      ( cd /tmp && gemini -p "$combined" ) > "$out" 2>"$err" || rc=$?
+      ;;
+    *)
+      echo "unknown provider: $prov" >&2
+      return 2
+      ;;
+  esac
+
+  if (( rc != 0 )); then
+    local reason
+    reason="$(head -c 200 "$err" 2>/dev/null | tr '\n' ' ' | sed 's/"/\\"/g')"
+    {
+      echo "## Verdict"
+      echo "UNAVAILABLE (${prov} CLI failed, rc=${rc}: ${reason})"
+      echo ""
+      echo "## Retrieval"
+      echo "(none — invocation failed before the provider could read the plan)"
+      echo ""
+      echo "## Findings"
+      echo "(none)"
+      echo ""
+      echo "## Blockers"
+      echo "(none — this provider contributed no signal to the review)"
+    } > "$out"
+  fi
+  rm -f "$err"
+}
+
+# ── Parallel fan-out ─────────────────────────────────────────────────────
+IFS=',' read -ra PROV_LIST <<< "$PROVIDERS"
+pids=()
+for prov in "${PROV_LIST[@]}"; do
+  invoke_provider "$prov" &
+  pids+=($!)
+done
+for pid in "${pids[@]}"; do
+  wait "$pid" || true
+done
+
+# ── Disagreement report (stub — fleshed out in next TDD batch) ───────────
+DISAGREEMENT_FILE="$OUTPUT_DIR/${TODAY}-plan-${ISSUE_NUM}-disagreement.md"
+if [[ -x "$SCRIPT_DIR/lib/disagreement-diff.sh" ]]; then
+  bash "$SCRIPT_DIR/lib/disagreement-diff.sh" "$OUTPUT_DIR" "$TODAY" "$ISSUE_NUM" > "$DISAGREEMENT_FILE"
+fi
+
+echo "wrote artifacts to $OUTPUT_DIR for plan #${ISSUE_NUM} ($TODAY)"

--- a/scripts/review/plan-review-prompt.md
+++ b/scripts/review/plan-review-prompt.md
@@ -1,0 +1,51 @@
+# Adversarial plan review
+
+You are an **adversarial reviewer**. Your job is to find what is wrong, missing, false, or risky in the plan you are about to read. Assume the plan has defects until you have evidence otherwise.
+
+## Stance — six non-negotiable rules
+
+1. **Opening framing.** You are an adversarial reviewer. Default to assuming the plan is wrong and prove otherwise. A review that ends in APPROVE is the exception, not the rule.
+
+2. **Anti-flatter.** Do not restate the plan. Do not praise. Do not note what the plan does well. Focus exclusively on what is wrong, missing, or risky.
+
+3. **Default to non-approve.** Return APPROVE only if you have affirmatively verified each correctness-critical claim AND can find no gap. When in doubt, return MINOR or MAJOR — being wrong about MINOR is cheap; missing a MAJOR is expensive.
+
+4. **Evidence over opinion.** Each finding must cite a specific file path, plan section, or quoted claim. Statements without citations are not findings and will be stripped.
+
+5. **Retrieval skepticism.** Treat the plan's cited sources as assertions to verify, not facts. If a file path is named, assume it may not exist until checked. If a claim about behavior is made, assume it may be outdated. If a tool or CLI is named, assume the invocation may be wrong.
+
+6. **Silence is failure.** If you have no concrete finding, explicitly say the plan was reviewed against [list checks] and none found — do not return an empty review. An empty review is a failure, not an implicit APPROVE.
+
+## Output shape
+
+Return exactly these sections:
+
+```
+## Verdict
+APPROVE | MINOR | MAJOR
+
+## Retrieval
+[Bullet list of every file/section you actually read or grep'd to verify the plan's claims. Be specific. "Read docs/plans/foo.md lines 40-60" beats "Read the plan".]
+
+## Findings
+[Numbered list. Each finding = one defect. Each finding MUST cite a file path, plan section, or quoted claim. No praise. No restatement. Only what is wrong, missing, or risky.]
+
+## Blockers
+[Subset of findings that must be resolved before the plan can be implemented. Empty list allowed only if every finding is MINOR.]
+```
+
+## What counts as a finding
+
+Good findings (keep):
+- "Plan §Pseudocode line 103 invokes `codex exec "$plan_file"` — passing a path. Codex CLI falls back to GitHub MCP on path args, returning false MAJOR. Verify empirically or fix."
+- "Acceptance criterion #8 is circular: weak-fixture + adversarial-stance → non-APPROVE regardless of wrapper correctness. This tests the fixture, not the code."
+- "Plan references `scripts/foo.sh` — no such file exists at HEAD. Grep returns zero matches."
+
+Bad findings (strip):
+- "The plan is well-structured and covers the main cases." → praise, not a finding.
+- "Consider adding more tests." → no citation, no specific gap.
+- "Looks good to me." → silence-is-failure violation.
+
+## If context is truncated
+
+If the plan is passed to you inline (prompt body) and appears truncated, say so explicitly as your verdict: `UNAVAILABLE (context truncation — plan body appears cut at line N)`. Do not return APPROVE/MINOR/MAJOR against a truncated plan.

--- a/scripts/review/tests/fixtures/2026-04-17-issue-9001-known-good.md
+++ b/scripts/review/tests/fixtures/2026-04-17-issue-9001-known-good.md
@@ -1,0 +1,20 @@
+# Plan for #9001: Known-good fixture plan for two-fixture plumbing test
+
+> **Status:** fixture
+> **Complexity:** T1
+> **Date:** 2026-04-17
+> **Issue:** fixture-only; not a real issue
+
+## Deliverable
+
+A two-line helper script that prints "hello" and exits 0.
+
+## Acceptance Criteria
+
+- [ ] Script exists at scripts/tmp/hello.sh.
+- [ ] Running it prints "hello" on stdout.
+
+This fixture is deliberately simple and self-consistent. It is used only by
+`test_two_fixture_plumbing` to verify that the wrapper routes fixture-specific
+prompts to fixture-specific artifacts. It is NOT used to verify reviewer
+adversarial behavior.

--- a/scripts/review/tests/fixtures/2026-04-17-issue-9002-known-broken.md
+++ b/scripts/review/tests/fixtures/2026-04-17-issue-9002-known-broken.md
@@ -1,0 +1,25 @@
+# Plan for #9002: Known-broken fixture plan for two-fixture plumbing test
+
+> **Status:** fixture
+> **Complexity:** T1
+> **Date:** 2026-04-17
+> **Issue:** fixture-only; not a real issue
+
+## Deliverable
+
+A script at scripts/nonexistent/foo.sh that will never exist.
+
+## Acceptance Criteria
+
+- [ ] Fictional script references a fictional dir.
+- [ ] Plan claims compatibility with kernel 2.6, which is EOL.
+- [ ] Pseudocode below is syntactically invalid bash.
+
+```bash
+if then while do () echo "broken"
+```
+
+This fixture is deliberately broken. Paired with `known-good-plan.md` it
+proves the wrapper's plumbing passes fixture-specific prompts through to
+per-provider artifacts without cross-contamination. The review quality of
+the paired mocks is NOT tested by this pair — only the routing.

--- a/scripts/review/tests/mocks/claude
+++ b/scripts/review/tests/mocks/claude
@@ -2,6 +2,7 @@
 # Mock claude CLI — captures argv + pwd + stdin to PLAN_REVIEW_CAPTURE_DIR/claude.capture,
 # emits a canned review on stdout.
 set -u
+[[ -n "${MOCK_SLEEP_S:-}" ]] && sleep "$MOCK_SLEEP_S"
 capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/claude.capture"
 {
   printf 'ARGV:'

--- a/scripts/review/tests/mocks/claude
+++ b/scripts/review/tests/mocks/claude
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Mock claude CLI — captures argv + pwd + stdin to PLAN_REVIEW_CAPTURE_DIR/claude.capture,
+# emits a canned review on stdout.
+set -u
+capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/claude.capture"
+{
+  printf 'ARGV:'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\n'
+  echo "PWD: $PWD"
+  echo "STDIN:"
+  if [[ ! -t 0 ]]; then cat; else echo "(no stdin)"; fi
+} > "$capture"
+cat <<'EOF'
+## Verdict
+MAJOR
+
+## Retrieval
+- Read the plan at the path provided.
+
+## Findings
+1. Mock finding from claude — invocation was path-reference style.
+
+## Blockers
+1. Mock blocker.
+EOF

--- a/scripts/review/tests/mocks/codex
+++ b/scripts/review/tests/mocks/codex
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Mock codex CLI — captures argv + pwd + stdin, emits canned review.
 set -u
+[[ -n "${MOCK_SLEEP_S:-}" ]] && sleep "$MOCK_SLEEP_S"
 capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/codex.capture"
 {
   printf 'ARGV:'

--- a/scripts/review/tests/mocks/codex
+++ b/scripts/review/tests/mocks/codex
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Mock codex CLI — captures argv + pwd + stdin, emits canned review.
+set -u
+capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/codex.capture"
+{
+  printf 'ARGV:'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\n'
+  echo "PWD: $PWD"
+  echo "STDIN:"
+  if [[ ! -t 0 ]]; then cat; else echo "(no stdin)"; fi
+} > "$capture"
+cat <<'EOF'
+## Verdict
+MAJOR
+
+## Retrieval
+- Read inline plan body.
+
+## Findings
+1. Mock finding from codex — invocation was inline-content style.
+
+## Blockers
+1. Mock blocker.
+EOF

--- a/scripts/review/tests/mocks/gemini
+++ b/scripts/review/tests/mocks/gemini
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Mock gemini CLI — captures argv + pwd + stdin, emits canned review.
+# Extra: supports ${MOCK_GEMINI_FAIL:-0}=1 to simulate quota/outage (exit 1, no stdout).
+set -u
+capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/gemini.capture"
+{
+  printf 'ARGV:'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\n'
+  echo "PWD: $PWD"
+  echo "STDIN:"
+  if [[ ! -t 0 ]]; then cat; else echo "(no stdin)"; fi
+} > "$capture"
+if [[ "${MOCK_GEMINI_FAIL:-0}" == "1" ]]; then
+  echo "gemini: 429 No capacity" >&2
+  exit 1
+fi
+cat <<'EOF'
+## Verdict
+MINOR
+
+## Retrieval
+- Read inline plan body.
+
+## Findings
+1. Mock finding from gemini — a tiny nit only gemini noticed.
+
+## Blockers
+(none)
+EOF

--- a/scripts/review/tests/mocks/gemini
+++ b/scripts/review/tests/mocks/gemini
@@ -2,6 +2,7 @@
 # Mock gemini CLI — captures argv + pwd + stdin, emits canned review.
 # Extra: supports ${MOCK_GEMINI_FAIL:-0}=1 to simulate quota/outage (exit 1, no stdout).
 set -u
+[[ -n "${MOCK_SLEEP_S:-}" ]] && sleep "$MOCK_SLEEP_S"
 capture="${PLAN_REVIEW_CAPTURE_DIR:-/tmp}/gemini.capture"
 {
   printf 'ARGV:'

--- a/scripts/review/tests/test_plan_review_fanout.sh
+++ b/scripts/review/tests/test_plan_review_fanout.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_UNDER_TEST="${SCRIPT_DIR}/../lib/plan-file-parse.sh"
+PROMPT_FILE="${SCRIPT_DIR}/../plan-review-prompt.md"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -61,10 +62,45 @@ test_rejects_nonconforming_filename() {
   fi
 }
 
+test_prompt_file_contains_all_six_stance_clauses() {
+  run_test "shared prompt file carries all six adversarial-stance clauses"
+
+  if [[ ! -f "$PROMPT_FILE" ]]; then
+    fail "prompt file not found at $PROMPT_FILE"
+    return
+  fi
+
+  # The six clauses per .claude/skills/coordination/cross-review-policy/SKILL.md "Reviewer Stance"
+  # and the plan's "Reviewer-stance contract" section. Asserting one keyword/phrase per clause.
+  local clauses=(
+    "adversarial reviewer"       # 1. Opening framing
+    "Do not restate"             # 2. Anti-flatter rule (matches "Do not restate the plan")
+    "when in doubt"              # 3. Default-to-non-approve (matches "when in doubt, return MINOR or MAJOR")
+    "cite a specific"            # 4. Evidence over opinion
+    "treat the plan's cited"     # 5. Retrieval skepticism
+    "silence is failure"         # 6. Empty-review-is-failure
+  )
+
+  local missing=()
+  local clause
+  for clause in "${clauses[@]}"; do
+    if ! grep -iqF "$clause" "$PROMPT_FILE"; then
+      missing+=("$clause")
+    fi
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    pass "all 6 stance-clause keywords present"
+  else
+    fail "missing stance-clause keywords: ${missing[*]}"
+  fi
+}
+
 # --- Runner ---
 
 test_extracts_issue_num_from_filename
 test_rejects_nonconforming_filename
+test_prompt_file_contains_all_six_stance_clauses
 
 echo ""
 echo "=================================="

--- a/scripts/review/tests/test_plan_review_fanout.sh
+++ b/scripts/review/tests/test_plan_review_fanout.sh
@@ -216,6 +216,87 @@ test_gemini_runs_from_tmp_cwd() {
   rm -rf "$td"
 }
 
+test_writes_claude_artifact() {
+  run_test "writes claude artifact to <output-dir>/<date>-plan-<num>-claude.md"
+
+  local td; td="$(mktemp -d)"
+  run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+
+  # Fixture plan is 2026-04-17-issue-9999-test-slug.md. Date in filename comes
+  # from `date +%Y-%m-%d` at runtime, so we search by suffix.
+  local artifact
+  artifact="$(ls "$td/results/"*-plan-9999-claude.md 2>/dev/null | head -1)"
+  if [[ -z "$artifact" ]]; then
+    fail "no artifact matching *-plan-9999-claude.md in $td/results/"
+    rm -rf "$td"; return
+  fi
+
+  # Artifact should contain the canned mock verdict header.
+  if grep -q '^## Verdict' "$artifact" && grep -qF 'Mock finding from claude' "$artifact"; then
+    pass "claude artifact present at $(basename "$artifact") and contains mock review text"
+  else
+    fail "claude artifact at $artifact missing expected content"
+  fi
+  rm -rf "$td"
+}
+
+test_parallel_execution() {
+  run_test "3 providers run in parallel (wall time ≈ slowest, not sum)"
+
+  local td; td="$(mktemp -d)"
+  # Each mock sleeps 2s. Serial = 6s, parallel ≈ 2s. Pass threshold: < 4s.
+  local t0 t1 elapsed
+  t0="$(date +%s)"
+  MOCK_SLEEP_S=2 run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+  t1="$(date +%s)"
+  elapsed=$((t1 - t0))
+
+  if (( elapsed < 4 )); then
+    pass "wall time ${elapsed}s < 4s (parallel behavior confirmed)"
+  else
+    fail "wall time ${elapsed}s ≥ 4s (looks serial — 3×2s=6s)" "expected <4s"
+  fi
+  rm -rf "$td"
+}
+
+test_gemini_unavailable_does_not_abort_codex() {
+  run_test "gemini CLI failure leaves codex + claude artifacts intact, writes UNAVAILABLE for gemini"
+
+  local td; td="$(mktemp -d)"
+
+  # Invoke wrapper with MOCK_GEMINI_FAIL=1 in a subshell so other tests aren't affected.
+  (
+    export PATH="$MOCKS_DIR:$PATH"
+    export PLAN_REVIEW_CAPTURE_DIR="$td/captures"
+    export MOCK_GEMINI_FAIL=1
+    mkdir -p "$td/captures" "$td/results"
+    local fixture="$td/2026-04-17-issue-9999-test-slug.md"
+    printf '%s\n%s\n' "$FIXTURE_FIRST_LINE" "Plan body line 2." > "$fixture"
+    bash "$WRAPPER" "$fixture" --output-dir="$td/results"
+  ) >/dev/null 2>&1 || true
+
+  local gemini_art codex_art claude_art
+  gemini_art="$(ls "$td/results/"*-plan-9999-gemini.md 2>/dev/null | head -1)"
+  codex_art="$(ls "$td/results/"*-plan-9999-codex.md 2>/dev/null | head -1)"
+  claude_art="$(ls "$td/results/"*-plan-9999-claude.md 2>/dev/null | head -1)"
+
+  if [[ -z "$gemini_art" || -z "$codex_art" || -z "$claude_art" ]]; then
+    fail "missing one or more artifact files" "gemini='$gemini_art' codex='$codex_art' claude='$claude_art'"
+    rm -rf "$td"; return
+  fi
+
+  if ! grep -q '^UNAVAILABLE' "$gemini_art" && ! grep -qF 'UNAVAILABLE' "$gemini_art"; then
+    fail "gemini artifact missing UNAVAILABLE verdict"
+  elif ! grep -qF 'Mock finding from codex' "$codex_art"; then
+    fail "codex artifact does not contain normal mock output (was it aborted?)"
+  elif ! grep -qF 'Mock finding from claude' "$claude_art"; then
+    fail "claude artifact does not contain normal mock output"
+  else
+    pass "gemini=UNAVAILABLE, codex + claude = normal mock output"
+  fi
+  rm -rf "$td"
+}
+
 # --- Runner ---
 
 test_extracts_issue_num_from_filename
@@ -225,6 +306,9 @@ test_claude_invocation_uses_path_reference
 test_codex_invocation_inlines_plan_body
 test_gemini_invocation_inlines_plan_body
 test_gemini_runs_from_tmp_cwd
+test_writes_claude_artifact
+test_parallel_execution
+test_gemini_unavailable_does_not_abort_codex
 
 echo ""
 echo "=================================="

--- a/scripts/review/tests/test_plan_review_fanout.sh
+++ b/scripts/review/tests/test_plan_review_fanout.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# test_plan_review_fanout.sh — Tests for the cross-AI plan-review fan-out wrapper (#2323).
+# Harness matches scripts/enforcement/tests/test_require_review_on_push.sh style.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_UNDER_TEST="${SCRIPT_DIR}/../lib/plan-file-parse.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  echo "  FAIL: $1"
+  if [[ -n "${2:-}" ]]; then
+    echo "        $2"
+  fi
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo "--- Test ${TESTS_RUN}: $1 ---"
+}
+
+# --- Tests ---
+
+test_extracts_issue_num_from_filename() {
+  run_test "extracts issue num from conforming plan filename"
+
+  # shellcheck source=/dev/null
+  source "$LIB_UNDER_TEST"
+
+  local got
+  got="$(extract_issue_num "docs/plans/2026-04-17-issue-2323-cross-ai-review-fanout.md")"
+
+  if [[ "$got" == "2323" ]]; then
+    pass "extract_issue_num returned 2323"
+  else
+    fail "extract_issue_num returned '$got' (want '2323')"
+  fi
+}
+
+test_rejects_nonconforming_filename() {
+  run_test "rejects non-date-prefixed filename with non-zero exit"
+
+  # shellcheck source=/dev/null
+  source "$LIB_UNDER_TEST"
+
+  if extract_issue_num "bad-name.md" >/dev/null 2>&1; then
+    fail "extract_issue_num accepted 'bad-name.md' (want non-zero exit)"
+  else
+    pass "extract_issue_num rejected 'bad-name.md'"
+  fi
+}
+
+# --- Runner ---
+
+test_extracts_issue_num_from_filename
+test_rejects_nonconforming_filename
+
+echo ""
+echo "=================================="
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "=================================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/review/tests/test_plan_review_fanout.sh
+++ b/scripts/review/tests/test_plan_review_fanout.sh
@@ -7,6 +7,31 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_UNDER_TEST="${SCRIPT_DIR}/../lib/plan-file-parse.sh"
 PROMPT_FILE="${SCRIPT_DIR}/../plan-review-prompt.md"
+WRAPPER="${SCRIPT_DIR}/../plan-review-fanout.sh"
+MOCKS_DIR="${SCRIPT_DIR}/mocks"
+FIXTURE_FIRST_LINE="FIXTURE_PLAN_FIRST_LINE_MARKER"
+
+# run_wrapper_under_mocks <out-dir> — echoes nothing, leaves side effects:
+#   - runs wrapper against a synthetic fixture plan
+#   - captures per-provider invocation info at $out_dir/captures/<provider>.capture
+#   - writes artifacts to $out_dir/results/
+# Returns the wrapper's exit code.
+run_wrapper_under_mocks() {
+  local out_dir="$1"
+  shift
+  local extra_env=("$@")
+
+  mkdir -p "$out_dir/captures" "$out_dir/results"
+  local fixture="$out_dir/2026-04-17-issue-9999-test-slug.md"
+  printf '%s\n%s\n' "$FIXTURE_FIRST_LINE" "Plan body line 2." > "$fixture"
+
+  (
+    export PATH="$MOCKS_DIR:$PATH"
+    export PLAN_REVIEW_CAPTURE_DIR="$out_dir/captures"
+    for kv in "${extra_env[@]}"; do export "$kv"; done
+    bash "$WRAPPER" "$fixture" --output-dir="$out_dir/results"
+  )
+}
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -96,11 +121,110 @@ test_prompt_file_contains_all_six_stance_clauses() {
   fi
 }
 
+test_claude_invocation_uses_path_reference() {
+  run_test "claude is invoked with @prompt sigil + plan path, NOT inline plan body"
+
+  local td; td="$(mktemp -d)"
+  run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+
+  local cap="$td/captures/claude.capture"
+  if [[ ! -f "$cap" ]]; then
+    fail "claude capture file not written ($cap)"
+    rm -rf "$td"; return
+  fi
+
+  # Scan the whole capture (argv may span multiple lines when a multi-line
+  # prompt arg is recorded). Assertions:
+  #   - capture contains '@' sigil
+  #   - capture contains the plan path
+  #   - capture does NOT contain the fixture's first-line marker (=> no inline body)
+  if ! grep -qF '@' "$cap"; then
+    fail "claude invocation missing '@' sigil"
+  elif ! grep -qF '2026-04-17-issue-9999-test-slug.md' "$cap"; then
+    fail "claude invocation missing plan path"
+  elif grep -qF "$FIXTURE_FIRST_LINE" "$cap"; then
+    fail "claude invocation inlined plan body (should use path reference)"
+  else
+    pass "claude invoked with @path reference, no inline body"
+  fi
+  rm -rf "$td"
+}
+
+test_codex_invocation_inlines_plan_body() {
+  run_test "codex is invoked with INLINE plan body (not a path reference)"
+
+  local td; td="$(mktemp -d)"
+  run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+
+  local cap="$td/captures/codex.capture"
+  if [[ ! -f "$cap" ]]; then
+    fail "codex capture file not written ($cap)"
+    rm -rf "$td"; return
+  fi
+
+  # Whole-capture grep (argv may span multiple lines).
+  if ! grep -qF "$FIXTURE_FIRST_LINE" "$cap"; then
+    fail "codex invocation missing inline plan body"
+  elif ! grep -qF -- '--- PLAN' "$cap"; then
+    fail "codex invocation missing '--- PLAN' delimiter"
+  else
+    pass "codex invoked with inline plan body + delimiter"
+  fi
+  rm -rf "$td"
+}
+
+test_gemini_invocation_inlines_plan_body() {
+  run_test "gemini is invoked with INLINE plan body (not a path reference)"
+
+  local td; td="$(mktemp -d)"
+  run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+
+  local cap="$td/captures/gemini.capture"
+  if [[ ! -f "$cap" ]]; then
+    fail "gemini capture file not written ($cap)"
+    rm -rf "$td"; return
+  fi
+
+  if ! grep -qF "$FIXTURE_FIRST_LINE" "$cap"; then
+    fail "gemini invocation missing inline plan body"
+  elif ! grep -qF -- '--- PLAN' "$cap"; then
+    fail "gemini invocation missing '--- PLAN' delimiter"
+  else
+    pass "gemini invoked with inline plan body + delimiter"
+  fi
+  rm -rf "$td"
+}
+
+test_gemini_runs_from_tmp_cwd() {
+  run_test "gemini is invoked with cwd=/tmp to dodge .gemini/agents/*.md permissionMode bug"
+
+  local td; td="$(mktemp -d)"
+  run_wrapper_under_mocks "$td" >/dev/null 2>&1 || true
+
+  local cap="$td/captures/gemini.capture"
+  if [[ ! -f "$cap" ]]; then
+    fail "gemini capture file not written ($cap)"
+    rm -rf "$td"; return
+  fi
+
+  local pwd_line; pwd_line="$(grep '^PWD:' "$cap" || true)"
+  if [[ "$pwd_line" == 'PWD: /tmp' ]]; then
+    pass "gemini cwd was /tmp"
+  else
+    fail "gemini cwd was not /tmp" "$pwd_line"
+  fi
+  rm -rf "$td"
+}
+
 # --- Runner ---
 
 test_extracts_issue_num_from_filename
 test_rejects_nonconforming_filename
 test_prompt_file_contains_all_six_stance_clauses
+test_claude_invocation_uses_path_reference
+test_codex_invocation_inlines_plan_body
+test_gemini_invocation_inlines_plan_body
+test_gemini_runs_from_tmp_cwd
 
 echo ""
 echo "=================================="

--- a/scripts/review/tests/test_plan_review_fanout.sh
+++ b/scripts/review/tests/test_plan_review_fanout.sh
@@ -8,7 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_UNDER_TEST="${SCRIPT_DIR}/../lib/plan-file-parse.sh"
 PROMPT_FILE="${SCRIPT_DIR}/../plan-review-prompt.md"
 WRAPPER="${SCRIPT_DIR}/../plan-review-fanout.sh"
+DISAGREEMENT_LIB="${SCRIPT_DIR}/../lib/disagreement-diff.sh"
 MOCKS_DIR="${SCRIPT_DIR}/mocks"
+FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
 FIXTURE_FIRST_LINE="FIXTURE_PLAN_FIRST_LINE_MARKER"
 
 # run_wrapper_under_mocks <out-dir> — echoes nothing, leaves side effects:
@@ -259,6 +261,93 @@ test_parallel_execution() {
   rm -rf "$td"
 }
 
+test_disagreement_report_captures_unique_finding() {
+  run_test "disagreement report highlights findings unique to one provider"
+
+  local td; td="$(mktemp -d)"
+  local rdir="$td/results"
+  mkdir -p "$rdir"
+
+  # Pre-seed three artifacts with divergent findings.
+  # claude + codex both say MAJOR + Shared finding A.
+  # gemini says MINOR + Uniquely-gemini finding OMEGA.
+  printf '## Verdict\nMAJOR\n\n## Findings\n1. Shared finding A\n' > "$rdir/2026-04-17-plan-8888-claude.md"
+  printf '## Verdict\nMAJOR\n\n## Findings\n1. Shared finding A\n' > "$rdir/2026-04-17-plan-8888-codex.md"
+  printf '## Verdict\nMINOR\n\n## Findings\n1. Uniquely-gemini finding OMEGA\n' > "$rdir/2026-04-17-plan-8888-gemini.md"
+
+  local out="$td/disagreement.md"
+  bash "$DISAGREEMENT_LIB" "$rdir" "2026-04-17" "8888" > "$out" 2>/dev/null
+
+  # The unique gemini finding must appear under the gemini section.
+  # Using awk to extract content between "### gemini" and next "###" or EOF.
+  local gemini_section
+  gemini_section="$(awk '/^### gemini$/{flag=1;next}/^### /{flag=0}flag' "$out")"
+
+  if [[ "$gemini_section" == *"Uniquely-gemini finding OMEGA"* ]]; then
+    pass "unique gemini finding appeared under gemini section"
+  else
+    fail "gemini section missing unique finding" "$(echo "$gemini_section" | head -5)"
+  fi
+  rm -rf "$td"
+}
+
+test_two_fixture_plumbing() {
+  run_test "two fixtures produce distinguishable per-provider artifacts (wrapper routes prompts correctly)"
+
+  local td1; td1="$(mktemp -d)"
+  local td2; td2="$(mktemp -d)"
+
+  # Known-good fixture (#9001).
+  (
+    export PATH="$MOCKS_DIR:$PATH"
+    export PLAN_REVIEW_CAPTURE_DIR="$td1"
+    mkdir -p "$td1/results"
+    bash "$WRAPPER" "$FIXTURES_DIR/2026-04-17-issue-9001-known-good.md" --output-dir="$td1/results"
+  ) >/dev/null 2>&1 || true
+
+  # Known-broken fixture (#9002).
+  (
+    export PATH="$MOCKS_DIR:$PATH"
+    export PLAN_REVIEW_CAPTURE_DIR="$td2"
+    mkdir -p "$td2/results"
+    bash "$WRAPPER" "$FIXTURES_DIR/2026-04-17-issue-9002-known-broken.md" --output-dir="$td2/results"
+  ) >/dev/null 2>&1 || true
+
+  # Each run must produce three per-provider artifacts (claude/codex/gemini).
+  # The wrapper ALSO writes a <issue>-disagreement.md; we require its presence
+  # separately so the provider count stays honest.
+  local missing=()
+  for prov in claude codex gemini; do
+    [[ -f "$(ls "$td1/results/"*-plan-9001-"$prov".md 2>/dev/null | head -1)" ]] || missing+=("good/$prov")
+    [[ -f "$(ls "$td2/results/"*-plan-9002-"$prov".md 2>/dev/null | head -1)" ]] || missing+=("broken/$prov")
+  done
+  [[ -f "$(ls "$td1/results/"*-plan-9001-disagreement.md 2>/dev/null | head -1)" ]] || missing+=("good/disagreement")
+  [[ -f "$(ls "$td2/results/"*-plan-9002-disagreement.md 2>/dev/null | head -1)" ]] || missing+=("broken/disagreement")
+
+  if (( ${#missing[@]} != 0 )); then
+    fail "missing expected artifacts" "${missing[*]}"
+    rm -rf "$td1" "$td2"; return
+  fi
+
+  # Capture files must differ: the plan body passed to codex/gemini differs
+  # between the two fixtures, so the recorded ARGV must differ too.
+  if diff -q "$td1/codex.capture" "$td2/codex.capture" >/dev/null 2>&1; then
+    fail "codex captures identical across both fixtures (wrapper not routing per-fixture)"
+    rm -rf "$td1" "$td2"; return
+  fi
+
+  # Specifically, the known-good fixture should mention 'hello' (its deliverable),
+  # and the known-broken fixture should mention 'kernel 2.6' (its deliberate defect).
+  if ! grep -qF 'hello' "$td1/codex.capture"; then
+    fail "known-good codex capture missing fixture-specific marker 'hello'"
+  elif ! grep -qF 'kernel 2.6' "$td2/codex.capture"; then
+    fail "known-broken codex capture missing fixture-specific marker 'kernel 2.6'"
+  else
+    pass "per-fixture per-provider artifacts + captures differ as expected"
+  fi
+  rm -rf "$td1" "$td2"
+}
+
 test_gemini_unavailable_does_not_abort_codex() {
   run_test "gemini CLI failure leaves codex + claude artifacts intact, writes UNAVAILABLE for gemini"
 
@@ -309,6 +398,8 @@ test_gemini_runs_from_tmp_cwd
 test_writes_claude_artifact
 test_parallel_execution
 test_gemini_unavailable_does_not_abort_codex
+test_disagreement_report_captures_unique_finding
+test_two_fixture_plumbing
 
 echo ""
 echo "=================================="


### PR DESCRIPTION
## Summary

- New wrapper `scripts/review/plan-review-fanout.sh <plan-file> [--providers=...] [--output-dir=...]` runs adversarial plan review across Claude + Codex + Gemini in parallel, writes canonical per-provider artifacts plus a disagreement report. Wall time dominated by the slowest provider, not the sum.
- Shared `scripts/review/plan-review-prompt.md` encodes the 6-clause adversarial-stance contract (opening framing, anti-flatter, default-to-non-approve, evidence, retrieval skepticism, silence-is-failure) — guarded by a regression test asserting each clause is present verbatim.
- Per-provider invocation shape is empirically tuned: `claude -p` takes an `@path` sigil; `codex` and `gemini` receive INLINE plan body (path-only was found to trigger Codex's GitHub MCP fallback and return false MAJOR in wave v1). Gemini runs from `cwd=/tmp` to dodge the local `.gemini/agents/*.md` permissionMode validation bug. Single-provider failure does not abort the other two — the failing provider's artifact records `UNAVAILABLE`.

## Pre-execution plan revisions

Two contradictions between the v1 plan and its approval-with-debt marker were resolved **before** any code was written (see plan commit `35236d06d` on `main`):

1. **File-path vs inline content.** v1 pseudocode + AC #7 said "never inline plan body." Wave v1 empirically proved Codex and Gemini both need INLINE body. Inverted per-provider; `test_prompt_is_file_path_based` dropped, replaced by three per-provider invocation-shape tests.
2. **Circular self-test AC.** v1 AC #8 required non-APPROVE from the wrapper's self-test against a deliberately-weak fixture under adversarial stance — guaranteed regardless of wrapper correctness. Replaced with a two-fixture (known-good + known-broken) prompt-plumbing test; adversarial-behavior assertion separated into a prompt-contents-only test.

## Test Plan

- [x] `scripts/review/tests/test_plan_review_fanout.sh` — 12/12 tests pass (filename parse, prompt stance, per-provider invocation shape, gemini-cwd, artifact write, parallel timing, gemini-unavailable graceful-degrade, disagreement report, two-fixture plumbing).
- [ ] Manual smoke: `bash scripts/review/plan-review-fanout.sh docs/plans/2026-04-17-issue-2323-cross-ai-review-fanout.md` — expect 3 per-provider artifacts + 1 disagreement report under `scripts/review/results/`.
- [ ] Single-provider smoke: same command with `--providers=claude` — expect only the claude artifact + disagreement report that marks codex/gemini as missing.

## Docs

- `docs/plans/README.md` Step 4 now documents this as the canonical way to run adversarial review.
- `docs/plans/2026-04-17-issue-2323-cross-ai-review-fanout.md` Status flipped draft → implemented.

## Notes

- Push required `GIT_PRE_PUSH_SKIP=1` (sanctioned bypass per `.claude/skills/workspace-hub/worktree-pre-push-bypass-for-tier1-checks/SKILL.md`) because `.git/hooks/pre-push.sh` invokes `uv run --no-project python scripts/quality/check_config_drift.py` and the `--no-project` tool env lacks PyYAML. Bypass logged to `logs/hooks/pre-push-bypass.jsonl`. Filing a separate follow-up issue for the underlying hook bug (related to #2203).

Closes #2323.