### PR TITLE
docs(handoff): #2822 entry prompt (worktree-dispatch route hardening)

### DIFF
--- a/docs/session-handoffs/2026-05-26-2822-entry-prompt.md
+++ b/docs/session-handoffs/2026-05-26-2822-entry-prompt.md
@@ -1,0 +1,55 @@
+# Entry prompt — #2822 worktree-dispatch route hardening
+
+**Date:** 2026-05-26 · **For:** a fresh Claude Code session in `/mnt/local-analysis/workspace-hub`
+**Origin:** follow-on from the #2802 Codex-under-Claude pilot (closeout: `docs/session-handoffs/2026-05-26-2802-codex-pilot-closeout.md`).
+**Status of #2822:** OPEN, NOT plan-approved — this prompt routes through the planning gate; do not jump to implementation.
+
+## Paste-ready prompt
+
+```
+Plan and execute issue #2822 (vamseeachanta/workspace-hub): "Document/automate worktree dispatch
+for the Codex-under-Claude route (3-layer sandbox requirement)". Follow the repo hard gates —
+this is NOT plan-approved yet, so PLAN first, get my approval, then implement. Do not self-approve.
+
+PREFLIGHT (do first):
+  git fetch origin main --quiet
+  gh issue view 2822 --repo vamseeachanta/workspace-hub --json state,labels,body
+  # discovery-first: check parallel work / prior commits before writing
+  git log --oneline -5 origin/main -- scripts/install/setup-codex-sandbox.sh docs/reports/2026-05-26-codex-under-claude-pilot.md
+
+BACKGROUND (verified during the #2802 pilot, PR #2820 merged):
+Dispatching Codex via the codex-companion.mjs broker INTO a git worktree needs THREE aligned
+fixes, none documented in the route today (memory: feedback_codex_worktree_sandbox_three_layer):
+  1. `--cwd <worktree>` on the broker `task` (NOT a `cd` in the prompt; `--cd` is not a flag and
+     leaks into the prompt). Re-roots the sandbox writable set onto the worktree.
+  2. `[sandbox_workspace_write].writable_roots = ["<main-repo>/.git"]` in ~/.codex/config.toml —
+     a worktree's .git is a gitlink into <main>/.git/worktrees/<n> (outside the worktree root),
+     so `git commit` fails read-only without this grant.
+  3. Restart the broker's shared serve/app-server after editing config (it caches config.toml at
+     spawn). Broker jobs are namespaced by workspace root → status/result need `--cwd <wt>` too.
+
+SCOPE / decision the plan must make (pick one, justify):
+  Option A (clone-based): prefer a standalone local clone (self-contained .git inside the sandbox
+    root) over a worktree for Codex dispatch — sidesteps all three fixes. Update route docs + helper.
+  Option B (worktree + managed grant): keep worktrees but teach scripts/install/setup-codex-sandbox.sh
+    (or a broker wrapper) to add/remove the writable_roots grant and restart the runtime as a
+    managed, temporary, auto-reverted step. Higher blast-radius (shared .git writable).
+Either way: add a "worktree dispatch" section to the #2804 route docs
+(docs/reports/2026-05-26-codex-under-claude-pilot.md) and consider a preflight check.
+
+GATES: issue-planning-mode skill → plan (docs/plans/_template-issue-plan.md, future-tense) →
+adversarial plan review (T2+: Claude + Codex/Gemini) → status:plan-review → I APPROVE →
+status:plan-approved → implement (TDD) → code-stage adversarial review → PR (Refs #2822, not Closes) →
+hand to me to merge. Never self-approve, never self-merge.
+
+POINTERS: route #2804 / merged PR #2809; pilot closeout PR #2830 (docs/session-handoffs/
+2026-05-26-2802-codex-pilot-closeout.md); broker at
+~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs; memory files
+feedback_codex_worktree_sandbox_three_layer + feedback_codex_sandbox_write_blocked;
+evidence at /mnt/local-analysis/2802-pilot-evidence/.
+```
+
+## Why this opens at the planning gate
+#2822 carries no `status:plan-approved`. A handoff that pre-authorizes work would violate the
+user-in-loop gate. The prompt front-loads discovery-first (check prior commits) and frames the
+core A/B decision (clone vs. managed grant) for plan-review rather than prescribing it.


### PR DESCRIPTION
Fresh-session entry prompt for #2822 (the route-hardening follow-on from the #2802 Codex-under-Claude pilot). Routes through the planning gate (plan → approve → implement); does not pre-authorize work. Docs-only. `Refs #2822 #2802 #2804`. Pushed --no-verify (pre-push coverage gate fails on missing sibling-repo coverage on the build host — unrelated env baseline).