### PR TITLE
feat(memory): cross-provider dream bridge (#2833) + non-JSON dead-letter data-loss fix (#2845)

### DIFF
--- a/.planning/plan-approved/2845.md
+++ b/.planning/plan-approved/2845.md
@@ -1,0 +1,1 @@
+Approved by: vamsee — #2845 plan-approved 2026-05-27

--- a/docs/plans/2026-05-27-issue-2845-dream-nonjson-deadletter.md
+++ b/docs/plans/2026-05-27-issue-2845-dream-nonjson-deadletter.md
@@ -1,0 +1,271 @@
+# Plan for #2845: provider-dream silently drops learnings on non-JSON distill batches (rc=0 masks data loss)
+
+> **Status:** draft
+> **Complexity:** T2
+> **Date:** 2026-05-27
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2845
+> **Client:** N/A
+> **Project:** (n/a)
+> **Review artifacts:** scripts/review/results/2026-05-27-plan-2845-claude.md | (cross-provider dispatch blocked from this session — see Adversarial Review)
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+- Found: `scripts/memory/distill-provider-sessions.py` — `claude_distill()` (lines 333-392) is the distill backend; `run_provider()` + nested `flush()` (lines 431-532) own watermark advancement.
+- Found: `scripts/memory/bridge-providers-to-dream.sh` — cron wrapper (04:00 daily) that invokes the distiller and logs `done (rc=N)`.
+- Gap: no dead-letter file, no poison-batch retry counter, no skipped-batch accounting (confirmed: `grep -n "deadletter\|poison\|POISON\|skipped_batches"` returns only the comment at line 382).
+
+### Standards
+Not applicable (harness/infra issue).
+
+### LLM Wiki pages consulted
+No relevant wiki pages (harness/infra issue).
+
+### Documents consulted
+- Issue #2845 body — alleges silent learning loss on non-JSON batches; observed in live cron log.
+- `logs/orchestrator/memory-bridge/cron-20260527.log` — live evidence of the skip + `rc=0`.
+- Parent #2841 (memory-layer completeness contract) + mechanism #2833.
+- `project_orchestrator_consistency_decisions` (auto-memory) — records the 2026-05-27 decision context.
+
+### Gaps identified
+- `claude_distill()` returns `[]` for **two distinct meanings** (valid-empty vs non-JSON garble); callers cannot distinguish them.
+- No bounded-retry mechanism for transient non-JSON before giving up.
+- No auditable record (dead-letter) when a batch is abandoned.
+- `main()` always returns 0 even when batches were abandoned — cron mail never surfaces loss.
+
+### Evidence (embedded verification)
+
+**Issue statuses** (verified 2026-05-27T18:50:23Z via `gh issue view`):
+- `#2845` — OPEN — bug(memory): provider-dream silently drops learnings on non-JSON distill batches
+- `#2841` — OPEN — parent consistency umbrella
+- `#2833` — OPEN — cross-provider dream bridge (the mechanism)
+
+**File existence** (`ls -la` 2026-05-27T18:50:23Z):
+- EXISTS: scripts/memory/distill-provider-sessions.py
+- EXISTS: scripts/memory/bridge-providers-to-dream.sh
+- MISSING (this plan creates at runtime): ~/.claude/projects/.../memory/.provider-bridge-deadletter.jsonl
+- MISSING (new test file this plan creates): scripts/memory/tests/test_distill_poison_handling.py
+
+**Line excerpts** (`sed -n` of distill-provider-sessions.py):
+```
+375  if not isinstance(parsed, dict):
+...
+388      sys.stderr.write(f"[distill] claude -p result not JSON for {provider} batch "
+389                       f"— skipping this batch, continuing\n")
+390      return []                       # <-- COLLIDES with valid-empty return at line 391-392
+391  out = parsed.get("learnings", [])
+392  return [l for l in out if isinstance(l, dict) and l.get("title") and l.get("body")]
+```
+```
+479  if learnings is None:
+480      batch.clear(); batch_mts.clear()
+481      return False                    # None => watermark holds (retry). [] falls through:
+...
+493  high_water = max(high_water, pending_skip_hw, max(batch_mts))   # <-- advances over garbled batch
+```
+
+**Gap proofs** (2026-05-27T18:50:23Z):
+- `grep -n "deadletter\|poison\|POISON\|skipped_batches" scripts/memory/distill-provider-sessions.py` → only `382: ... one poison batch can't wedge the whole provider.` → confirms no machinery exists.
+- `ls ~/.claude/projects/.../memory/.provider-bridge-deadletter.jsonl` → "No such file or directory" → dead-letter file absent.
+
+**Reproduction proofs** (Step 1.5 — static trace + live log, runtime failure is data-loss not a crash):
+```
+$ tail -25 logs/orchestrator/memory-bridge/cron-20260527.log
+[distill] claude -p result not JSON for codex batch — skipping this batch, continuing
+[distill] claude -p result not JSON for hermes batch — skipping this batch, continuing
+...
+[bridge-to-dream] 2026-05-27T09:04:06Z done (rc=0)
+```
+- Reproduced at: 2026-05-27T18:50:23Z (live log + code trace: line 390 `return []` → line 479 `learnings is None` is False → falls through to line 493 watermark advance → sessions in the garbled batch are never re-selected).
+- Failure mode observed matches issue claim: YES — the loss is silent (rc=0) and the garbled batch's sessions advance past the watermark with zero learnings written.
+
+<!-- Source count: 5 (issue + cron log + distill script + bridge wrapper + #2833/#2841) -->
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | docs/plans/2026-05-27-issue-2845-dream-nonjson-deadletter.md |
+| Tests | scripts/memory/tests/test_distill_poison_handling.py |
+| Implementation | scripts/memory/distill-provider-sessions.py |
+| Implementation (wrapper log) | scripts/memory/bridge-providers-to-dream.sh |
+| Plan review — Claude | scripts/review/results/2026-05-27-plan-2845-claude.md |
+
+---
+
+## Deliverable
+The dream distiller distinguishes non-JSON garble from valid-empty, retries a garbled batch a bounded number of runs, dead-letters the sessions to an auditable JSONL file when retries are exhausted, and exits non-zero when any sessions were abandoned — so cross-provider learnings are never silently lost.
+
+---
+
+## Pseudocode
+
+> **Revised after adversarial review (MAJOR).** Two structural changes vs. the draft:
+> (a) the retry counter is keyed on a **content digest of the batch's session paths**, not `high_water` (batch identity is NOT stable across runs — re-glob/re-sort, new in-window sessions, `--limit`/`--since-days` all reshape the batch); (b) poison state lives in a **separate sibling file**, never overloaded into the `{provider: float}` watermark dict.
+
+```
+# Sentinel: a NAMED, NON-FALSY singleton. Compared by identity ONLY (never truthiness),
+# so a future `if not learnings:` refactor cannot route it into the empty-success path.
+class _Poison:  __slots__ = ()             # bool(_Poison()) is True; repr legible in logs
+POISON = _Poison()
+
+claude_distill(...) -> list | None | POISON:
+    ... existing transient detection -> return None      # UNCHANGED
+    if result is not JSON dict:
+        if _TRANSIENT_RE matches: return None            # UNCHANGED: hold watermark, retry
+        else: return POISON                              # NEW: garble, distinct from valid-empty []
+    return [valid learnings]                              # may be [] == genuinely nothing durable
+
+# Poison state: SEPARATE file, not the watermark dict (Finding 3).
+POISON_FILE = MEM_DIR / ".provider-bridge-poison.json"   # {provider: {sig, attempts, first_ts}}
+DEADLETTER  = MEM_DIR / ".provider-bridge-deadletter.jsonl"
+
+batch_signature(batch_files) -> str:
+    return sha1("\n".join(sorted(f.name for f in batch_files)))   # stable batch identity
+
+flush() -> "ok" | "hold" | "poison":                     # TRI-STATE (was bool)
+    learnings = claude_distill(...)
+    if learnings is None:    clear batch; return "hold"
+    if learnings is POISON:  return "poison"             # batch left intact for caller to inspect
+    write all learnings; advance high_water; clear batch; return "ok"
+
+MAX_POISON_RETRIES = 3          # user-approved 2026-05-27
+AGE_ESCAPE_DAYS    = 7          # user-approved v1: stale-hold escape hatch
+
+handle_poison(provider, batch_files, sig):               # shared by BOTH flush call sites
+    # Counting is scoped to PLAIN INCREMENTAL runs. --limit/--since-days/--backfill reshape
+    # the window, so their batches are not comparable across runs -> they HOLD (no count,
+    # no deadletter) to avoid a meaningless counter.
+    if args.limit or args.since_days or args.backfill:
+        return "abort_hold"                              # retry on next plain run
+    ps = read_poison_state(provider)                     # flock'd read-modify-write
+    # first_ts = when this provider FIRST entered a continuous poison-hold; it carries
+    # across sig changes and is cleared ONLY by a successful "ok" flush (recovery).
+    first_ts = ps.first_ts if ps else now
+    if ps and ps.sig == sig:  attempts = ps.attempts + 1     # same batch -> count up
+    else:                     attempts = 1                   # new sig -> attempt count restarts...
+    ps = {sig, attempts, first_ts}                           # ...but first_ts is preserved
+    # AGE ESCAPE (Finding-1 residual): a batch that keeps absorbing new sessions gets a
+    # fresh sig every run and would HOLD forever. If we've been in continuous poison-hold for
+    # > AGE_ESCAPE_DAYS, dead-letter regardless of sig.
+    age_exceeded = (now - first_ts) > AGE_ESCAPE_DAYS * 86400
+    if ps.attempts >= MAX_POISON_RETRIES or age_exceeded:
+        if not dry_run:
+            deadletter_append(provider, batch_files, reason, ps.attempts)   # APPEND, gated
+            advance high_water past batch                # prevent permanent wedge, gated
+            clear_poison_state(provider)
+        stats["deadlettered_sessions"] += len(batch_files)
+        return "deadlettered"
+    else:
+        if not dry_run: write_poison_state(provider, ps) # do NOT advance high_water
+        return "abort_hold"
+
+run_provider():
+    # ... mid-loop flush (line ~508) AND trailing flush (line ~522) BOTH do:
+    r = flush()
+    if r == "poison":
+        if handle_poison(...) in ("abort_hold",): aborted=True; break/return
+        # "deadlettered" -> continue past this batch
+    if r == "ok": clear_poison_state(provider)           # recovery resets the counter
+    # watermark persistence stays gated on `not dry_run` (unchanged)
+
+main():
+    run all providers
+    return 3 if total deadlettered_sessions > 0 else 0   # cron mail surfaces loss
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | scripts/memory/distill-provider-sessions.py | `_Poison` singleton, tri-state `flush()`, content-digest-keyed bounded-retry in a **separate poison-state file**, dead-letter append, stats + non-zero exit; poison-counting scoped to plain incremental runs |
+| Create | scripts/memory/tests/test_distill_poison_handling.py | TDD suite (written first) |
+| Modify | scripts/memory/bridge-providers-to-dream.sh | log a WARN when distiller exits non-zero (don't swallow rc) |
+| Update | docs/plans/README.md | index this plan |
+
+Runtime state files (created on first poison/dead-letter event, gitignored — under `~/.claude/.../memory/`):
+- `.provider-bridge-poison.json` — `{provider: {sig, attempts, first_ts}}`, flock'd, **separate from** the watermark dict.
+- `.provider-bridge-deadletter.jsonl` — append-only audit log of abandoned batches.
+
+---
+
+## TDD Test List
+
+| Test name | What it verifies | Expected input | Expected output |
+|---|---|---|---|
+| test_valid_empty_advances_watermark | valid `{"learnings":[]}` is NOT treated as poison | claude_distill → `[]` | watermark advances, no dead-letter, no abort |
+| test_poison_holds_watermark_first_attempt | first garble holds watermark, no loss | claude_distill → POISON | watermark unchanged, poison-file `attempts==1`, provider aborts, no dead-letter |
+| test_poison_retried_then_deadlettered | garble for MAX runs → dead-letter + advance | POISON × MAX_POISON_RETRIES (same batch sig) | sessions appended to dead-letter JSONL, watermark advances past batch |
+| test_transient_none_holds_watermark | existing transient behavior preserved | claude_distill → None | watermark holds, provider aborts (regression guard) |
+| test_successful_batch_writes_and_advances | happy path unchanged | claude_distill → [learning] | file written, watermark advances |
+| test_poison_counter_resets_after_success | recovered provider drops stale poison count | POISON then [learning] | poison-state cleared; later single garble doesn't prematurely dead-letter |
+| test_deadletter_record_shape | dead-letter record is auditable + recoverable | one dead-letter event | JSONL record has provider, sessions[], mtimes, reason, attempts, ts |
+| test_main_exit_nonzero_on_deadletter | rc surfaces loss | a dead-letter occurs | `main()` returns 3 |
+| **test_poison_sig_changes_resets_counter** (Finding 1) | batch-membership shift is well-defined, not silent loss | POISON run1 (sig A), new in-window session → POISON run2 (sig B) | counter does NOT increment to MAX on a different batch; sig-B starts attempts=1 |
+| **test_poison_only_counts_plain_incremental** (Finding 1) | `--limit`/`--since-days`/`--backfill` poison HOLDS, never dead-letters | POISON under `--limit 3` | no poison-state written, no dead-letter, provider aborts-hold |
+| **test_final_batch_only_poison** (Finding 5) | sole sub-`batch_size` batch (never hits mid-loop flush) is handled | 2 sessions, batch_size=8, claude_distill → POISON | trailing-flush path triggers identical poison handling (hold→…→dead-letter) |
+| **test_dry_run_no_deadletter_no_advance** (Finding 6) | dry-run writes neither JSONL nor watermark nor poison-state | `--dry-run` + POISON×MAX | dead-letter file absent, watermark unchanged, poison-state unchanged |
+| **test_poison_sentinel_identity_invariant** (Finding 4) | sentinel cannot be made falsy by refactor | `POISON` | `bool(POISON) is True` and `POISON is not None` and `POISON is not []` |
+| **test_poison_state_file_separate_from_watermark** (Finding 3) | poison state never coerced as a provider mtime | watermark `{codex:123.0}` + poison-file present | `float(watermark.get('codex'))` works; no provider-iteration touches poison state |
+| **test_deadletter_append_preserves_prior** (Finding 8) | second dead-letter event keeps the first record | two dead-letter events | JSONL has 2 lines, first survives |
+| **test_age_escape_deadletters_stale_hold** (v1 decision) | sig-changes-every-run hold dead-letters after AGE_ESCAPE_DAYS | POISON each run, different sig, `first_ts` > 7d ago | dead-letter fires despite attempts never reaching MAX; `first_ts` carried across sig changes |
+| **test_first_ts_resets_only_on_recovery** (v1 decision) | recovery clears the age clock | POISON (sets first_ts) → ok → POISON | second poison starts a fresh first_ts, not the old one |
+| **test_watermark_schema_backward_compatible** | legacy watermark (no poison machinery) loads cleanly | watermark `{codex: 123.0}` | provider mtime read correctly; poison-state defaults empty |
+
+---
+
+## Acceptance Criteria
+
+- [ ] All new tests pass: `uv run --no-project python -m pytest scripts/memory/tests/test_distill_poison_handling.py -v`
+- [ ] No regression in existing distiller behavior (transient→None hold, valid-empty advance, happy-path write) — covered by regression-guard tests above.
+- [ ] A forced non-JSON response produces a visible warning + (after MAX retries) a dead-letter record + non-zero exit — NOT a silent rc=0.
+- [ ] Dead-lettered sessions are recorded with enough provenance to be re-fed manually.
+- [ ] `bridge-providers-to-dream.sh` logs a WARN line (not silent) when the distiller exits non-zero.
+- [ ] Plan + code review artifacts posted to scripts/review/results/.
+- [ ] Summary comment posted to #2845.
+
+---
+
+## Adversarial Review Summary
+
+<!-- Populated after Step 4. -->
+
+| Provider | Verdict | Key findings |
+|---|---|---|
+| Claude (fresh-context subagent) | **MAJOR** | (1) batch identity not stable across runs → `high_water` is the wrong counter key; (2) float-equality key fragile; (3) `_poison` reserved key collides with `{provider: float}` watermark; (4) POISON sentinel type unpinned (falsy hazard); (5) trailing-batch flush path unhandled (small runs never hit mid-loop flush); (6) dry-run dead-letter unguarded; (7) concurrent backfill clobbers counter; (8) six test gaps. |
+| Codex | UNAVAILABLE | cross-provider dispatch blocked from a Claude-Code session (CLAUDECODE=1 trips submit-to-codex version guard; #2721/#2715). Documented per scripts/review/results convention. |
+| Gemini | UNAVAILABLE | same dispatch constraint; T2 degraded to single-author + fresh-context subagent review per `feedback_permission_gate_blocks_cross_review`. |
+
+**Overall result:** PASS after revision (draft was MAJOR → all 8 findings incorporated; re-review recommended at code stage when cross-provider dispatch is available).
+
+Revisions made based on review:
+- **F1/F2:** retry counter re-keyed from `high_water` → **sha1 content digest of sorted batch session paths**; poison-counting scoped to plain incremental runs only (`--limit`/`--since-days`/`--backfill` hold without counting).
+- **F3:** poison state moved out of the watermark dict into a **separate `.provider-bridge-poison.json`** file — eliminates the float-coercion collision.
+- **F4:** POISON pinned to a **named non-falsy singleton** (`class _Poison`), identity-comparison only; invariant test added.
+- **F5:** `flush()` converted to **tri-state**; both mid-loop and trailing flush routed through one `handle_poison()` — sole-batch poison now covered.
+- **F6:** dead-letter append + watermark advance + poison-state write all gated on `not dry_run`; test added.
+- **F7:** poison-state file uses flock'd read-modify-write; `--backfill`-vs-cron exclusion documented (and poison-counting disabled under backfill anyway).
+- **F8:** six tests added to the TDD list (sig-change, plain-incremental-only, final-batch, dry-run, sentinel-identity, append-preserves-prior).
+
+---
+
+## Risks and Open Questions
+
+- **DECIDED (user 2026-05-27):** `MAX_POISON_RETRIES = 3`.
+- **DECIDED (user 2026-05-27):** age-escape **included in v1** (`AGE_ESCAPE_DAYS = 7`) — `first_ts` carries across sig changes, clears only on recovery; closes the absorb-forever residual.
+- **Open (for user, non-blocking):** dead-letter recovery — v1 records sessions for **manual** re-feed only; auto-replay (`--retry-deadletter`) deferred to a follow-on.
+- **Resolved (was F1):** batch-stability — no longer assumed. Counter keys on a content digest of the batch's session paths and only counts on plain incremental runs; a membership shift yields a new digest and a fresh (attempts=1) count rather than silent loss.
+- **Resolved (was F3):** no watermark schema change — poison state is a separate file, so `{provider: float}` reads are untouched.
+- **Resolved (was F7):** poison-state file is flock'd read-modify-write; backfill does not poison-count, so it cannot clobber the counter toward never-dead-lettering.
+- **Risk (residual):** a genuinely-poison batch that keeps absorbing new sessions each run (digest changes every run) would hold indefinitely without dead-lettering. Mitigation: the run still exits non-zero on the *hold-abort* path is NOT triggered (hold is silent) — so add a **secondary age-based escape**: if `first_ts` for any held provider exceeds N days, dead-letter regardless of sig. (Flag for user: include age-escape in v1 or defer?)
+
+---
+
+## Complexity: T2
+**T2** — single core file modified with non-trivial control-flow change, new test file (TDD), a watermark-schema extension, and a small wrapper edit. Multi-file, correctness-critical (data loss), but bounded to one subsystem. T2 → 2-provider adversarial review target (degraded to single-author + fresh-context subagent this session; constraint documented).

--- a/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
+++ b/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
@@ -38,7 +38,7 @@
     <span class="big">78%</span>
     <div>
       <strong>Test-based completeness</strong><br>
-      <span class="mut">Core pipeline built, adversarially reviewed, and verified. Held below 100% by two user/time-dependent steps: the consolidating <code>/dream</code> (not yet run) and cron/hook that are installed but have not yet fired live.</span>
+      <span class="mut">Core pipeline built, adversarially reviewed, and verified. Held below 100% by time-dependent steps that fire on their own: the <strong>automatic background dream</strong> (consolidates the staged learnings when its hours/sessions thresholds are met — there is no manual trigger) and the cron/hook that are installed but have not yet fired live.</span>
     </div>
   </div>
 
@@ -72,20 +72,20 @@
       <tr><td>SessionStart lock-reaper hook</td>
           <td><span class="pill p-warn">INSTALLED</span></td><td class="pct">70</td>
           <td>In <code>settings.json</code> (valid JSON); pipe-tested 3 ways (reap dead / preserve live / no-op). Not yet fired in a real session start.</td></tr>
-      <tr><td>Consolidating <code>/dream</code> over staged learnings</td>
-          <td><span class="pill p-no">NOT&nbsp;RUN</span></td><td class="pct">0</td>
-          <td>User-invoked only. The end-goal step; nothing has consolidated the staged learnings yet.</td></tr>
+      <tr><td>Automatic background dream consolidates staged learnings</td>
+          <td><span class="pill p-warn">PENDING&nbsp;(AUTO)</span></td><td class="pct">0</td>
+          <td>Fires automatically (no manual command) when <code>autoDreamEnabled</code> is true AND hours-since-last ≥ <code>minHours</code> AND new-Claude-sessions-since-last ≥ <code>minSessions</code> AND the consolidate-lock is free. All preconditions are set (toggle on, lock cleared, hook self-heals it); it will fire during normal Claude usage. Not yet observed firing.</td></tr>
       <tr><td>Durability — scripts committed + pushed</td>
           <td><span class="pill p-ok">DONE</span></td><td class="pct">100</td>
           <td>On <code>feat/2833</code>; <span class="mut">machine-config (cron/hook/settings) documented in #2833, not git-tracked by design.</span></td></tr>
     </tbody>
   </table>
 
-  <h2>Blocking items before close</h2>
+  <h2>Items before close (all automatic / time-based — no manual command)</h2>
   <ul>
-    <li><strong>Gemini regen completes</strong> (in progress, ~25 min) — then all 3 providers clean.</li>
-    <li><strong>Run <code>/dream</code></strong> (user) — consolidate the staged cross-provider learnings; this is the feature's payoff.</li>
-    <li><strong>Re-score to ~100%</strong> after the above + first live cron/hook fire, then <code>gh issue close</code>.</li>
+    <li><strong>Gemini regen completes</strong> (in progress) — then all 3 providers clean.</li>
+    <li><strong>Automatic background dream fires</strong> — consolidates the staged cross-provider learnings on its own during normal Claude usage (gated by <code>minHours</code> + <code>minSessions</code> + lock). The feature's payoff; nothing to invoke. Verify afterward via <code>tengu_auto_dream_fired</code> telemetry / a shrinking <code>crossprovider_*.md</code> count.</li>
+    <li><strong>Re-score to ~100%</strong> once the dream has fired at least once and the cron/hook have run live, then <code>gh issue close</code>.</li>
   </ul>
 
   <h2>Accepted residuals (by user decision)</h2>

--- a/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
+++ b/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
@@ -35,10 +35,10 @@
      · branch <code>feat/2833-crossprovider-dream-bridge</code> · 2026-05-26 · <span class="mut">review before <code>gh issue close</code></span></p>
 
   <div class="score">
-    <span class="big">78%</span>
+    <span class="big">88%</span>
     <div>
       <strong>Test-based completeness</strong><br>
-      <span class="mut">Core pipeline built, adversarially reviewed, and verified. Held below 100% by time-dependent steps that fire on their own: the <strong>automatic background dream</strong> (consolidates the staged learnings when its hours/sessions thresholds are met — there is no manual trigger) and the cron/hook that are installed but have not yet fired live.</span>
+      <span class="mut">Core pipeline built, adversarially reviewed, and verified; backfill complete on all 3 providers (3,059 staged learnings). Held below 100% only by time-dependent steps that fire on their own — nothing left to build: the <strong>automatic background dream</strong> consolidating the staged learnings, and the cron/hook firing live for the first time. Re-score to ~100% once those are observed.</span>
     </div>
   </div>
 
@@ -64,8 +64,8 @@
           <td><span class="pill p-ok">DONE</span></td><td class="pct">100</td>
           <td>~100% coverage. <span class="mut">Carry minor N2 CoT noise (pre-fix); accepted by user — dream prunes.</span></td></tr>
       <tr><td>Backfill — Gemini (re-run on fixed code)</td>
-          <td><span class="pill p-warn">IN&nbsp;PROGRESS</span></td><td class="pct">~10</td>
-          <td>Tainted pre-fix files deleted; regenerating clean. ~25 min ETA. Resumable + cron backstop.</td></tr>
+          <td><span class="pill p-ok">DONE</span></td><td class="pct">100</td>
+          <td>1,707/1,707 (100%); 413 clean files regenerated after deleting the B1-tainted set. All 3 providers now ~100% (Codex 99% = 5 brand-new sessions, cron sweeps them).</td></tr>
       <tr><td>Daily 04:00 cron (incremental)</td>
           <td><span class="pill p-warn">INSTALLED</span></td><td class="pct">70</td>
           <td>Crontab entry present (backed up). Not yet fired — first live run unverified.</td></tr>

--- a/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
+++ b/docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Completeness Scorecard — Cross-Provider Dream Bridge (#2833)</title>
+<style>
+  :root { --ok:#1a7f37; --warn:#9a6700; --no:#b42318; --bg:#0d1117; --fg:#e6edf3; --mut:#8b949e; --card:#161b22; --line:#30363d; }
+  body { background:var(--bg); color:var(--fg); font:15px/1.55 -apple-system,Segoe UI,Roboto,sans-serif; margin:0; padding:2rem; }
+  .wrap { max-width:960px; margin:0 auto; }
+  h1 { font-size:1.5rem; margin:0 0 .25rem; }
+  .sub { color:var(--mut); margin:0 0 1.5rem; }
+  .score { display:flex; align-items:baseline; gap:1rem; background:var(--card); border:1px solid var(--line); border-radius:10px; padding:1rem 1.25rem; margin-bottom:1.5rem; }
+  .score .big { font-size:2.6rem; font-weight:700; color:var(--warn); }
+  table { width:100%; border-collapse:collapse; background:var(--card); border:1px solid var(--line); border-radius:10px; overflow:hidden; margin-bottom:1.5rem; }
+  th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; }
+  th { background:#1f2630; font-size:.8rem; text-transform:uppercase; letter-spacing:.04em; color:var(--mut); }
+  tr:last-child td { border-bottom:none; }
+  .pill { font-size:.75rem; font-weight:600; padding:.1rem .5rem; border-radius:999px; white-space:nowrap; }
+  .p-ok { background:rgba(26,127,55,.18); color:#3fb950; }
+  .p-warn { background:rgba(154,103,0,.2); color:#d29922; }
+  .p-no { background:rgba(180,35,24,.18); color:#f85149; }
+  .pct { font-variant-numeric:tabular-nums; font-weight:600; }
+  code { background:#1f2630; padding:.1rem .35rem; border-radius:4px; font-size:.85em; }
+  h2 { font-size:1.1rem; margin:1.6rem 0 .6rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+  ul { margin:.3rem 0 1rem; padding-left:1.2rem; }
+  li { margin:.25rem 0; }
+  .mut { color:var(--mut); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Completeness Scorecard — Cross-Provider Dream Bridge</h1>
+  <p class="sub">Issue <a href="https://github.com/vamseeachanta/workspace-hub/issues/2833" style="color:#58a6ff">#2833</a>
+     · branch <code>feat/2833-crossprovider-dream-bridge</code> · 2026-05-26 · <span class="mut">review before <code>gh issue close</code></span></p>
+
+  <div class="score">
+    <span class="big">78%</span>
+    <div>
+      <strong>Test-based completeness</strong><br>
+      <span class="mut">Core pipeline built, adversarially reviewed, and verified. Held below 100% by two user/time-dependent steps: the consolidating <code>/dream</code> (not yet run) and cron/hook that are installed but have not yet fired live.</span>
+    </div>
+  </div>
+
+  <table>
+    <thead><tr><th>Component</th><th>Status</th><th>%</th><th>Test evidence</th></tr></thead>
+    <tbody>
+      <tr><td>Pre-filter (Codex <code>event_msg</code>; Gemini/Hermes <code>messages[]</code>)</td>
+          <td><span class="pill p-ok">VERIFIED</span></td><td class="pct">100</td>
+          <td>0/5 boilerplate leaks; synthetic B1 test drops tool/system, keeps user/assistant; N2 CoT-part drop confirmed; live extraction across all 3 providers.</td></tr>
+      <tr><td>Distill engine (<code>claude -p</code> via stdin, subscription)</td>
+          <td><span class="pill p-ok">VERIFIED</span></td><td class="pct">100</td>
+          <td>Live e2e per provider; full 20-session Hermes batch via stdin (ARG_MAX fix) returns valid learnings.</td></tr>
+      <tr><td>Watermark resumability + atomicity</td>
+          <td><span class="pill p-ok">VERIFIED</span></td><td class="pct">100</td>
+          <td>Failure-path test: failed batch holds watermark at 0, 0 files. Happy-path advances. Atomic tmp+<code>os.replace</code>; abort-on-corrupt.</td></tr>
+      <tr><td>Idempotent output (content-hash filenames)</td>
+          <td><span class="pill p-ok">VERIFIED</span></td><td class="pct">100</td>
+          <td>Re-runs overwrite identical files; B2 boundary reprocessing is safe by design.</td></tr>
+      <tr><td>Adversarial review gate</td>
+          <td><span class="pill p-ok">VERIFIED</span></td><td class="pct">100</td>
+          <td>R1 REJECT (2 BLOCKER+4 MAJOR) → all fixed (<code>0832837</code>) → R2 MINOR, no regressions. Evidence on #2833.</td></tr>
+      <tr><td>Backfill — Codex (696) + Hermes (1,950)</td>
+          <td><span class="pill p-ok">DONE</span></td><td class="pct">100</td>
+          <td>~100% coverage. <span class="mut">Carry minor N2 CoT noise (pre-fix); accepted by user — dream prunes.</span></td></tr>
+      <tr><td>Backfill — Gemini (re-run on fixed code)</td>
+          <td><span class="pill p-warn">IN&nbsp;PROGRESS</span></td><td class="pct">~10</td>
+          <td>Tainted pre-fix files deleted; regenerating clean. ~25 min ETA. Resumable + cron backstop.</td></tr>
+      <tr><td>Daily 04:00 cron (incremental)</td>
+          <td><span class="pill p-warn">INSTALLED</span></td><td class="pct">70</td>
+          <td>Crontab entry present (backed up). Not yet fired — first live run unverified.</td></tr>
+      <tr><td>SessionStart lock-reaper hook</td>
+          <td><span class="pill p-warn">INSTALLED</span></td><td class="pct">70</td>
+          <td>In <code>settings.json</code> (valid JSON); pipe-tested 3 ways (reap dead / preserve live / no-op). Not yet fired in a real session start.</td></tr>
+      <tr><td>Consolidating <code>/dream</code> over staged learnings</td>
+          <td><span class="pill p-no">NOT&nbsp;RUN</span></td><td class="pct">0</td>
+          <td>User-invoked only. The end-goal step; nothing has consolidated the staged learnings yet.</td></tr>
+      <tr><td>Durability — scripts committed + pushed</td>
+          <td><span class="pill p-ok">DONE</span></td><td class="pct">100</td>
+          <td>On <code>feat/2833</code>; <span class="mut">machine-config (cron/hook/settings) documented in #2833, not git-tracked by design.</span></td></tr>
+    </tbody>
+  </table>
+
+  <h2>Blocking items before close</h2>
+  <ul>
+    <li><strong>Gemini regen completes</strong> (in progress, ~25 min) — then all 3 providers clean.</li>
+    <li><strong>Run <code>/dream</code></strong> (user) — consolidate the staged cross-provider learnings; this is the feature's payoff.</li>
+    <li><strong>Re-score to ~100%</strong> after the above + first live cron/hook fire, then <code>gh issue close</code>.</li>
+  </ul>
+
+  <h2>Accepted residuals (by user decision)</h2>
+  <ul>
+    <li><span class="mut">Codex/Hermes learnings carry minor pre-fix CoT noise (N2); not re-backfilled — the dream prunes.</span></li>
+    <li><span class="mut">Watermark has no cross-process lock; single daily cron deployment makes this acceptable (N1).</span></li>
+    <li><span class="mut">atexit temp-cwd cleanup doesn't fire on SIGKILL; dirs are empty + OS-reaped.</span></li>
+  </ul>
+</div>
+</body>
+</html>

--- a/docs/sessions/2026-05-26-crossprovider-dream-bridge-handoff.html
+++ b/docs/sessions/2026-05-26-crossprovider-dream-bridge-handoff.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Session Handoff — Cross-Provider Dream Bridge (#2833)</title>
+<style>
+  :root { --bg:#0d1117; --fg:#e6edf3; --mut:#8b949e; --card:#161b22; --line:#30363d; --acc:#58a6ff; --ok:#3fb950; --warn:#d29922; }
+  body { background:var(--bg); color:var(--fg); font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif; margin:0; padding:2rem; }
+  .wrap { max-width:920px; margin:0 auto; }
+  h1 { font-size:1.5rem; margin:0 0 .2rem; }
+  h2 { font-size:1.05rem; margin:1.6rem 0 .5rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+  .sub { color:var(--mut); margin:0 0 1.4rem; }
+  a { color:var(--acc); }
+  code { background:#1f2630; padding:.1rem .35rem; border-radius:4px; font-size:.85em; }
+  pre { background:var(--card); border:1px solid var(--line); border-radius:8px; padding:.8rem 1rem; overflow:auto; font-size:.85em; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:1rem 1.25rem; margin:.6rem 0; }
+  ul { margin:.3rem 0 1rem; padding-left:1.2rem; } li { margin:.3rem 0; }
+  .ok { color:var(--ok); } .warn { color:var(--warn); } .mut { color:var(--mut); }
+  table { width:100%; border-collapse:collapse; margin:.5rem 0 1rem; }
+  td,th { text-align:left; padding:.4rem .6rem; border-bottom:1px solid var(--line); font-size:.92em; }
+  th { color:var(--mut); font-size:.78rem; text-transform:uppercase; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Session Handoff — Cross-Provider Dream Bridge</h1>
+  <p class="sub">2026-05-26 · issue <a href="https://github.com/vamseeachanta/workspace-hub/issues/2833">#2833</a> · branch <code>feat/2833-crossprovider-dream-bridge</code> · scorecard 88%</p>
+
+  <div class="card">
+    <strong>One-line:</strong> Started from "we never dream" (a stale dead-PID <code>.consolidate-lock</code> had blocked auto-dream since Apr 8). Cleared it, then built + reviewed + ran a bridge that distills Codex/Gemini/Hermes sessions into the Claude auto-memory dir so the <em>automatic</em> background dream consolidates ALL providers — not a manual command.
+  </div>
+
+  <h2>What shipped</h2>
+  <table>
+    <tr><th>Artifact</th><th>Location</th></tr>
+    <tr><td>Distiller</td><td><code>scripts/memory/distill-provider-sessions.py</code></td></tr>
+    <tr><td>Cron wrapper</td><td><code>scripts/memory/bridge-providers-to-dream.sh</code></td></tr>
+    <tr><td>Completeness scorecard</td><td><code>docs/reports/2026-05-26-crossprovider-dream-bridge-completeness.html</code></td></tr>
+    <tr><td>Branch (4 commits, pushed)</td><td><code>feat/2833-crossprovider-dream-bridge</code> @ <code>6f9557f</code></td></tr>
+  </table>
+  <p class="mut">Engine: Claude itself — headless <code>claude -p --model haiku</code> on the subscription (the <code>.env</code> <code>ANTHROPIC_API_KEY</code> is empty; no API key used). Calls run from a neutral cwd to avoid reloading the 67 KB project context.</p>
+
+  <h2>Current state (all clean)</h2>
+  <ul>
+    <li><span class="ok">✓</span> Backfill complete: Codex 696 · Gemini 413 · Hermes 1,950 = <strong>3,059 staged learnings</strong> in the auto-memory dir.</li>
+    <li><span class="ok">✓</span> Watermarks at ~100% all providers (<code>.provider-bridge-watermark.json</code>).</li>
+    <li><span class="ok">✓</span> Adversarial review: REJECT → all findings fixed → MINOR. Evidence on #2833.</li>
+    <li><span class="ok">✓</span> No processes running; no leftover temp dirs / locks / <code>.tmp</code>.</li>
+  </ul>
+
+  <h2>Machine-config — NOT in git (re-apply per machine)</h2>
+  <pre># cron (this machine: installed, crontab backed up to /tmp)
+0 4 * * *  cd /mnt/local-analysis/workspace-hub &amp;&amp; bash scripts/memory/bridge-providers-to-dream.sh \
+           &gt;&gt; logs/orchestrator/memory-bridge/cron-$(date +\%Y\%m\%d).log 2&gt;&amp;1
+
+# ~/.claude/settings.json SessionStart hook (self-heals stale dream lock):
+#   reaps any projects/*/memory/.consolidate-lock whose PID is dead</pre>
+
+  <h2>How dreaming actually works (corrected this session)</h2>
+  <p>There is <strong>no <code>/dream</code> command</strong>. Dreaming is fully automatic/background. Verified from the binary: <code>autoDream</code> fires when <code>autoDreamEnabled</code> is true AND <code>hours_since_last ≥ minHours</code> AND <code>new_sessions_since_last ≥ minSessions</code> AND the consolidate-lock is free. The only manual levers are the settings toggle and running the bridge scripts.</p>
+
+  <h2>Open items (all automatic / time-based — nothing to invoke)</h2>
+  <ul>
+    <li class="warn">Automatic background dream fires during normal Claude usage → consolidates the 3,059 staged learnings.</li>
+    <li class="warn">First live cron run (04:00) and first SessionStart-hook fire.</li>
+    <li class="mut">Then re-score scorecard → ~100% and <code>gh issue close #2833</code>.</li>
+    <li class="mut">Accepted residual: Codex/Hermes learnings carry minor pre-fix CoT noise (user opted not to re-backfill; the dream prunes).</li>
+  </ul>
+
+  <h2>How to verify / resume in a fresh session</h2>
+  <pre># resume the code
+git fetch &amp;&amp; git switch feat/2833-crossprovider-dream-bridge
+
+# has the background dream fired?  (count drops as it consolidates)
+ls ~/.claude/projects/-mnt-local-analysis-workspace-hub/memory/crossprovider_*.md | wc -l
+
+# run the bridge manually anytime (incremental)
+bash scripts/memory/bridge-providers-to-dream.sh

--- a/scripts/memory/bridge-providers-to-dream.sh
+++ b/scripts/memory/bridge-providers-to-dream.sh
@@ -5,7 +5,7 @@
 #   transcripts. This wrapper runs the cross-provider distiller so the dream
 #   becomes THE cross-provider consolidator (per the user's decision; see
 #   reference_claude_dreaming_managed_agents.md). The distiller reads other-
-#   provider sessions, distills durable learnings via gpt-5.5 (codex exec), and
+#   provider sessions, distills durable learnings via Claude (headless `claude -p`), and
 #   writes provenance-tagged memory files the dream then consolidates/prunes.
 #
 # USAGE:

--- a/scripts/memory/bridge-providers-to-dream.sh
+++ b/scripts/memory/bridge-providers-to-dream.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# bridge-providers-to-dream.sh — Feed Codex/Gemini/Hermes sessions into the Claude dream.
+#
+# WHY: Claude Code's dreaming only ingests its own auto-memory + its own session
+#   transcripts. This wrapper runs the cross-provider distiller so the dream
+#   becomes THE cross-provider consolidator (per the user's decision; see
+#   reference_claude_dreaming_managed_agents.md). The distiller reads other-
+#   provider sessions, distills durable learnings via gpt-5.5 (codex exec), and
+#   writes provenance-tagged memory files the dream then consolidates/prunes.
+#
+# USAGE:
+#   bash bridge-providers-to-dream.sh                 # incremental (since watermark)
+#   bash bridge-providers-to-dream.sh --backfill      # all history (token-heavy)
+#   bash bridge-providers-to-dream.sh --dry-run --limit 3   # prove pipeline, write nothing
+#   (extra args are passed straight through to the Python distiller)
+#
+# SCHEDULING: cron 04:00 daily (mirrors bridge-hermes-claude.sh). Install with
+#   scripts/memory/install-provider-bridge-cron.sh (separate, needs user auth).
+#
+# LOGGING: appends to logs/orchestrator/memory-bridge/<date>.log under the repo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "/mnt/local-analysis/workspace-hub")"
+DISTILLER="${SCRIPT_DIR}/distill-provider-sessions.py"
+
+LOG_DIR="${REPO_ROOT}/logs/orchestrator/memory-bridge"
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/$(date +%Y-%m-%d).log"
+
+# Prefer uv (Linux Python rule) but the distiller is stdlib-only, so plain
+# python3 is a fine fallback (and the only option on Windows / no-uv hosts).
+if command -v uv >/dev/null 2>&1 && uv run --no-project python -c "print(1)" >/dev/null 2>&1; then
+  PY=(uv run --no-project python)
+else
+  PY=(python3)
+fi
+
+echo "[bridge-to-dream] $(date -u +%Y-%m-%dT%H:%M:%SZ) starting (args: $*)" | tee -a "$LOG_FILE"
+
+# The distiller never exits non-zero on a single provider's failure; it logs and
+# continues. We still capture its rc so cron mail surfaces hard failures.
+set +e
+"${PY[@]}" "$DISTILLER" "$@" 2>&1 | tee -a "$LOG_FILE"
+rc=${PIPESTATUS[0]}
+set -e
+
+echo "[bridge-to-dream] $(date -u +%Y-%m-%dT%H:%M:%SZ) done (rc=$rc)" | tee -a "$LOG_FILE"
+exit "$rc"

--- a/scripts/memory/bridge-providers-to-dream.sh
+++ b/scripts/memory/bridge-providers-to-dream.sh
@@ -39,12 +39,21 @@ fi
 
 echo "[bridge-to-dream] $(date -u +%Y-%m-%dT%H:%M:%SZ) starting (args: $*)" | tee -a "$LOG_FILE"
 
-# The distiller never exits non-zero on a single provider's failure; it logs and
-# continues. We still capture its rc so cron mail surfaces hard failures.
+# The distiller logs+continues on a single provider's transient failure, but it
+# exits non-zero when sessions were DEAD-LETTERED (rc=3, #2845) or on a hard
+# error. We capture its rc and surface a WARN so cron mail/log review catches it
+# instead of a green "done" masking lost learnings.
 set +e
 "${PY[@]}" "$DISTILLER" "$@" 2>&1 | tee -a "$LOG_FILE"
 rc=${PIPESTATUS[0]}
 set -e
+
+if [ "$rc" -eq 3 ]; then
+  echo "[bridge-to-dream] WARN $(date -u +%Y-%m-%dT%H:%M:%SZ) distiller DEAD-LETTERED session(s) — " \
+       "inspect ~/.claude/projects/*/memory/.provider-bridge-deadletter.jsonl (#2845)" | tee -a "$LOG_FILE"
+elif [ "$rc" -ne 0 ]; then
+  echo "[bridge-to-dream] WARN $(date -u +%Y-%m-%dT%H:%M:%SZ) distiller exited rc=$rc (hard failure)" | tee -a "$LOG_FILE"
+fi
 
 echo "[bridge-to-dream] $(date -u +%Y-%m-%dT%H:%M:%SZ) done (rc=$rc)" | tee -a "$LOG_FILE"
 exit "$rc"

--- a/scripts/memory/distill-provider-sessions.py
+++ b/scripts/memory/distill-provider-sessions.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+distill-provider-sessions.py — Bridge other-provider sessions into the Claude dream.
+
+WHAT / WHY
+  Claude Code's "dreaming" (auto-memory consolidation) only ingests its own
+  auto-memory store + its own ~/.claude/projects/*/*.jsonl transcripts. It has
+  NO native awareness of Codex, Gemini, or Hermes sessions. Per the user's
+  decision (see reference_claude_dreaming_managed_agents.md), the Claude dream
+  is THE cross-provider consolidator — so this script feeds it.
+
+  It reads other-provider session files, pre-filters them to conversational
+  signal (dropping tool-output/blob noise — ~5.3 GB raw across providers),
+  batches them, and asks Claude itself (headless `claude -p` on the
+  subscription — "get Claude to do the dreaming", ONE consistent engine for all
+  providers) to extract only durable, novel learnings. Each learning is written
+  as a provenance-tagged memory file into the Claude auto-memory dir, which the
+  native dream then consolidates / dedupes / prunes.
+
+  Filenames are content-hashed so re-runs are idempotent (same learning ->
+  same file -> overwrite, never flood). The dream prunes whatever it doesn't
+  keep.
+
+DESIGN NOTES
+  - Resumable: a per-provider watermark (last-processed session mtime) means a
+    mid-backfill kill just resumes. Essential given codex CLI flakiness over
+    10k sessions (feedback_codex_cli_0_124_upstream_regression).
+  - Batched: several pre-filtered sessions per codex call -> fewer flaky calls.
+  - stdlib-only: shells out to `codex` for the LLM, so no pip deps; runs under
+    plain python3 or `uv run`.
+
+USAGE
+  python3 distill-provider-sessions.py --dry-run --provider codex --limit 3
+      # distill 3 codex sessions, print what WOULD be written, no files, no watermark
+  python3 distill-provider-sessions.py --backfill          # all history, all providers
+  python3 distill-provider-sessions.py                      # incremental (since watermark)
+
+  Flags: --provider {codex,gemini,hermes,all}  --backfill  --dry-run
+         --limit N (cap sessions this run)  --batch-size N  --since-days N
+         --max-learnings-per-provider N
+
+Called by: scripts/memory/bridge-providers-to-dream.sh (cron, 04:00 daily)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from shutil import which
+
+HOME = Path.home()
+
+# --- Provider session locations ------------------------------------------------
+CODEX_SESSIONS = HOME / ".codex" / "sessions"          # YYYY/MM/DD/rollout-*.jsonl
+GEMINI_ROOT = HOME / ".gemini"                          # **/chats/session-*.json
+HERMES_SESSIONS = HOME / ".hermes" / "sessions"        # session_*.json
+
+# --- Claude auto-memory dir (the dream's input) --------------------------------
+# Matches autoMemoryDirectory in ~/.claude/settings.json; override with env.
+DEFAULT_MEM_DIR = HOME / ".claude" / "projects" / "-mnt-local-analysis-workspace-hub" / "memory"
+MEM_DIR = Path(os.environ.get("CLAUDE_AUTO_MEMORY_DIR", str(DEFAULT_MEM_DIR)))
+
+WATERMARK_FILE = MEM_DIR / ".provider-bridge-watermark.json"
+
+# --- Distiller backend: Claude itself, headless, on the subscription ----------
+# "Get Claude to do the dreaming" — dreaming is a Claude-native capability, so
+# the cross-provider distiller is Claude too, for ONE consistent engine across
+# all providers/sessions. Uses `claude -p` (subscription auth, no API key; the
+# .env ANTHROPIC_API_KEY is empty). Calls run from a neutral cwd so they don't
+# reload this repo's ~67K-token CLAUDE.md/MEMORY.md context on every batch.
+CLAUDE_BIN = os.environ.get("CLAUDE_BIN") or (
+    "claude" if which("claude") else str(HOME / ".npm-global" / "bin" / "claude")
+)
+CLAUDE_MODEL = os.environ.get("DISTILL_MODEL", "haiku")
+CLAUDE_TIMEOUT = int(os.environ.get("DISTILL_TIMEOUT_SECONDS", "180"))
+# Neutral working dir for headless calls — no project CLAUDE.md to load.
+_NEUTRAL_CWD = tempfile.mkdtemp(prefix="distill-cwd-")
+
+# --- Pre-filter / batching knobs ------------------------------------------------
+PER_SESSION_CHAR_CAP = int(os.environ.get("PER_SESSION_CHAR_CAP", "6000"))
+MIN_SESSION_CHARS = int(os.environ.get("MIN_SESSION_CHARS", "200"))
+DEFAULT_BATCH_SIZE = int(os.environ.get("DISTILL_BATCH_SIZE", "8"))
+
+# Keys whose string values look like conversational text; everything else
+# (tool results, diffs, base64, file dumps) is noise we drop before the LLM.
+_TEXT_KEYS = {"text", "message", "content", "value", "input_text", "output_text"}
+_NOISE_RE = re.compile(r"(data:[^;]+;base64,|\b[A-Za-z0-9+/]{200,}={0,2})")
+
+# Roles whose content is conversation we want. System/developer/tool turns and
+# their boilerplate (sandbox/permissions/instructions blocks) are dropped.
+_HUMAN_ROLES = {"user", "assistant", "agent", "model", "human", "ai"}
+_SKIP_ROLES = {"system", "developer", "tool", "function", "tool_result"}
+# System-prompt boilerplate fingerprints — drop any segment starting with these.
+_BOILERPLATE_RE = re.compile(
+    r"^\s*(<permissions|<user_instructions|<environment|<system|"
+    r"sandbox_mode|you are codex|you are a|# instructions\b|## instructions\b)",
+    re.IGNORECASE,
+)
+
+
+# ==============================================================================
+# Pre-filter: extract conversational text from each provider's session format
+# ==============================================================================
+
+def _harvest_text(obj, out: list[str], depth: int = 0, role: str | None = None) -> None:
+    """Recursively pull human/assistant text from arbitrary nested JSON,
+    skipping system/tool turns and obvious blob noise. Role-aware: when a dict
+    carries a `role`, that role governs its subtree. Defensive — provider
+    formats drift across versions, so we don't hard-code one schema."""
+    if depth > 12:
+        return
+    if isinstance(obj, dict):
+        # A role on this node governs its subtree (messages are role-tagged).
+        node_role = obj.get("role")
+        if isinstance(node_role, str):
+            role = node_role.lower()
+        if role in _SKIP_ROLES:
+            return  # drop system/developer/tool turns wholesale
+        for k, v in obj.items():
+            if k == "role":
+                continue
+            if isinstance(v, str):
+                seg = v.strip()
+                # Only collect text under known human/assistant roles, or when
+                # role is still unknown (many formats put the first user turn
+                # before any role tag). Never collect once role is a skip-role.
+                collectable = role in _HUMAN_ROLES or role is None
+                if (k in _TEXT_KEYS and seg and collectable
+                        and not _NOISE_RE.search(seg)
+                        and not _BOILERPLATE_RE.match(seg)):
+                    out.append(seg)
+            else:
+                _harvest_text(v, out, depth + 1, role)
+    elif isinstance(obj, list):
+        for item in obj:
+            _harvest_text(item, out, depth + 1, role)
+
+
+def _filter_codex(path: Path) -> str:
+    """Codex JSONL. The clean conversation lives in `event_msg` records of
+    subtype user_message / agent_message (the `message` field). We target those
+    exclusively — `response_item/message` duplicates the assistant text AND
+    carries the AGENTS.md / <permissions> injections, `reasoning` is encrypted,
+    and function_call(_output) is tool noise. All dropped."""
+    parts: list[str] = []
+    found_event_msg = False
+    try:
+        with path.open("r", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("type") != "event_msg":
+                    continue
+                p = rec.get("payload", {})
+                if not isinstance(p, dict) or p.get("type") not in ("user_message", "agent_message"):
+                    continue
+                found_event_msg = True
+                msg = p.get("message")
+                if isinstance(msg, str) and msg.strip() and not _NOISE_RE.search(msg) \
+                        and not _BOILERPLATE_RE.match(msg.strip()):
+                    parts.append(msg.strip())
+    except OSError:
+        return ""
+    # Fallback for older codex formats with no event_msg stream.
+    if not found_event_msg:
+        return _filter_json_messages(path) if path.suffix == ".json" else ""
+    return _join(parts)
+
+
+def _filter_json_messages(path: Path) -> str:
+    """Gemini & Hermes: single JSON object with a `messages[]` array."""
+    try:
+        data = json.loads(path.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    parts: list[str] = []
+    msgs = data.get("messages") if isinstance(data, dict) else None
+    _harvest_text(msgs if msgs is not None else data, parts)
+    return _join(parts)
+
+
+def _join(parts: list[str]) -> str:
+    seen, uniq = set(), []
+    for p in parts:
+        key = p[:120]
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(p)
+    text = "\n".join(uniq).strip()
+    return text[:PER_SESSION_CHAR_CAP]
+
+
+PROVIDERS = {
+    "codex":  (lambda: sorted(CODEX_SESSIONS.rglob("rollout-*.jsonl")), _filter_codex),
+    "gemini": (lambda: sorted(GEMINI_ROOT.rglob("session-*.json")),     _filter_json_messages),
+    "hermes": (lambda: sorted(HERMES_SESSIONS.glob("session_*.json")),  _filter_json_messages),
+}
+
+
+# ==============================================================================
+# Watermark
+# ==============================================================================
+
+def load_watermark() -> dict:
+    if WATERMARK_FILE.exists():
+        try:
+            return json.loads(WATERMARK_FILE.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {}
+
+
+def save_watermark(wm: dict) -> None:
+    WATERMARK_FILE.write_text(json.dumps(wm, indent=2))
+
+
+# ==============================================================================
+# Distillation via codex exec (gpt-5.5)
+# ==============================================================================
+
+_PROMPT = """You are performing a DREAM — distilling AI-agent session logs into \
+durable memory for a cross-provider memory store. The sessions below come from \
+the {provider} agent.
+
+Extract ONLY learnings that are durable, non-obvious, and worth remembering across \
+future sessions: converged workflows, recurring mistakes and their fixes, tooling \
+quirks, user preferences, environment facts, and architectural decisions.
+
+STRICT rules:
+- Skip anything transient (one-off task state, ephemeral file paths, "now doing X").
+- Skip anything a competent engineer would already know.
+- Each learning must stand alone without the session context.
+- Prefer FEWER, higher-signal learnings. An empty list is correct when the batch \
+holds nothing durable.
+- Keep each body to 1-3 sentences. Tags are short kebab-case topic labels.
+
+OUTPUT: Return ONLY a single JSON object, no prose and no markdown fences, shaped \
+exactly as: {{"learnings": [{{"title": "...", "body": "...", "tags": ["..."]}}]}}
+
+--- SESSIONS ---
+{body}
+"""
+
+
+def _extract_json_obj(text: str) -> dict | None:
+    """Parse a JSON object out of model output that may be fence-wrapped or
+    prefixed with prose."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```\s*$", "", text).strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        m = re.search(r"\{.*\}", text, re.DOTALL)
+        if not m:
+            return None
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            return None
+
+
+def claude_distill(provider: str, batch_text: str) -> list[dict] | None:
+    """Distill via headless `claude -p` (the subscription). Returns a list of
+    learning dicts on success (possibly empty == nothing durable in the batch),
+    or None on FAILURE (non-zero exit, no output, unparseable). Callers must
+    NOT advance the watermark past a None batch — those sessions get retried.
+    One consistent Claude engine for all providers."""
+    prompt = _PROMPT.format(provider=provider, body=batch_text)
+    # Prompt goes via STDIN, not argv — a full batch (~120 KB) exceeds the OS
+    # per-argument limit (MAX_ARG_STRLEN ~128 KB). `claude -p` with no positional
+    # reads instructions from stdin.
+    cmd = [
+        "timeout", str(CLAUDE_TIMEOUT), CLAUDE_BIN, "-p",
+        "--output-format", "json", "--model", CLAUDE_MODEL,
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, input=prompt, cwd=_NEUTRAL_CWD,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+    except OSError as e:
+        sys.stderr.write(f"[distill] claude -p spawn error for {provider} batch: {e}\n")
+        return None  # transient/infra — abort provider, retry next run
+    if proc.returncode != 0 or not proc.stdout.strip():
+        sys.stderr.write(
+            f"[distill] claude -p FAILED (rc={proc.returncode}) for {provider} batch: "
+            f"{(proc.stderr or proc.stdout or '')[:300]}\n"
+        )
+        return None
+    envelope = _extract_json_obj(proc.stdout)
+    if not envelope:
+        sys.stderr.write(f"[distill] claude -p unparseable envelope for {provider} batch\n")
+        return None
+    # A subscription error surfaces inside the envelope, not via exit code.
+    if isinstance(envelope, dict) and envelope.get("is_error"):
+        sys.stderr.write(
+            f"[distill] claude -p envelope error for {provider} batch: "
+            f"{str(envelope.get('result') or envelope.get('api_error_status'))[:200]}\n"
+        )
+        return None
+    # `claude -p --output-format json` wraps the answer in `.result`.
+    inner = envelope.get("result", envelope) if isinstance(envelope, dict) else None
+    parsed = _extract_json_obj(inner) if isinstance(inner, str) else inner
+    if not isinstance(parsed, dict):
+        # Claude REPLIED but the result wasn't JSON (prose, refusal, garbled).
+        # This is a content problem with THIS batch, not an infra failure —
+        # return [] (skip this batch, advance watermark, continue) rather than
+        # None (which would abort the whole provider and wedge it forever on a
+        # persistently-bad batch). The infra-failure paths above still return None.
+        sys.stderr.write(f"[distill] claude -p result not JSON for {provider} batch "
+                         f"— skipping this batch, continuing\n")
+        return []
+    out = parsed.get("learnings", [])
+    return [l for l in out if isinstance(l, dict) and l.get("title") and l.get("body")]
+
+
+# ==============================================================================
+# Memory-file emission (idempotent, content-hashed)
+# ==============================================================================
+
+def write_learning(provider: str, learning: dict, dry_run: bool) -> Path | None:
+    title = learning["title"].strip()
+    body = learning["body"].strip()
+    tags = [str(t).strip() for t in learning.get("tags", []) if str(t).strip()]
+    digest = hashlib.sha1(f"{provider}:{title}:{body}".encode()).hexdigest()[:8]
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:48] or "untitled"
+    fname = f"crossprovider_{provider}_{slug}_{digest}.md"
+    path = MEM_DIR / fname
+    content = (
+        "---\n"
+        f"name: crossprovider {provider} {slug}\n"
+        f"description: {title}\n"
+        "metadata:\n"
+        "  type: reference\n"
+        f"  source: {provider}\n"
+        f"  bridged: {datetime.now(timezone.utc).date().isoformat()}\n"
+        f"  tags: [{', '.join(tags)}]\n"
+        "---\n\n"
+        f"{body}\n\n"
+        f"*(Distilled from {provider} sessions by bridge-providers-to-dream; "
+        "the Claude dream consolidates and prunes these.)*\n"
+    )
+    if dry_run:
+        return path
+    path.write_text(content)
+    return path
+
+
+# ==============================================================================
+# Main per-provider run
+# ==============================================================================
+
+def run_provider(provider: str, args, watermark: dict) -> dict:
+    lister, filt = PROVIDERS[provider]
+    files = lister()
+    last_ts = 0.0 if args.backfill else float(watermark.get(provider, 0))
+    since_cut = (time.time() - args.since_days * 86400) if args.since_days else None
+
+    # Select sessions newer than watermark (and within --since-days if set).
+    pending = []
+    for f in files:
+        try:
+            mt = f.stat().st_mtime
+        except OSError:
+            continue
+        if mt <= last_ts:
+            continue
+        if since_cut and mt < since_cut:
+            continue
+        pending.append((mt, f))
+    pending.sort()
+    if args.limit:
+        pending = pending[: args.limit]
+
+    stats = {"provider": provider, "available": len(files), "pending": len(pending),
+             "distilled_sessions": 0, "learnings": 0, "batches": 0, "files": []}
+    if not pending:
+        return stats
+
+    max_learn = args.max_learnings_per_provider
+    high_water = last_ts
+    pending_skip_hw = last_ts  # advances over skipped (too-small) sessions only
+    batch: list[str] = []
+    batch_mts: list[float] = []
+
+    def flush() -> bool:
+        """Process the current batch. Returns True on success (watermark may
+        advance), False on distill FAILURE (watermark must hold so the batch
+        is retried next run)."""
+        nonlocal high_water
+        if not batch:
+            return True
+        stats["batches"] += 1
+        learnings = claude_distill(provider, "\n\n===== NEXT SESSION =====\n\n".join(batch))
+        if learnings is None:
+            batch.clear(); batch_mts.clear()
+            return False
+        for ln in learnings:
+            if max_learn and stats["learnings"] >= max_learn:
+                break
+            p = write_learning(provider, ln, args.dry_run)
+            if p:
+                stats["files"].append(p.name)
+            stats["learnings"] += 1
+        # Success: it is safe to advance past every session in this batch
+        # (and any skipped-small sessions we passed on the way to it).
+        high_water = max(high_water, pending_skip_hw, max(batch_mts))
+        batch.clear(); batch_mts.clear()
+        return True
+
+    aborted = False
+    for mt, f in pending:
+        text = filt(f)
+        if len(text) < MIN_SESSION_CHARS:
+            pending_skip_hw = max(pending_skip_hw, mt)
+            continue
+        header = f"[{provider}] {f.name} ({datetime.fromtimestamp(mt).date()})"
+        batch.append(f"{header}\n{text}")
+        batch_mts.append(mt)
+        stats["distilled_sessions"] += 1
+        if len(batch) >= args.batch_size:
+            ok = flush()
+            if not args.dry_run:
+                watermark[provider] = high_water
+                save_watermark(watermark)
+            if not ok:
+                # Distill failed (quota/timeout/transport) — stop this provider
+                # at the last good watermark; next run resumes here.
+                sys.stderr.write(f"[distill] {provider}: aborting run at watermark "
+                                 f"{high_water} after batch failure (will retry next run)\n")
+                aborted = True
+                break
+        if max_learn and stats["learnings"] >= max_learn:
+            break
+    if not aborted:
+        if flush():
+            # Final batch good — safe to advance over any trailing pure-skip tail.
+            high_water = max(high_water, pending_skip_hw)
+        else:
+            aborted = True
+
+    if not args.dry_run:
+        watermark[provider] = high_water
+        save_watermark(watermark)
+    stats["aborted"] = aborted
+    return stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--provider", choices=list(PROVIDERS) + ["all"], default="all")
+    ap.add_argument("--backfill", action="store_true",
+                    help="ignore watermark; process ALL history (token-heavy)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="distill but write no files and do not advance watermark")
+    ap.add_argument("--limit", type=int, default=0, help="cap sessions processed this run")
+    ap.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    ap.add_argument("--since-days", type=int, default=0,
+                    help="only sessions modified within N days")
+    ap.add_argument("--max-learnings-per-provider", type=int, default=0,
+                    help="cap learnings written per provider this run (0 = no cap)")
+    args = ap.parse_args()
+
+    if not MEM_DIR.exists():
+        sys.stderr.write(f"[distill] auto-memory dir not found: {MEM_DIR}\n")
+        return 1
+
+    providers = list(PROVIDERS) if args.provider == "all" else [args.provider]
+    watermark = load_watermark()
+
+    print(f"[distill] mode={'BACKFILL' if args.backfill else 'incremental'}"
+          f"{' DRY-RUN' if args.dry_run else ''} | engine=claude:{CLAUDE_MODEL} | mem={MEM_DIR}")
+    grand = {"learnings": 0, "sessions": 0}
+    for prov in providers:
+        st = run_provider(prov, args, watermark)
+        grand["learnings"] += st["learnings"]
+        grand["sessions"] += st["distilled_sessions"]
+        print(f"[distill] {prov}: available={st['available']} pending={st['pending']} "
+              f"distilled={st['distilled_sessions']} batches={st['batches']} "
+              f"learnings={st['learnings']}")
+        if args.dry_run and st["files"]:
+            print(f"           would write: {', '.join(st['files'][:10])}"
+                  + (" ..." if len(st["files"]) > 10 else ""))
+    print(f"[distill] TOTAL: {grand['sessions']} sessions -> {grand['learnings']} learnings")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/memory/distill-provider-sessions.py
+++ b/scripts/memory/distill-provider-sessions.py
@@ -45,10 +45,12 @@ Called by: scripts/memory/bridge-providers-to-dream.sh (cron, 04:00 daily)
 from __future__ import annotations
 
 import argparse
+import atexit
 import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -84,6 +86,7 @@ CLAUDE_MODEL = os.environ.get("DISTILL_MODEL", "haiku")
 CLAUDE_TIMEOUT = int(os.environ.get("DISTILL_TIMEOUT_SECONDS", "180"))
 # Neutral working dir for headless calls — no project CLAUDE.md to load.
 _NEUTRAL_CWD = tempfile.mkdtemp(prefix="distill-cwd-")
+atexit.register(shutil.rmtree, _NEUTRAL_CWD, ignore_errors=True)  # m1: no /tmp leak
 
 # --- Pre-filter / batching knobs ------------------------------------------------
 PER_SESSION_CHAR_CAP = int(os.environ.get("PER_SESSION_CHAR_CAP", "6000"))
@@ -97,12 +100,20 @@ _NOISE_RE = re.compile(r"(data:[^;]+;base64,|\b[A-Za-z0-9+/]{200,}={0,2})")
 
 # Roles whose content is conversation we want. System/developer/tool turns and
 # their boilerplate (sandbox/permissions/instructions blocks) are dropped.
-_HUMAN_ROLES = {"user", "assistant", "agent", "model", "human", "ai"}
-_SKIP_ROLES = {"system", "developer", "tool", "function", "tool_result"}
+# NOTE: providers tag turns differently — Hermes uses `role` (user/assistant/
+# tool), Gemini uses `type` (user/gemini). _harvest_text reads role-OR-type.
+_HUMAN_ROLES = {"user", "assistant", "agent", "model", "human", "ai", "gemini"}
+# Skip system/tool turns AND model chain-of-thought content-part types (N2:
+# Hermes/Codex assistant turns carry reasoning/summary_text parts = verbose
+# internal planning, not durable signal).
+_SKIP_ROLES = {"system", "developer", "tool", "function", "tool_result", "tool_call",
+               "reasoning", "summary_text", "thinking", "tool_use", "function_call",
+               "function_call_output", "functionresponse"}
 # System-prompt boilerplate fingerprints — drop any segment starting with these.
+# "you are \w+" catches "You are Hermes/Gemini/Claude/Codex/a ..." openers.
 _BOILERPLATE_RE = re.compile(
-    r"^\s*(<permissions|<user_instructions|<environment|<system|"
-    r"sandbox_mode|you are codex|you are a|# instructions\b|## instructions\b)",
+    r"^\s*(<permissions|<user_instructions|<environment|<system|<instructions|"
+    r"sandbox_mode|you are \w+|# agents\.md|# instructions\b|## instructions\b)",
     re.IGNORECASE,
 )
 
@@ -120,21 +131,29 @@ def _harvest_text(obj, out: list[str], depth: int = 0, role: str | None = None) 
         return
     if isinstance(obj, dict):
         # A role on this node governs its subtree (messages are role-tagged).
+        # Providers differ: Hermes tags with `role`, Gemini with `type`
+        # (user/gemini). Read whichever is present so the skip/human gates
+        # actually engage for both (B1: previously Gemini `type` was ignored,
+        # leaving role=None which made everything collectable).
         node_role = obj.get("role")
+        if not isinstance(node_role, str):
+            node_role = obj.get("type")
         if isinstance(node_role, str):
             role = node_role.lower()
         if role in _SKIP_ROLES:
             return  # drop system/developer/tool turns wholesale
         for k, v in obj.items():
-            if k == "role":
+            if k in ("role", "type"):
                 continue
             if isinstance(v, str):
                 seg = v.strip()
-                # Only collect text under known human/assistant roles, or when
-                # role is still unknown (many formats put the first user turn
-                # before any role tag). Never collect once role is a skip-role.
-                collectable = role in _HUMAN_ROLES or role is None
-                if (k in _TEXT_KEYS and seg and collectable
+                # Skip-roles already short-circuited above, so anything reaching
+                # here is user/assistant/unknown. Collect ONLY whitelisted text
+                # keys, and drop blob-noise + system-prompt boilerplate. (We do
+                # NOT gate on _HUMAN_ROLES here: nested content-parts get tagged
+                # type="text"/"output_text" etc., and gating would wrongly drop
+                # the actual message text — B1 follow-on.)
+                if (k in _TEXT_KEYS and seg
                         and not _NOISE_RE.search(seg)
                         and not _BOILERPLATE_RE.match(seg)):
                     out.append(seg)
@@ -175,9 +194,11 @@ def _filter_codex(path: Path) -> str:
                     parts.append(msg.strip())
     except OSError:
         return ""
-    # Fallback for older codex formats with no event_msg stream.
+    # No event_msg stream (unexpected for rollout-*.jsonl) — yield nothing
+    # rather than guessing; the lister only globs .jsonl so there is no .json
+    # path to fall back to anyway (m5: former fallback was dead code).
     if not found_event_msg:
-        return _filter_json_messages(path) if path.suffix == ".json" else ""
+        return ""
     return _join(parts)
 
 
@@ -187,16 +208,23 @@ def _filter_json_messages(path: Path) -> str:
         data = json.loads(path.read_text(errors="replace"))
     except (OSError, json.JSONDecodeError):
         return ""
+    # Only harvest the messages[] array. Do NOT fall back to the whole document
+    # (M2: that would expose top-level system_prompt / tool definitions — e.g.
+    # Hermes' 13 KB "You are Hermes Agent..." block).
+    if not isinstance(data, dict) or not isinstance(data.get("messages"), list):
+        return ""
     parts: list[str] = []
-    msgs = data.get("messages") if isinstance(data, dict) else None
-    _harvest_text(msgs if msgs is not None else data, parts)
+    _harvest_text(data["messages"], parts)
     return _join(parts)
 
 
 def _join(parts: list[str]) -> str:
+    # Dedup on the FULL segment (m3: a 120-char prefix collapsed distinct turns
+    # that share a common preamble, e.g. "The following content is untrusted
+    # review input...", dropping real content before the LLM saw it).
     seen, uniq = set(), []
     for p in parts:
-        key = p[:120]
+        key = hashlib.sha1(p.encode("utf-8", "replace")).digest()
         if key in seen:
             continue
         seen.add(key)
@@ -217,20 +245,36 @@ PROVIDERS = {
 # ==============================================================================
 
 def load_watermark() -> dict:
-    if WATERMARK_FILE.exists():
-        try:
-            return json.loads(WATERMARK_FILE.read_text())
-        except (OSError, json.JSONDecodeError):
-            pass
-    return {}
+    if not WATERMARK_FILE.exists():
+        return {}  # genuinely first run — start fresh
+    try:
+        return json.loads(WATERMARK_FILE.read_text())
+    except json.JSONDecodeError as e:
+        # M3: a corrupt (e.g. partially-written) watermark must NOT be treated as
+        # "never processed" — that would silently reprocess ALL history. Abort
+        # loudly so a human/cron-mail sees it; the file is preserved for repair.
+        sys.stderr.write(f"[distill] FATAL: watermark file corrupt ({e}); refusing to "
+                         f"reprocess all history. Inspect/repair {WATERMARK_FILE}\n")
+        sys.exit(2)
+    except OSError as e:
+        sys.stderr.write(f"[distill] FATAL: cannot read watermark: {e}\n")
+        sys.exit(2)
 
 
 def save_watermark(wm: dict) -> None:
-    WATERMARK_FILE.write_text(json.dumps(wm, indent=2))
+    # M3: atomic write — a reader never sees a truncated file. N1: per-PID tmp
+    # name so a still-running backfill and the daily cron don't fight over one
+    # tmp path (os.replace would FileNotFoundError). os.replace is atomic per
+    # writer; with two writers the final file is intact (last-write-wins) — not
+    # corrupt. There is still NO lock, so a concurrent run can lost-update the
+    # watermark; the deployment is a single daily cron, so this is acceptable.
+    tmp = WATERMARK_FILE.with_suffix(f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(wm, indent=2))
+    os.replace(tmp, WATERMARK_FILE)
 
 
 # ==============================================================================
-# Distillation via codex exec (gpt-5.5)
+# Distillation via headless `claude -p` (the subscription)
 # ==============================================================================
 
 _PROMPT = """You are performing a DREAM — distilling AI-agent session logs into \
@@ -255,6 +299,16 @@ exactly as: {{"learnings": [{{"title": "...", "body": "...", "tags": ["..."]}}]}
 --- SESSIONS ---
 {body}
 """
+
+
+# Prose signatures of a TRANSIENT failure surfaced inside an is_error:false
+# result (rate limit / overload / capacity). These should retry, not skip.
+_TRANSIENT_RE = re.compile(
+    r"(rate.?limit|overloaded|capacity|too many requests|try again|"
+    r"temporarily unavailable|unable to (process|respond|complete)|"
+    r"service is (busy|unavailable)|please retry|usage limit)",
+    re.IGNORECASE,
+)
 
 
 def _extract_json_obj(text: str) -> dict | None:
@@ -319,11 +373,18 @@ def claude_distill(provider: str, batch_text: str) -> list[dict] | None:
     inner = envelope.get("result", envelope) if isinstance(envelope, dict) else None
     parsed = _extract_json_obj(inner) if isinstance(inner, str) else inner
     if not isinstance(parsed, dict):
-        # Claude REPLIED but the result wasn't JSON (prose, refusal, garbled).
-        # This is a content problem with THIS batch, not an infra failure —
-        # return [] (skip this batch, advance watermark, continue) rather than
-        # None (which would abort the whole provider and wedge it forever on a
-        # persistently-bad batch). The infra-failure paths above still return None.
+        # Claude REPLIED but the result wasn't JSON. Two sub-cases:
+        #  (a) TRANSIENT prose (rate-limited / overloaded / "try again") inside
+        #      an is_error:false envelope -> return None so the provider aborts
+        #      and retries next run (M4: otherwise these sessions are silently
+        #      lost by advancing the watermark over an "empty" batch).
+        #  (b) genuine garbled/refusal content -> return [] (skip THIS batch,
+        #      continue) so one poison batch can't wedge the whole provider.
+        result_text = inner if isinstance(inner, str) else str(inner)
+        if _TRANSIENT_RE.search(result_text or ""):
+            sys.stderr.write(f"[distill] claude -p TRANSIENT prose for {provider} batch "
+                             f"— aborting provider, will retry next run\n")
+            return None
         sys.stderr.write(f"[distill] claude -p result not JSON for {provider} batch "
                          f"— skipping this batch, continuing\n")
         return []
@@ -380,7 +441,13 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
             mt = f.stat().st_mtime
         except OSError:
             continue
-        if mt <= last_ts:
+        # B2: strict `<`, not `<=`. With `<=` a session whose mtime exactly
+        # equals the watermark (mtime ties under burst writes) is excluded
+        # FOREVER = silent data loss. With `<`, boundary-mtime sessions are
+        # re-processed each run instead — harmless because output filenames are
+        # content-hashed (idempotent overwrite), and bounded to the few files
+        # sharing the max mtime. Gap-free beats a handful of redundant calls.
+        if mt < last_ts:
             continue
         if since_cut and mt < since_cut:
             continue
@@ -412,9 +479,11 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
         if learnings is None:
             batch.clear(); batch_mts.clear()
             return False
+        # Write ALL learnings from a successfully-distilled batch. (M1: never
+        # truncate mid-batch — that dropped learnings #N+1.. AND advanced the
+        # watermark past their sessions = data loss. The cap instead stops us
+        # from STARTING new batches, in the intake loop below.)
         for ln in learnings:
-            if max_learn and stats["learnings"] >= max_learn:
-                break
             p = write_learning(provider, ln, args.dry_run)
             if p:
                 stats["files"].append(p.name)

--- a/scripts/memory/distill-provider-sessions.py
+++ b/scripts/memory/distill-provider-sessions.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 
 import argparse
 import atexit
+import contextlib
+import fcntl
 import hashlib
 import json
 import os
@@ -72,6 +74,87 @@ DEFAULT_MEM_DIR = HOME / ".claude" / "projects" / "-mnt-local-analysis-workspace
 MEM_DIR = Path(os.environ.get("CLAUDE_AUTO_MEMORY_DIR", str(DEFAULT_MEM_DIR)))
 
 WATERMARK_FILE = MEM_DIR / ".provider-bridge-watermark.json"
+
+# --- Non-JSON "poison" handling (#2845) ---------------------------------------
+# A garbled (non-JSON, non-transient) distill response must NOT be confused with
+# a valid-but-empty {"learnings": []}. The POISON sentinel breaks that collision.
+# It is a NAMED, NON-FALSY singleton compared by identity ONLY — a falsy sentinel
+# could be routed into the empty-success path by a future `if not learnings:` edit.
+class _Poison:
+    __slots__ = ()
+    def __repr__(self) -> str:  # legible in logs / tracebacks / dead-letter reason
+        return "<POISON>"
+    def __bool__(self) -> bool:  # explicit: never falsy
+        return True
+
+
+POISON = _Poison()
+
+# A garbled batch HOLDS the watermark and is retried, bounded by MAX_POISON_RETRIES
+# plain-incremental runs, keyed on a CONTENT DIGEST of the batch's session paths
+# (batch identity is not stable across runs — re-glob/re-sort/new-sessions reshape
+# it, so the watermark float is the wrong key). After the cap (or AGE_ESCAPE_DAYS
+# of continuous hold) the batch is dead-lettered and the watermark advances, so a
+# permanently-poison batch can never wedge the provider forever.
+MAX_POISON_RETRIES = int(os.environ.get("MAX_POISON_RETRIES", "3"))
+AGE_ESCAPE_DAYS = int(os.environ.get("POISON_AGE_ESCAPE_DAYS", "7"))
+POISON_FILE = MEM_DIR / ".provider-bridge-poison.json"      # {provider: {sig, attempts, first_ts}}
+DEADLETTER_FILE = MEM_DIR / ".provider-bridge-deadletter.jsonl"  # append-only audit log
+
+
+def _batch_sig(files: list[Path]) -> str:
+    """Stable identity for a batch = sha1 of its sorted session names."""
+    return hashlib.sha1("\n".join(sorted(f.name for f in files)).encode("utf-8", "replace")).hexdigest()
+
+
+@contextlib.contextmanager
+def _poison_lock():
+    """flock'd critical section for the poison-state read-modify-write so a
+    concurrent backfill + cron can't lost-update the retry counter."""
+    lock = POISON_FILE.with_suffix(".lock")
+    with lock.open("w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def _load_poison_state() -> dict:
+    if not POISON_FILE.exists():
+        return {}
+    try:
+        return json.loads(POISON_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}  # corrupt poison state is non-fatal — worst case re-counts from 0
+
+
+def _save_poison_state(state: dict) -> None:
+    tmp = POISON_FILE.with_suffix(f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(state, indent=2))
+    os.replace(tmp, POISON_FILE)
+
+
+def _clear_poison(provider: str) -> None:
+    with _poison_lock():
+        state = _load_poison_state()
+        if provider in state:
+            del state[provider]
+            _save_poison_state(state)
+
+
+def _deadletter_append(provider: str, files: list[Path], mts: list[float],
+                       reason: str, attempts: int) -> None:
+    rec = {
+        "provider": provider,
+        "sessions": [f.name for f in files],
+        "mtimes": list(mts),
+        "reason": reason,
+        "attempts": attempts,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+    with DEADLETTER_FILE.open("a") as fh:
+        fh.write(json.dumps(rec) + "\n")
 
 # --- Distiller backend: Claude itself, headless, on the subscription ----------
 # "Get Claude to do the dreaming" — dreaming is a Claude-native capability, so
@@ -378,16 +461,18 @@ def claude_distill(provider: str, batch_text: str) -> list[dict] | None:
         #      an is_error:false envelope -> return None so the provider aborts
         #      and retries next run (M4: otherwise these sessions are silently
         #      lost by advancing the watermark over an "empty" batch).
-        #  (b) genuine garbled/refusal content -> return [] (skip THIS batch,
-        #      continue) so one poison batch can't wedge the whole provider.
+        #  (b) genuine garbled/refusal content -> return POISON (#2845: distinct
+        #      from valid-empty []). The caller HOLDS + retries (bounded), then
+        #      dead-letters — instead of the old `return []` that advanced the
+        #      watermark over the batch = silent data loss.
         result_text = inner if isinstance(inner, str) else str(inner)
         if _TRANSIENT_RE.search(result_text or ""):
             sys.stderr.write(f"[distill] claude -p TRANSIENT prose for {provider} batch "
                              f"— aborting provider, will retry next run\n")
             return None
         sys.stderr.write(f"[distill] claude -p result not JSON for {provider} batch "
-                         f"— skipping this batch, continuing\n")
-        return []
+                         f"— POISON (will hold + retry, then dead-letter)\n")
+        return POISON
     out = parsed.get("learnings", [])
     return [l for l in out if isinstance(l, dict) and l.get("title") and l.get("body")]
 
@@ -457,7 +542,8 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
         pending = pending[: args.limit]
 
     stats = {"provider": provider, "available": len(files), "pending": len(pending),
-             "distilled_sessions": 0, "learnings": 0, "batches": 0, "files": []}
+             "distilled_sessions": 0, "learnings": 0, "batches": 0,
+             "deadlettered_sessions": 0, "files": []}
     if not pending:
         return stats
 
@@ -466,19 +552,32 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
     pending_skip_hw = last_ts  # advances over skipped (too-small) sessions only
     batch: list[str] = []
     batch_mts: list[float] = []
+    batch_files: list[Path] = []
+    # flush() stashes a poison batch's identity here (it clears the working lists)
+    # so handle_poison() can bounded-retry / dead-letter it (#2845).
+    poison_files: list[Path] = []
+    poison_mts: list[float] = []
 
-    def flush() -> bool:
-        """Process the current batch. Returns True on success (watermark may
-        advance), False on distill FAILURE (watermark must hold so the batch
-        is retried next run)."""
-        nonlocal high_water
+    def flush() -> str:
+        """Process the current batch. Returns:
+          'noop'   — empty batch, nothing to do.
+          'ok'     — distilled (learnings possibly empty); watermark advanced.
+          'hold'   — transient failure (None); watermark MUST hold, retry next run.
+          'poison' — non-JSON garble; batch stashed for handle_poison() (#2845).
+        Previously this returned [] for BOTH valid-empty AND garble, so the caller
+        advanced the watermark over garbled batches = silent data loss."""
+        nonlocal high_water, poison_files, poison_mts
         if not batch:
-            return True
+            return "noop"
         stats["batches"] += 1
         learnings = claude_distill(provider, "\n\n===== NEXT SESSION =====\n\n".join(batch))
         if learnings is None:
-            batch.clear(); batch_mts.clear()
-            return False
+            batch.clear(); batch_mts.clear(); batch_files.clear()
+            return "hold"
+        if learnings is POISON:
+            poison_files = list(batch_files); poison_mts = list(batch_mts)
+            batch.clear(); batch_mts.clear(); batch_files.clear()
+            return "poison"
         # Write ALL learnings from a successfully-distilled batch. (M1: never
         # truncate mid-batch — that dropped learnings #N+1.. AND advanced the
         # watermark past their sessions = data loss. The cap instead stops us
@@ -491,8 +590,46 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
         # Success: it is safe to advance past every session in this batch
         # (and any skipped-small sessions we passed on the way to it).
         high_water = max(high_water, pending_skip_hw, max(batch_mts))
-        batch.clear(); batch_mts.clear()
-        return True
+        batch.clear(); batch_mts.clear(); batch_files.clear()
+        return "ok"
+
+    def handle_poison() -> str:
+        """Bounded-retry + dead-letter for the stashed poison batch (#2845).
+        Returns 'hold' (abort provider, retry next run) or 'deadlettered'
+        (recorded + advanced past it). Counting happens ONLY on plain incremental
+        runs — --limit/--since-days/--backfill reshape the window so their batches
+        are not comparable across runs (they just hold). Keyed on a content digest
+        of the batch's session paths (the watermark float is NOT a stable key)."""
+        nonlocal high_water
+        if args.limit or args.since_days or args.backfill:
+            return "hold"
+        sig = _batch_sig(poison_files)
+        now = time.time()
+        with _poison_lock():
+            state = _load_poison_state()
+            ps = state.get(provider)
+            # first_ts tracks CONTINUOUS poison-hold: carries across sig changes
+            # (a batch that keeps absorbing new sessions), cleared only on recovery.
+            first_ts = ps["first_ts"] if ps else now
+            attempts = (ps["attempts"] + 1) if (ps and ps.get("sig") == sig) else 1
+            age_exceeded = (now - first_ts) > AGE_ESCAPE_DAYS * 86400
+            if attempts >= MAX_POISON_RETRIES or age_exceeded:
+                reason = "age_escape" if (age_exceeded and attempts < MAX_POISON_RETRIES) else "max_retries"
+                if not args.dry_run:
+                    _deadletter_append(provider, poison_files, poison_mts, reason, attempts)
+                    state.pop(provider, None)
+                    _save_poison_state(state)
+                stats["deadlettered_sessions"] += len(poison_files)
+                sys.stderr.write(f"[distill] {provider}: DEAD-LETTERED {len(poison_files)} session(s) "
+                                 f"after {attempts} attempt(s) (reason={reason})\n")
+                high_water = max(high_water, pending_skip_hw, max(poison_mts))
+                return "deadlettered"
+            if not args.dry_run:
+                state[provider] = {"sig": sig, "attempts": attempts, "first_ts": first_ts}
+                _save_poison_state(state)
+            sys.stderr.write(f"[distill] {provider}: poison batch HELD "
+                             f"(attempt {attempts}/{MAX_POISON_RETRIES}); retry next run\n")
+            return "hold"
 
     aborted = False
     for mt, f in pending:
@@ -503,26 +640,36 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
         header = f"[{provider}] {f.name} ({datetime.fromtimestamp(mt).date()})"
         batch.append(f"{header}\n{text}")
         batch_mts.append(mt)
+        batch_files.append(f)
         stats["distilled_sessions"] += 1
         if len(batch) >= args.batch_size:
-            ok = flush()
+            status = flush()
+            if status == "poison":
+                status = handle_poison()          # -> 'hold' or 'deadlettered'
+            elif status == "ok" and not args.dry_run:
+                _clear_poison(provider)           # recovery resets the counter
             if not args.dry_run:
                 watermark[provider] = high_water
                 save_watermark(watermark)
-            if not ok:
-                # Distill failed (quota/timeout/transport) — stop this provider
-                # at the last good watermark; next run resumes here.
+            if status == "hold":
                 sys.stderr.write(f"[distill] {provider}: aborting run at watermark "
-                                 f"{high_water} after batch failure (will retry next run)\n")
+                                 f"{high_water} (will retry next run)\n")
                 aborted = True
                 break
+            # 'ok' / 'deadlettered' -> continue intake
         if max_learn and stats["learnings"] >= max_learn:
             break
+
     if not aborted:
-        if flush():
-            # Final batch good — safe to advance over any trailing pure-skip tail.
+        status = flush()
+        if status == "poison":
+            status = handle_poison()
+        if status in ("ok", "noop", "deadlettered"):
+            if status == "ok" and not args.dry_run:
+                _clear_poison(provider)
+            # Safe to advance over any trailing pure-skip tail.
             high_water = max(high_water, pending_skip_hw)
-        else:
+        elif status == "hold":
             aborted = True
 
     if not args.dry_run:
@@ -556,19 +703,23 @@ def main() -> int:
 
     print(f"[distill] mode={'BACKFILL' if args.backfill else 'incremental'}"
           f"{' DRY-RUN' if args.dry_run else ''} | engine=claude:{CLAUDE_MODEL} | mem={MEM_DIR}")
-    grand = {"learnings": 0, "sessions": 0}
+    grand = {"learnings": 0, "sessions": 0, "deadlettered": 0}
     for prov in providers:
         st = run_provider(prov, args, watermark)
         grand["learnings"] += st["learnings"]
         grand["sessions"] += st["distilled_sessions"]
+        grand["deadlettered"] += st.get("deadlettered_sessions", 0)
         print(f"[distill] {prov}: available={st['available']} pending={st['pending']} "
               f"distilled={st['distilled_sessions']} batches={st['batches']} "
-              f"learnings={st['learnings']}")
+              f"learnings={st['learnings']} deadlettered={st.get('deadlettered_sessions', 0)}")
         if args.dry_run and st["files"]:
             print(f"           would write: {', '.join(st['files'][:10])}"
                   + (" ..." if len(st["files"]) > 10 else ""))
-    print(f"[distill] TOTAL: {grand['sessions']} sessions -> {grand['learnings']} learnings")
-    return 0
+    dl = grand["deadlettered"]
+    print(f"[distill] TOTAL: {grand['sessions']} sessions -> {grand['learnings']} learnings"
+          + (f" | {dl} DEAD-LETTERED (see {DEADLETTER_FILE.name})" if dl else ""))
+    # rc=3 surfaces dead-lettered (silently-lost-before-this-fix) sessions to cron mail.
+    return 3 if dl else 0
 
 
 if __name__ == "__main__":

--- a/scripts/memory/distill-provider-sessions.py
+++ b/scripts/memory/distill-provider-sessions.py
@@ -125,8 +125,13 @@ def _load_poison_state() -> dict:
         return {}
     try:
         return json.loads(POISON_FILE.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {}  # corrupt poison state is non-fatal — worst case re-counts from 0
+    except (OSError, json.JSONDecodeError) as e:
+        # Non-fatal, but NOT silent: a corrupt file resets attempts to 0 each run,
+        # so the MAX_POISON_RETRIES cap is unreachable and a poison batch escapes
+        # only via the slower AGE_ESCAPE_DAYS path (#2845 r2 F5). Surface it.
+        sys.stderr.write(f"[distill] WARN: poison-state unreadable ({e}); retry cap "
+                         f"degrades to age-escape until repaired: {POISON_FILE}\n")
+        return {}
 
 
 def _save_poison_state(state: dict) -> None:
@@ -155,6 +160,28 @@ def _deadletter_append(provider: str, files: list[Path], mts: list[float],
     }
     with DEADLETTER_FILE.open("a") as fh:
         fh.write(json.dumps(rec) + "\n")
+
+
+def _load_deadlettered_names() -> set[str]:
+    """Session names already dead-lettered — excluded permanently on intake so a
+    permanently-garbled session isn't re-distilled + re-dead-lettered every cycle
+    (#2845 r2 F2). Bounded: dead-letters are rare. Filenames are unique per provider."""
+    names: set[str] = set()
+    if not DEADLETTER_FILE.exists():
+        return names
+    try:
+        for line in DEADLETTER_FILE.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            names.update(rec.get("sessions", []))
+    except OSError:
+        pass
+    return names
 
 # --- Distiller backend: Claude itself, headless, on the subscription ----------
 # "Get Claude to do the dreaming" — dreaming is a Claude-native capability, so
@@ -518,10 +545,18 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
     files = lister()
     last_ts = 0.0 if args.backfill else float(watermark.get(provider, 0))
     since_cut = (time.time() - args.since_days * 86400) if args.since_days else None
+    # Sessions already dead-lettered are skipped PERMANENTLY (#2845 r2 F2): the
+    # strict-`<` watermark below re-globs the boundary session, so without this a
+    # permanently-garbled newest session would be re-distilled and re-dead-lettered
+    # every MAX_POISON_RETRIES runs (duplicate audit records + recurring false rc=3).
+    # Session filenames are unique per provider, so name-skipping is safe.
+    deadlettered = _load_deadlettered_names()
 
     # Select sessions newer than watermark (and within --since-days if set).
     pending = []
     for f in files:
+        if f.name in deadlettered:
+            continue
         try:
             mt = f.stat().st_mtime
         except OSError:
@@ -601,7 +636,12 @@ def run_provider(provider: str, args, watermark: dict) -> dict:
         are not comparable across runs (they just hold). Keyed on a content digest
         of the batch's session paths (the watermark float is NOT a stable key)."""
         nonlocal high_water
-        if args.limit or args.since_days or args.backfill:
+        # dry-run never progresses state: no lock, no counter, no dead-letter, no
+        # advance (#2845 r2 F1/F4 — otherwise a dry-run over pre-seeded poison
+        # state phantom-incremented deadlettered_sessions => false rc=3, and
+        # leaked a .lock file). --limit/--since-days/--backfill reshape the window
+        # so their batches aren't comparable across runs — they just hold too.
+        if args.dry_run or args.limit or args.since_days or args.backfill:
             return "hold"
         sig = _batch_sig(poison_files)
         now = time.time()

--- a/scripts/memory/tests/test_distill_poison_handling.py
+++ b/scripts/memory/tests/test_distill_poison_handling.py
@@ -254,3 +254,100 @@ def test_watermark_schema_backward_compatible(mod, tmp_path, monkeypatch):
     st = mod.run_provider("codex", _args(), wm)
     assert float(wm.get("codex")) == 123.0
     assert st["pending"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# r2 review fixes — mid-loop path (F3), dry-run preseeded (F1), re-deadletter
+# loop (F2), age-escape (F3 gap)
+# --------------------------------------------------------------------------- #
+
+def test_mid_loop_poison_holds(mod, tmp_path, monkeypatch):
+    """F3: with batch_size=1 the MID-LOOP flush fires (not just trailing). A poison
+    mid-loop batch must hold + abort, exercising the previously-untested path."""
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    st = mod.run_provider("codex", _args(batch_size=1), wm)
+    assert wm.get("codex", 0) == 0
+    assert st["batches"] >= 1
+    import json
+    assert json.loads((mod.MEM_DIR / ".provider-bridge-poison.json").read_text())["codex"]["attempts"] == 1
+
+
+def test_mid_loop_recovery_advances(mod, tmp_path, monkeypatch):
+    """F3: batch_size=1, two good batches via the mid-loop path -> both written, advanced."""
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill",
+                        lambda p, t: [{"title": "t", "body": "b", "tags": []}])
+    wm = {}
+    st = mod.run_provider("codex", _args(batch_size=1), wm)
+    assert st["learnings"] == 2
+    assert wm.get("codex", 0) > 0
+
+
+def test_mid_loop_dead_letter_then_continue(mod, tmp_path, monkeypatch):
+    """F3: mid-loop dead-letter of batch-1 must NOT lose batch-2 (the continue path)."""
+    files = _fake_sessions(mod, tmp_path, n=2)
+    import json, time as _t
+    sig0 = mod._batch_sig([files[0]])
+    # Pre-seed batch-0 at the cap edge so its mid-loop poison dead-letters this run.
+    (mod.MEM_DIR / ".provider-bridge-poison.json").write_text(
+        json.dumps({"codex": {"sig": sig0, "attempts": mod.MAX_POISON_RETRIES - 1, "first_ts": _t.time()}}))
+    monkeypatch.setattr(mod, "claude_distill",
+                        lambda p, t: mod.POISON if "rollout-0" in t
+                        else [{"title": "t", "body": "b", "tags": []}])
+    wm = {}
+    st = mod.run_provider("codex", _args(batch_size=1), wm)
+    assert st["deadlettered_sessions"] == 1          # batch-0 dead-lettered
+    assert st["learnings"] == 1                       # batch-1 STILL processed (continue worked)
+    assert "rollout-0.jsonl" in (mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").read_text()
+
+
+def test_dry_run_preseeded_no_phantom_rc3(mod, tmp_path, monkeypatch):
+    """F1: a --dry-run over poison state pre-seeded near the cap must NOT phantom-
+    increment deadlettered_sessions (which would make main() return 3) nor leak a .lock."""
+    files = _fake_sessions(mod, tmp_path, n=2)
+    import json, time as _t
+    sig = mod._batch_sig(files)
+    (mod.MEM_DIR / ".provider-bridge-poison.json").write_text(
+        json.dumps({"codex": {"sig": sig, "attempts": mod.MAX_POISON_RETRIES - 1, "first_ts": _t.time()}}))
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    st = mod.run_provider("codex", _args(dry_run=True), wm)
+    assert st["deadlettered_sessions"] == 0
+    assert not (mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").exists()
+    assert not (mod.MEM_DIR / ".provider-bridge-poison.lock").exists()
+
+
+def test_deadlettered_session_skipped_on_reintake(mod, tmp_path, monkeypatch):
+    """F2: once dead-lettered, a session is excluded from intake forever — no
+    re-distill + duplicate dead-letter record on subsequent runs."""
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    for _ in range(mod.MAX_POISON_RETRIES):
+        wm = mod.load_watermark()
+        mod.run_provider("codex", _args(), wm)
+    dl = mod.MEM_DIR / ".provider-bridge-deadletter.jsonl"
+    lines_after_first = len(dl.read_text().splitlines())
+    # Several more runs must NOT re-dead-letter the same sessions.
+    for _ in range(3):
+        wm = mod.load_watermark()
+        st = mod.run_provider("codex", _args(), wm)
+        assert st["pending"] == 0          # dead-lettered sessions excluded from intake
+    assert len(dl.read_text().splitlines()) == lines_after_first   # no duplicates
+
+
+def test_age_escape_deadletters_stale_hold(mod, tmp_path, monkeypatch):
+    """F3 gap: a batch whose sig changes every run (absorbs new sessions) still
+    dead-letters once first_ts exceeds AGE_ESCAPE_DAYS, even though attempts<MAX."""
+    _fake_sessions(mod, tmp_path, n=2)
+    import json, time as _t
+    old = _t.time() - (mod.AGE_ESCAPE_DAYS + 1) * 86400
+    (mod.MEM_DIR / ".provider-bridge-poison.json").write_text(
+        json.dumps({"codex": {"sig": "stale-different-sig", "attempts": 1, "first_ts": old}}))
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    st = mod.run_provider("codex", _args(), wm)
+    assert st["deadlettered_sessions"] == 2
+    rec = json.loads((mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").read_text().splitlines()[0])
+    assert rec["reason"] == "age_escape"

--- a/scripts/memory/tests/test_distill_poison_handling.py
+++ b/scripts/memory/tests/test_distill_poison_handling.py
@@ -1,0 +1,256 @@
+"""TDD suite for #2845 — non-JSON poison handling in the cross-provider dream distiller.
+
+The distiller (`scripts/memory/distill-provider-sessions.py`) previously returned `[]`
+for BOTH "Claude returned valid {"learnings":[]}" AND "Claude returned non-JSON garble".
+The caller advanced the watermark over garbled batches => silent data loss.
+
+This suite pins the fixed contract:
+  - `claude_distill` returns the `POISON` sentinel (not []) for non-JSON, non-transient output.
+  - garbled batches HOLD the watermark and are retried (bounded by MAX_POISON_RETRIES),
+    keyed on a content digest of the batch's session paths (batch identity is not stable).
+  - after MAX_POISON_RETRIES (or AGE_ESCAPE_DAYS of continuous hold) the batch is
+    dead-lettered to an auditable JSONL file and the watermark advances (no permanent wedge).
+  - `main()` exits non-zero when any sessions were dead-lettered.
+  - dry-run writes neither the dead-letter file, the watermark, nor poison state.
+
+The script is kebab-named (not importable as a package), so we load it via importlib with
+the auto-memory dir redirected to a tmp path BEFORE import (module-level paths derive from it).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "distill-provider-sessions.py"
+
+
+def _load_module(mem_dir: Path):
+    """Import the kebab-named script with MEM_DIR redirected to `mem_dir`."""
+    import os
+    os.environ["CLAUDE_AUTO_MEMORY_DIR"] = str(mem_dir)
+    spec = importlib.util.spec_from_file_location("distill_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so any @dataclass/forward refs resolve (defensive).
+    sys.modules["distill_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod(tmp_path):
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    m = _load_module(mem)
+    # Sanity: the new public surface must exist.
+    assert hasattr(m, "POISON"), "POISON sentinel missing"
+    return m
+
+
+def _args(**over):
+    base = dict(provider="codex", backfill=False, dry_run=False, limit=0,
+                batch_size=8, since_days=0, max_learnings_per_provider=0)
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def _fake_sessions(mod, tmp_path, n=2, base_mtime=1_000_000.0):
+    """Create n fake session files and point PROVIDERS[codex] at them with a
+    filter that always yields enough text to clear MIN_SESSION_CHARS."""
+    files = []
+    d = tmp_path / "sessions"
+    d.mkdir(exist_ok=True)
+    for i in range(n):
+        f = d / f"rollout-{i}.jsonl"
+        f.write_text("x")
+        import os
+        os.utime(f, (base_mtime + i, base_mtime + i))
+        files.append(f)
+    mod.PROVIDERS = dict(mod.PROVIDERS)
+    mod.PROVIDERS["codex"] = (lambda: sorted(files), lambda p: "DURABLE LEARNING TEXT " * 30)
+    return files
+
+
+# --------------------------------------------------------------------------- #
+# claude_distill return contract
+# --------------------------------------------------------------------------- #
+
+def test_poison_sentinel_identity_invariant(mod):
+    """POISON must be a unique, NON-falsy singleton compared by identity — a falsy
+    sentinel could be routed into the empty-success path by a future refactor."""
+    assert mod.POISON is not None
+    assert mod.POISON != []
+    assert bool(mod.POISON) is True
+
+
+def test_claude_distill_returns_poison_on_non_json(mod, monkeypatch):
+    """Non-JSON, non-transient model output -> POISON (was []), distinct from valid-empty."""
+    class P:
+        returncode = 0
+        stdout = '{"type":"result","result":"sorry, here is some prose not json"}'
+        stderr = ""
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: P())
+    assert mod.claude_distill("codex", "body") is mod.POISON
+
+
+def test_claude_distill_valid_empty_is_list_not_poison(mod, monkeypatch):
+    """Valid {"learnings":[]} stays [] — genuinely nothing durable, safe to advance."""
+    class P:
+        returncode = 0
+        stdout = '{"type":"result","result":"{\\"learnings\\": []}"}'
+        stderr = ""
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: P())
+    out = mod.claude_distill("codex", "body")
+    assert out == [] and out is not mod.POISON
+
+
+# --------------------------------------------------------------------------- #
+# run_provider poison handling
+# --------------------------------------------------------------------------- #
+
+def test_valid_empty_advances_watermark(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: [])
+    wm = {}
+    st = mod.run_provider("codex", _args(), wm)
+    assert wm.get("codex", 0) > 0          # advanced
+    assert st.get("deadlettered_sessions", 0) == 0
+    assert not (mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").exists()
+
+
+def test_poison_holds_watermark_first_attempt(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    st = mod.run_provider("codex", _args(), wm)
+    assert wm.get("codex", 0) == 0         # held, not advanced
+    assert st.get("deadlettered_sessions", 0) == 0
+    pf = mod.MEM_DIR / ".provider-bridge-poison.json"
+    assert pf.exists()                      # attempt recorded
+    import json
+    assert json.loads(pf.read_text())["codex"]["attempts"] == 1
+
+
+def test_poison_retried_then_deadlettered(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    assert mod.MAX_POISON_RETRIES >= 1
+    last = None
+    for _ in range(mod.MAX_POISON_RETRIES):
+        wm = mod.load_watermark()
+        last = mod.run_provider("codex", _args(), wm)
+    # On the MAX-th run the batch is dead-lettered and the watermark advances.
+    assert last.get("deadlettered_sessions", 0) == 2
+    dl = mod.MEM_DIR / ".provider-bridge-deadletter.jsonl"
+    assert dl.exists() and dl.read_text().strip()
+    assert mod.load_watermark().get("codex", 0) > 0
+
+
+def test_transient_none_holds_watermark(mod, tmp_path, monkeypatch):
+    """Regression guard: transient None still HOLDS the watermark (existing behavior)."""
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: None)
+    wm = {}
+    mod.run_provider("codex", _args(), wm)
+    assert wm.get("codex", 0) == 0
+    assert not (mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").exists()
+
+
+def test_successful_batch_writes_and_advances(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    learning = {"title": "t", "body": "b", "tags": ["x"]}
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: [learning])
+    wm = {}
+    st = mod.run_provider("codex", _args(), wm)
+    assert wm.get("codex", 0) > 0
+    assert st["learnings"] == 1
+    assert list(mod.MEM_DIR.glob("crossprovider_codex_*.md"))
+
+
+def test_poison_counter_resets_after_success(mod, tmp_path, monkeypatch):
+    """A recovered provider drops its poison count so a later single garble
+    doesn't prematurely dead-letter."""
+    _fake_sessions(mod, tmp_path, n=2)
+    seq = [mod.POISON, [{"title": "t", "body": "b", "tags": []}]]
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: seq.pop(0))
+    for _ in range(2):
+        wm = mod.load_watermark()
+        mod.run_provider("codex", _args(), wm)
+    pf = mod.MEM_DIR / ".provider-bridge-poison.json"
+    state = {} if not pf.exists() else __import__("json").loads(pf.read_text())
+    assert state.get("codex") in (None, {})   # cleared on recovery
+
+
+def test_final_batch_only_poison(mod, tmp_path, monkeypatch):
+    """A sole sub-batch_size batch never hits the mid-loop flush — the trailing
+    flush path must apply identical poison handling."""
+    _fake_sessions(mod, tmp_path, n=2)        # 2 < batch_size 8
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    st = mod.run_provider("codex", _args(batch_size=8), wm)
+    assert wm.get("codex", 0) == 0            # held via trailing-flush poison path
+    assert (mod.MEM_DIR / ".provider-bridge-poison.json").exists()
+    assert st.get("deadlettered_sessions", 0) == 0
+
+
+def test_dry_run_no_deadletter_no_advance(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    for _ in range(mod.MAX_POISON_RETRIES + 1):
+        wm = mod.load_watermark()
+        mod.run_provider("codex", _args(dry_run=True), wm)
+    assert not (mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").exists()
+    assert not (mod.MEM_DIR / ".provider-bridge-poison.json").exists()
+    assert mod.load_watermark().get("codex", 0) == 0
+
+
+def test_limit_run_holds_without_counting(mod, tmp_path, monkeypatch):
+    """--limit reshapes the window, so poison under --limit must HOLD without
+    incrementing the counter (batches aren't comparable across runs)."""
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    wm = {}
+    mod.run_provider("codex", _args(limit=2), wm)
+    pf = mod.MEM_DIR / ".provider-bridge-poison.json"
+    # No poison-state counting under --limit (hold-only).
+    assert not pf.exists() or __import__("json").loads(pf.read_text()).get("codex") in (None, {})
+    assert wm.get("codex", 0) == 0
+
+
+def test_deadletter_record_shape(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    for _ in range(mod.MAX_POISON_RETRIES):
+        wm = mod.load_watermark()
+        mod.run_provider("codex", _args(), wm)
+    import json
+    rec = json.loads((mod.MEM_DIR / ".provider-bridge-deadletter.jsonl").read_text().splitlines()[0])
+    for key in ("provider", "sessions", "reason", "attempts", "ts"):
+        assert key in rec, f"dead-letter record missing {key}"
+    assert rec["provider"] == "codex"
+
+
+def test_main_exit_nonzero_on_deadletter(mod, tmp_path, monkeypatch):
+    _fake_sessions(mod, tmp_path, n=2)
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: mod.POISON)
+    monkeypatch.setattr(sys, "argv", ["distill", "--provider", "codex"])
+    # Drive MAX-1 holds first, then the MAX-th run via main() should dead-letter -> rc 3.
+    for _ in range(mod.MAX_POISON_RETRIES - 1):
+        wm = mod.load_watermark()
+        mod.run_provider("codex", _args(), wm)
+    assert mod.main() == 3
+
+
+def test_watermark_schema_backward_compatible(mod, tmp_path, monkeypatch):
+    """A legacy watermark with no poison machinery loads and is read as a float mtime."""
+    import json
+    (mod.MEM_DIR / ".provider-bridge-watermark.json").write_text(json.dumps({"codex": 123.0}))
+    _fake_sessions(mod, tmp_path, n=1, base_mtime=50.0)   # older than watermark -> nothing pending
+    monkeypatch.setattr(mod, "claude_distill", lambda *a, **k: [])
+    wm = mod.load_watermark()
+    st = mod.run_provider("codex", _args(), wm)
+    assert float(wm.get("codex")) == 123.0
+    assert st["pending"] == 0

--- a/scripts/review/results/2026-05-27-code-2845-claude.md
+++ b/scripts/review/results/2026-05-27-code-2845-claude.md
@@ -1,0 +1,20 @@
+# Code Review — #2845 (dream non-JSON dead-letter) — Claude (fresh-context subagent)
+
+- **Date:** 2026-05-28
+- **Stage:** code/artifact (adversarial), on committed diff 258c5c5d5
+- **Reviewer:** Claude fresh-context subagent; Codex/Gemini UNAVAILABLE from a Claude-Code session (#2721/#2715). T2 degraded to single-author + fresh-context per `feedback_permission_gate_blocks_cross_review`.
+- **Verdict:** MAJOR (diff) → all findings fixed in 040442f37.
+
+## Findings
+1. **[MAJOR] F1** dry-run phantom rc=3 — `handle_poison` incremented `deadlettered_sessions` + advanced `high_water` unconditionally; a dry-run over pre-seeded poison state returned rc=3 without writing. → dry-run short-circuits to "hold".
+2. **[MAJOR] F2** re-dead-letter loop — strict-`<` watermark re-globs the boundary session; a permanently-garbled newest session re-dead-lettered every MAX runs (dup records + recurring false rc=3). → permanent dead-letter skip-set on intake (`_load_deadlettered_names`).
+3. **[MAJOR] F3** mid-loop flush path untested (all tests `batch_size=8, n≤2`). → +6 tests incl. `batch_size=1` mid-loop (hold/recovery/dead-letter-then-continue), dry-run-preseeded, skip-set, age-escape.
+4. **[MINOR] F4** dry-run `.lock` leak → fixed by F1 short-circuit.
+5. **[MINOR] F5** corrupt poison file silently degrades cap to age-escape → now warns to stderr.
+6. **[MINOR] F6** MEM_DIR-readonly hard-crash — pre-existing behavior (watermark/learnings already assume writable); not newly introduced, deferred.
+
+## Confirmed correct (no defect)
+POISON identity/non-falsy; flock RMW atomicity; first_ts carry-across-sig + reset-on-recovery; off-by-one (3 iterations → dead-letter on 3rd); os.replace atomic save.
+
+## Resolution
+Fixed in 040442f37; full suite 21 passed. Code-stage cross-provider re-review recommended when dispatch is available.

--- a/scripts/review/results/2026-05-27-plan-2845-claude.md
+++ b/scripts/review/results/2026-05-27-plan-2845-claude.md
@@ -1,0 +1,20 @@
+# Plan Review — #2845 (dream non-JSON dead-letter) — Claude (fresh-context subagent)
+
+- **Date:** 2026-05-27
+- **Stage:** plan (adversarial)
+- **Reviewer:** Claude fresh-context subagent (general-purpose); cross-provider Codex/Gemini UNAVAILABLE from this session (CLAUDECODE=1 trips submit-to-codex guard, #2721/#2715) — T2 degraded to single-author + fresh-context per `feedback_permission_gate_blocks_cross_review`.
+- **Verdict:** MAJOR (draft) → all findings incorporated, plan revised.
+
+## Findings (verbatim severities)
+
+1. **[MAJOR]** Batch composition is NOT stable across runs; retry counter tracks a moving target. `run_provider` re-globs (`:433`) + re-sorts (`:455`) every run; new in-window sessions shift membership; `--limit` (`:456`), `--since-days` (`:435,452`), mtime rewrites all reshape the first batch. `high_water`-keyed counter is wrong. → Re-key on sha1 content digest of sorted batch session paths; scope counting to plain incremental runs.
+2. **[MAJOR]** `high_water` float-equality key fragile (subsumed by #1's content-digest fix).
+3. **[MAJOR]** `_poison` reserved key collides with `{provider: float}` watermark; `float(watermark.get(provider))` at `:434` and any future `.items()` loop crash. → Separate poison-state file.
+4. **[MAJOR→MINOR]** POISON sentinel type unpinned; falsy/list-subclass choices break existing guards. → Named non-falsy singleton, identity comparison only.
+5. **[MAJOR]** Trailing-batch flush (`:521-527`) unhandled; small incremental runs (< batch_size) never hit the mid-loop flush (`:507-518`). → Tri-state `flush()`, both call sites route through one `handle_poison()`.
+6. **[MINOR]** dry-run dead-letter/advance unguarded. → gate on `not dry_run`; test added.
+7. **[MINOR]** concurrent backfill clobbers `_poison` counter. → flock'd RMW + backfill excluded from counting.
+8. **[MINOR]** six test gaps. → all added to TDD list.
+
+## Resolution
+Plan revised 2026-05-27: Pseudocode, Files-to-Change, TDD list (8→15 tests), Risks, and this Review Summary updated. Result: PASS after revision. Code-stage re-review recommended when cross-provider dispatch is available.


### PR DESCRIPTION
## Summary

Lands the **cross-provider dream bridge** (#2833) — the distiller that feeds Codex/Gemini/Hermes sessions into the Claude dream (the canonical cross-provider memory consolidator) — **with the #2845 data-loss fix folded in** so the buggy distiller never ships to `main`.

This branch was already running in production via an on-disk copy + a hand-installed 04:00 cron, but had **never merged** — meaning a known data-loss bug (#2845) was live but unreviewed on `main`. Folding the fix in before merge is deliberate.

## What's included
- **#2833** cross-provider dream bridge: `scripts/memory/distill-provider-sessions.py` + `bridge-providers-to-dream.sh` (already adversarially reviewed — see commit `083283740`).
- **#2845** data-loss fix (this PR's new commit `258c5c5d5`):
  - `claude_distill()` returned `[]` for BOTH valid-empty `{"learnings":[]}` AND non-JSON garble → caller advanced the watermark over garbled batches → **silent loss** (live: `rc=0` despite `result not JSON ... skipping`).
  - `POISON` sentinel (named, non-falsy, identity-compared) breaks the collision.
  - Tri-state `flush()`; both mid-loop **and** trailing-batch paths route poison through one `handle_poison()` (small daily runs only ever hit the trailing flush).
  - Bounded retry keyed on a **content digest** of the batch's session paths (the watermark float is not a stable batch key), in a **separate flock'd** `.provider-bridge-poison.json` (not overloaded into the watermark dict). Counts only on plain incremental runs.
  - **Age-escape** (`AGE_ESCAPE_DAYS=7`): a batch that keeps absorbing new sessions still dead-letters after continuous-hold timeout.
  - After `MAX_POISON_RETRIES=3` (or age-escape), the batch is appended to an auditable `.provider-bridge-deadletter.jsonl` and the watermark advances (no permanent wedge). `main()` exits `3`; the wrapper logs a `WARN`.

## Tests
`scripts/memory/tests/test_distill_poison_handling.py` — 15 tests, RED→GREEN:
```
15 passed in 0.15s   (uv run --no-project --with pytest python -m pytest scripts/memory/tests/)
```
Covers: POISON-vs-`[]` distinction, hold-then-dead-letter, sig-change reset, plain-incremental-only counting, trailing-batch-only poison, dry-run no-op, age-escape, dead-letter record shape, `main()` rc=3, watermark backward-compat.

## Review status (do NOT merge until complete)
- **Plan-stage adversarial review:** DONE — fresh-context subagent returned MAJOR; all 8 findings incorporated (`scripts/review/results/2026-05-27-plan-2845-claude.md`).
- **Code-stage adversarial review:** PENDING — cross-provider Codex/Gemini dispatch is blocked from a Claude-Code session (`CLAUDECODE=1`, #2721/#2715). A code-stage review should run before merge.
- **Completeness gate:** #2833 carries scorecards (78%→88%); recompute after this fix.

## Plan & approval
- Plan: `docs/plans/2026-05-27-issue-2845-dream-nonjson-deadletter.md`
- Approval marker: `.planning/plan-approved/2845.md`

Closes #2833
Closes #2845
