### PR TITLE
fix(hooks): pin python 3.11 + pyyaml for drift checks (#2618)

### DIFF
--- a/scripts/quality/check-all.sh
+++ b/scripts/quality/check-all.sh
@@ -503,7 +503,7 @@ run_doc_drift() {
     echo "WARNING: check_doc_drift.py not found — skipping" >&2
     return 0
   fi
-  uv run --no-project python "$drift_script" 2>&1 || true
+  uv run --no-project --python 3.11 --with pyyaml python "$drift_script" 2>&1 || true
   return 0
 }
 
@@ -545,7 +545,7 @@ run_config_drift() {
     echo "WARNING: check_config_drift.py not found — skipping" >&2
     return 0
   fi
-  uv run --no-project python "$drift_script" 2>&1
+  uv run --no-project --python 3.11 --with pyyaml python "$drift_script" 2>&1
 }
 
 if $OPT_CONFIG_DRIFT; then


### PR DESCRIPTION
## Summary

Single 4-line fix to `scripts/quality/check-all.sh` so the 2 yaml-importing drift scripts (`check_config_drift.py`, `check_doc_drift.py`) get pyyaml installed in their `uv run --no-project` ephemeral env.

## What this PR ships

| Site | Change |
|------|--------|
| `scripts/quality/check-all.sh:506` (run_doc_drift) | `uv run --no-project python` → `uv run --no-project --python 3.11 --with pyyaml python` |
| `scripts/quality/check-all.sh:548` (run_config_drift) | same |

The other 11 `uv run --no-project python` invocations in this file are stdlib-clean (ratchet/JSON helpers) — untouched.

## What this PR does NOT ship (local-only / future)

- **`.git/hooks/pre-push.sh` lines 132 + 258** — same fix conceptually, but `.git/hooks/` is not git-tracked. Per-machine manual apply needed until [#2203](https://github.com/vamseeachanta/workspace-hub/issues/2203) lands the hook-source migration. I've applied the fix to `ace-linux-1`'s local hook in this session; other machines (e.g., `ace-linux-2`) will need the same 2-line patch applied locally.

## Closes
- #2618

## Test plan

- [ ] CI passes
- [ ] After merge: a fresh `git worktree add` push from this machine succeeds without `--no-verify` against the harness-changed config-drift gate (subject to local hook also being patched, which it is)
- [ ] After merge: cross-machine drift in pre-push behavior tracked via #2203

## Why staged across PRs (#2618 only / not #2203 too)

- This PR: the 2 broken script invocations that ARE git-tracked
- [#2203](https://github.com/vamseeachanta/workspace-hub/issues/2203): the hook-source migration (durable per-machine fix)

Don't fold them — different scopes, different urgency, different blast radius.