### PR TITLE
chore(ci-health): add ecosystem audit guard (#2424)

### DIFF
--- a/docs/reports/2026-04-27-issue-2424-ecosystem-ci-health-audit.md
+++ b/docs/reports/2026-04-27-issue-2424-ecosystem-ci-health-audit.md
@@ -1,0 +1,39 @@
+# Issue #2424 ecosystem CI health audit
+
+Generated: `2026-04-27T22:30:00+00:00`
+
+## Summary
+
+| State | Count |
+|---|---:|
+| Green | 3 |
+| Red | 4 |
+| No signal | 0 |
+| Unknown | 0 |
+
+Open tracked issue evidence: `#2424` OPEN `enhancement,priority:medium,cat:infrastructure,status:working,agent:codex,maintenance,status:plan-approved`; `#2433` OPEN `priority:high,cat:infrastructure,status:working,agent:codex,status:plan-approved`; `#2459` OPEN `priority:medium,cat:infrastructure,status:working,agent:codex,status:plan-approved`; `#2490` OPEN `enhancement,priority:medium,cat:infrastructure,status:plan-review`
+
+## Repo Evidence
+
+| Repo | State | Tracker | Latest main-branch workflow evidence | Note |
+|---|---|---|---|---|
+| [`vamseeachanta/workspace-hub`](https://github.com/vamseeachanta/workspace-hub) | Green | #2437 | [Baseline Testing](https://github.com/vamseeachanta/workspace-hub/actions/runs/25020714455) `success` at `2026-04-27T21:33:02Z` | workspace-hub child closed; parent remains rollup |
+| [`vamseeachanta/worldenergydata`](https://github.com/vamseeachanta/worldenergydata) | Red | #2433 | [CI](https://github.com/vamseeachanta/worldenergydata/actions/runs/24996694082) `failure` at `2026-04-27T13:04:34Z`<br>[.github/workflows/docs.yml](https://github.com/vamseeachanta/worldenergydata/actions/runs/24996693327) `failure` at `2026-04-27T13:04:33Z`<br>[Dependabot Updates](https://github.com/vamseeachanta/worldenergydata/actions/runs/24996650191) `success` at `2026-04-27T13:03:41Z`<br>[Nightly](https://github.com/vamseeachanta/worldenergydata/actions/runs/24974448044) `failure` at `2026-04-27T03:00:31Z` | main CI and Dependabot blocker lane |
+| [`vamseeachanta/digitalmodel`](https://github.com/vamseeachanta/digitalmodel) | Red | #2441 / #2490 | [Dependency Graph](https://github.com/vamseeachanta/digitalmodel/actions/runs/24975627332) `failure` at `2026-04-27T03:49:26Z`<br>[Build API Docs](https://github.com/vamseeachanta/digitalmodel/actions/runs/24975626763) `success` at `2026-04-27T03:49:25Z`<br>[Quality Gates](https://github.com/vamseeachanta/digitalmodel/actions/runs/24975626765) `failure` at `2026-04-27T03:49:25Z` | pylife child closed; coverage-gate follow-up open |
+| [`vamseeachanta/assethold`](https://github.com/vamseeachanta/assethold) | Red | #2442 / #2448 / #2459 | [Python Tests](https://github.com/vamseeachanta/assethold/actions/runs/24946909831) `failure` at `2026-04-26T03:06:28Z`<br>[.github/workflows/docs.yml](https://github.com/vamseeachanta/assethold/actions/runs/24792042937) `failure` at `2026-04-22T17:12:17Z` | startup/smoke children closed; hardening plan remains |
+| [`vamseeachanta/achantas-data`](https://github.com/vamseeachanta/achantas-data) | Red | #2443 | [link-check](https://github.com/vamseeachanta/achantas-data/actions/runs/24998480318) `failure` at `2026-04-27T13:40:43Z`<br>[markdown-lint](https://github.com/vamseeachanta/achantas-data/actions/runs/24959525884) `success` at `2026-04-26T14:54:30Z`<br>[Python Tests](https://github.com/vamseeachanta/achantas-data/actions/runs/18252775917) `failure` at `2025-10-05T02:35:49Z` | CI restored; scheduled link-check must stay observable |
+| [`vamseeachanta/aceengineer-admin`](https://github.com/vamseeachanta/aceengineer-admin) | Green | #2444 | [CI](https://github.com/vamseeachanta/aceengineer-admin/actions/runs/24961076938) `success` at `2026-04-26T16:09:41Z` | minimal CI bootstrap child closed |
+| [`vamseeachanta/assetutilities`](https://github.com/vamseeachanta/assetutilities) | Green | reference | [Source Hygiene](https://github.com/vamseeachanta/assetutilities/actions/runs/25020866448) `success` at `2026-04-27T21:36:34Z`<br>[Tests](https://github.com/vamseeachanta/assetutilities/actions/runs/25020866457) `success` at `2026-04-27T21:36:34Z`<br>[Build API Docs](https://github.com/vamseeachanta/assetutilities/actions/runs/25020866480) `success` at `2026-04-27T21:36:34Z` | known green reference repo |
+
+## Guard Contract
+
+- The audit filters to `main` branch runs and CI-like events so Dependabot PR noise cannot mask red main evidence.
+- One latest run per workflow is shown to avoid stale older failures overriding newer green runs.
+- The seven-repo scoreboard is hard-coded because #2424 is a fixed ecosystem rollup, not a broad repo rewrite lane.
+- This report is evidence only; child issue implementation and closure still follow their individual approved plans.
+
+## Reproduce
+
+```bash
+uv run python scripts/ci_health/ecosystem_ci_audit.py --output docs/reports/2026-04-27-issue-2424-ecosystem-ci-health-audit.md --limit 30
+```

--- a/scripts/ci_health/__init__.py
+++ b/scripts/ci_health/__init__.py
@@ -1,0 +1,1 @@
+"""CI health audit helpers."""

--- a/scripts/ci_health/ecosystem_ci_audit.py
+++ b/scripts/ci_health/ecosystem_ci_audit.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+"""Generate a bounded cross-repo CI health audit for workspace-hub issue #2424."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RELEVANT_EVENTS = {"push", "schedule", "workflow_dispatch", "dynamic"}
+RED_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+GREEN_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+
+@dataclass(frozen=True)
+class EcosystemRepo:
+    full_name: str
+    tracker: str
+    note: str
+
+
+EXPECTED_REPOS = [
+    EcosystemRepo(
+        "vamseeachanta/workspace-hub",
+        "#2437",
+        "workspace-hub child closed; parent remains rollup",
+    ),
+    EcosystemRepo(
+        "vamseeachanta/worldenergydata", "#2433", "main CI and Dependabot blocker lane"
+    ),
+    EcosystemRepo(
+        "vamseeachanta/digitalmodel",
+        "#2441 / #2490",
+        "pylife child closed; coverage-gate follow-up open",
+    ),
+    EcosystemRepo(
+        "vamseeachanta/assethold",
+        "#2442 / #2448 / #2459",
+        "startup/smoke children closed; hardening plan remains",
+    ),
+    EcosystemRepo(
+        "vamseeachanta/achantas-data",
+        "#2443",
+        "CI restored; scheduled link-check must stay observable",
+    ),
+    EcosystemRepo(
+        "vamseeachanta/aceengineer-admin", "#2444", "minimal CI bootstrap child closed"
+    ),
+    EcosystemRepo(
+        "vamseeachanta/assetutilities", "reference", "known green reference repo"
+    ),
+]
+
+TRACKED_ISSUES = [2424, 2433, 2437, 2441, 2442, 2443, 2444, 2448, 2459, 2490]
+
+
+def _run_json(command: list[str]) -> Any:
+    completed = subprocess.run(
+        command, check=True, capture_output=True, text=True, timeout=60
+    )
+    return json.loads(completed.stdout)
+
+
+def latest_relevant_runs_by_workflow(
+    runs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return the newest main-branch CI-like run for each workflow."""
+
+    latest: dict[str, dict[str, Any]] = {}
+    for run in sorted(runs, key=lambda item: item.get("createdAt") or "", reverse=True):
+        if run.get("headBranch") != "main":
+            continue
+        if run.get("event") not in RELEVANT_EVENTS:
+            continue
+        workflow_name = run.get("workflowName") or "<unnamed>"
+        latest.setdefault(workflow_name, run)
+    return list(latest.values())
+
+
+def classify_repo(latest_runs: list[dict[str, Any]]) -> dict[str, Any]:
+    if not latest_runs:
+        return {"state": "no-signal", "red_workflows": []}
+
+    red_workflows = [
+        run.get("workflowName") or "<unnamed>"
+        for run in latest_runs
+        if run.get("status") != "completed" or run.get("conclusion") in RED_CONCLUSIONS
+    ]
+    unknown_workflows = [
+        run.get("workflowName") or "<unnamed>"
+        for run in latest_runs
+        if run.get("status") == "completed"
+        and run.get("conclusion") not in RED_CONCLUSIONS
+        and run.get("conclusion") not in GREEN_CONCLUSIONS
+    ]
+
+    if red_workflows:
+        return {"state": "red", "red_workflows": red_workflows}
+    if unknown_workflows:
+        return {"state": "unknown", "red_workflows": []}
+    return {"state": "green", "red_workflows": []}
+
+
+def fetch_repo_runs(repo: str, limit: int) -> list[dict[str, Any]]:
+    return _run_json(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--branch",
+            "main",
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,workflowName,displayTitle,headBranch,conclusion,status,createdAt,url,event",
+        ]
+    )
+
+
+def fetch_issue_rows() -> dict[int, dict[str, Any]]:
+    rows: dict[int, dict[str, Any]] = {}
+    for issue_number in TRACKED_ISSUES:
+        try:
+            raw = _run_json(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--repo",
+                    "vamseeachanta/workspace-hub",
+                    "--json",
+                    "number,state,labels,title,url",
+                ]
+            )
+        except subprocess.CalledProcessError:
+            rows[issue_number] = {
+                "state": "MISSING",
+                "labels": [],
+                "title": "",
+                "url": "",
+            }
+            continue
+        rows[issue_number] = {
+            "state": raw["state"],
+            "labels": [label["name"] for label in raw.get("labels", [])],
+            "title": raw.get("title", ""),
+            "url": raw.get("url", ""),
+        }
+    return rows
+
+
+def _state_label(state: str) -> str:
+    return {
+        "green": "Green",
+        "red": "Red",
+        "no-signal": "No signal",
+        "unknown": "Unknown",
+    }.get(state, state.title())
+
+
+def _repo_url(repo: str) -> str:
+    return f"https://github.com/{repo}"
+
+
+def _format_run(run: dict[str, Any]) -> str:
+    workflow = run.get("workflowName") or "<unnamed>"
+    conclusion = run.get("conclusion") or run.get("status") or "unknown"
+    created_at = run.get("createdAt") or "unknown-time"
+    url = run.get("url") or ""
+    if url:
+        return f"[{workflow}]({url}) `{conclusion}` at `{created_at}`"
+    return f"{workflow} `{conclusion}` at `{created_at}`"
+
+
+def _open_issue_summary(issue_rows: dict[int, dict[str, Any]]) -> str:
+    open_items = [
+        f"`#{issue_number}` OPEN `{','.join(row.get('labels', [])) or 'no-labels'}`"
+        for issue_number, row in sorted(issue_rows.items())
+        if row.get("state") == "OPEN"
+    ]
+    return "; ".join(open_items) if open_items else "None"
+
+
+def render_markdown_report(
+    repo_runs: dict[str, list[dict[str, Any]]],
+    issue_rows: dict[int, dict[str, Any]],
+    generated_at: str,
+) -> str:
+    repo_names = {repo.full_name for repo in EXPECTED_REPOS}
+    missing = sorted(repo_names.difference(repo_runs))
+    if missing:
+        raise ValueError(f"Missing repo run evidence for: {', '.join(missing)}")
+
+    rows: list[tuple[EcosystemRepo, dict[str, Any], list[dict[str, Any]]]] = []
+    counts = {"green": 0, "red": 0, "no-signal": 0, "unknown": 0}
+    for repo in EXPECTED_REPOS:
+        latest_runs = latest_relevant_runs_by_workflow(repo_runs[repo.full_name])
+        classification = classify_repo(latest_runs)
+        counts[classification["state"]] = counts.get(classification["state"], 0) + 1
+        rows.append((repo, classification, latest_runs))
+
+    lines = [
+        "# Issue #2424 ecosystem CI health audit",
+        "",
+        f"Generated: `{generated_at}`",
+        "",
+        "## Summary",
+        "",
+        "| State | Count |",
+        "|---|---:|",
+        f"| Green | {counts.get('green', 0)} |",
+        f"| Red | {counts.get('red', 0)} |",
+        f"| No signal | {counts.get('no-signal', 0)} |",
+        f"| Unknown | {counts.get('unknown', 0)} |",
+        "",
+        f"Open tracked issue evidence: {_open_issue_summary(issue_rows)}",
+        "",
+        "## Repo Evidence",
+        "",
+        "| Repo | State | Tracker | Latest main-branch workflow evidence | Note |",
+        "|---|---|---|---|---|",
+    ]
+
+    for repo, classification, latest_runs in rows:
+        if latest_runs:
+            evidence = "<br>".join(_format_run(run) for run in latest_runs)
+        else:
+            evidence = "No relevant `main` push/schedule/workflow_dispatch/dynamic runs returned by `gh run list`."
+        lines.append(
+            "| "
+            f"[`{repo.full_name}`]({_repo_url(repo.full_name)}) | "
+            f"{_state_label(classification['state'])} | "
+            f"{repo.tracker} | "
+            f"{evidence} | "
+            f"{repo.note} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Guard Contract",
+            "",
+            "- The audit filters to `main` branch runs and CI-like events so Dependabot PR noise cannot mask red main evidence.",
+            "- One latest run per workflow is shown to avoid stale older failures overriding newer green runs.",
+            "- The seven-repo scoreboard is hard-coded because #2424 is a fixed ecosystem rollup, not a broad repo rewrite lane.",
+            "- This report is evidence only; child issue implementation and closure still follow their individual approved plans.",
+            "",
+            "## Reproduce",
+            "",
+            "```bash",
+            "uv run python scripts/ci_health/ecosystem_ci_audit.py "
+            "--output docs/reports/2026-04-27-issue-2424-ecosystem-ci-health-audit.md "
+            "--limit 30",
+            "```",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def collect_live_repo_runs(limit: int) -> dict[str, list[dict[str, Any]]]:
+    return {
+        repo.full_name: fetch_repo_runs(repo.full_name, limit)
+        for repo in EXPECTED_REPOS
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output", type=Path, help="Write the Markdown report to this path."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Run rows to fetch per repository."
+    )
+    parser.add_argument(
+        "--generated-at",
+        default=datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+    )
+    args = parser.parse_args()
+
+    report = render_markdown_report(
+        collect_live_repo_runs(args.limit),
+        fetch_issue_rows(),
+        generated_at=args.generated_at,
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(report, encoding="utf-8")
+    else:
+        print(report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/quality/test_ecosystem_ci_audit.py
+++ b/tests/quality/test_ecosystem_ci_audit.py
@@ -1,0 +1,141 @@
+from scripts.ci_health.ecosystem_ci_audit import (
+    EXPECTED_REPOS,
+    classify_repo,
+    latest_relevant_runs_by_workflow,
+    render_markdown_report,
+)
+
+
+def test_latest_relevant_runs_ignore_pull_request_noise() -> None:
+    runs = [
+        {
+            "workflowName": "CI",
+            "headBranch": "dependabot/example",
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "success",
+            "createdAt": "2026-04-27T13:04:44Z",
+            "url": "https://example.invalid/pr-success",
+        },
+        {
+            "workflowName": "CI",
+            "headBranch": "main",
+            "event": "push",
+            "status": "completed",
+            "conclusion": "failure",
+            "createdAt": "2026-04-27T12:00:00Z",
+            "url": "https://example.invalid/main-failure",
+        },
+    ]
+
+    latest = latest_relevant_runs_by_workflow(runs)
+
+    assert latest == [
+        {
+            "workflowName": "CI",
+            "headBranch": "main",
+            "event": "push",
+            "status": "completed",
+            "conclusion": "failure",
+            "createdAt": "2026-04-27T12:00:00Z",
+            "url": "https://example.invalid/main-failure",
+        }
+    ]
+    assert classify_repo(latest)["state"] == "red"
+
+
+def test_report_covers_expected_ecosystem_repos_and_open_followups() -> None:
+    repo_runs = {
+        "vamseeachanta/workspace-hub": [
+            {
+                "workflowName": "Baseline Testing",
+                "headBranch": "main",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-04-27T10:00:00Z",
+                "url": "https://example.invalid/ws",
+            }
+        ],
+        "vamseeachanta/worldenergydata": [
+            {
+                "workflowName": "CI",
+                "headBranch": "main",
+                "event": "schedule",
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "2026-04-27T09:00:00Z",
+                "url": "https://example.invalid/wed",
+            }
+        ],
+        "vamseeachanta/digitalmodel": [
+            {
+                "workflowName": "Quality Gates",
+                "headBranch": "main",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "2026-04-27T08:00:00Z",
+                "url": "https://example.invalid/dm",
+            }
+        ],
+        "vamseeachanta/assethold": [
+            {
+                "workflowName": "Python Tests",
+                "headBranch": "main",
+                "event": "schedule",
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "2026-04-27T07:00:00Z",
+                "url": "https://example.invalid/ah",
+            }
+        ],
+        "vamseeachanta/achantas-data": [
+            {
+                "workflowName": "markdown-lint",
+                "headBranch": "main",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-04-27T06:00:00Z",
+                "url": "https://example.invalid/data",
+            }
+        ],
+        "vamseeachanta/aceengineer-admin": [
+            {
+                "workflowName": "CI",
+                "headBranch": "main",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-04-27T05:00:00Z",
+                "url": "https://example.invalid/admin",
+            }
+        ],
+        "vamseeachanta/assetutilities": [
+            {
+                "workflowName": "Tests",
+                "headBranch": "main",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-04-27T04:00:00Z",
+                "url": "https://example.invalid/au",
+            }
+        ],
+    }
+
+    issue_rows = {
+        2433: {"state": "OPEN", "labels": ["status:plan-approved"]},
+        2490: {"state": "OPEN", "labels": ["status:plan-review"]},
+    }
+
+    report = render_markdown_report(
+        repo_runs, issue_rows, generated_at="2026-04-27T22:00:00Z"
+    )
+
+    for repo in EXPECTED_REPOS:
+        assert f"`{repo.full_name}`" in report
+    assert "`#2433` OPEN" in report
+    assert "`#2490` OPEN" in report
+    assert "| Red | 3 |" in report


### PR DESCRIPTION
Salvage PR for workspace-hub issue #2424 after Codex next-wave execution.

Scope:
- Add bounded seven-repo ecosystem CI health audit CLI.
- Add focused parser/rendering/report guard tests.
- Add generated #2424 evidence report.

Verified from isolated worktree /mnt/local-analysis/codex-nextwave-20260427/issue-2424:
- uv run pytest tests/quality/test_ecosystem_ci_audit.py -q -> 2 passed
- uv run python scripts/ci_health/ecosystem_ci_audit.py --help -> pass
- git diff --check -> pass

Notes:
- Branch was already pushed by Codex: codex/nextwave-20260427-issue-2424 at a12e01b7b863edb9327fb539da46a4d2577a34a7.
- This PR is for review/reconciliation only; no force-push used.

Closes #2424 only if merged and parent/child issue closeout criteria are reconciled.
