### PR TITLE
fix(statusline): accurate Codex quota + headroom/git-state signals

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -18,23 +18,29 @@ ws_root=$(cd "$cwd" 2>/dev/null && git rev-parse --show-superproject-working-tre
 # Git branch
 branch=$(cd "$ws_root" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
 
-# Work queue counts (fast find, no recursion)
-wq="$ws_root/.claude/work-queue"
-if [[ -d "$wq/pending" ]]; then
-    p=$(find "$wq/pending" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-    w=$(find "$wq/working" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-    b=$(find "$wq/blocked" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-else
-    p=0; w=0; b=0
+# Git state markers — surface unpushed/uncommitted risk at a glance.
+# GIT_OPTIONAL_LOCKS=0 avoids the index-lock contention the ecosystem hits
+# in long sessions; -uno skips the untracked-file scan to keep this cheap on
+# the ~33K-file workspace-hub checkout.
+git_marker=""
+if [[ "$branch" != "?" ]]; then
+    if [[ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" status --porcelain -uno 2>/dev/null | head -1)" ]]; then
+        git_marker="\033[1;31m*\033[0m"   # bold red: dirty (tracked changes/staged)
+    fi
+    # ahead/behind vs upstream (rev-list is cheap — no working-tree scan)
+    lr=$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" rev-list --count --left-right '@{u}...HEAD' 2>/dev/null)
+    if [[ -n "$lr" ]]; then
+        behind=${lr%%[[:space:]]*}; ahead=${lr##*[[:space:]]}
+        (( ahead  > 0 )) && git_marker="${git_marker}\033[32m↑${ahead}\033[0m"   # green: unpushed
+        (( behind > 0 )) && git_marker="${git_marker}\033[31m↓${behind}\033[0m"  # red: behind remote
+    fi
 fi
 
-# Active WRK item (from per-machine state file)
-active_wrk=""
-active_wrk_file="$ws_root/.claude/state/active-wrk"
-if [[ -f "$active_wrk_file" ]]; then
-    active_id=$(head -1 "$active_wrk_file" | tr -d '[:space:]')
-    [[ -n "$active_id" ]] && active_wrk=" >${active_id}"
-fi
+# Issue badge — "GitHub issues only" ecosystem: derive the active issue from
+# the branch name (e.g. fix/2795-... -> #2795) instead of local WRK counters.
+issue_seg=""
+issue_num=$(echo "$branch" | grep -oE '[0-9]{3,5}' | head -1)
+[[ -n "$issue_num" ]] && issue_seg="\033[36m#${issue_num}\033[0m"
 
 # AI usage remaining percentages
 # C: uses Claude.ai 7-day subscription quota (from statusline JSON) as primary,
@@ -60,22 +66,37 @@ extract_pct() {
     fi
 }
 
+# Render a "LABEL:NN%" segment colored by remaining headroom so a throttle is
+# glance-able for delegation: red <20%, yellow <40%, green otherwise, dim when
+# the figure is unknown. Emits literal \033 escapes for the final printf %b.
+color_pct() {
+    local label="$1" rem="$2" suffix="${3:-}"
+    if [[ -z "$rem" || "$rem" == "-" ]]; then
+        echo "\033[2m${label}:-%${suffix}\033[0m"   # dim: unknown/unavailable
+        return
+    fi
+    local color='\033[32m'                            # green: ample headroom
+    (( rem < 40 )) && color='\033[33m'                # yellow: getting tight
+    (( rem < 20 )) && color='\033[31m'                # red: near throttle
+    echo "${color}${label}:${rem}%${suffix}\033[0m"
+}
+
 # Claude: prefer 7-day subscription remaining from API (most accurate)
 week_used=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+c_suffix=""
 if [[ -n "$week_used" ]]; then
-    c_display=$(awk -v u="$week_used" 'BEGIN { printf "%d", 100 - u }')"%"
+    c_rem=$(awk -v u="$week_used" 'BEGIN { printf "%d", 100 - u }')
 else
     # Fallback to agent-quota file
-    c_pct=$(extract_pct "claude")
-    c_display="${c_pct:--}%"
+    c_rem=$(extract_pct "claude")
     # Sonnet sub-bucket: show tighter limit with (S) indicator
-    if [[ -f "$quota_primary" ]]; then
+    if [[ -f "$quota_primary" && -n "$c_rem" ]]; then
         s_val=$(jq -r '.agents[] | select(.provider == "claude") | .sonnet_pct // empty' \
             "$quota_primary" 2>/dev/null)
-        if [[ -n "$s_val" && "$s_val" != "null" && -n "$c_pct" ]]; then
+        if [[ -n "$s_val" && "$s_val" != "null" ]]; then
             s_remaining=$(awk -v s="$s_val" 'BEGIN { printf "%d", 100 - s }')
-            if (( s_remaining < c_pct )); then
-                c_display="${s_remaining}%(S)"
+            if (( s_remaining < c_rem )); then
+                c_rem="$s_remaining"; c_suffix="(S)"
             fi
         fi
     fi
@@ -83,7 +104,7 @@ fi
 
 o_pct=$(extract_pct "codex")
 g_pct=$(extract_pct "gemini")
-ai_usage="C:${c_display}|O:${o_pct:--}%|G:${g_pct:--}%"
+ai_usage="$(color_pct C "$c_rem" "$c_suffix")|$(color_pct O "$o_pct")|$(color_pct G "$g_pct")"
 
 # Repo module name (basename of workspace root)
 repo_name=$(basename "$ws_root")
@@ -113,9 +134,9 @@ parts=()
 parts+=("\033[1;33m[${hostname_s}]\033[0m")
 parts+=("\033[1;35m${model}\033[0m")
 parts+=("\033[1;37m${repo_name}\033[0m")
-parts+=("\033[33m${branch}\033[0m")
-parts+=("\033[36mWRK:${p}p/${w}w/${b}b${active_wrk}\033[0m")
-parts+=("\033[35m${ai_usage}\033[0m")
+parts+=("\033[33m${branch}\033[0m${git_marker}")
+[[ -n "$issue_seg" ]] && parts+=("${issue_seg}")
+parts+=("${ai_usage}")
 parts+=("${cost_fmt}")
 parts+=("ctx:${ctx}")
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lib/
 !scripts/coordination/routing/lib/
 !scripts/setup/lib/
 !scripts/review/lib/
+!scripts/ai/assessment/lib/
 !scripts/cron/lib/
 !scripts/improve/lib/
 !scripts/lib/

--- a/scripts/ai/assessment/lib/display.sh
+++ b/scripts/ai/assessment/lib/display.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ABOUTME: Display and logging functions for AI usage reports
+# Requires: utils.sh sourced, providers.sh sourced
+
+bar_graph() {
+    local pct=$1 width=10
+    local filled=$(( pct * width / 100 ))
+    local empty=$(( width - filled ))
+    local bar=""
+    for ((i=0; i<filled; i++)); do bar+="█"; done
+    for ((i=0; i<empty; i++)); do bar+="░"; done
+    echo "$bar"
+}
+
+color_for_pct() {
+    local pct=$1
+    if (( pct > 50 )); then echo "32"
+    elif (( pct > 20 )); then echo "33"
+    else echo "31"; fi
+}
+
+display_summary() {
+    local data="$1"
+    echo ""
+    echo "Agent Credits ($(date +%A) $(date +%Y-%m-%d)):"
+
+    for provider in claude codex gemini; do
+        local entry
+        entry=$(echo "$data" | jq -r --arg p "$provider" '.agents[] | select(.provider == $p)')
+        if [[ -z "$entry" ]]; then
+            printf "  %-8s ░░░░░░░░░░  — (no data)\n" "$provider:"; continue
+        fi
+
+        local pct
+        pct=$(echo "$entry" | jq -r '.pct_remaining // empty' 2>/dev/null || true)
+
+        # No authoritative rate-limit % — keep Claude as N/A until fixed.
+        if [[ -z "$pct" || "$pct" == "null" ]]; then
+            printf "  %-8s ░░░░░░░░░░  N/A (authoritative source unavailable)\n" "$provider:"
+            continue
+        fi
+
+        local msgs limit bar color detail
+        msgs=$(echo "$entry" | jq -r '.week_messages // .today_messages // 0')
+        limit=$(echo "$entry" | jq -r '.weekly_limit // .daily_limit // 0')
+        bar=$(bar_graph "$pct")
+        color=$(color_for_pct "$pct")
+
+        if [[ "$provider" == "claude" ]]; then
+            local approx sessions tools trend icon cost
+            approx=$(echo "$entry" | jq -r '.approx_requests // 0')
+            sessions=$(echo "$entry" | jq -r '.week_sessions // 0')
+            tools=$(echo "$entry" | jq -r '.week_tool_calls // 0')
+            trend=$(echo "$entry" | jq -r '.trend // "stable"')
+            icon=""; case "$trend" in high) icon=" ↑" ;; low) icon=" ↓" ;; esac
+            detail="(~${approx} reqs, ${sessions} sessions, ${tools} tools${icon})"
+            cost=$(echo "$entry" | jq -r '.week_cost_usd // empty' 2>/dev/null || true)
+            [[ -n "$cost" && "$cost" != "0" ]] && detail="\$${cost}/wk equiv, ${detail}"
+        else
+            detail="(${msgs}/${limit} msgs)"
+        fi
+
+        printf "  %-8s \033[%sm%s\033[0m  %d%% remaining %s\n" \
+            "$provider:" "$color" "$bar" "$pct" "$detail"
+    done
+    echo ""
+}
+
+show_weekly_summary() {
+    local week_start
+    week_start=$(last_monday_date)
+    echo "Weekly Usage Summary (since $week_start):"
+    echo ""
+
+    # Claude: authoritative OAuth snapshot only
+    local oauth
+    oauth=$(get_claude_oauth_entry)
+    if [[ -n "$oauth" ]]; then
+        local pct rem five reset
+        pct=$(echo "$oauth" | jq -r '.week_pct // 0')
+        rem=$(awk -v w="$pct" 'BEGIN { printf "%d", 100 - w }')
+        five=$(echo "$oauth" | jq -r '.five_hour_pct // 0')
+        reset=$(echo "$oauth" | jq -r '.hours_to_reset // 0')
+        printf "  %-8s used: %s%%  remaining: %s%%  5h: %s%%  reset in: %sh\n" \
+            "claude:" "$pct" "$rem" "$five" "$reset"
+    else
+        printf "  %-8s N/A  (authoritative source unavailable)\n" "claude:"
+    fi
+
+    # Codex: history.jsonl count
+    local codex_count=0
+    [[ -f "${HOME}/.codex/history.jsonl" ]] && \
+        codex_count=$(uv run --no-project python -c "
+import json, time, os
+h=os.path.expanduser('~/.codex/history.jsonl'); cutoff=time.time()-7*86400; c=0
+try:
+    [c := c+1 for line in open(h) if line.strip() and json.loads(line).get('ts',0) >= cutoff]
+except: pass
+print(c)
+" 2>/dev/null || echo 0)
+    printf "  %-8s week msgs: %s  (limit: %s)\n" \
+        "codex:" "$codex_count" "${CODEX_WEEKLY_MESSAGES:-1400}"
+
+    # Gemini: daily count only (weekly not available)
+    local gemini_count=0
+    [[ -f "${HOME}/.config/gemini/state.json" ]] && \
+        gemini_count=$(jq -r '.dailyRequestCount // 0' "${HOME}/.config/gemini/state.json" 2>/dev/null || echo 0)
+    printf "  %-8s today msgs: %s  (weekly data unavailable from source)\n" \
+        "gemini:" "$gemini_count"
+    echo ""
+}
+
+log_snapshot() {
+    local data="$1" log_file="$2"
+    mkdir -p "$(dirname "$log_file")"
+    jq -cn \
+        --arg ts "$(iso_now)" \
+        --argjson agents "$(echo "$data" | jq -c '.agents')" \
+        '{ timestamp: $ts, agents: $agents }' >> "$log_file"
+}

--- a/scripts/ai/assessment/lib/providers.sh
+++ b/scripts/ai/assessment/lib/providers.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# ABOUTME: AI provider usage query functions (Claude, Codex, Gemini)
+# Requires: utils.sh sourced, REPO_QUOTA_FILE/CLAUDE_MESSAGE_RATIO globals set
+
+# ── Claude ────────────────────────────────────────────────────────────────────
+
+# Returns current-week cost/token data from ccusage (reads session JSONL — always current)
+# Note: auxiliary only; not authoritative for quota percentages.
+get_ccusage_weekly() {
+    command -v npx &>/dev/null || { echo "null"; return; }
+    local since raw
+    since=$(this_monday_yyyymmdd 2>/dev/null || date -d "-7 days" +%Y%m%d)
+    raw=$(NO_COLOR=1 npx ccusage weekly --json --since "$since" 2>/dev/null)
+    [[ -z "$raw" ]] && { echo "null"; return; }
+    echo "$raw" | uv run --no-project python -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    weeks = data.get('weekly', [])
+    if not weeks:
+        print('null'); sys.exit(0)
+    w = weeks[-1]
+    print(json.dumps({
+        'cost_usd':     round(w.get('totalCost', 0), 2),
+        'total_tokens': w.get('totalTokens', 0),
+        'input_tokens': w.get('inputTokens', 0),
+        'output_tokens': w.get('outputTokens', 0),
+        'models':       w.get('modelsUsed', [])
+    }))
+except Exception:
+    print('null')
+" 2>/dev/null || echo "null"
+}
+
+# Returns validated claude entry from REPO_QUOTA_FILE (authoritative only)
+get_claude_oauth_entry() {
+    [[ -f "$REPO_QUOTA_FILE" ]] || return 0
+    local entry
+    entry=$(jq -c '.agents[] | select(.provider == "claude") | select(.source == "oauth-api")' \
+        "$REPO_QUOTA_FILE" 2>/dev/null || true)
+    [[ -z "$entry" ]] && return 0
+    echo "$entry" | jq -e '.week_pct != null' &>/dev/null && echo "$entry"
+}
+
+# Returns weekly stats from ~/.claude/stats-cache.json (local CLI tracker, may be stale)
+query_claude_stats() {
+    local creds="${HOME}/.claude/.credentials.json"
+    local stats="${HOME}/.claude/stats-cache.json"
+    local tier="unknown" weekly_limit=10000
+
+    if [[ -f "$creds" ]]; then
+        tier=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$creds" 2>/dev/null)
+        local rate_tier
+        rate_tier=$(jq -r '.claudeAiOauth.rateLimitTier // ""' "$creds" 2>/dev/null)
+        case "${rate_tier:-$tier}" in
+            pro)                   weekly_limit=2000  ;;
+            max)                   weekly_limit=10000 ;;
+            default_claude_max_20x) weekly_limit=20000 ;;
+            team)                  weekly_limit=3500  ;;
+        esac
+    fi
+
+    local weekly
+    weekly=$(uv run --no-project python - <<PYEOF
+import json, datetime, os
+cache = os.path.expanduser("~/.claude/stats-cache.json")
+try:
+    with open(cache) as f:
+        data = json.load(f)
+    cutoff = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
+    messages = sessions = tools = 0
+    for day in data.get("dailyActivity", []):
+        if day.get("date", "") > cutoff:
+            messages += day.get("messageCount", 0)
+            sessions += day.get("sessionCount", 0)
+            tools    += day.get("toolCallCount", 0)
+    print(messages, sessions, tools)
+except Exception:
+    print(0, 0, 0)
+PYEOF
+)
+    local messages sessions tools
+    read -r messages sessions tools <<< "$weekly"
+    messages=${messages:-0}; sessions=${sessions:-0}; tools=${tools:-0}
+
+    local approx=0 pct_used=0 pct_remaining=100
+    if (( weekly_limit > 0 && messages > 0 )); then
+        approx=$(awk -v m="$messages" -v r="${CLAUDE_MESSAGE_RATIO:-15}" 'BEGIN { printf "%d", m/r }')
+        pct_used=$(awk -v u="$approx" -v l="$weekly_limit" 'BEGIN { printf "%d", (u/l)*100 }')
+        (( pct_used > 100 )) && pct_used=100
+        pct_remaining=$(( 100 - pct_used ))
+    fi
+
+    local avg=0 trend="stable"
+    if [[ -f "$stats" ]]; then
+        avg=$(jq -r '[.dailyActivity[].messageCount] | add / length | floor' "$stats" 2>/dev/null || echo 0)
+        local today_msgs
+        today_msgs=$(jq -r '.dailyActivity[-1].messageCount // 0' "$stats" 2>/dev/null || echo 0)
+        if (( today_msgs > 0 && avg > 0 )); then
+            awk -v t="$today_msgs" -v a="$avg" 'BEGIN { exit !(t/a > 1.5) }' && trend="high"
+            awk -v t="$today_msgs" -v a="$avg" 'BEGIN { exit !(t/a < 0.5) }' && trend="low"
+        fi
+    fi
+
+    jq -n \
+        --arg tier "$tier" \
+        --argjson limit "$weekly_limit" \
+        --argjson messages "$messages" \
+        --argjson approx "$approx" \
+        --argjson sessions "$sessions" \
+        --argjson tools "$tools" \
+        --argjson pct "$pct_remaining" \
+        --argjson avg "$avg" \
+        --arg trend "$trend" \
+        '{provider:"claude", tier:$tier, weekly_limit:$limit,
+          week_messages:$messages, approx_requests:$approx,
+          week_sessions:$sessions, week_tool_calls:$tools,
+          pct_remaining:$pct, avg_daily_messages:$avg,
+          trend:$trend, source:"stats-cache.json"}'
+}
+
+# Merges ccusage token/cost data into a provider JSON entry as auxiliary metadata only.
+# Use this only when the base quota source is authoritative.
+_enrich_with_ccusage() {
+    local entry="$1"
+    local ccusage
+    ccusage=$(get_ccusage_weekly)
+    [[ "$ccusage" == "null" || -z "$ccusage" ]] && { echo "$entry"; return; }
+    echo "$entry" | jq \
+        --argjson cc "$ccusage" \
+        '. + {week_cost_usd: $cc.cost_usd, week_tokens: $cc.total_tokens,
+              week_input_tokens: $cc.input_tokens, week_output_tokens: $cc.output_tokens,
+              models_used: $cc.models}'
+}
+
+# Main claude query: authoritative OAuth snapshot only.
+# If unavailable, surface N/A rather than an estimated quota.
+query_claude() {
+    local oauth
+    oauth=$(get_claude_oauth_entry)
+    if [[ -n "$oauth" ]]; then
+        _enrich_with_ccusage "$oauth"
+        return
+    fi
+
+    local creds="${HOME}/.claude/.credentials.json"
+    local tier="unknown" weekly_limit=10000
+    if [[ -f "$creds" ]]; then
+        tier=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$creds" 2>/dev/null)
+        local rate_tier
+        rate_tier=$(jq -r '.claudeAiOauth.rateLimitTier // ""' "$creds" 2>/dev/null)
+        case "${rate_tier:-$tier}" in
+            pro)                    weekly_limit=2000  ;;
+            max)                    weekly_limit=10000 ;;
+            default_claude_max_20x) weekly_limit=20000 ;;
+            team)                   weekly_limit=3500  ;;
+        esac
+    fi
+
+    local unavailable
+    jq -n \
+        --arg tier "$tier" \
+        --argjson limit "$weekly_limit" \
+        '{
+            provider:"claude",
+            tier:$tier,
+            weekly_limit:$limit,
+            week_pct:null,
+            five_hour_pct:null,
+            pct_remaining:null,
+            hours_to_reset:null,
+            resets_at:"",
+            source:"unavailable"
+        }'
+}
+
+# ── Codex ─────────────────────────────────────────────────────────────────────
+
+query_codex() {
+    local history="${HOME}/.codex/history.jsonl"
+    local messages=0
+    if [[ -f "$history" ]]; then
+        messages=$(uv run --no-project python - <<PYEOF
+import json, time, os
+history = os.path.expanduser("~/.codex/history.jsonl")
+cutoff = time.time() - 7 * 86400
+count = 0
+try:
+    with open(history) as f:
+        for line in f:
+            line = line.strip()
+            if not line: continue
+            try:
+                entry = json.loads(line)
+                if entry.get("ts", 0) >= cutoff:
+                    count += 1
+            except (json.JSONDecodeError, ValueError):
+                pass
+except Exception:
+    pass
+print(count)
+PYEOF
+)
+        messages=${messages:-0}
+    fi
+    local limit="${CODEX_WEEKLY_MESSAGES:-1400}"
+
+    # Authoritative: Codex's own server-reported rate-limit telemetry
+    # (rate_limits.secondary in each session rollout). This matches the
+    # ChatGPT Codex Analytics dashboard exactly. The history.jsonl
+    # message-count below is a coarse estimate that wildly undercounts
+    # (assumes a flat 1400-msg cap, ignores token/tool weighting) and is
+    # used only as a fallback when no session telemetry is available.
+    local assess_dir telemetry
+    assess_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
+    telemetry=$(bash "$assess_dir/query-codex-usage.sh" --json 2>/dev/null || true)
+    if [[ -n "$telemetry" ]] \
+        && echo "$telemetry" | jq -e '.source == "local-session-rate-limits" and .pct_remaining != null' &>/dev/null; then
+        echo "$telemetry" | jq -c \
+            --argjson limit "$limit" \
+            --argjson messages "$messages" \
+            '{provider:"codex", tier:"subscription", weekly_limit:$limit,
+              week_messages:$messages, week_pct:.week_pct,
+              five_hour_pct:.five_hour_pct, pct_remaining:.pct_remaining,
+              hours_to_reset:.hours_to_reset, resets_at:.resets_at,
+              source:"local-session-rate-limits"}'
+        return
+    fi
+
+    # Fallback: coarse message-count estimate (no live rate-limit telemetry).
+    local pct_used=0
+    (( limit > 0 )) && pct_used=$(awk -v u="$messages" -v l="$limit" 'BEGIN { printf "%d", (u/l)*100 }')
+    (( pct_used > 100 )) && pct_used=100
+    jq -n \
+        --argjson limit "$limit" \
+        --argjson messages "$messages" \
+        --argjson pct "$(( 100 - pct_used ))" \
+        '{provider:"codex", tier:"subscription", weekly_limit:$limit,
+          week_messages:$messages, pct_remaining:$pct, source:"history.jsonl-estimate"}'
+}
+
+# ── Gemini ────────────────────────────────────────────────────────────────────
+
+query_gemini() {
+    local state="${HOME}/.config/gemini/state.json"
+    local today messages=0
+    today=$(date +%Y-%m-%d)
+
+    if [[ -f "$state" ]]; then
+        local count
+        count=$(jq -r '.dailyRequestCount // 0' "$state" 2>/dev/null)
+        [[ "$count" != "null" && "$count" != "0" ]] && messages=$count
+    fi
+
+    if (( messages == 0 )); then
+        [[ ! -f /tmp/.gemini-day-marker ]] && touch_midnight /tmp/.gemini-day-marker "$today"
+        messages=$(find "${HOME}/.config/gemini/tmp" -maxdepth 1 \
+            -newer /tmp/.gemini-day-marker -type f 2>/dev/null | wc -l)
+    fi
+
+    local limit="${GEMINI_DAILY_REQUESTS:-1000}"
+    local pct_used=0
+    (( limit > 0 )) && pct_used=$(awk -v u="$messages" -v l="$limit" 'BEGIN { printf "%d", (u/l)*100 }')
+    (( pct_used > 100 )) && pct_used=100
+    jq -n \
+        --argjson limit "$limit" \
+        --argjson messages "$messages" \
+        --argjson pct "$(( 100 - pct_used ))" \
+        '{provider:"gemini", tier:"google_login", daily_limit:$limit,
+          today_messages:$messages, pct_remaining:$pct, source:"estimated"}'
+}

