### PR TITLE
fix(#1583): tighten Hermes sync parity docs

### DIFF
--- a/docs/ops/scheduled-tasks.md
+++ b/docs/ops/scheduled-tasks.md
@@ -36,7 +36,7 @@
 
 | Time | ID | Description | Log |
 |------|-----|-------------|-----|
-| 01:15 daily | harness-update | AI harness tools update (GStack, Hermes, Superpowers, GSD) | `logs/maintenance/harness-update-*.log` |
+| 01:45 daily | harness-update | AI harness tools update (GStack, Hermes, Superpowers, GSD) | `logs/maintenance/harness-update-*.log` |
 | */4h | repository-sync | Pull/push all repos | `.claude/state/learning-reports/cron.log` |
 
 ## Skills Curation v2 Contract
@@ -82,7 +82,7 @@ crontab -l
 
 ## Audit Notes (2026-04-01)
 
-- `harness-update` added to ace-linux-2 (was ace-linux-1 only) — updates GStack, Hermes, Superpowers, GSD daily at 01:15
+- `harness-update` added to ace-linux-2 (was ace-linux-1 only) — updates GStack, Hermes, Superpowers, GSD daily at 01:45
 - Hermes config templates added to `config/agents/hermes/` — synced via `sync-agent-configs.sh`
 - ace-linux-2 NVIDIA kernel module missing for 6.17.0-20 — tracked in #1581
 - Hermes install on ace-linux-2 — tracked in #1582

--- a/scripts/_core/sync-agent-configs.sh
+++ b/scripts/_core/sync-agent-configs.sh
@@ -1262,7 +1262,11 @@ CLAUDE_MEM_SNAP="$WS_HUB/config/agents/claude/memory-snapshots"
 WS_HUB_ENCODED="$(echo "$WS_HUB" | sed 's|^/||; s|/|-|g')"
 CLAUDE_MEM_TARGET="$HOME/.claude/projects/-${WS_HUB_ENCODED}/memory"
 if [[ -d "$CLAUDE_MEM_SNAP" && -d "$HOME/.claude" ]]; then
-    EXISTING_COUNT=$(ls "$CLAUDE_MEM_TARGET"/*.md 2>/dev/null | wc -l || echo 0)
+    if [[ -d "$CLAUDE_MEM_TARGET" ]]; then
+        EXISTING_COUNT=$(find "$CLAUDE_MEM_TARGET" -maxdepth 1 -type f -name '*.md' | wc -l)
+    else
+        EXISTING_COUNT=0
+    fi
     if [[ "$EXISTING_COUNT" -lt 5 ]] || [[ "$FORCE" == "true" ]]; then
         mkdir -p "$CLAUDE_MEM_TARGET"
         if [[ "$DRY_RUN" == "true" ]]; then

--- a/scripts/_core/tests/test_sync_agent_helpers.sh
+++ b/scripts/_core/tests/test_sync_agent_helpers.sh
@@ -312,6 +312,34 @@ PY
     rm -rf "$tmpdir"
 }
 
+run_dry_run_claude_memory_missing_target_count_test() {
+    local tmpdir ws_root home_root output
+    tmpdir="$(mktemp -d)"
+    ws_root="$tmpdir/ws"
+    home_root="$tmpdir/home"
+
+    make_workspace "$ws_root"
+    mkdir -p "$home_root/.claude" "$ws_root/config/agents/claude/memory-snapshots"
+    cat > "$ws_root/config/agents/claude/memory-snapshots/context.md" <<'EOF'
+# context
+EOF
+
+    output="$(HOME="$home_root" bash "$ws_root/scripts/_core/sync-agent-configs.sh" --dry-run 2>&1)" || {
+        fail "dry_run_claude_memory_missing_target_count command completed"
+        rm -rf "$tmpdir"
+        return
+    }
+    pass "dry_run_claude_memory_missing_target_count command completed"
+
+    if printf '%s\n' "$output" | grep -q "syntax error in expression"; then
+        fail "dry_run_claude_memory_missing_target_count has no arithmetic warning"
+    else
+        pass "dry_run_claude_memory_missing_target_count has no arithmetic warning"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
 echo "=== test_sync_agent_helpers.sh ==="
 run_hermes_placeholder_and_terminal_test
 run_invalid_json_create_test
@@ -319,6 +347,7 @@ run_invalid_json_create_without_jq_test
 run_invalid_yaml_create_test
 run_invalid_json_update_cleanup_test
 run_python3_fallback_to_uv_test
+run_dry_run_claude_memory_missing_target_count_test
 
 echo ""
 echo "Results: ${PASS} PASS, ${FAIL} FAIL"

--- a/tests/docs/test_scheduled_tasks_docs.py
+++ b/tests/docs/test_scheduled_tasks_docs.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEDULE_PATH = REPO_ROOT / "config" / "scheduled-tasks" / "schedule-tasks.yaml"
+DOCS_PATH = REPO_ROOT / "docs" / "ops" / "scheduled-tasks.md"
+
+
+def _cron_to_daily_time(cron_expr: str) -> str:
+    minute, hour, day_of_month, month, day_of_week = cron_expr.split()
+    assert day_of_month == month == day_of_week == "*"
+    return f"{int(hour):02d}:{int(minute):02d} daily"
+
+
+def test_ace_linux_2_harness_update_docs_match_schedule_source() -> None:
+    schedule = yaml.safe_load(SCHEDULE_PATH.read_text(encoding="utf-8"))
+    harness_update = next(
+        task for task in schedule["tasks"] if task["id"] == "harness-update"
+    )
+    expected = _cron_to_daily_time(
+        harness_update["schedule_by_machine"]["ace-linux-2"]
+    )
+
+    docs = DOCS_PATH.read_text(encoding="utf-8")
+    section = docs.split(
+        "## Task Schedule (ace-linux-2 / dev-secondary — contribute variant)", 1
+    )[1].split("\n## ", 1)[0]
+    row = re.search(r"^\| (?P<time>[^|]+) \| harness-update \|", section, re.M)
+
+    assert row is not None
+    assert row.group("time").strip() == expected


### PR DESCRIPTION
## Summary
- Updates ace-linux-2 scheduled-task docs for the harness update time
- Fixes Claude memory sync counting when the target memory directory does not exist
- Adds regression coverage for the sync helper and scheduled task docs

## Verification
- `uv run pytest tests/docs/test_scheduled_tasks_docs.py -q` → 1 passed
- `bash scripts/_core/tests/test_sync_agent_helpers.sh` → 15 PASS, 0 FAIL

## Closeout
Part of preserved branch PR sweep requested 2026-05-01.