### PR TITLE
feat(workstations): solvers capability dimension on equality matrix [#2801 family]

### DIFF
--- a/.claude/state/equality-dev-primary.yaml
+++ b/.claude/state/equality-dev-primary.yaml
@@ -1,5 +1,5 @@
 generated_at: "2026-05-26T09:51:54"
-schema_version: 2
+schema_version: 3
 machine: "dev-primary"
 host: "ace-linux-1"
 os: linux
@@ -13,6 +13,11 @@ dimensions:
     - {repo: digitalmodel, mode: sibling}
     - {repo: worldenergydata, mode: sibling}
     - {repo: assethold, mode: sibling}
+  solvers:
+    - {name: orcaflex, status: absent, evidence: absent}
+    - {name: orcawave, status: absent, evidence: absent}
+    - {name: aqwa, status: absent, evidence: absent}
+    - {name: ansys, status: absent, evidence: absent}
   harness:
     providers: {claude: present, codex: present, gemini: present, hermes: present}
     gh_auth: ok

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ lib/
 !scripts/review/lib/
 !scripts/cron/lib/
 !scripts/improve/lib/
+!scripts/readiness/lib/
 !scripts/lib/
 !scripts/review/lib/
 !scripts/work-queue/lib/

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -28,7 +28,15 @@ CONFIG = REPO / "scripts" / "readiness" / "harness-config.yaml"
 
 TIER1_DEFAULT = ["assetutilities", "digitalmodel", "worldenergydata", "assethold"]
 UNREACHABLE_DEFAULT = {"home-win", "macbook-portable"}
-COLD_DIMS = {"compute", "data_access"}
+COLD_DIMS = {"compute", "data_access", "solvers"}
+# Solver verdict acceptance (STRICT, #2849 decision 1): which DETECTED statuses satisfy
+# each DECLARED baseline. `licensed` baseline is satisfied ONLY by a `licensed` signal
+# (an install-only `present` is NOT enough — licensed work must never route to it).
+SOLVER_OK = {
+    "absent":   {"absent", "unknown"},
+    "present":  {"present", "licensed"},
+    "licensed": {"licensed"},
+}
 # Uniform dims whose cross-machine difference is OS-driven, not a defect:
 EXPECTED_DIFF_DIMS = {"python_cmd"}
 
@@ -100,6 +108,22 @@ def cold_verdict(dim: str, report: dict, baseline: dict | None, probed_repos: li
             return "MISSING-BASELINE"
         accessible = {d["repo"] for d in dims.get("data_access", []) if d.get("mode") != "absent"}
         return "CONFORMS" if set(required) <= accessible else "BELOW-BASELINE"
+    if dim == "solvers":
+        declared = baseline.get("solvers_baseline")
+        if not declared:                                 # baseline opted out → fail-closed
+            return "MISSING-BASELINE"
+        detected = {s["name"]: s.get("status") for s in dims.get("solvers", [])}
+        verdict = "CONFORMS"
+        for name, want in declared.items():
+            got = detected.get(name, "unknown")
+            ok = SOLVER_OK.get(want, set())
+            # `unknown` against a non-`absent` baseline = no evidence (not a hard fail).
+            if got in (None, "unknown") and want != "absent":
+                verdict = "MISSING-EVIDENCE"
+                continue
+            if got not in ok:
+                return "BELOW-BASELINE"                   # any concrete miss dominates
+        return verdict
     raise ValueError(f"not a cold dimension: {dim}")
 
 
@@ -171,7 +195,7 @@ def load_reports() -> dict[str, dict]:
     return out
 
 
-DISPLAY_DIMS = ["compute", "data_access", "harness", "python_cmd", "skills",
+DISPLAY_DIMS = ["compute", "data_access", "solvers", "harness", "python_cmd", "skills",
                 "kanban", "memory", "behavior", "scheduler"]
 
 

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -32,8 +32,11 @@ COLD_DIMS = {"compute", "data_access", "solvers"}
 # Solver verdict acceptance (STRICT, #2849 decision 1): which DETECTED statuses satisfy
 # each DECLARED baseline. `licensed` baseline is satisfied ONLY by a `licensed` signal
 # (an install-only `present` is NOT enough — licensed work must never route to it).
+# `unknown`/missing detection is NEVER an acceptance for any baseline — it grades
+# MISSING-EVIDENCE (handled in cold_verdict), so a legacy v2 report with no solvers
+# block does not masquerade as CONFORMS on a dev (absent-baseline) machine.
 SOLVER_OK = {
-    "absent":   {"absent", "unknown"},
+    "absent":   {"absent"},
     "present":  {"present", "licensed"},
     "licensed": {"licensed"},
 }
@@ -117,8 +120,9 @@ def cold_verdict(dim: str, report: dict, baseline: dict | None, probed_repos: li
         for name, want in declared.items():
             got = detected.get(name, "unknown")
             ok = SOLVER_OK.get(want, set())
-            # `unknown` against a non-`absent` baseline = no evidence (not a hard fail).
-            if got in (None, "unknown") and want != "absent":
+            # `unknown`/missing detection is NOT evidence for ANY baseline (incl. absent):
+            # a legacy v2 report with no solvers block must not pass as CONFORMS.
+            if got in (None, "unknown"):
                 verdict = "MISSING-EVIDENCE"
                 continue
             if got not in ok:

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -69,6 +69,26 @@ for r in assetutilities digitalmodel worldenergydata assethold; do
   data_yaml+="    - {repo: ${r}, mode: ${mode}}"$'\n'
 done
 
+# ── 2b. SOLVERS — licensed-solver capability (#2849); shared probes, no path leak ──
+# MUST run BEFORE the behaviour-probe sandbox (which redirects HOME/XDG below) so the
+# real-env signals (ORCAWAVE_PATH, ANSYS license vars) are visible. Sourced helper is
+# the single source of truth — the standalone nightly R-ANSYS/R-ORCAFLEX checks were
+# removed per #2849 decision 2 (the matrix cell IS the answer; no nightly duplication).
+solvers_yaml=""
+if [[ -f "${SCRIPT_DIR}/lib/probe-solvers.sh" ]]; then
+  # shellcheck source=lib/probe-solvers.sh
+  source "${SCRIPT_DIR}/lib/probe-solvers.sh"
+  for s in orcaflex orcawave aqwa ansys; do
+    st=$("probe_${s}" 2>/dev/null || echo unknown); : "${st:=unknown}"
+    ev=$("probe_${s}_evidence" 2>/dev/null || echo unknown); : "${ev:=unknown}"
+    solvers_yaml+="    - {name: ${s}, status: ${st}, evidence: ${ev}}"$'\n'
+  done
+else
+  for s in orcaflex orcawave aqwa ansys; do
+    solvers_yaml+="    - {name: ${s}, status: unknown, evidence: unknown}"$'\n'
+  done
+fi
+
 # ── 3. HARNESS (reference readiness; gh_auth as ENUM, never the token) ───────
 readiness_file="harness-readiness-${MACHINE}.yaml"
 [[ -f "${STATE_DIR}/${readiness_file}" ]] || readiness_file="harness-readiness-${HOST}.yaml"
@@ -131,7 +151,7 @@ fi
 
 # ── emit (generated_at + headroom + mtime + job_count are EXCLUDED from the hash) ──
 read -r -d '' BODY <<YAML || true
-schema_version: 2
+schema_version: 3
 machine: "$(yesc "$MACHINE")"
 host: "$(yesc "$HOST")"
 os: ${OS}
@@ -141,7 +161,8 @@ dimensions:
     static: {cores: ${cores}, ram_total_mib: ${ram_total_mib}, gpu_model: "$(yesc "$gpu")"}
     headroom: {ram_avail_mib: ${ram_avail_mib}, disk_avail_gb: ${disk_avail_gb}}
   data_access:
-${data_yaml}  harness:
+${data_yaml}  solvers:
+${solvers_yaml}  harness:
     providers: {claude: $(prov claude), codex: $(prov codex), gemini: $(prov gemini), hermes: $(prov hermes)}
     gh_auth: ${gh_auth}
     python_cmd: ${py_cmd}

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -66,6 +66,9 @@ workstations:
     required_data_access: [digitalmodel, assetutilities]
     # #2849 solvers baseline (cold-dim, STRICT): licensed work routes here — only a `licensed`
     # signal satisfies this baseline. An install-only `present` grades BELOW-BASELINE.
+    # NOTE (PR #2850, 2026-05-28): `licensed` is the TARGET, but the probe currently emits at
+    # most `present` (install/import detection only — no real license probe). Until the
+    # Windows-side license probe follow-up lands, these cells grade BELOW-BASELINE by design.
     solvers_baseline: {orcaflex: licensed, orcawave: licensed, aqwa: licensed, ansys: licensed}
   licensed-win-2:
     ws_hub_path: 'D:\workspace-hub'
@@ -79,6 +82,8 @@ workstations:
     compute_floor: {cores_min: 8}
     required_data_access: [digitalmodel, assetutilities]
     # #2849 solvers baseline (cold-dim, STRICT): licensed-solver workstation.
+    # NOTE (PR #2850, 2026-05-28): grades BELOW-BASELINE until the Windows license-probe
+    # follow-up emits a real `licensed` signal (probe only detects install/import → `present`).
     solvers_baseline: {orcaflex: licensed, orcawave: licensed, aqwa: licensed, ansys: licensed}
   home-win:
     ws_hub_path: 'D:\workspace-hub'

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -43,6 +43,8 @@ workstations:
     role: high-context-linux-execution
     compute_floor: {cores_min: 16, ram_gib_min: 16}
     required_data_access: [assetutilities, digitalmodel, worldenergydata, assethold]
+    # #2849 solvers baseline (cold-dim): a Linux dev box is EXPECTED to lack solvers → absent
+    solvers_baseline: {orcaflex: absent, orcawave: absent, aqwa: absent, ansys: absent}
   dev-secondary:
     ws_hub_path: /mnt/local-analysis/workspace-hub
     ssh_target: ace-linux-2
@@ -50,6 +52,7 @@ workstations:
     role: linux-execution
     compute_floor: {cores_min: 8, ram_gib_min: 8}
     required_data_access: [assetutilities, digitalmodel, worldenergydata, assethold]
+    solvers_baseline: {orcaflex: absent, orcawave: absent, aqwa: absent, ansys: absent}
   licensed-win-1:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null
@@ -61,6 +64,9 @@ workstations:
     # MISSING-EVIDENCE). RAM floor returns when the .ps1 compute companion lands (C2 follow-up).
     compute_floor: {cores_min: 8}
     required_data_access: [digitalmodel, assetutilities]
+    # #2849 solvers baseline (cold-dim, STRICT): licensed work routes here — only a `licensed`
+    # signal satisfies this baseline. An install-only `present` grades BELOW-BASELINE.
+    solvers_baseline: {orcaflex: licensed, orcawave: licensed, aqwa: licensed, ansys: licensed}
   licensed-win-2:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null
@@ -72,6 +78,8 @@ workstations:
     # MISSING-EVIDENCE). RAM floor returns when the .ps1 compute companion lands (C2 follow-up).
     compute_floor: {cores_min: 8}
     required_data_access: [digitalmodel, assetutilities]
+    # #2849 solvers baseline (cold-dim, STRICT): licensed-solver workstation.
+    solvers_baseline: {orcaflex: licensed, orcawave: licensed, aqwa: licensed, ansys: licensed}
   home-win:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null

--- a/scripts/readiness/lib/probe-solvers.sh
+++ b/scripts/readiness/lib/probe-solvers.sh
@@ -7,13 +7,23 @@
 # (The standalone nightly R-ANSYS/R-ORCAFLEX checks were removed per #2849 decision 2:
 #  the equality matrix `solvers` cell is the single source of truth — no nightly duplication.)
 #
-# Detection semantics (closed enum on status):
-#   licensed = vendor binary/SDK present AND a licensing signal present
-#              (import-success for the OrcFxAPI SDK, which a real solve fails-closed without;
-#               or a license env var for ANSYS/AQWA).
-#   present  = install root / SDK found but no licensing evidence.
-#   absent   = neither found.
+# Detection semantics (closed enum on status), per #2849 / PR #2850 user decision 2026-05-28:
+#   licensed = a REAL license signal was detected — an actual solver/SDK license
+#              status or checkout probe succeeded. Install/import/env presence is NOT
+#              such a signal. No real license probe exists on Linux yet (and import does
+#              not check out a license), so `licensed` is NEVER emitted by these helpers
+#              today; it will be emitted by a Windows-side license probe (follow-up issue).
+#   present  = the solver is importable / installed (SDK import succeeds, an install
+#              root exists, or a configured env path resolves) but with NO real license
+#              signal. `import OrcFxAPI` success classifies as `present`, not `licensed`.
+#   absent   = no install / import / env evidence found.
 #   unknown  = the probe could not run (e.g. no python interpreter for an import probe).
+#
+# Why: import-success / install-root / a license env var prove the solver can be *found*,
+# not that this machine holds a usable license entitlement at solve time. Conflating the
+# two would let dispatch route licensed work to an install-only machine. Until the real
+# Windows license probe lands, install-presence stays `present` and a `licensed` baseline
+# grades BELOW-BASELINE (STRICT, build-equality-matrix.py SOLVER_OK).
 #
 # Output contract: each probe echoes ONE token on stdout from {licensed, present, absent, unknown}.
 # A separate evidence token (how it was detected) is echoed by *_evidence helpers from the
@@ -62,13 +72,14 @@ probe_orcaflex_root() {
 }
 
 # ── orcaflex solver status ──────────────────────────────────────────────────────
-# licensed = `import OrcFxAPI` succeeds (the SDK is the licensed runtime gate);
-# present  = install root found but no importable SDK;
+# present  = `import OrcFxAPI` succeeds (SDK importable) OR an install root is found;
 # absent   = neither.
+# `licensed` is NEVER emitted here — import-success proves SDK presence, not a license
+# entitlement. A real license signal will come from the Windows-side probe (follow-up).
 probe_orcaflex() {
   local py; py="$(_ps_python)"
   if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then
-    echo "licensed"; return 0
+    echo "present"; return 0
   fi
   case "$(probe_orcaflex_root)" in
     present:*) echo "present";;
@@ -82,43 +93,35 @@ probe_orcaflex_evidence() {
 }
 
 # ── orcawave solver status ───────────────────────────────────────────────────────
-# OrcaWave shares the OrcFxAPI SDK gate. licensed = SDK import ok + ORCAWAVE_PATH set;
-# present  = ORCAWAVE_PATH set (dir exists) but no importable SDK, OR install root found;
-# absent   = none.
+# OrcaWave shares the OrcFxAPI SDK. present = SDK import ok, OR ORCAWAVE_PATH set
+# (dir exists), OR install root found; absent = none.
+# `licensed` is NEVER emitted here — none of import/env/root is a real license signal.
 probe_orcawave() {
   local py; py="$(_ps_python)"
-  local env_ok=0
-  [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]] && env_ok=1
-  if [[ "$env_ok" == "1" ]] && [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then
-    echo "licensed"; return 0
-  fi
-  if [[ "$env_ok" == "1" ]]; then echo "present"; return 0; fi
+  if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then echo "present"; return 0; fi
+  if [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]]; then echo "present"; return 0; fi
   local root="/c/Program Files (x86)/Orcina/OrcaWave"
   [[ -d "$root" ]] && { echo "present"; return 0; }
   echo "absent"
 }
 probe_orcawave_evidence() {
   local py; py="$(_ps_python)"
-  if [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]]; then
-    if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then echo "import"; else echo "env"; fi
-    return 0
-  fi
+  if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then echo "import"; return 0; fi
+  if [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]]; then echo "env"; return 0; fi
   [[ -d "/c/Program Files (x86)/Orcina/OrcaWave" ]] && { echo "root"; return 0; }
   echo "absent"
 }
 
 # ── ansys solver status ──────────────────────────────────────────────────────────
-# licensed = install root present AND a license env var set (ANSYSLI_SERVERS or
-#            ANSYSLMD_LICENSE_FILE); present = root only; absent = no root.
+# present = install root found (with or without a license env var set); absent = no root.
+# `licensed` is NEVER emitted here. A license env var (ANSYSLI_SERVERS / ANSYSLMD_LICENSE_FILE)
+# only points at a license *server* — it is not proof of a usable checkout, so it is recorded
+# as evidence (`env`) but does not upgrade the status. A real `licensed` signal requires an
+# actual license-status/checkout probe (Windows-side follow-up).
 probe_ansys() {
   case "$(probe_ansys_root)" in
-    present:*)
-      if [[ -n "${ANSYSLI_SERVERS:-}" || -n "${ANSYSLMD_LICENSE_FILE:-}" ]]; then
-        echo "licensed"
-      else
-        echo "present"
-      fi;;
-    *) echo "absent";;
+    present:*) echo "present";;
+    *)         echo "absent";;
   esac
 }
 probe_ansys_evidence() {

--- a/scripts/readiness/lib/probe-solvers.sh
+++ b/scripts/readiness/lib/probe-solvers.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# probe-solvers.sh — shared licensed-solver detection helpers (#2849, #2801 family).
+#
+# Single source of truth for "which diffraction/FEA solvers are present/licensed here?"
+# Sourced by:
+#   * scripts/readiness/collect-equality.sh  — emits the `solvers` equality dimension.
+# (The standalone nightly R-ANSYS/R-ORCAFLEX checks were removed per #2849 decision 2:
+#  the equality matrix `solvers` cell is the single source of truth — no nightly duplication.)
+#
+# Detection semantics (closed enum on status):
+#   licensed = vendor binary/SDK present AND a licensing signal present
+#              (import-success for the OrcFxAPI SDK, which a real solve fails-closed without;
+#               or a license env var for ANSYS/AQWA).
+#   present  = install root / SDK found but no licensing evidence.
+#   absent   = neither found.
+#   unknown  = the probe could not run (e.g. no python interpreter for an import probe).
+#
+# Output contract: each probe echoes ONE token on stdout from {licensed, present, absent, unknown}.
+# A separate evidence token (how it was detected) is echoed by *_evidence helpers from the
+# closed evidence enum {import, env, root, absent, unknown} — NEVER an absolute path
+# (matches the collect-equality.sh data_access bare-name rule, no machine-layout leak).
+#
+# Every probe is failure-swallowing: a missing interpreter or unreadable dir yields a clean
+# enum token, never a non-zero exit that would abort the sourcing script.
+
+# Guard against double-sourcing (idempotent).
+[[ -n "${__PROBE_SOLVERS_SH:-}" ]] && return 0
+__PROBE_SOLVERS_SH=1
+
+_ps_have() { command -v "$1" >/dev/null 2>&1; }
+
+# Resolve a python interpreter for SDK import probes. Prefer a plain `python`
+# (Windows Git-Bash convention); fall back to python3. Echoes "" if none.
+_ps_python() {
+  if _ps_have python; then echo python
+  elif _ps_have python3; then echo python3
+  else echo ""; fi
+}
+
+# ── ANSYS / AQWA: install-root detection (factored from the old nightly R-ANSYS) ──
+# Echoes "absent" OR "present:<v252 v251 ...>" (latest last, sorted) — version dirs
+# under the Windows ANSYS install root. NO absolute path is echoed (only the bare
+# vNNN tokens). Linux/macOS have no such root → "absent".
+probe_ansys_root() {
+  local root="/c/Program Files/ANSYS Inc"
+  [[ -d "$root" ]] || { echo "absent"; return 0; }
+  local versions
+  versions=$(ls "$root" 2>/dev/null | grep -E '^v[0-9]+$' | sort -V | tr '\n' ' ' | sed 's/ $//')
+  [[ -z "$versions" ]] && { echo "absent"; return 0; }
+  echo "present:${versions}"
+}
+
+# ── OrcaFlex install-root detection (Windows; bare version tokens only) ──────────
+# Echoes "absent" OR "present:<11.5 11.6 ...>" — version dirs under the Orcina root.
+probe_orcaflex_root() {
+  local root="/c/Program Files (x86)/Orcina/OrcaFlex"
+  [[ -d "$root" ]] || { echo "absent"; return 0; }
+  local versions
+  versions=$(ls "$root" 2>/dev/null | grep -E '^[0-9]+\.' | sort -V | tr '\n' ' ' | sed 's/ $//')
+  [[ -z "$versions" ]] && { echo "absent"; return 0; }
+  echo "present:${versions}"
+}
+
+# ── orcaflex solver status ──────────────────────────────────────────────────────
+# licensed = `import OrcFxAPI` succeeds (the SDK is the licensed runtime gate);
+# present  = install root found but no importable SDK;
+# absent   = neither.
+probe_orcaflex() {
+  local py; py="$(_ps_python)"
+  if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then
+    echo "licensed"; return 0
+  fi
+  case "$(probe_orcaflex_root)" in
+    present:*) echo "present";;
+    *)         echo "absent";;
+  esac
+}
+probe_orcaflex_evidence() {
+  local py; py="$(_ps_python)"
+  if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then echo "import"; return 0; fi
+  case "$(probe_orcaflex_root)" in present:*) echo "root";; *) echo "absent";; esac
+}
+
+# ── orcawave solver status ───────────────────────────────────────────────────────
+# OrcaWave shares the OrcFxAPI SDK gate. licensed = SDK import ok + ORCAWAVE_PATH set;
+# present  = ORCAWAVE_PATH set (dir exists) but no importable SDK, OR install root found;
+# absent   = none.
+probe_orcawave() {
+  local py; py="$(_ps_python)"
+  local env_ok=0
+  [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]] && env_ok=1
+  if [[ "$env_ok" == "1" ]] && [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then
+    echo "licensed"; return 0
+  fi
+  if [[ "$env_ok" == "1" ]]; then echo "present"; return 0; fi
+  local root="/c/Program Files (x86)/Orcina/OrcaWave"
+  [[ -d "$root" ]] && { echo "present"; return 0; }
+  echo "absent"
+}
+probe_orcawave_evidence() {
+  local py; py="$(_ps_python)"
+  if [[ -n "${ORCAWAVE_PATH:-}" && -d "${ORCAWAVE_PATH:-/nonexistent}" ]]; then
+    if [[ -n "$py" ]] && "$py" -c "import OrcFxAPI" >/dev/null 2>&1; then echo "import"; else echo "env"; fi
+    return 0
+  fi
+  [[ -d "/c/Program Files (x86)/Orcina/OrcaWave" ]] && { echo "root"; return 0; }
+  echo "absent"
+}
+
+# ── ansys solver status ──────────────────────────────────────────────────────────
+# licensed = install root present AND a license env var set (ANSYSLI_SERVERS or
+#            ANSYSLMD_LICENSE_FILE); present = root only; absent = no root.
+probe_ansys() {
+  case "$(probe_ansys_root)" in
+    present:*)
+      if [[ -n "${ANSYSLI_SERVERS:-}" || -n "${ANSYSLMD_LICENSE_FILE:-}" ]]; then
+        echo "licensed"
+      else
+        echo "present"
+      fi;;
+    *) echo "absent";;
+  esac
+}
+probe_ansys_evidence() {
+  case "$(probe_ansys_root)" in
+    present:*)
+      if [[ -n "${ANSYSLI_SERVERS:-}" || -n "${ANSYSLMD_LICENSE_FILE:-}" ]]; then echo "env"; else echo "root"; fi;;
+    *) echo "absent";;
+  esac
+}
+
+# ── aqwa solver status ───────────────────────────────────────────────────────────
+# AQWA ships inside the ANSYS install; share the ANSYS root + license-env signal.
+probe_aqwa() { probe_ansys; }
+probe_aqwa_evidence() { probe_ansys_evidence; }

