### PR TITLE
docs(plans): draft follow-on plans (#2826 Phase2, #2827 Phase3, #2828 GraphQL, #2813 rollout)

### DIFF
--- a/docs/plans/2026-05-26-2813-route-fleet-rollout.md
+++ b/docs/plans/2026-05-26-2813-route-fleet-rollout.md
@@ -1,0 +1,33 @@
+# Plan for #2813: Roll out the Codex-under-Claude route to remaining ecosystem machines
+
+> **Status:** draft (needs adversarial review → user approval) · **Complexity:** T2 · **Date:** 2026-05-26
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2813 · **Refs:** #2804 (route, merged #2809) · **Client:** N/A
+
+## Resource Intelligence Summary
+- Route validated + codified on `main`: `scripts/install/{codex-bwrap.aa,setup-codex-sandbox.sh,teardown-codex-sandbox.sh}`; `docs/reports/2026-05-26-codex-under-claude-pilot.md`; memory `feedback_codex_sandbox_write_blocked`.
+- Installer is **guarded**: `--check` default (no mutation), `--dry-run`, explicit `--accept-userns-lpe-risk` to write, Ubuntu/AppArmor detection (fail-fast on others), sentinel refuse-overwrite, `codex --version` log.
+- Currently applied **only on `ace-linux-1`**. Memory: `feedback_cross_machine_execution` (per-machine via shared git, not fleet-push); the "verify coverage empirically" rule (don't assume a machine list).
+
+## Problem
+The fix is reproducible but deployed on one box. Other Ubuntu machines that want Codex-under-Claude orchestration need the one-time, user-authorized install; non-Ubuntu machines (e.g. Windows `D:\workspace-hub`) must no-op cleanly.
+
+## Approach
+1. **Enumerate the live ecosystem machines** (verify on the filesystem / machine registry — do not assume a fixed list).
+2. Per Ubuntu machine where wanted: `git pull` → `setup-codex-sandbox.sh --check` → `--accept-userns-lpe-risk` (user sudo, per-machine). Verify with a broker `task --write` smoke test.
+3. Non-Ubuntu / not-wanted: document **N/A** with reason (installer already fail-fasts).
+4. **No silent/batch privileged auto-run** — each install is an explicit per-machine, user-authorized action.
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| Security tradeoff (bwrap-wide userns) re-decided per machine | installer requires `--accept-userns-lpe-risk`; teardown documented; same tradeoff the user accepted on ace-linux-1 |
+| Batch agent runs the privileged installer | installer defaults to `--check`; refuses to write without the explicit flag; no-ops on non-Ubuntu |
+| Coverage claim overstated | enumerate live machines; per-machine smoke test; coverage table |
+
+## Acceptance criteria
+1. Live machines enumerated (not assumed). Per machine: Ubuntu+wanted → installed, `--check` shows profile + `network_access`, broker smoke test passes; else documented N/A.
+2. Per-machine coverage table committed (append to the pilot report).
+3. No silent privileged auto-runs; each install explicit + user-authorized.
+
+## Dependencies
+Independent of the kanban issues. Sequenced after the route proved out on ace-linux-1 (done).

--- a/docs/plans/2026-05-26-2826-reconciler-phase2-activation.md
+++ b/docs/plans/2026-05-26-2826-reconciler-phase2-activation.md
@@ -1,0 +1,37 @@
+# Plan for #2826: Reconciler Phase 2 — activation (cron + GitHub App + nudge)
+
+> **Status:** draft (needs adversarial review → user approval) · **Complexity:** T2 · **Date:** 2026-05-26
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2826 · **Parent:** #2802 (Phase 1 engine merged: #2820+#2823) · #2795 · **Client:** N/A
+
+## Resource Intelligence Summary
+- **Engine (done):** `scripts/kanban/reconcile.py` + `.github/workflows/kanban-reconcile.yml` on `main` (merged #2820/#2823); 13 tests; cron is **commented** with a `# TODO(#2802 phase 2)` block; `workflow_dispatch` live; `permissions: contents:write, issues:read`.
+- **Gap:** the Action authenticates `gh` with the default `GITHUB_TOKEN`, scoped to workspace-hub only → cannot read sibling-repo issues. The workflow-contract test currently asserts cron stays **deferred** (must flip when activated).
+- **Standards/Wiki:** N/A.
+
+## Problem
+The reconciler engine is built+tested but does not run automatically, so issues do not yet auto-appear. Activation needs (a) a cross-repo issue-read token and (b) the cron enabled, without re-introducing the P1s the plan-stage review caught (concurrency cancel, push race, self-loop).
+
+## Approach
+1. **GitHub App (human install step):** create a fine-grained App — `issues:read` on the active sibling repos, `contents:write` on workspace-hub. Store the App id + private key in **one org-level secret**. The workflow mints an installation token at run time and exports it for `gh issue list` (cross-repo reads), while the **contents push keeps the default `GITHUB_TOKEN`** so it does not retrigger CI (anti-loop).
+2. **Enable cron:** uncomment the `*/20` schedule. Concurrency group `kanban-reconcile` with `cancel-in-progress: false` is already correct (no card-dropping). Bounded push-retry already classifies non-fast-forward (from #2823).
+3. **Optional `repository_dispatch` nudge (low-latency):** per-repo lightweight workflow on `issues.opened/reopened/transferred` → `repository_dispatch` to trigger an early reconciler run; **excludes `labeled`** (high-frequency); workspace-hub ignores self-generated dispatches. Correctness never depends on it.
+
+## Scope
+In: App install runbook + secret wiring; token step in the workflow; uncomment cron; flip the workflow-contract test to assert cron **active**; per-repo nudge workflow (templated). Out: Phase 3 Hermes loader (#2827); GraphQL fetch (#2828).
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| App token leaks / over-scope | fine-grained `issues:read` only on siblings; org secret; never echoed in logs |
+| Scheduled run reads a partial cross-repo set | #2823 count-delta fail-closed guard already aborts on shrink |
+| Cron + human + autosync push contention | bounded non-fast-forward retry (#2823) |
+| Nudge storm / loops | exclude `labeled`; ignore self-dispatch; cron is the guarantee |
+
+## Acceptance criteria
+1. App installed; one org secret; workflow mints an installation token and `gh issue list` reads all active sibling repos (verified on a **2-repo pilot run** first — the original Phase-1 pilot AC).
+2. Cron enabled; a scheduled run reconciles end-to-end and commits one batched commit with the default token (no CI retrigger).
+3. Workflow-contract test updated to assert cron **active** + token step present; tests green.
+4. Nudge workflow fires a reconciler run on `issues.opened` and excludes `labeled`.
+
+## Dependencies / sequencing
+Do **#2828** (GraphQL fetch hardening) before or with this, so the *scheduled* reconciler is robust against partial fetches. Human App-install is the gating manual step.

--- a/docs/plans/2026-05-26-2827-hermes-loader-phase3.md
+++ b/docs/plans/2026-05-26-2827-hermes-loader-phase3.md
@@ -1,0 +1,36 @@
+# Plan for #2827: Reconciler Phase 3 — per-machine Hermes loader cron
+
+> **Status:** draft (needs adversarial review → user approval) · **Complexity:** T2 · **Date:** 2026-05-26
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2827 · **Parent:** #2802 · #2795 · **Client:** N/A
+
+## Resource Intelligence Summary
+- Board YAML under `.claude/memory/kanban/boards/*.yaml` is the **SSoT** (kept current by the reconciler once Phase 2 / #2826 is live).
+- A **manual mirror snapshot** currently projects board YAML into each machine's `~/.hermes/kanban.db`. Verify the exact current loader path before planning the cron (likely a script under `scripts/` or a Hermes-side importer).
+- Memory: `feedback_cross_machine_execution` (per-machine via shared git, not SSH/rsync); `feedback_hermes_*`.
+
+## Problem
+The board YAML is auto-current (post-#2826), but each machine's `~/.hermes/kanban.db` projection is updated **manually**, so the local Hermes view drifts until someone runs the mirror. Need an automatic, idempotent per-machine projection.
+
+## Approach
+- Identify/!consolidate the existing YAML→`kanban.db` loader into one idempotent script (re-run = no-op when YAML unchanged; safe on partial/locked DB).
+- Add a **per-machine cron** (systemd timer or cron entry, installed by a small guarded installer like `setup-codex-sandbox.sh`) that pulls latest board YAML (git) and runs the loader.
+- Per-machine, not fleet-pushed (cf. `feedback_cross_machine_execution`): each machine opts in; the installer is idempotent + reports state via a `--check` mode.
+
+## Scope
+In: idempotent loader consolidation; per-machine cron installer + `--check`/teardown; docs. Out: changing the YAML SSoT or the reconciler (that's Phase 1/2).
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| Loader corrupts kanban.db on concurrent write | atomic write / transaction; lock; idempotent re-run |
+| Stale git checkout on a machine | loader does `git pull` (or reads the SSoT path) before projecting; log the SHA projected |
+| Per-machine drift in coverage | `--check` reports installed state; enumerate live machines (don't assume) |
+
+## Acceptance criteria
+1. Idempotent loader: running twice with unchanged YAML makes no DB change (assert).
+2. Per-machine installer with `--check` + teardown; cron/timer installed on opt-in machines; projected SHA logged.
+3. Manual mirror snapshot decommissioned (or documented as superseded).
+4. Coverage table (per-machine installed / N/A) committed.
+
+## Dependencies
+Sequenced **after #2826** (board YAML must be auto-current for the projection to be meaningful).

--- a/docs/plans/2026-05-26-2828-graphql-pagination-hardening.md
+++ b/docs/plans/2026-05-26-2828-graphql-pagination-hardening.md
@@ -1,0 +1,33 @@
+# Plan for #2828: Reconciler fetch hardening — GraphQL pagination (hasNextPage)
+
+> **Status:** draft (needs adversarial review → user approval) · **Complexity:** T2 · **Date:** 2026-05-26
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2828 · **Refs:** #2802 (follow-on from #2820/#2823 review) · **Client:** N/A
+
+## Resource Intelligence Summary
+- `scripts/kanban/reconcile.py:fetch_repo_issues()` uses `gh issue list --state all --limit 100000 --json ...`, aborting only when `len(items) >= limit` (hard truncation).
+- #2823 added a **count-delta fail-closed guard** (abort when fetched live count < existing card count; `--allow-shrink` override) — the proportionate mitigation for partial-fetch silent deletion, but it depends on the prior board baseline.
+- Tests: `tests/test_kanban_reconcile.py` (13) — would extend with a paginated-fetch test double.
+
+## Problem
+`gh issue list --limit N` returns an opaque set; a partial-but-nonzero result (paging defect, rate-limit, visibility drift) below the limit looks authoritative. The count-delta guard catches it *relative to the existing baseline* but isn't a structural guarantee (e.g., first run with no baseline, or simultaneous legitimate growth + partial loss).
+
+## Approach
+Replace the fetch with **`gh api graphql`** paginating the repository `issues` connection until `pageInfo.hasNextPage == false`, accumulating nodes by cursor. A fetch that cannot exhaust pagination (error mid-loop) **raises** rather than returning a partial set — making partial fetches structurally impossible. Keep the #2823 count-delta guard as defense-in-depth.
+
+## Scope
+In: rewrite `fetch_repo_issues` to GraphQL cursor pagination; map fields to the existing card shape; preserve truncation-abort semantics as "incomplete pagination → raise"; tests with a paginated fetcher double (multi-page, mid-page error → raise). Out: changing upsert/board logic; the workflow.
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| GraphQL field mapping diverges from `gh issue list` JSON | golden-test the mapped card shape against the prior fetcher's output for a known repo |
+| Rate-limit on many small pages | reasonable page size (e.g., 100); honor `gh api` retry; abort (not partial) on persistent failure |
+| Behavior change breaks existing tests | keep the same return type; run the full suite |
+
+## Acceptance criteria
+1. `fetch_repo_issues` pages via GraphQL to `hasNextPage=false`; mid-pagination failure raises (no partial return).
+2. Tests: multi-page fetch returns the union; a mid-page error → RuntimeError; field-shape parity with the prior fetcher.
+3. Full suite green; `reconcile.py --dry-run` unchanged behavior.
+
+## Dependencies
+Independent; **do before/with #2826** so the *scheduled* reconciler is robust. Low coupling to Phase 2/3.


### PR DESCRIPTION
Draft plans for the four follow-ons spun out of #2802/#2804. **All status: draft** — each needs adversarial review + user approval before `status:plan-approved` (not self-approving any).

- `...-2826-reconciler-phase2-activation.md` — enable cron + GitHub App token + repository_dispatch nudge (the 'auto-appear' guarantee)
- `...-2828-graphql-pagination-hardening.md` — GraphQL cursor fetch to structurally eliminate partial fetches (do before/with #2826)
- `...-2827-hermes-loader-phase3.md` — per-machine Hermes loader cron (after #2826)
- `...-2813-route-fleet-rollout.md` — roll the #2804 route to other ecosystem machines (independent)

Suggested order: #2828 → #2826 → #2827; #2813 independent. For user review/merge of the drafts; per-issue planning gates proceed separately.