### PR TITLE
fix(kanban): address PR #2820 code-review findings (Refs #2802)

### DIFF
--- a/.github/workflows/kanban-reconcile.yml
+++ b/.github/workflows/kanban-reconcile.yml
@@ -56,12 +56,6 @@ jobs:
             git fetch origin "$GITHUB_REF_NAME"
             git reset --hard "origin/$GITHUB_REF_NAME"
 
-            if ! git pull --rebase origin "$GITHUB_REF_NAME"; then
-              git rebase --abort || true
-              sleep $((attempt * 5))
-              continue
-            fi
-
             uv run python scripts/kanban/reconcile.py
 
             if git diff --quiet -- .claude/memory/kanban/boards; then
@@ -72,8 +66,17 @@ jobs:
             git add .claude/memory/kanban/boards
             git commit -m "chore: reconcile kanban board"
 
-            if git push origin "HEAD:$GITHUB_REF_NAME"; then
+            push_stderr="$(mktemp)"
+            if git push origin "HEAD:$GITHUB_REF_NAME" 2>"$push_stderr"; then
+              rm -f "$push_stderr"
               exit 0
+            fi
+            push_error="$(cat "$push_stderr")"
+            rm -f "$push_stderr"
+            printf '%s\n' "$push_error" >&2
+            if ! grep -Eiq 'non-fast-forward|fetch first' <<<"$push_error"; then
+              echo "Non-retryable git push failure." >&2
+              exit 1
             fi
             sleep $((attempt * 5))
           done

--- a/scripts/kanban/reconcile.py
+++ b/scripts/kanban/reconcile.py
@@ -65,6 +65,7 @@ def dump_yaml(data: dict) -> str:
 
 
 def yaml_rt() -> YAML:
+    # ruamel round-trip mode preserves formatting and does not execute Python tags.
     yaml = YAML()
     yaml.preserve_quotes = True
     yaml.width = 1000
@@ -128,9 +129,22 @@ def active_repos(entries: list[BoardEntry]) -> list[str]:
 
 
 def board_files(kanban_root: Path, entries: list[BoardEntry]) -> list[Path]:
-    files = {entry.file for entry in entries}
-    files.update((kanban_root / "boards").glob("*.yaml"))
-    return sorted(files)
+    return sorted({entry.file for entry in entries})
+
+
+def validate_unmanifested_boards(kanban_root: Path, entries: list[BoardEntry]) -> None:
+    manifest_files = {entry.file for entry in entries}
+    for path in sorted((kanban_root / "boards").glob("*.yaml")):
+        if path in manifest_files:
+            continue
+        rel_path = path.relative_to(kanban_root)
+        cards = load_yaml(path).get("cards") or []
+        if cards:
+            raise RuntimeError(
+                f"unmanifested board {rel_path} has {len(cards)} card(s); "
+                "add it to manifest.yaml before reconciling"
+            )
+        print(f"WARNING: unmanifested empty board ignored: {rel_path}", file=sys.stderr)
 
 
 def repo_board_map(entries: list[BoardEntry]) -> dict[str, Path]:
@@ -265,16 +279,29 @@ def build_live_cards(
     existing: dict[str, dict],
     existing_counts: dict[str, int],
     allow_empty_repos: set[str],
+    allow_shrink_repos: set[str],
 ) -> dict[str, tuple[Path, dict]]:
     live = {}
     for repo in repos:
         issues = issue_fetcher(repo)
