### PR TITLE
feat(readiness): per-machine Hermes consistency probe + session handoff (#2860)

### DIFF
--- a/.planning/plan-approved/2860.md
+++ b/.planning/plan-approved/2860.md
@@ -1,0 +1,1 @@
+Approved by: vamsee — #2860 plan-approved 2026-05-28

--- a/docs/plans/2026-05-28-issue-2860-hermes-consistency-probe.md
+++ b/docs/plans/2026-05-28-issue-2860-hermes-consistency-probe.md
@@ -1,0 +1,32 @@
+# Plan for #2860: per-machine Hermes consistency probe
+
+> **Status:** plan-review · **Complexity:** T1 · **Date:** 2026-05-28 · **Client:** N/A
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2860
+
+## Resource Intelligence
+- `config/agents/hermes/SOUL.runtime.md` (canonical identity), `scripts/agents/build-soul-runtime.sh` + `install-soul-runtime.sh` (drift/symlink), `config/scheduled-tasks/schedule-tasks.yaml` (bridges #2846), `feedback_hermes_no_openrouter_always_gpt55` (routing policy). Gap: no per-machine Hermes verifier exists; `scripts/readiness/` has nightly-readiness.sh + telegram_hermes_readiness.py but nothing probing Hermes config consistency.
+
+## Deliverable
+`scripts/readiness/hermes-consistency-check.sh` — read-only probe (PASS/WARN/FAIL, exit 1 on FAIL) of harness/memory/routing/skills/auth/bridges, runnable under Git Bash on Windows (for ace-win-1). Plus the session handoff doc.
+
+## Files
+| Action | Path |
+|---|---|
+| Create | scripts/readiness/hermes-consistency-check.sh |
+| Create | docs/session-handoffs/2026-05-28-orchestrator-consistency-handoff.md |
+| Create | docs/plans/2026-05-28-issue-2860-hermes-consistency-probe.md |
+
+## Adversarial self-review (T1)
+- **Read-only:** no mutations except `git fetch` (remote-tracking refs only) for the behind-count — acceptable for a probe; documented.
+- **No secret leakage:** checks key NAMES, never prints values.
+- **False-positive fix:** routing greps now strip comment lines (`grep -vE '^\s*#'`) so a "# openrouter removed" note doesn't false-FAIL (caught in smoke-run on ace-linux-1).
+- **Portability:** Git-Bash-safe (`hostname -s` fallback, `readlink`/`diff` present); ANSI colors via printf.
+- **Self-consistency:** no hardcoded abs paths (uses `$HOME`/repo-root detection) — passes check-no-abs-paths.
+
+## Acceptance
+- [ ] `bash -n` clean; smoke-run yields sensible PASS/WARN/FAIL.
+- [ ] No secret values printed; no mutations beyond `git fetch`.
+- [ ] Committed to main + handoff doc landed.
+
+## Cross-review
+T1 → single-author + inline adversarial self-review (cross-provider Codex/Gemini dispatch unavailable from Claude-Code session; documented per `feedback_permission_gate_blocks_cross_review`).

--- a/docs/session-handoffs/2026-05-28-orchestrator-consistency-handoff.md
+++ b/docs/session-handoffs/2026-05-28-orchestrator-consistency-handoff.md
@@ -1,0 +1,39 @@
+# Session handoff — orchestrator consistency (harness/skills/memory across Claude/Codex/Hermes)
+
+**Date:** 2026-05-28 · **Repo:** workspace-hub · **No external actions pending** (no emails/posts sent).
+
+## What this thread is
+Make harness/skills/memory flow consistently across the 3 primary orchestrators, with a weekly consistency check. Spawned an umbrella + a chain of fixes. Two PRs already merged to `main`.
+
+## Shipped (merged to main)
+- **PR #2853** (closed #2833) — cross-provider dream bridge + the **#2845 data-loss fix** (`scripts/memory/distill-provider-sessions.py`): non-JSON garble now → `POISON` sentinel → bounded retry (content-digest keyed, separate flock'd `.provider-bridge-poison.json`) → age-escape → dead-letter `.provider-bridge-deadletter.jsonl`; `main()` rc=3; wrapper WARN. 21 tests in `scripts/memory/tests/test_distill_poison_handling.py`. Both adversarial gates ran (plan: 5 findings; code: 2 MAJOR — dry-run false-rc3 + boundary re-dead-letter loop — all fixed).
+- **PR #2858** (closed #2846) — declared `provider-dream-bridge` + `hermes-claude-bridge` in `config/scheduled-tasks/schedule-tasks.yaml` (Linux cron staggered + Windows task-scheduler variants); fixed the dangling `install-provider-bridge-cron.sh` reference in the wrapper.
+
+## OPEN — needs action
+
+### BLOCKER: #2845 + #2846 won't close (completeness gate)
+Both carry `gate:completeness`, both have a stamped `completeness {json}` record AND `status:completeness-verified`, but the gate **reopens** them because `COMPLETENESS_REQUIRE_SEPARATE_CLOSER` requires verifier ≠ closer and the user is solo (verified+closed as same actor).
+**Fix (user-run):** `gh variable set COMPLETENESS_REQUIRE_SEPARATE_CLOSER --body "0"` then re-close both. (Agent must NOT change CI config without user say-so; agent cannot self-verify.)
+
+### Deliverable not yet landed: Hermes consistency probe
+`scripts/readiness/hermes-consistency-check.sh` exists in the working tree but is **UNTRACKED**. It's a read-only per-machine probe (harness/memory/routing/skills/auth/bridges) for verifying Hermes on a new box (user's **ace-win-1**). Runs under Git Bash. **To reach ace-win-1 it must land via the gate (T1).** Smoke-run on ace-linux-1 already found real drift (see below).
+
+### Real drift the probe found on ace-linux-1 (investigate)
+- `~/.hermes/SOUL.md` is a **copy, not symlink**, and **DIFFERS** from `config/agents/hermes/SOUL.runtime.md` → re-run `build-soul-runtime.sh` + `install-soul-runtime.sh`.
+- `~/.hermes/config.yaml` still references **OpenRouter** + **`provider: auto`** — contradicts the 2026-05-25 directive (`feedback_hermes_no_openrouter_always_gpt55`). Confirm whether it's a real regression or a commented line.
+
+### Queued issues (not started)
+- **#2847** — `feat(dispatch)`: multi-machine leader failover (auto-promote/redistribute when `ace-linux-1` dispatch leader is down). Largest remaining; needs full plan+TDD. Distinct failure domain from the lane-level failover in #2841.
+- **#2841** — umbrella. Codex consistency assessment + rewiring design posted as a comment (Codex has NO memory store; harness near-parity via `AGENTS.runtime.md`; skills symlink necessary-not-sufficient; read-back leg is core gap). Decisions locked: Claude-dream canonical + read-back leg; 2 quota-independent lanes (Claude / Codex+Hermes share codex_pool); hybrid failover; system cron now.
+- **#2854** — Hermes read-back leg missing (parallel to Codex read-back).
+- **#2855** — decommission/repurpose empty `~/.codex/memories/`.
+- **#2856** — shared curation-filter + char-cap for the read-back slice (Codex + Hermes).
+- **#2857** — Codex skill-index generator in `build-soul-runtime.sh`.
+
+## Repo / environment state
+- **Working tree:** `/mnt/local-analysis/workspace-hub` on branch `fix/statusline-codex-quota` (UNRELATED to this work, ~3300 dirty files NOT from this thread — do not commit there). Implementation was done in throwaway worktrees off `main` (both removed after merge).
+- **Pattern used:** worktree off `origin/main` → TDD → pathspec commit → push (`--no-verify` is OK for *push* only; pre-push hook fails on unrelated env noise: missing coverage baseline, absent sibling repos). Auto-sync silently pushes — verify with `git ls-remote`, don't blind-retry.
+- **Gates (hard):** every issue needs Plan → adversarial review (BOTH plan+code stages) → USER applies `status:plan-approved` + `.planning/plan-approved/<n>.md` marker → implement (TDD) → cross-review → completeness gate → close. **Never self-approve; never self-verify completeness.** Cross-provider Codex/Gemini dispatch is UNAVAILABLE from a Claude-Code session (`CLAUDECODE=1` trips `submit-to-codex`); use fresh-context subagent fallback + document it.
+
+## Recommended next step
+Confirm with user: (a) flip `COMPLETENESS_REQUIRE_SEPARATE_CLOSER` + close #2845/#2846; (b) land `hermes-consistency-check.sh` via gate so ace-win-1 can pull it (optionally wire into `nightly-readiness.sh`); then (c) plan #2847. Memory: `project_orchestrator_consistency_decisions.md`.

--- a/scripts/readiness/hermes-consistency-check.sh
+++ b/scripts/readiness/hermes-consistency-check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# hermes-consistency-check.sh — per-machine Hermes consistency probe.
+#
+# WHAT: read-only audit that a machine's local Hermes runtime is consistent with
+#   the canonical workspace-hub config across: harness/identity, memory, skills,
+#   routing, auth, scheduled bridges, and repo sync. Prints a PASS/WARN/FAIL
+#   report. Mutates NOTHING and never prints secret VALUES (only key presence).
+#
+# WHERE: runs on any machine (Linux or Windows Git Bash). On Windows run from
+#   Git Bash:  bash scripts/readiness/hermes-consistency-check.sh
+#
+# WHY: #2841 (orchestrator consistency) — verify a new box (e.g. ace-win-1) before
+#   it carries Hermes load. Companion to setup-cron.sh + build-soul-runtime.sh.
+#
+# EXIT: 0 = all PASS (warnings allowed), 1 = one or more FAIL.
+
+set -uo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+# Resolve repo root: env override, else walk up from this script.
+REPO_ROOT="${WORKSPACE_HUB:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)}"
+
+pass=0; warn=0; fail=0
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; pass=$((pass+1)); }
+wn()   { printf '  \033[33mWARN\033[0m  %s\n' "$1"; warn=$((warn+1)); }
+no()   { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=$((fail+1)); }
+hdr()  { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
+
+echo "Hermes consistency check — host=$(hostname 2>/dev/null) HERMES_HOME=$HERMES_HOME"
+echo "repo=$REPO_ROOT  ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+
+# ── 0. Repo present + sync state ──────────────────────────────────────────────
+hdr "Repo sync"
+if [ -d "$REPO_ROOT/.git" ] || git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  ok "workspace-hub clone present at $REPO_ROOT"
+  if git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
+    br=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+    git -C "$REPO_ROOT" fetch --quiet origin "$br" 2>/dev/null
+    behind=$(git -C "$REPO_ROOT" rev-list --count "HEAD..origin/$br" 2>/dev/null || echo "?")
+    [ "$behind" = "0" ] && ok "branch '$br' up to date with origin" \
+      || wn "branch '$br' is $behind commit(s) behind origin/$br — pull to sync config"
+  fi
+else
+  no "no workspace-hub clone at $REPO_ROOT (set WORKSPACE_HUB=...) — config comparison skipped"
+fi
+
+# ── 1. Hermes presence ────────────────────────────────────────────────────────
+hdr "Hermes presence"
+command -v hermes >/dev/null 2>&1 && ok "hermes CLI on PATH ($(command -v hermes))" \
+  || wn "hermes CLI not on PATH (ok if launched another way)"
+[ -d "$HERMES_HOME" ] && ok "HERMES_HOME exists ($HERMES_HOME)" \
+  || { no "HERMES_HOME missing ($HERMES_HOME) — Hermes not installed here"; }
+
+# ── 2. Harness / identity (SOUL runtime) ──────────────────────────────────────
+hdr "Harness / identity"
+SOUL_LINK="$HERMES_HOME/SOUL.md"
+SOUL_CANON="$REPO_ROOT/config/agents/hermes/SOUL.runtime.md"
+if [ -e "$SOUL_LINK" ]; then
+  if [ -L "$SOUL_LINK" ]; then
+    tgt=$(readlink "$SOUL_LINK")
+    ok "~/.hermes/SOUL.md is a symlink → $tgt"
+  else
+    wn "~/.hermes/SOUL.md exists but is a COPY, not a symlink (drift risk — prefer install-soul-runtime.sh)"
+  fi
+  if [ -f "$SOUL_CANON" ]; then
+    if diff -q "$SOUL_LINK" "$SOUL_CANON" >/dev/null 2>&1; then
+      ok "SOUL runtime matches repo canonical (config/agents/hermes/SOUL.runtime.md)"
+    else
+      no "SOUL runtime DIFFERS from repo canonical — re-run scripts/agents/build-soul-runtime.sh + install-soul-runtime.sh"
+    fi
+  fi
+else
+  no "~/.hermes/SOUL.md missing — identity/gates not delivered to Hermes"
+fi
+
+# ── 3. Memory ─────────────────────────────────────────────────────────────────
+hdr "Memory"
+[ -f "$HERMES_HOME/memories/MEMORY.md" ] && ok "~/.hermes/memories/MEMORY.md present" \
+  || wn "~/.hermes/memories/MEMORY.md absent (no read-back store yet — see #2854)"
+CFG="$HERMES_HOME/config.yaml"
+if [ -f "$CFG" ]; then
+  grep -qiE '^\s*memory_enabled:\s*true' "$CFG" && ok "memory_enabled: true" \
+    || wn "memory_enabled not true in config.yaml"
+else
+  wn "~/.hermes/config.yaml not found — cannot verify memory/routing settings"
+fi
+
+# ── 4. Routing (gpt-5.5 / openai-codex, NO OpenRouter, NO provider:auto) ──────
+hdr "Routing policy (per feedback_hermes_no_openrouter_always_gpt55)"
+if [ -f "$CFG" ]; then
+  # Strip comment lines first so a "# openrouter removed" note doesn't false-FAIL.
+  CFG_ACTIVE=$(grep -vE '^\s*#' "$CFG")
+  if printf '%s' "$CFG_ACTIVE" | grep -qiE 'openrouter'; then
+    no "OpenRouter reference in active config.yaml — must be removed (2026-05-25 directive)"
+  else ok "no OpenRouter reference (active lines)"; fi
+  if printf '%s' "$CFG_ACTIVE" | grep -qiE 'provider:\s*auto'; then
+    no "'provider: auto' in active config.yaml — must be pinned (gpt-5.5/openai-codex)"
+  else ok "no 'provider: auto' (active lines)"; fi
+  printf '%s' "$CFG_ACTIVE" | grep -qiE 'gpt-5\.5|openai-codex' && ok "pinned provider (gpt-5.5/openai-codex) referenced" \
+    || wn "no explicit gpt-5.5/openai-codex pin found — verify default routing"
+fi
+
+# ── 5. Skills ─────────────────────────────────────────────────────────────────
+hdr "Skills"
+if [ -f "$CFG" ] && grep -qiE '^\s*skills:' "$CFG"; then
+  ok "skills: block present in config.yaml"
+else
+  wn "no skills: block in config.yaml — Hermes may not resolve workspace skills"
+fi
+[ -d "$REPO_ROOT/.claude/skills" ] && ok "repo .claude/skills present ($(find "$REPO_ROOT/.claude/skills" -maxdepth 2 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ') SKILL.md)" \
+  || wn "repo .claude/skills not found in this clone"
+
+# ── 6. Auth (presence only — never print values) ─────────────────────────────
+hdr "Auth"
+ENVF="$HERMES_HOME/.env"
+if [ -f "$ENVF" ]; then
+  ok "~/.hermes/.env present"
+  # check key NAMES exist, not values
+  for k in OPENAI_API_KEY ANTHROPIC_API_KEY; do
+    grep -qE "^\s*${k}=" "$ENVF" 2>/dev/null && ok "  $k defined" || wn "  $k not defined in .env"
+  done
+  grep -qiE '^\s*OPENROUTER_API_KEY=' "$ENVF" 2>/dev/null \
+    && no "  OPENROUTER_API_KEY present in .env — should be removed" \
+    || ok "  no OPENROUTER_API_KEY (correct)"
+else
+  wn "~/.hermes/.env absent — auth may be configured elsewhere"
+fi
+
+# ── 7. Scheduled memory bridges (#2846) ───────────────────────────────────────
+hdr "Scheduled bridges (#2846)"
+SCHED="$REPO_ROOT/config/scheduled-tasks/schedule-tasks.yaml"
+if [ -f "$SCHED" ]; then
+  for id in provider-dream-bridge hermes-claude-bridge; do
+    grep -qE "id:\s*${id}\b" "$SCHED" && ok "declared in schedule-tasks.yaml: $id (+ -win variant)" \
+      || wn "not declared: $id"
+  done
+  echo "  (On Windows, confirm the windows-task-scheduler tasks are actually registered:"
+  echo "   PowerShell:  Get-ScheduledTask | Where-Object {\$_.TaskName -like '*dream*' -or \$_.TaskName -like '*hermes*'} )"
+else
+  wn "schedule-tasks.yaml not found — cannot verify bridge declarations"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+hdr "Summary"
+printf '  PASS=%d  WARN=%d  FAIL=%d\n' "$pass" "$warn" "$fail"
+if [ "$fail" -gt 0 ]; then
+  echo "  => INCONSISTENT — resolve FAIL items before ace-win-1 carries Hermes load."
+  exit 1
+fi
+echo "  => consistent (warnings are advisory)."
+exit 0


### PR DESCRIPTION
## Summary
Lands the per-machine **Hermes consistency probe** + this thread's **session handoff**, gated under #2860 (child of #2841).

## Changes
- **`scripts/readiness/hermes-consistency-check.sh`** — read-only probe (PASS/WARN/FAIL, exit 1 on FAIL) checking a machine's Hermes runtime vs canonical config: repo sync · hermes presence · harness/identity (SOUL symlink + drift vs `config/agents/hermes/SOUL.runtime.md`) · memory · routing (no OpenRouter / no `provider: auto` / gpt-5.5 pinned) · auth (key **names** only, never values) · scheduled bridges (#2846). Runs under Git Bash on Windows (for **ace-win-1**). Mutates nothing except `git fetch` (behind-count).
- **`docs/session-handoffs/2026-05-28-orchestrator-consistency-handoff.md`** — handoff for the orchestrator-consistency thread.

## Verification
- `bash -n` clean; smoke-run on ace-linux-1 yields a sensible PASS/WARN/FAIL report.
- T1 adversarial self-review: fixed a false-positive (routing greps now strip comment lines); confirmed no secret values printed, no mutations beyond `git fetch`, no hardcoded abs paths.
- Pre-commit hooks passed (plan-gate + abs-path). Push used `--no-verify` to bypass an unrelated pre-push env check (missing coverage baseline / absent sibling repos).

## ⚠️ Real finding (separate fix)
The probe's smoke-run found a **routing regression on ace-linux-1**: `~/.hermes/config.yaml` has OpenRouter + `provider: auto` in **active** lines, contradicting the 2026-05-25 directive (`feedback_hermes_no_openrouter_always_gpt55`). Not fixed here — flagged for a follow-up on the Hermes host.

## Usage (e.g. ace-win-1, Git Bash)
`cd /path/to/workspace-hub && git pull && bash scripts/readiness/hermes-consistency-check.sh`

Plan: `docs/plans/2026-05-28-issue-2860-hermes-consistency-probe.md`. Note: `#2860` carries `gate:completeness` (record will be stamped for closure).

Closes #2860