--- a/scripts/ai/assessment/lib/utils.sh
+++ b/scripts/ai/assessment/lib/utils.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ABOUTME: Portable helper functions shared across AI assessment scripts
+
+# Portable file modification time (seconds since epoch)
+file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# Portable ISO-8601 datetime
+iso_now() {
+    date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z
+}
+
+# Monday of the current week in YYYY-MM-DD
+last_monday_date() {
+    local dow days_back
+    dow=$(date +%u 2>/dev/null || date +%w)
+    [[ "$dow" == "0" ]] && dow=7
+    days_back=$(( dow - 1 ))
+    (( days_back == 0 )) && days_back=7
+    date -d "-${days_back} days" +%Y-%m-%d 2>/dev/null && return
+    date -v-${days_back}d +%Y-%m-%d 2>/dev/null && return
+    date -d "-7 days" +%Y-%m-%d 2>/dev/null || date -v-7d +%Y-%m-%d
+}
+
+# Monday of the current week in YYYYMMDD (for ccusage --since)
+this_monday_yyyymmdd() {
+    local dow days_back
+    dow=$(date +%u 2>/dev/null || echo 1)
+    [[ "$dow" == "0" ]] && dow=7
+    days_back=$(( dow - 1 ))
+    date -d "-${days_back} days" +%Y%m%d 2>/dev/null \
+        || date -v-${days_back}d +%Y%m%d 2>/dev/null \
+        || date -d "-7 days" +%Y%m%d
+}
+
+# Portable touch-to-midnight (for day-marker files)
+touch_midnight() {
+    local marker="$1" today="$2"
+    touch -d "${today} 00:00:00" "$marker" 2>/dev/null && return
+    touch -t "$(echo "${today}" | tr -d '-')0000" "$marker" 2>/dev/null || true
+}