--- a/scripts/readiness/nightly-readiness.sh
+++ b/scripts/readiness/nightly-readiness.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# nightly-readiness.sh — 11 ecosystem health checks for the nightly cron pipeline
+# nightly-readiness.sh — 9 ecosystem health checks for the nightly cron pipeline
 # Called from comprehensive-learning-nightly.sh Step 5 (WRK-308)
 # Each check is best-effort: failures are logged but never abort the pipeline.
 # Issues append to .claude/state/readiness-issues.md for Phase 6 to surface.
@@ -275,52 +275,10 @@ check_r_harness() {
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# R-ANSYS: Installed ANSYS versions include expected latest (v252 = R25.2)
-# Windows-workstation check; silently skips on non-Windows machines.
-# ─────────────────────────────────────────────────────────────────────────────
-check_r_ansys() {
-  local ansys_root="/c/Program Files/ANSYS Inc"
-  [[ -d "$ansys_root" ]] || { log_pass "R-ANSYS: ANSYS root absent — skip (non-Windows)"; return; }
-  local expected_ver="v252"
-  local versions latest
-  versions=$(ls "$ansys_root" 2>/dev/null | grep -E '^v[0-9]+$' | sort -V | tr '\n' ' ' | sed 's/ $//')
-  if [[ -z "$versions" ]]; then
-    log_fail "R-ANSYS: no version dirs under '$ansys_root'"
-    return
-  fi
-  latest=$(echo "$versions" | tr ' ' '\n' | tail -1)
-  if [[ "$latest" == "$expected_ver" ]]; then
-    log_pass "R-ANSYS: latest=${latest}, installed: ${versions}"
-  else
-    log_fail "R-ANSYS: latest installed=${latest}, expected ${expected_ver} — installed: ${versions}"
-  fi
-} ; check_r_ansys || true
-
-# ─────────────────────────────────────────────────────────────────────────────
-# R-ORCAFLEX: OrcaFlex 11.6 installed and OrcaFlex64.exe present
-# Windows-workstation check; silently skips on non-Windows machines.
-# ─────────────────────────────────────────────────────────────────────────────
-check_r_orcaflex() {
-  local orcaflex_root="/c/Program Files (x86)/Orcina/OrcaFlex"
-  [[ -d "$orcaflex_root" ]] || { log_pass "R-ORCAFLEX: OrcaFlex root absent — skip (non-Windows)"; return; }
-  local expected_ver="11.6"
-  local versions latest
-  versions=$(ls "$orcaflex_root" 2>/dev/null | grep -E '^[0-9]+\.' | sort -V | tr '\n' ' ' | sed 's/ $//')
-  if [[ -z "$versions" ]]; then
-    log_fail "R-ORCAFLEX: no version dirs under '$orcaflex_root'"
-    return
-  fi
-  latest=$(echo "$versions" | tr ' ' '\n' | tail -1)
-  local exe="${orcaflex_root}/${latest}/OrcaFlex64.exe"
-  if [[ "$latest" == "$expected_ver" && -f "$exe" ]]; then
-    log_pass "R-ORCAFLEX: version=${latest}, OrcaFlex64.exe present"
-  elif [[ "$latest" == "$expected_ver" ]]; then
-    log_fail "R-ORCAFLEX: version=${latest} but OrcaFlex64.exe missing"
-  else
-    log_fail "R-ORCAFLEX: latest installed=${latest}, expected ${expected_ver}"
-  fi
-} ; check_r_orcaflex || true
-
+# (R-ANSYS + R-ORCAFLEX removed per #2849 decision 2 — the equality-matrix `solvers`
+#  cell is now the single source of truth for licensed-solver capability. Detection
+#  logic lives in scripts/readiness/lib/probe-solvers.sh, consumed by collect-equality.sh.
+#  No per-solver nightly-board duplication, to avoid re-introducing drift.)
 # ─────────────────────────────────────────────────────────────────────────────
 # R-AI-CLI: AI agent CLIs present and at or above minimum version
 # Delegates to ai-agent-readiness.sh; reads JSONL to count warn/error rows.

--- a/scripts/review/results/2026-05-27-code-2849-codex.md
+++ b/scripts/review/results/2026-05-27-code-2849-codex.md
@@ -1,0 +1,11 @@
+1. **[MAJOR] `scripts/readiness/build-equality-matrix.py:35-37,115-126`**  
+   `unknown` satisfies an `absent` baseline. That makes legacy v2 reports with no `dimensions.solvers` block show `CONFORMS` on dev machines instead of `MISSING-EVIDENCE`. Fix: remove `unknown` from `SOLVER_OK["absent"]`; treat `None`/`unknown` as `MISSING-EVIDENCE` for any baseline unless a later concrete miss returns `BELOW-BASELINE`. Add a legacy-v2 + absent-baseline test.
+
+2. **[MAJOR] `scripts/readiness/lib/probe-solvers.sh:70,80,92,103`**  
+   `import OrcFxAPI` is used as a `licensed` signal. If import is non-consuming, it proves SDK presence, not license availability; if it checks out/contacts a license, it violates the probe constraint. Orcina docs describe licensing around OrcaFlex activity/DLL protection, not import as a safe entitlement probe: https://www.orcina.com/webhelp/OrcFxAPI/Content/html/Introduction.htm. Fix: classify import/root as `present`; reserve `licensed` for an explicit non-consuming license-status signal.
+
+3. **[MINOR] `tests/readiness/test_collect_equality.py:149-160`**  
+   Solver collector tests are host-dependent and mostly pass through the all-absent path. They do not fake `probe-solvers.sh`, so present/licensed/path-leak regressions can pass vacuously on Linux. Fix: add a probe-lib override or fixture hook, then test fake `licensed`, `present`, malformed/path output, and env visibility before HOME/XDG sandboxing.
+
+Verification: `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/readiness/test_build_equality_matrix.py tests/readiness/test_collect_equality.py` passed, 58 tests. `shellcheck` only reported info/pre-existing style plus `ls|grep` warnings in the new probe.
+hook: Stop

--- a/tests/readiness/test_build_equality_matrix.py
+++ b/tests/readiness/test_build_equality_matrix.py
@@ -221,10 +221,18 @@ def test_solvers_missing_evidence_when_unknown_against_licensed():
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "MISSING-EVIDENCE"
 
 
-def test_solvers_absent_baseline_tolerates_unknown_detection():
-    # declared absent + detected unknown → still CONFORMS (unknown ⊆ absent acceptance)
+def test_solvers_absent_baseline_unknown_is_missing_evidence():
+    # declared absent + detected unknown → MISSING-EVIDENCE (unknown is never evidence,
+    # for ANY baseline — a missing probe must not masquerade as CONFORMS). #2849 Codex r1 #1.
     rep = _report("dev-primary", solvers=_solvers(orcaflex="unknown"))
-    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "CONFORMS"
+    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "MISSING-EVIDENCE"
+
+
+def test_solvers_legacy_v2_absent_baseline_missing_evidence():
+    # a v2 report (no solvers block) against a dev absent-baseline → MISSING-EVIDENCE,
+    # NOT CONFORMS (the whole solvers cell is unknown). #2849 Codex r1 #1.
+    rep = _report("dev-primary")  # base fixture has no solvers key
+    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "MISSING-EVIDENCE"
 
 
 def test_solvers_concrete_miss_dominates_unknown():

--- a/tests/readiness/test_build_equality_matrix.py
+++ b/tests/readiness/test_build_equality_matrix.py
@@ -157,6 +157,118 @@ def test_matrix_baseline_unprobed_repo_is_config_error():
                             _baseline(required=["foo-repo"]), TIER1) == "MISSING-BASELINE"
 
 
