### PR TITLE
docs(handoff): durable #2802 Codex-under-Claude pilot handoff

### DIFF
--- a/docs/session-handoffs/2026-05-26-codex-pilot-2802.md
+++ b/docs/session-handoffs/2026-05-26-codex-pilot-2802.md
@@ -1,0 +1,88 @@
+# Fresh-Session Handoff — Execute #2802 as the Codex-under-Claude pilot
+
+**Date:** 2026-05-26 · **For:** a fresh Claude Code session · **Repo:** `/mnt/local-analysis/workspace-hub`
+
+## Your mission
+
+Execute **[#2802](https://github.com/vamseeachanta/workspace-hub/issues/2802)** (kanban auto-add reconciler) as the **first real-world pilot** of the Codex-under-Claude route landed in #2804 / merged PR #2809. **You orchestrate via the Codex broker; Codex implements autonomously. You do NOT implement #2802 yourself, you do NOT self-approve, you do NOT merge.**
+
+## Background (already done — don't redo)
+
+- The Codex-under-Claude sandbox block is **FIXED and on `main`** (PR #2809): AppArmor profile grants `userns` to `/usr/bin/bwrap`; `~/.codex/config.toml` has `[sandbox_workspace_write] network_access=true`. Validated: both `codex exec` and the broker run shell + write files nested under Claude. See `docs/reports/2026-05-26-codex-under-claude-pilot.md` and memory `feedback_codex_sandbox_write_blocked`.
+- **Use the broker, NOT raw `codex exec`, NOT brain/hands.** Claude orchestrates: `codex-companion.mjs task --write --background`; Codex executes its own shell/tests/writes.
+- #2802 is `status:plan-approved` (reconciler-primary plan v2 — read the issue body). Do NOT re-plan; do NOT re-approve.
+
+## Preflight
+
+```bash
+cd /mnt/local-analysis/workspace-hub
+git fetch origin main --quiet
+gh issue view 2802 --repo vamseeachanta/workspace-hub --json state,labels   # OPEN + status:plan-approved
+bash scripts/install/setup-codex-sandbox.sh --check                          # restriction active + profile present + network_access true
+/usr/bin/bwrap --unshare-user --ro-bind / / /bin/true && echo BWRAP_OK       # userns works (no sudo)
+BROKER=$(ls -d ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)
+node "$BROKER" status --all --json                                           # broker healthy, no orphan jobs
+```
+If `setup-codex-sandbox.sh --check` shows the profile missing (e.g., after reboot/reinstall), run `bash scripts/install/setup-codex-sandbox.sh --accept-userns-lpe-risk` (one-time sudo).
+
+## Worktree runbook (mandatory — abort, never fall back to the dirty main repo)
+
+The main working tree carries 120+ dirty files from parallel sessions on `fix/2795`. **Codex must run in an isolated worktree off `origin/main`.**
+```bash
+WT=/mnt/local-analysis/wt-2802
+[ -e "$WT" ] && { echo "WT exists — inspect/remove explicitly before proceeding"; }   # do NOT blindly reuse
+SHA=$(git rev-parse origin/main)
+git worktree add -b codex/2802-kanban-reconciler "$WT" "$SHA"
+git -C "$WT" status --short; git -C "$WT" rev-parse HEAD; git -C "$WT" branch --show-current   # record
+```
+**If `git worktree add` fails or stalls (poll at 5 min): ABORT the pilot and report. Do NOT run Codex in the dirty main repo** (a temp-index/dirty-main fallback would expose the 120+ dirty files to Codex — Gemini r3 BLOCKER). Honest note: the worktree isolates *working-tree files* only; global git config, credentials, Codex auth, and the remote branch namespace remain shared.
+
+## Dispatch to Codex (broker, autonomous)
+
+```bash
+node "$BROKER" task --write --background --effort high --cd /mnt/local-analysis/wt-2802 "$(cat <<'PROMPT'
+ROLE: Implement workspace-hub issue #2802 (auto-add every GitHub issue to the kanban board) in THIS worktree, following the repo's hard gates.
+
+STEP 0 — GATES: `gh issue view 2802 --repo vamseeachanta/workspace-hub --json state,labels,body`. If it lacks `status:plan-approved`, STOP and print "blocked: not plan-approved" — never self-apply the label. Read plan v2 in the body (RECONCILER-PRIMARY: a scheduled GitHub Action, single committer, self-healing). Read .claude/memory/kanban/{SCHEMA,manifest,domains}.yaml and scripts/dispatch/route.py (reuse its idempotency-key + fetch_open_issues truncation-abort patterns).
+
+STEP 1 — You are already on branch codex/2802-kanban-reconciler off origin/main. Commit only within this worktree. Never commit to main; never use the GitHub API to create branches/commits.
+
+STEP 2 — TDD (tests BEFORE code, mandatory, COMMIT-PINNED):
+  a) Write the failing tests FIRST and COMMIT them. Run pytest and capture the RED output — failures must be behavioral ASSERTION failures on the target behavior, not import/collection errors.
+  b) Then implement scripts/kanban/reconcile.py: for each active repo in manifest.yaml, `gh issue list --state all --json number,title,state,labels` (one batched call/repo; detect --limit truncation and ABORT, do not silently drop). Upsert cards keyed `gh:owner/repo#N`, UNIQUE across the whole board tree (moving a card deletes the old entry). Update gh_state/title; handle closed/transferred/deleted; idempotent.
+  c) .github/workflows/kanban-reconcile.yml: scheduled (cron ~*/20), single concurrency group cancel-in-progress:false, ONE batched commit/run, git pull --rebase + bounded push retry, commit with GITHUB_TOKEN so the push does not retrigger CI.
+  d) Re-run pytest, capture GREEN. The red→green delta must be attributable to the implementation diff only.
+  e) Phase-2 repository_dispatch nudge + GitHub App: TODO stub only, do not build.
+
+STEP 3 — VERIFY: run the tests; run `python scripts/kanban/reconcile.py --dry-run` and show the diff it would apply. NO live GitHub writes.
+
+STEP 4 — Commit (pathspec, no --no-verify on commit), push the branch, open a PR with `Refs #2802` (NOT "Closes"). DO NOT MERGE. Summarize what you built, the red→green TDD trace (commit SHAs), and the dry-run diff. Post a summary comment on #2802.
+
+CONSTRAINTS: TDD non-negotiable + commit-pinned. No secrets in code. Repo-root-relative paths (git rev-parse), never hardcoded absolute paths. Pass scripts/legal/legal-sanity-scan.sh. If blocked, STOP and report — never improvise around a gate.
+PROMPT
+)"
+# capture job id; poll: node "$BROKER" status <job-id> --json ; node "$BROKER" result <job-id> --json
+```
+
+## Provenance contract (keep the pilot honest)
+
+**Codex owns all implementation patches.** When code-review findings come back, relay them to Codex to fix (re-dispatch/resume) — do NOT patch the implementation yourself. Claude may apply only mechanical metadata (rename, lint nits) and must log any such edit; if Claude makes a semantic change, mark the run **mixed-author** and say so in the pilot outcome. This is what makes it a real Codex-under-Claude pilot rather than Claude-with-extra-steps.
+
+## After Codex opens its PR
+
+1. Verify gates: branch off `origin/main`, commit-pinned RED→GREEN TDD trace (check the failing-test commit precedes the implementation commit; the red was a behavioral assertion), `reconcile.py --dry-run` shown, `Refs #2802` not `Closes`, no merge, `legal-sanity-scan.sh` passes.
+2. **Code-stage T3 adversarial review** on the diff: Claude subagent + Codex (broker, writes its own artifact) + Gemini. Force defect-hunting. Loop findings back to Codex.
+3. Hand the reviewed PR to the **user to merge**. Never self-merge; never self-apply `status:plan-approved`.
+4. `git worktree remove /mnt/local-analysis/wt-2802` after the PR is open. Post a #2802 summary comment with the PR link + provenance note.
+
+## Discipline (hard gates)
+
+- Codex delegation = OpenAI spend: one `task` per delegation, don't autonomously re-fire; resume for fixes.
+- Never merge or self-approve. User-in-loop is load-bearing.
+- Don't touch the 120+ dirty files on `fix/2795` or `git add -A` anywhere. Pathspec commits only.
+- Adversarial code review BEFORE handing the PR to the user.
+
+## Pointers
+- Route: `docs/reports/2026-05-26-codex-under-claude-pilot.md`, `scripts/install/setup-codex-sandbox.sh`, memory `feedback_codex_sandbox_write_blocked`.
+- Plan: #2802 body · #2804 (route decision) · merged PR #2809.
+- Patterns: `scripts/dispatch/route.py`, `.claude/memory/kanban/{SCHEMA,manifest,domains}.yaml`.


### PR DESCRIPTION
Makes the #2802 pilot handoff durable (committed, cross-machine retrievable) instead of working-tree-only.

Self-contained fresh-session entry doc to execute #2802 as the first pilot of the #2804 route (merged #2809):
- broker dispatch (not raw `codex exec`/brain-hands)
- mandatory worktree off `origin/main`, **abort-on-fail** (no dirty-main fallback — Gemini r3 BLOCKER)
- commit-pinned RED→GREEN TDD with behavioral assertions
- provenance contract (Codex owns implementation patches; else mixed-author)
- `Refs #2802` not `Closes`, code-stage T3 review, legal scan, **user merges** (no self-approve/self-merge)

Single file; committed via temp-index off `origin/main` to avoid the 120+ dirty tree on `fix/2795`.

Refs #2802 #2804. For user review/merge.