### PR DESCRIPTION
## Problem
The statusline showed `O:100%` for OpenAI Codex while the Codex Analytics dashboard reported **94% weekly remaining** — a misleading signal for delegation decisions.

Root cause was **upstream of the statusline**: `query_codex()` estimated usage by counting lines in `~/.codex/history.jsonl` over 7 days ÷ an assumed 1400-message cap. With 12 logged messages that floored to 0% used → "100% remaining". Codex already records the real server-side quota in each session's `rate_limits.secondary` payload (the same number the dashboard shows).

## Changes
- **`scripts/ai/assessment/lib/providers.sh`** — `query_codex` now reads Codex's server-reported `rate_limits.secondary` (via `query-codex-usage.sh`). `O:` matches the dashboard (94%, 98% 5h). Falls back to the coarse message-count estimate only when no session telemetry exists.
- **`.claude/statusline-command.sh`**
  - Color `C/O/G` by remaining headroom (red <20% / yellow <40% / green) so a throttle is glance-able.
  - Git dirty `*` + ahead/behind `↑N/↓N` markers (surfaces unpushed/uncommitted risk).
  - Replace vestigial `WRK:0p/0w/0b` counters with the issue number parsed from the branch (`fix/2795-…` → `#2795`) — aligns with "GitHub issues only".
- **`.gitignore`** — un-ignore `scripts/ai/assessment/lib/`. The bare `lib/` pattern silently dropped the entire quota-query library: `query-quota.sh` is tracked but sourced `lib/*.sh` (`utils.sh`, `providers.sh`, `display.sh`) that were **never committed** → a fresh clone had a broken quota pipeline. This PR newly tracks all three.

## Verification
- `query-codex-usage.sh --json` → `week_pct: 6.0, pct_remaining: 94`, matches the dashboard (94% weekly, 98% 5h, resets May 30).
- `query-quota.sh --refresh` regenerates `agent-quota-latest.json` with `source: local-session-rate-limits`.
- Statusline renders `O:94%` (green); color thresholds verified at 94/35/12/unknown.
- `bash -n` clean; existing `scripts/session/tests/test_quota_status.sh` → 9 PASS / 0 FAIL.