+# ── solvers cold-dim conformance (#2849, STRICT) ────────────────────────────
+def _solvers(orcaflex="absent", orcawave="absent", aqwa="absent", ansys="absent"):
+    return [{"name": "orcaflex", "status": orcaflex, "evidence": "absent"},
+            {"name": "orcawave", "status": orcawave, "evidence": "absent"},
+            {"name": "aqwa", "status": aqwa, "evidence": "absent"},
+            {"name": "ansys", "status": ansys, "evidence": "absent"}]
+
+
+def _solver_baseline(**want):
+    base = {"orcaflex": "absent", "orcawave": "absent", "aqwa": "absent", "ansys": "absent"}
+    base.update(want)
+    return {"solvers_baseline": base}
+
+
+def test_solvers_is_cold_dim():
+    assert "solvers" in bem.COLD_DIMS
+
+
+def test_solvers_conforms_dev_primary_all_absent():
+    # dev-primary: declared all-absent + detected all-absent → CONFORMS (expected divergence)
+    rep = _report("dev-primary", solvers=_solvers())
+    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "CONFORMS"
+
+
+def test_solvers_conforms_licensed_baseline_met():
+    rep = _report("licensed-win-1", solvers=_solvers(
+        orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed"))
+    bl = _solver_baseline(orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "CONFORMS"
+
+
+def test_solvers_below_baseline_when_licensed_missing():
+    # licensed baseline but detected absent → BELOW-BASELINE
+    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="absent"))
+    bl = _solver_baseline(orcaflex="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
+
+
+def test_solvers_strict_present_does_not_satisfy_licensed():
+    # STRICT (decision 1): an install-only `present` must FAIL a `licensed` baseline.
+    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="present"))
+    bl = _solver_baseline(orcaflex="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
+
+
+def test_solvers_below_baseline_when_unexpected_extra():
+    # declared absent but detected licensed (probe found one we didn't declare) → BELOW-BASELINE
+    rep = _report("dev-primary", solvers=_solvers(orcaflex="licensed"))
+    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "BELOW-BASELINE"
+
+
+def test_solvers_missing_baseline_when_unset():
+    # a machine with compute_floor but no solvers_baseline → MISSING-BASELINE (fail-closed)
+    rep = _report("dev-primary", solvers=_solvers())
+    assert bem.cold_verdict("solvers", rep, {"compute_floor": {"cores_min": 8}}, TIER1) == "MISSING-BASELINE"
+
+
+def test_solvers_missing_evidence_when_unknown_against_licensed():
+    # licensed baseline but detected `unknown` (probe couldn't run) → MISSING-EVIDENCE, not fail
+    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="unknown"))
+    bl = _solver_baseline(orcaflex="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "MISSING-EVIDENCE"
+
+
+def test_solvers_absent_baseline_tolerates_unknown_detection():
+    # declared absent + detected unknown → still CONFORMS (unknown ⊆ absent acceptance)
+    rep = _report("dev-primary", solvers=_solvers(orcaflex="unknown"))
+    assert bem.cold_verdict("solvers", rep, _solver_baseline(), TIER1) == "CONFORMS"
+
+
+def test_solvers_concrete_miss_dominates_unknown():
+    # one concrete BELOW miss + one unknown → BELOW-BASELINE wins (hard fail dominates)
+    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="absent", orcawave="unknown"))
+    bl = _solver_baseline(orcaflex="licensed", orcawave="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
+
+
+def test_solvers_legacy_v2_report_missing_evidence():
+    # a v2 report (no solvers block) against a licensed baseline → MISSING-EVIDENCE, not a crash
+    rep = _report("licensed-win-1")  # base fixture has no solvers key
+    bl = _solver_baseline(orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed")
+    assert bem.cold_verdict("solvers", rep, bl, TIER1) == "MISSING-EVIDENCE"
+
+
+def test_solvers_in_display_dims_after_data_access():
+    assert "solvers" in bem.DISPLAY_DIMS
+    assert bem.DISPLAY_DIMS.index("solvers") == bem.DISPLAY_DIMS.index("data_access") + 1
+
+
+def test_solvers_renders_row_in_html(tmp_path, monkeypatch):
+    # End-to-end: matrix HTML includes a solvers row. Drive main() against a tmp state dir.
+    state = tmp_path / "state"
+    state.mkdir()
+    reports_dir = tmp_path / "reports"
+    cfg = tmp_path / "harness-config.yaml"
+    cfg.write_text(yaml.safe_dump({"workstations": {
+        "dev-primary": {"compute_floor": {"cores_min": 8}, "required_data_access": ["digitalmodel"],
+                        "solvers_baseline": {"orcaflex": "absent", "orcawave": "absent",
+                                             "aqwa": "absent", "ansys": "absent"}}},
+        "tier1_repos": TIER1}))
+    rep = _report("dev-primary", data_access=[{"repo": "digitalmodel", "mode": "sibling"}],
+                  solvers=_solvers())
+    (state / "equality-dev-primary.yaml").write_text(yaml.safe_dump(rep))
+    monkeypatch.setattr(bem, "STATE", state)
+    monkeypatch.setattr(bem, "REPORTS", reports_dir)
+    monkeypatch.setattr(bem, "CONFIG", cfg)
+    bem.main()
+    html = next(reports_dir.glob("*-machine-equality-matrix.html")).read_text()
+    assert "<th>solvers</th>" in html
+    assert "conforms" in html  # the dev-primary all-absent cell
+
+
 # ── uniform-dim equality + ties (C1) ────────────────────────────────────────
 def test_matrix_pending_under_two():
     assert bem.uniform_verdict("skills", ["407"]) == "PENDING"
@@ -205,6 +317,10 @@ def test_harness_config_real_roster_and_baselines():
         assert "compute_floor" in baselines[m] and "required_data_access" in baselines[m]
         # baseline must only name repos the collector actually probes (D2-1)
         assert set(baselines[m]["required_data_access"]) <= set(TIER1)
+        # #2849: every active machine declares a solvers baseline over the 4 named solvers
+        sb = baselines[m]["solvers_baseline"]
+        assert set(sb) == {"orcaflex", "orcawave", "aqwa", "ansys"}
+        assert all(v in ("licensed", "present", "absent") for v in sb.values())
 
 
 def test_wiring_single_source_schedule():

--- a/tests/readiness/test_collect_equality.py
+++ b/tests/readiness/test_collect_equality.py
@@ -127,6 +127,61 @@ def test_collect_commit_on_change_idempotent(tmp_path):
     assert out.stat().st_mtime_ns == first_mtime         # unchanged content → not rewritten
 
 
+SOLVER_NAMES = {"orcaflex", "orcawave", "aqwa", "ansys"}
+STATUS_ENUM = {"licensed", "present", "absent", "unknown"}
+EVIDENCE_ENUM = {"import", "env", "root", "absent", "unknown"}
+
+
+def test_collect_emits_schema_v3(tmp_path):
+    # #2849: schema bumped to 3 with the solvers dimension added.
+    d = _run(_fixture(tmp_path))
+    assert d["schema_version"] == 3
+
+
+def test_collect_emits_solvers_block(tmp_path):
+    # #2849: solvers dimension carries all four named solvers.
+    d = _run(_fixture(tmp_path))
+    solvers = d["dimensions"]["solvers"]
+    assert isinstance(solvers, list) and len(solvers) == 4
+    assert {s["name"] for s in solvers} == SOLVER_NAMES
+
+
+def test_collect_solvers_status_enum_only(tmp_path):
+    # Every emitted status/evidence is from the closed enum (no free-form leakage).
+    solvers = _run(_fixture(tmp_path))["dimensions"]["solvers"]
+    for s in solvers:
+        assert s["status"] in STATUS_ENUM
+        assert s["evidence"] in EVIDENCE_ENUM
+
+
+def test_collect_solvers_absent_on_clean_fixture(tmp_path):
+    # The fixture host has no OrcFxAPI / ORCAWAVE_PATH / ANSYS root → all absent.
+    solvers = _run(_fixture(tmp_path))["dimensions"]["solvers"]
+    assert all(s["status"] == "absent" for s in solvers), solvers
+
+
+def test_collect_solvers_no_abs_paths(tmp_path):
+    # bare-name rule: no '/' or '\' characters in any solver status/evidence value.
+    solvers = _run(_fixture(tmp_path))["dimensions"]["solvers"]
+    for s in solvers:
+        assert "/" not in str(s["status"]) and "\\" not in str(s["status"])
+        assert "/" not in str(s["evidence"]) and "\\" not in str(s["evidence"])
+
+
+def test_collect_solvers_canonical_hash_includes_block(tmp_path):
+    # Toggling a solver status in the committed file is a MEANINGFUL change → rewrite.
+    ws = _fixture(tmp_path)
+    out = ws / ".claude" / "state" / "equality-dev-primary.yaml"
+    env = {"WORKSPACE_HUB": str(ws), "PATH": "/usr/bin:/bin:/usr/local/bin"}
+    subprocess.run(["bash", str(SCRIPT), "--machine", "dev-primary"], env=env, timeout=60, check=True)
+    text = out.read_text().replace(
+        "{name: orcaflex, status: absent", "{name: orcaflex, status: licensed")
+    out.write_text(text)
+    subprocess.run(["bash", str(SCRIPT), "--machine", "dev-primary"], env=env, timeout=60, check=True)
+    # real collection differs from the tampered file → rewritten back to absent
+    assert "{name: orcaflex, status: absent" in out.read_text()
+
+
 def test_collect_commit_on_change_detects_real_drift(tmp_path):
     # DC4: a change to a MEANINGFUL (non-volatile) field MUST trigger a rewrite. Guards the
     # canonical()-grep bug where a volatile field sharing a line masked its neighbors.

--- a/tests/readiness/test_collect_equality.py
+++ b/tests/readiness/test_collect_equality.py
@@ -168,6 +168,27 @@ def test_collect_solvers_no_abs_paths(tmp_path):
         assert "/" not in str(s["evidence"]) and "\\" not in str(s["evidence"])
 
 
+def test_collect_solvers_present_via_env_before_sandbox(tmp_path):
+    # Non-vacuous: a real ORCAWAVE_PATH dir → orcawave `present` (evidence: env). Proves the
+    # solver probe sees the real environment (runs BEFORE the HOME/XDG behaviour sandbox) and
+    # that the present-classification path actually executes, not just the all-absent path.
+    ws = _fixture(tmp_path)
+    owp = tmp_path / "OrcaWaveInstall"
+    owp.mkdir()
+    res = subprocess.run(
+        ["bash", str(SCRIPT), "--stdout", "--machine", "dev-primary"],
+        env={"WORKSPACE_HUB": str(ws), "PATH": "/usr/bin:/bin:/usr/local/bin",
+             "ORCAWAVE_PATH": str(owp)},
+        capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0, res.stderr
+    solvers = {s["name"]: s for s in yaml.safe_load(res.stdout)["dimensions"]["solvers"]}
+    assert solvers["orcawave"]["status"] == "present"
+    assert solvers["orcawave"]["evidence"] == "env"
+    # the env-derived value must still not leak the absolute path into the emitted cell
+    assert "/" not in solvers["orcawave"]["status"] and "/" not in solvers["orcawave"]["evidence"]
+    assert str(owp) not in res.stdout.split("solvers:")[1].split("harness:")[0]
+
+
 def test_collect_solvers_canonical_hash_includes_block(tmp_path):
     # Toggling a solver status in the committed file is a MEANINGFUL change → rewrite.
     ws = _fixture(tmp_path)

--- a/tests/readiness/test_collect_equality.py
+++ b/tests/readiness/test_collect_equality.py
@@ -189,6 +189,67 @@ def test_collect_solvers_present_via_env_before_sandbox(tmp_path):
     assert str(owp) not in res.stdout.split("solvers:")[1].split("harness:")[0]
 
 
+# ── probe-solvers.sh unit semantics (#2849 / PR #2850 decision 2026-05-28) ──────
+# present ≠ licensed: install/import/env presence classifies as `present`; `licensed`
+# requires a real license signal (none available locally → never emitted here).
+PROBE_LIB = REPO_ROOT / "scripts" / "readiness" / "lib" / "probe-solvers.sh"
+
+
+def _probe(fn: str, env_extra: dict | None = None, fake_import_ok: bool = False,
+           tmp_path: Path | None = None) -> str:
+    """Source probe-solvers.sh and echo the result of one probe function.
+
+    fake_import_ok=True shims a `python` on PATH whose `import OrcFxAPI` succeeds,
+    so the OrcFxAPI SDK-present path is exercised without the real SDK installed.
+    """
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    path_prefix = ""
+    if fake_import_ok:
+        assert tmp_path is not None
+        binp = tmp_path / "bin"
+        binp.mkdir(exist_ok=True)
+        py = binp / "python"
+        py.write_text("#!/usr/bin/env bash\nexit 0\n")  # any args → success (import ok)
+        py.chmod(0o755)
+        path_prefix = f"{binp}:"
+    env["PATH"] = path_prefix + env["PATH"]
+    if env_extra:
+        env.update(env_extra)
+    res = subprocess.run(
+        ["bash", "-c", f'source "{PROBE_LIB}"; {fn}'],
+        env=env, capture_output=True, text=True, timeout=30)
+    assert res.returncode == 0, res.stderr
+    return res.stdout.strip()
+
+
+def test_probe_orcaflex_import_ok_is_present_not_licensed(tmp_path):
+    # `import OrcFxAPI` success → present (NOT licensed). Load-bearing decision.
+    assert _probe("probe_orcaflex", fake_import_ok=True, tmp_path=tmp_path) == "present"
+    assert _probe("probe_orcaflex_evidence", fake_import_ok=True, tmp_path=tmp_path) == "import"
+
+
+def test_probe_orcawave_import_ok_is_present_not_licensed(tmp_path):
+    assert _probe("probe_orcawave", fake_import_ok=True, tmp_path=tmp_path) == "present"
+
+
+def test_probe_orcawave_env_only_is_present(tmp_path):
+    owp = tmp_path / "ow"; owp.mkdir()
+    assert _probe("probe_orcawave", env_extra={"ORCAWAVE_PATH": str(owp)}) == "present"
+
+
+def test_probe_ansys_license_env_does_not_upgrade_to_licensed(tmp_path):
+    # A license-server env var is recorded as evidence but never upgrades status to licensed.
+    # No ANSYS root on the test host → absent regardless of env (real signal still needed).
+    assert _probe("probe_ansys",
+                  env_extra={"ANSYSLI_SERVERS": "1055@licsrv"}) == "absent"
+
+
+def test_probe_never_emits_licensed_locally(tmp_path):
+    # No real license probe exists locally → no probe emits `licensed` on this host.
+    for fn in ("probe_orcaflex", "probe_orcawave", "probe_aqwa", "probe_ansys"):
+        assert _probe(fn, fake_import_ok=True, tmp_path=tmp_path) != "licensed"
+
+
 def test_collect_solvers_canonical_hash_includes_block(tmp_path):
     # Toggling a solver status in the committed file is a MEANINGFUL change → rewrite.
     ws = _fixture(tmp_path)


### PR DESCRIPTION
## Summary

Adds a first-class **licensed-solver capability** dimension (`solvers`) to the machine-equality matrix, per [#2849](https://github.com/vamseeachanta/workspace-hub/issues/2849) (the [#2801](https://github.com/vamseeachanta/workspace-hub/issues/2801) family). Dispatch/routing can now read a single authoritative "can this machine run solver X" cell instead of inferring from a standalone harness check.

Builds directly on the #2801 substrate — no parallel registry.

## What changed

- **`scripts/readiness/lib/probe-solvers.sh`** (new): shared solver-detection helpers (orcaflex / orcawave / aqwa / ansys), factored from the old nightly `R-ANSYS` probe logic so detection lives in one place. Emits `{status: licensed|present|absent|unknown, evidence: import|env|root|absent|unknown}`. Failure-swallowing; no absolute-path leakage. **`present` vs `licensed` (see decision 1 below):** install/import/env presence (`import OrcFxAPI` success, an install root, or a configured env path) classifies as **`present`**. `licensed` requires a **real license signal** — no probe emits it locally today.
- **`collect-equality.sh`**: schema `v2 → v3`; emits the `solvers` dimension between `data_access` and `harness`. Probe runs **before** the behaviour-probe HOME/XDG sandbox redirect so real-env signals (`ORCAWAVE_PATH`, ANSYS license vars) are visible. Solver block is included in the canonical idempotency hash.
- **`harness-config.yaml`**: per-machine `solvers_baseline` — `dev-primary`/`dev-secondary` = all `absent` (expected divergence); `licensed-win-1`/`licensed-win-2` = all `licensed` (the **target**; commented to note they grade BELOW-BASELINE until the license-probe follow-up #2852 lands).
- **`build-equality-matrix.py`**: `solvers` added to `COLD_DIMS` + `DISPLAY_DIMS` (row after `data_access`); STRICT grading branch → `CONFORMS` / `BELOW-BASELINE` / `MISSING-BASELINE` / `MISSING-EVIDENCE`.
- **`nightly-readiness.sh`**: **removed** `R-ANSYS` + `R-ORCAFLEX` (11 → 9 checks). The matrix `solvers` cell is the single source of truth; no nightly-board duplication (avoids drift).
- **`.gitignore`**: negate `scripts/readiness/lib/` (matches the 6 existing `!scripts/*/lib/` negations against the global `lib/` build-artifact ignore).
- **tests**: +39 cases across `tests/readiness/test_build_equality_matrix.py` + `test_collect_equality.py` (incl. 5 probe-level cases asserting `present`-not-`licensed`).

## `present` vs `licensed` — the distinction (user decision 2026-05-28)

- **`present`** = the solver is *findable/runnable to import* on this machine: `import OrcFxAPI` succeeds, an install root exists, or a configured env path resolves. Proves the SDK/binary is installed — **not** that a usable license entitlement is held.
- **`licensed`** = a **real license signal** was detected (an actual license-status or checkout probe succeeded). This is the only status that satisfies a `licensed` baseline under STRICT grading.
- There is **no real license signal on Linux** today, and `import OrcFxAPI` does not check out a license. So **no probe emits `licensed` locally** — install-presence stays `present`. A license env var (`ANSYSLI_SERVERS` / `ANSYSLMD_LICENSE_FILE`) points at a license *server* and is recorded as `evidence: env`, but does **not** upgrade status to `licensed`.
- Applied **consistently across all 4 solvers** (orcaflex, orcawave, aqwa, ansys).
- **Consequence:** the `licensed-win-*` `solvers_baseline` cells stay `licensed` (the target), so under STRICT matching they will grade **BELOW-BASELINE** until the real Windows-side license probe lands. That follow-up is **[#2852](https://github.com/vamseeachanta/workspace-hub/issues/2852)** — it adds an actual OrcFxAPI/ANSYS license-status/checkout probe so licensed machines emit `licensed` and grade CONFORMS.

## Locked design decisions applied

1. **STRICT** matching — only a detected `licensed` satisfies a `licensed` baseline (an install-only `present` grades `BELOW-BASELINE`, so dispatch never routes licensed work to an install-only machine). The `import → present` (not `licensed`) decision above is the resolution of the prior open question.
2. **Dropped** per-solver nightly checks — `R-ANSYS`/`R-ORCAFLEX` removed; no new `R-ORCAWAVE`/`R-AQWA`.
3. `licensed-win-*` `solvers` cells land via the existing Windows Task Scheduler chain of `collect-equality.sh` (already wired in `config/scheduled-tasks/schedule-tasks.yaml`); the **real `licensed` signal** is the follow-up **[#2852](https://github.com/vamseeachanta/workspace-hub/issues/2852)**.

## Verification

- `PYTHONPATH=. uv run python -m pytest tests/readiness/ -q` → **170 passed**.
- Regenerated `equality-dev-primary.yaml` (schema 3): all 4 solvers `absent` → **CONFORMS** against the dev-primary absent baseline.
- Grading check: a detected `present` against a `licensed` baseline → **BELOW-BASELINE** (STRICT); `absent` vs `absent` baseline → **CONFORMS**.

Refs #2801

Closes #2849

---

## Resolved: `import OrcFxAPI` → `present`, not `licensed` (was Codex r1 #2)

The prior open question — does a successful `import OrcFxAPI` classify as `licensed` or `present`? — is **resolved (user decision 2026-05-28): `present`.** Import proves SDK presence, not license entitlement. A `licensed` status now requires a real license signal, which no local probe produces; it will come from the Windows-side license probe in follow-up **[#2852](https://github.com/vamseeachanta/workspace-hub/issues/2852)**. Until then the `licensed-win-*` cells grade BELOW-BASELINE by design (see the distinction section above).

Adversarial review evidence: Codex r1 (3 findings); #1 + #3 applied in commit `b78376517`; #2 resolved here per the user decision (commit `f70577cd2`).
