### PR TITLE
fix(#2798): freshness uses body lastEditedAt, not updatedAt (every close was reopening)

### DIFF
--- a/scripts/workflow/completeness_gate_check.py
+++ b/scripts/workflow/completeness_gate_check.py
@@ -30,6 +30,19 @@ class GateDecision:
     reason: str
 
 
+def body_is_fresh(label_at, last_edited_at, created_at) -> bool:
+    """Whether the verified label post-dates the last BODY edit (anti-forgery).
+
+    Compare against the issue body's edit time (``last_edited_at``, falling back to
+    ``created_at`` when the body was never edited) — NOT the issue's ``updatedAt``,
+    which bumps on labels/comments/**the close itself** and would make a legitimate
+    close fail freshness (fix #5; the close always post-dates the verified label).
+    All args are datetimes or None.
+    """
+    edited = last_edited_at or created_at
+    return bool(label_at and edited and label_at >= edited)
+
+
 def gate_applies(labels: list[str], opt_in_label: str = OPT_IN_LABEL,
                  plan_approved_label: str = PLAN_APPROVED_LABEL) -> bool:
     """Whether the completeness gate enforces on this issue at all.

--- a/scripts/workflow/completeness_gate_runner.py
+++ b/scripts/workflow/completeness_gate_runner.py
@@ -23,7 +23,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from completeness_gate_check import (  # noqa: E402
-    OPT_IN_LABEL, PLAN_APPROVED_LABEL, VERIFIED_LABEL, evaluate_close, gate_applies,
+    OPT_IN_LABEL, PLAN_APPROVED_LABEL, VERIFIED_LABEL,
+    body_is_fresh, evaluate_close, gate_applies,
 )
 
 _RECORD_RE = re.compile(r"```completeness\s*(\{.*?\})\s*```", re.DOTALL)
@@ -87,8 +88,14 @@ def main() -> int:
 
     record = _parse_record(data.get("body", ""))
     label_actor, label_at = _verified_label_event(repo, issue)
-    body_edited_at = _parse_iso(data.get("updatedAt"))
-    body_verified_fresh = bool(label_at and body_edited_at and label_at >= body_edited_at)
+    # Freshness anchors on the BODY edit time (lastEditedAt), NOT updatedAt — the close
+    # itself bumps updatedAt past the label and would falsely fail freshness (fix #5).
+    owner, name = repo.split("/", 1)
+    ts = _gh_json("api", "graphql", "-f", f'query={{repository(owner:"{owner}",name:"{name}")'
+                  f'{{issue(number:{issue}){{lastEditedAt createdAt}}}}}}') or {}
+    issue_ts = (((ts.get("data") or {}).get("repository") or {}).get("issue")) or {}
+    body_verified_fresh = body_is_fresh(
+        label_at, _parse_iso(issue_ts.get("lastEditedAt")), _parse_iso(issue_ts.get("createdAt")))
 
     require_separate = os.environ.get("COMPLETENESS_REQUIRE_SEPARATE_CLOSER", "").lower() in ("1", "true", "yes")
     decision = evaluate_close(

--- a/tests/workflow/test_completeness_gate_check.py
+++ b/tests/workflow/test_completeness_gate_check.py
@@ -104,3 +104,36 @@ def test_gate_does_not_apply_without_plan_approved():
 
 def test_gate_does_not_apply_to_unlabeled_issue():
     assert gate.gate_applies([]) is False
+
+
+# ---- body-freshness helper (fix #5: anchor on lastEditedAt, not updatedAt) ----
+
+import datetime as _dt  # noqa: E402
+
+def _t(h):  # helper: a UTC datetime at hour h on a fixed day
+    return _dt.datetime(2026, 5, 26, h, 0, tzinfo=_dt.timezone.utc)
+
+
+def test_fresh_when_label_after_body_edit():
+    assert gate.body_is_fresh(label_at=_t(16), last_edited_at=_t(12), created_at=_t(0)) is True
+
+
+def test_not_fresh_when_label_before_body_edit():
+    assert gate.body_is_fresh(label_at=_t(11), last_edited_at=_t(12), created_at=_t(0)) is False
+
+
+def test_falls_back_to_created_at_when_never_edited():
+    # body never edited (lastEditedAt None) -> compare against createdAt
+    assert gate.body_is_fresh(label_at=_t(16), last_edited_at=None, created_at=_t(0)) is True
+    assert gate.body_is_fresh(label_at=_t(11), last_edited_at=None, created_at=_t(12)) is False
+
+
+def test_not_fresh_when_no_label():
+    assert gate.body_is_fresh(label_at=None, last_edited_at=_t(12), created_at=_t(0)) is False
+
+
+def test_close_does_not_break_freshness_regression():
+    # the bug: a later updatedAt (e.g. from the close) must NOT enter the calc.
+    # helper only sees body-edit time, so a label applied after the body edit stays fresh
+    # regardless of any later issue activity.
+    assert gate.body_is_fresh(label_at=_t(16), last_edited_at=_t(12), created_at=_t(0)) is True


### PR DESCRIPTION
**Bug:** the gate computed `body_verified_fresh` from `issue.updatedAt`, which bumps on labels/comments/**the close action itself**. At gate-eval the close's timestamp is the latest, so `label_at < updatedAt` → freshness fails → **every gated close gets reopened**. Found by pre-flighting #2798's own close (lastEditedAt=12:20 vs updatedAt=16:16).

**Fix:** pure `body_is_fresh()` comparing the verified-label time to the body's `lastEditedAt` (GraphQL; falls back to `createdAt`), which close/comments/labels don't bump. +5 unit tests on the helper — closes the 'freshness computed in untested I/O runner' gap. 44 tests green. Refs #2798.