-        if not issues and existing_counts.get(repo, 0) > 0 and repo not in allow_empty_repos:
-            raise RuntimeError(
-                f"empty issue list for {repo} would remove "
-                f"{existing_counts[repo]} existing github_issue card(s); "
-                "use --allow-empty only after verifying the repo legitimately has zero issues"
-            )
+        existing_count = existing_counts.get(repo, 0)
+        if len(issues) < existing_count:
+            if not issues and repo in allow_empty_repos:
+                pass
+            elif repo in allow_shrink_repos:
+                pass
+            elif not issues:
+                raise RuntimeError(
+                    f"empty issue list for {repo} would remove "
+                    f"{existing_count} existing github_issue card(s); "
+                    "use --allow-empty only after verifying the repo legitimately has zero issues"
+                )
+            else:
+                raise RuntimeError(
+                    f"partial issue list for {repo} returned {len(issues)} live issue(s) "
+                    f"but {existing_count} existing github_issue card(s) are present; "
+                    "use --allow-shrink only after verifying the reduction is legitimate"
+                )
         for issue in issues:
             key = issue_key(repo, issue["number"])
             card = card_for_issue(repo, issue, existing.get(key))
@@ -321,8 +348,10 @@ def reconcile_kanban(
     write_files: bool = True,
     repo_filter: str | None = None,
     allow_empty_repos: set[str] | None = None,
+    allow_shrink_repos: set[str] | None = None,
 ) -> ReconcileResult:
     entries = load_manifest_entries(kanban_root)
+    validate_unmanifested_boards(kanban_root, entries)
     repos = active_repos(entries)
     if repo_filter:
         repos = [repo for repo in repos if repo == repo_filter]
@@ -340,13 +369,15 @@ def reconcile_kanban(
         existing,
         existing_issue_counts_by_repo(existing),
         allow_empty_repos or set(),
+        allow_shrink_repos or set(),
     )
     rebuilt = rebuild_boards(board_data, files, set(repos), live)
     after = {}
     for path in files:
         after[path] = before[path] if rebuilt[path] == board_data[path] else dump_yaml(rebuilt[path])
     changed_files = [path for path in files if before[path] != after[path]]
-    if write_files:
+    write = write_files and not dry_run
+    if write:
         for path in changed_files:
             path.write_text(after[path], encoding="utf-8")
     return ReconcileResult(
@@ -369,6 +400,13 @@ def main(argv: list[str] | None = None) -> int:
         metavar="OWNER/REPO",
         help="allow an active repo with existing cards to reconcile to zero live issues",
     )
+    parser.add_argument(
+        "--allow-shrink",
+        action="append",
+        default=[],
+        metavar="OWNER/REPO",
+        help="allow an active repo to reconcile fewer live issues than existing cards",
+    )
     args = parser.parse_args(argv)
 
     root = args.kanban_root or repo_root() / ".claude/memory/kanban"
@@ -383,6 +421,7 @@ def main(argv: list[str] | None = None) -> int:
         write_files=not args.dry_run,
         repo_filter=args.repo,
         allow_empty_repos=set(args.allow_empty),
+        allow_shrink_repos=set(args.allow_shrink),
     )
     if result.diff:
         print(result.diff, end="")

--- a/tests/test_kanban_reconcile.py
+++ b/tests/test_kanban_reconcile.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -107,7 +108,21 @@ def issue(number: int, title: str, state: str = "OPEN", labels: list[str] | None
     }
 
 
-def test_dry_run_moves_domain_labeled_issue_and_keeps_key_unique(tmp_path: Path):
+def existing_issue_card(number: int, title: str = "stale title", labels: list[str] | None = None) -> dict:
+    repo = "vamseeachanta/workspace-hub"
+    return {
+        "idempotency_key": f"gh:{repo}#{number}",
+        "title": title,
+        "source": "github_issue",
+        "source_url": f"https://github.com/{repo}/issues/{number}",
+        "gh_state": "open",
+        "gh_labels": labels or [],
+        "initial_status": "triage",
+        "priority": 0,
+    }
+
+
+def test_reconcile_moves_domain_labeled_issue_and_keeps_key_unique(tmp_path: Path):
     reconcile = load_reconcile()
     kanban = seed_kanban(tmp_path)
     key = "gh:vamseeachanta/workspace-hub#2802"
