### PR TITLE
docs(2802): completeness scorecard for kanban reconciler

### DIFF
--- a/docs/reports/2026-05-26-2802-completeness-scorecard.html
+++ b/docs/reports/2026-05-26-2802-completeness-scorecard.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Completeness Scorecard — #2802 kanban reconciler</title>
+<style>
+  :root{--bg:#0f1419;--panel:#1a2027;--panel2:#222b34;--ink:#e6edf3;--muted:#9aa7b2;
+    --line:#2d3742;--ok:#3fb950;--warn:#d29922;--bad:#f85149;--accent:#58a6ff;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:1080px;margin:0 auto;padding:32px 22px 80px}
+  h1{font-size:26px;margin:0 0 4px}
+  h2{font-size:19px;margin:32px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  .sub{color:var(--muted);font-size:13px;margin-bottom:4px}
+  code{background:#0b0f14;border:1px solid var(--line);border-radius:4px;padding:1px 6px;font:13px/1.5 ui-monospace,Menlo,Consolas,monospace;color:#c9d6e0}
+  table{width:100%;border-collapse:collapse;margin:8px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 11px;border:1px solid var(--line);vertical-align:top}
+  th{background:var(--panel2);color:#cfdae3;font-weight:600}
+  tr:nth-child(even) td{background:#161d24}
+  .bar{position:relative;background:#0b0f14;border:1px solid var(--line);border-radius:5px;height:18px;min-width:110px;overflow:hidden}
+  .bar > span{display:block;height:100%;}
+  .b100{background:var(--ok)} .b90{background:#5fb950} .b75{background:var(--warn)} .blow{background:var(--bad)}
+  .pct{font-weight:700;font-variant-numeric:tabular-nums}
+  .pill{display:inline-block;border-radius:999px;padding:1px 9px;font-size:12px;font-weight:600}
+  .p-ok{background:rgba(63,185,80,.15);color:var(--ok);border:1px solid rgba(63,185,80,.4)}
+  .p-warn{background:rgba(210,153,34,.15);color:var(--warn);border:1px solid rgba(210,153,34,.4)}
+  .p-bad{background:rgba(248,81,73,.15);color:var(--bad);border:1px solid rgba(248,81,73,.4)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px;margin:14px 0}
+  .muted{color:var(--muted)} ul{margin:6px 0 0;padding-left:20px} li{margin:3px 0}
+  .big{font-size:40px;font-weight:800;font-variant-numeric:tabular-nums}
+  .foot{margin-top:36px;color:var(--muted);font-size:12.5px;border-top:1px solid var(--line);padding-top:14px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Completeness Scorecard — #2802</h1>
+  <div class="sub">Auto-add every GitHub issue to the kanban board (reconciler) · machine <code>ace-linux-1</code> · 2026-05-26</div>
+  <div class="sub">Evidence: merged PRs #2820 (impl) + #2823 (review fixes); 13 passing tests on <code>main</code>; T2 code review. Scored adversarially against plan v2. Owner column = your override (down only).</div>
+
+  <div class="card" style="border-color:rgba(210,153,34,.5)">
+    <b style="color:var(--warn)">⚠ Headline:</b> the reconciler <b>engine is complete and tested</b>, but #2802's stated goal — "every issue reliably appears, <i>always-current</i>, enforced via cron" — is <b>not operational</b>: the <code>schedule</code> cron is deferred and the GitHub App cross-repo token isn't installed (both Phase&nbsp;2). This is <b>Phase-1-engine-complete, not goal-complete.</b>
+  </div>
+
+  <h2>Engine criteria (Phase 1 — what shipped)</h2>
+  <table>
+    <thead><tr><th>Criterion (plan v2)</th><th>Evidence</th><th style="width:120px">%</th><th style="width:70px">Owner</th></tr></thead>
+    <tbody>
+      <tr><td>Reconciler diff/upsert (state/title/label), remove on delete/transfer</td><td><code>reconcile.py</code> card_for_issue + rebuild_boards; review-verified</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Cross-tree uniqueness <code>gh:owner/repo#N</code>; move deletes old entry</td><td>verified in review; cross-tree-move test</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Idempotent + self-healing</td><td>idempotency test (#2823): 2nd run byte-identical</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Single committer, one batched commit, concurrency-safe</td><td>workflow: group <code>kanban-reconcile</code>, cancel-in-progress:false, one commit</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Push race-safe (rebase + bounded retry)</td><td>bounded retry; #2823 retries only non-fast-forward, fails fast otherwise</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Truncation-abort + partial-fetch fail-closed</td><td><code>len>=limit</code> abort + #2823 count-delta guard + <code>--allow-shrink</code></td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Security: manifest-keyed routing (not payload), no eval, sanitized</td><td>manifest SSoT (#2823); YAML-injection neutralized; review-verified</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Anti-loop: commit with default <code>GITHUB_TOKEN</code> (no CI retrigger)</td><td>workflow env token</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Domain-at-birth: repo-tier default → sub-board on <code>domain:</code> label</td><td><code>target_board()</code> domain routing + catch-all fallback</td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+      <tr><td>Tests: upsert/state/remove, cross-tree, truncation, idempotent, dry-run, drift</td><td>13 tests pass on <code>main</code></td><td><span class="pct">100%</span><div class="bar"><span class="b100" style="width:100%"></span></div></td><td></td></tr>
+    </tbody>
+  </table>
+
+  <h2>Operational-activation criteria (the actual goal)</h2>
+  <table>
+    <thead><tr><th>Criterion</th><th>Status</th><th style="width:120px">%</th><th style="width:70px">Owner</th></tr></thead>
+    <tbody>
+      <tr><td><b>Scheduled cron active</b> (the "always-current ~20 min" guarantee)</td><td><span class="pill p-bad">DEFERRED</span> cron commented; Phase-2 (needs App token)</td><td><span class="pct">0%</span><div class="bar"><span class="blow" style="width:4%"></span></div></td><td></td></tr>
+      <tr><td><b>GitHub App</b> cross-repo <code>issues:read</code> token</td><td><span class="pill p-bad">DEFERRED</span> needs human install (Phase 2)</td><td><span class="pct">0%</span><div class="bar"><span class="blow" style="width:4%"></span></div></td><td></td></tr>
+      <tr><td>Phase-1 AC: actual pilot reconcile run on 2 repos</td><td><span class="pill p-bad">NOT RUN</span> blocked on App token (no live cross-repo run)</td><td><span class="pct">0%</span><div class="bar"><span class="blow" style="width:4%"></span></div></td><td></td></tr>
+      <tr><td>repository_dispatch nudge</td><td><span class="pill p-warn">SCOPED OUT</span> Phase 2 (TODO stub)</td><td class="muted">n/a</td><td></td></tr>
+      <tr><td>Per-machine Hermes loader cron</td><td><span class="pill p-warn">SCOPED OUT</span> Phase 3</td><td class="muted">n/a</td><td></td></tr>
+    </tbody>
+  </table>
+
+  <h2>Overall</h2>
+  <div class="card" style="display:flex;align-items:center;gap:24px;flex-wrap:wrap">
+    <div><div class="big" style="color:var(--ok)">100%</div><div class="muted">engine (Phase 1 logic)</div></div>
+    <div><div class="big" style="color:var(--bad)">0%</div><div class="muted">operational activation</div></div>
+    <div><div class="big" style="color:var(--warn)">~70%</div><div class="muted">full goal (always-current via cron)</div></div>
+    <div style="flex:1;min-width:260px"><ul>
+      <li><b>The engine is closure-grade</b> — built, reviewed (T2), fixed (#2823), merged, 13 tests green.</li>
+      <li><b>The goal is not operational</b> — without cron + the GitHub App, issues do NOT yet auto-appear. The reconciler can only run manually (<code>workflow_dispatch</code>) and only reads workspace-hub's own issues under the default token.</li>
+    </ul></div>
+  </div>
+
+  <h2>Closure recommendation</h2>
+  <div class="card">
+    <b>Do not close #2802 as the full goal.</b> Two clean options:
+    <ul>
+      <li><b>A (recommended):</b> re-scope #2802 to "Phase 1 — reconciler engine" and close it at engine-100%; open <b>Phase 2</b> (enable cron + install GitHub App + repository_dispatch nudge) and <b>Phase 3</b> (Hermes loader cron) as separate issues. Matches the plan's own phasing.</li>
+      <li><b>B:</b> keep #2802 open until cron is live (Phase 2 done), tracking the full goal under one issue.</li>
+    </ul>
+    Either way the engine work is done and merged; the gap is purely the deliberately-deferred activation (cron + App, which needs your manual GitHub-App install).
+  </div>
+
+  <div class="foot">Evidence: PR #2820, PR #2823, <code>scripts/review/results/2026-05-26-code-2820-{claude,codex}.md</code>, 13 tests on <code>main</code>. Score is evidence-derived; owner may override down. Labels: <code>gate:completeness</code> on #2802.</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Evidence-based completeness scorecard for #2802 (HTML, `docs/reports/`), per `feedback_completeness_score_before_closure` + the `gate:completeness` label.

**Engine (Phase 1): 100%** — merged #2820 + #2823, 13 tests green, T2-reviewed. **Operational activation: 0%** — cron + GitHub App deferred to Phase 2. **Full goal (always-current via cron): ~70%.**

⚠️ **Recommends NOT closing #2802 as the full goal:** without cron + the App, issues don't yet auto-appear (manual `workflow_dispatch` only, workspace-hub-only reads). Options: (A, recommended) re-scope #2802 to Phase-1 engine + close, spin Phase 2 (cron+App+nudge) & Phase 3 (Hermes loader) as separate issues; or (B) keep #2802 open until cron is live.

Refs #2802.