@@ -117,13 +132,7 @@ def test_dry_run_moves_domain_labeled_issue_and_keeps_key_unique(tmp_path: Path)
     repo_data["cards"] = [
         {
             "idempotency_key": key,
-            "title": "stale title",
-            "source": "github_issue",
-            "source_url": "https://github.com/vamseeachanta/workspace-hub/issues/2802",
-            "gh_state": "open",
-            "gh_labels": [],
-            "initial_status": "triage",
-            "priority": 0,
+            **existing_issue_card(2802),
         }
     ]
     write_yaml(repo_board, repo_data)
@@ -133,13 +142,16 @@ def test_dry_run_moves_domain_labeled_issue_and_keeps_key_unique(tmp_path: Path)
         issue_fetcher=lambda repo: [
             issue(2802, "Auto-add every GitHub issue", labels=["domain:ops", "priority:high"])
         ],
-        dry_run=True,
+        dry_run=False,
     )
 
     assert result.changed is True
     assert "repo-workspace-hub-ops.yaml" in result.diff
-    assert key not in [card["idempotency_key"] for card in read_yaml(repo_board)["cards"]]
+    repo_keys = [card["idempotency_key"] for card in read_yaml(repo_board)["cards"]]
     domain_cards = read_yaml(domain_board)["cards"]
+    domain_keys = [card["idempotency_key"] for card in domain_cards]
+    assert key not in repo_keys
+    assert repo_keys + domain_keys == [key]
     assert [card["idempotency_key"] for card in domain_cards] == [key]
     assert domain_cards[0]["title"] == "Auto-add every GitHub issue"
     assert domain_cards[0]["gh_state"] == "open"
@@ -147,31 +159,17 @@ def test_dry_run_moves_domain_labeled_issue_and_keeps_key_unique(tmp_path: Path)
     assert domain_cards[0]["gh_labels"] == ["domain:ops", "priority:high"]
 
 
-def test_reconcile_removes_missing_issue_and_updates_closed_state(tmp_path: Path):
+def test_reconcile_removes_missing_issue_with_allow_shrink_and_updates_closed_state(tmp_path: Path):
     reconcile = load_reconcile()
     kanban = seed_kanban(tmp_path)
     repo_board = kanban / "boards/repo-workspace-hub.yaml"
     repo_data = read_yaml(repo_board)
     repo_data["cards"] = [
         {
-            "idempotency_key": "gh:vamseeachanta/workspace-hub#1",
-            "title": "deleted or transferred",
-            "source": "github_issue",
-            "source_url": "https://github.com/vamseeachanta/workspace-hub/issues/1",
-            "gh_state": "open",
-            "gh_labels": [],
-            "initial_status": "triage",
-            "priority": 0,
+            **existing_issue_card(1, "deleted or transferred"),
         },
         {
-            "idempotency_key": "gh:vamseeachanta/workspace-hub#2",
-            "title": "old title",
-            "source": "github_issue",
-            "source_url": "https://github.com/vamseeachanta/workspace-hub/issues/2",
-            "gh_state": "open",
-            "gh_labels": [],
-            "initial_status": "triage",
-            "priority": 0,
+            **existing_issue_card(2, "old title"),
         },
     ]
     write_yaml(repo_board, repo_data)
@@ -179,7 +177,8 @@ def test_reconcile_removes_missing_issue_and_updates_closed_state(tmp_path: Path
     result = reconcile.reconcile_kanban(
         kanban,
         issue_fetcher=lambda repo: [issue(2, "closed issue", state="CLOSED")],
-        dry_run=True,
+        dry_run=False,
+        allow_shrink_repos={"vamseeachanta/workspace-hub"},
     )
 
     assert result.changed is True
@@ -221,6 +220,136 @@ def test_reconcile_fails_closed_when_active_repo_fetch_returns_empty(tmp_path: P
     ]
 
 
+def test_reconcile_fails_closed_when_active_repo_fetch_shrinks_existing_cards(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    repo_board = kanban / "boards/repo-workspace-hub.yaml"
+    repo_data = read_yaml(repo_board)
+    repo_data["cards"] = [
+        existing_issue_card(1, "keep"),
+        existing_issue_card(2, "missing from partial fetch"),
+    ]
+    write_yaml(repo_board, repo_data)
+
+    with pytest.raises(RuntimeError, match="partial issue list"):
+        reconcile.reconcile_kanban(
+            kanban,
+            issue_fetcher=lambda repo: [issue(1, "keep")],
+            dry_run=False,
+        )
+
+    assert repo_board.read_text(encoding="utf-8") == yaml.safe_dump(repo_data, sort_keys=False)
+
+
+def test_reconcile_allows_shrink_with_explicit_repo_override(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    repo_board = kanban / "boards/repo-workspace-hub.yaml"
+    repo_data = read_yaml(repo_board)
+    repo_data["cards"] = [
+        existing_issue_card(1, "keep"),
+        existing_issue_card(2, "legitimate deletion"),
+    ]
+    write_yaml(repo_board, repo_data)
+
+    result = reconcile.reconcile_kanban(
+        kanban,
+        issue_fetcher=lambda repo: [issue(1, "keep")],
+        dry_run=False,
+        allow_shrink_repos={"vamseeachanta/workspace-hub"},
+    )
+
+    assert result.changed is True
+    assert [card["idempotency_key"] for card in read_yaml(repo_board)["cards"]] == [
+        "gh:vamseeachanta/workspace-hub#1"
+    ]
+
+
+def test_board_files_returns_manifest_boards_only(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    entries = reconcile.load_manifest_entries(kanban)
+    unmanifested = kanban / "boards/unmanifested-empty.yaml"
+    write_yaml(unmanifested, {"board": {"slug": "unmanifested-empty"}, "cards": []})
+
+    assert reconcile.board_files(kanban, entries) == [
+        kanban / "boards/repo-workspace-hub-ops.yaml",
+        kanban / "boards/repo-workspace-hub.yaml",
+    ]
+
+
+def test_unmanifested_board_with_card_aborts(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    write_yaml(
+        kanban / "boards/unmanifested.yaml",
+        {"board": {"slug": "unmanifested"}, "cards": [{"idempotency_key": "manual:1"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="unmanifested board"):
+        reconcile.reconcile_kanban(
+            kanban,
+            issue_fetcher=lambda repo: [],
+            dry_run=True,
+            allow_empty_repos={"vamseeachanta/workspace-hub"},
+        )
+
+
+def test_unmanifested_empty_board_warns_and_proceeds(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    write_yaml(kanban / "boards/unmanifested-empty.yaml", {"board": {"slug": "empty"}, "cards": []})
+
+    result = reconcile.reconcile_kanban(
+        kanban,
+        issue_fetcher=lambda repo: [],
+        dry_run=True,
+        allow_empty_repos={"vamseeachanta/workspace-hub"},
+    )
+
+    assert result.changed is False
+    assert "unmanifested empty board" in capsys.readouterr().err
+
+
+def test_dry_run_never_writes_even_when_write_files_true(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    repo_board = kanban / "boards/repo-workspace-hub.yaml"
+    before = repo_board.read_bytes()
+
+    result = reconcile.reconcile_kanban(
+        kanban,
+        issue_fetcher=lambda repo: [issue(2802, "new card")],
+        dry_run=True,
+        write_files=True,
+    )
+
+    assert result.changed is True
+    assert repo_board.read_bytes() == before
+
+
+def test_reconcile_is_idempotent_on_second_run(tmp_path: Path):
+    reconcile = load_reconcile()
+    kanban = seed_kanban(tmp_path)
+    repo_board = kanban / "boards/repo-workspace-hub.yaml"
+
+    first = reconcile.reconcile_kanban(
+        kanban,
+        issue_fetcher=lambda repo: [issue(2802, "stable title")],
+        dry_run=False,
+    )
+    after_first = repo_board.read_bytes()
+    second = reconcile.reconcile_kanban(
+        kanban,
+        issue_fetcher=lambda repo: [issue(2802, "stable title")],
+        dry_run=False,
+    )
+
+    assert first.changed is True
+    assert second.changed is False
+    assert repo_board.read_bytes() == after_first
+
+
 def test_reconcile_preserves_board_comments_and_wrapped_scalars(tmp_path: Path):
     reconcile = load_reconcile()
     kanban = seed_kanban(tmp_path)
@@ -251,7 +380,7 @@ cards:
     reconcile.reconcile_kanban(
         kanban,
         issue_fetcher=lambda repo: [issue(2802, "fresh title")],
-        dry_run=True,
+        dry_run=False,
     )
 
     text = repo_board.read_text(encoding="utf-8")
@@ -291,3 +420,25 @@ def test_fetch_repo_issues_aborts_when_gh_limit_is_reached():
             "number,title,state,labels",
         ]
     ]
+
+
+def test_workflow_contract_keeps_phase_2_cron_deferred_and_push_retry_bounded():
+    text = (ROOT / ".github/workflows/kanban-reconcile.yml").read_text(encoding="utf-8")
+    workflow = yaml.load(text, Loader=yaml.BaseLoader)
+
+    assert workflow["concurrency"] == {
+        "group": "kanban-reconcile",
+        "cancel-in-progress": "false",
+    }
+    assert workflow["permissions"] == {"contents": "write", "issues": "read"}
+    assert "# TODO(#2802 phase 2): re-enable the */20 schedule" in text
+    assert '  # schedule:\n  #   - cron: "*/20 * * * *"' in text
+    assert re.search(r"(?m)^  workflow_dispatch:", text)
+
+    run = workflow["jobs"]["reconcile"]["steps"][-1]["run"]
+    assert run.count('git commit -m "chore: reconcile kanban board"') == 1
+    assert "for attempt in 1 2 3; do" in run
+    assert "push_stderr=" in run
+    assert "non-fast-forward" in run
+    assert "fetch first" in run
+    assert "git pull --rebase" not in run


### PR DESCRIPTION
Follow-up to merged **#2820** — applies the code-stage T2 adversarial-review findings (#2820 merged before they were addressed).

**Authored by Codex** via the #2804 Codex-under-Claude route; committed by Claude (broker sandbox blocked Codex's worktree git). Independently verified: **13 tests pass**, `reconcile.py --dry-run` makes no file changes.

| Finding (sev) | Fix |
|---|---|
| Partial-fetch silent deletion (MAJOR) | fail-closed when fetched live count < existing card count; `--allow-shrink` per-repo override + 2 tests |
| Manifest/disk-drift collapse (MAJOR) | `board_files()` manifest-only (no glob); `validate_unmanifested_boards` aborts if a non-manifest board has cards, warns if empty + 3 tests |
| Inert `dry_run` write-through (MAJOR) | `write = write_files and not dry_run` (preview can never write) + test |
| Missing idempotency/cross-tree tests (MAJOR) | run-twice byte-identical + cross-tree-move no-dupe tests |
| Retry retries all push failures (MAJOR) | retry only non-fast-forward/fetch-first; fail fast on auth/permission; dropped redundant `pull --rebase` after `reset --hard` |
| No workflow-contract test (MINOR) | parses the workflow; pins concurrency/permissions/bounded-retry **and the Phase-2 cron deferral** (Decision: cron stays deferred until the GitHub App) |
| ruamel rt-mode (MINOR) | safe-by-default comment |

Review trail: `scripts/review/results/2026-05-26-code-2820-{claude,codex,gemini}.md`. GraphQL-pagination hardening intentionally deferred to a follow-on. For user review/merge.

Refs #2802.