### PR TITLE
fix(readiness): harden hermes-consistency probe per code-stage review (#2860 follow-up)

### DIFF
--- a/scripts/readiness/hermes-consistency-check.sh
+++ b/scripts/readiness/hermes-consistency-check.sh
@@ -21,12 +21,22 @@ HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 REPO_ROOT="${WORKSPACE_HUB:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)}"
 
 pass=0; warn=0; fail=0
-ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; pass=$((pass+1)); }
-wn()   { printf '  \033[33mWARN\033[0m  %s\n' "$1"; warn=$((warn+1)); }
-no()   { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=$((fail+1)); }
-hdr()  { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
+# Colors only on an interactive TTY and when NO_COLOR is unset — otherwise ANSI
+# escapes garble CI logs, redirected output, and some Windows terminals.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_G='\033[32m'; C_Y='\033[33m'; C_R='\033[31m'; C_B='\033[1m'; C_0='\033[0m'
+else
+  C_G=''; C_Y=''; C_R=''; C_B=''; C_0=''
+fi
+ok()   { printf '  %bPASS%b  %s\n' "$C_G" "$C_0" "$1"; pass=$((pass+1)); }
+wn()   { printf '  %bWARN%b  %s\n' "$C_Y" "$C_0" "$1"; warn=$((warn+1)); }
+no()   { printf '  %bFAIL%b  %s\n' "$C_R" "$C_0" "$1"; fail=$((fail+1)); }
+hdr()  { printf '\n%b== %s ==%b\n' "$C_B" "$1" "$C_0"; }
 
-echo "Hermes consistency check — host=$(hostname 2>/dev/null) HERMES_HOME=$HERMES_HOME"
+# Hostname: `hostname` is absent on some minimal Git Bash installs — fall back to
+# the Windows %COMPUTERNAME%, then "unknown".
+host=$(hostname 2>/dev/null); host=${host:-${COMPUTERNAME:-unknown}}
+echo "Hermes consistency check — host=$host HERMES_HOME=$HERMES_HOME"
 echo "repo=$REPO_ROOT  ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
 
 # ── 0. Repo present + sync state ──────────────────────────────────────────────
@@ -35,10 +45,21 @@ if [ -d "$REPO_ROOT/.git" ] || git -C "$REPO_ROOT" rev-parse --git-dir >/dev/nul
   ok "workspace-hub clone present at $REPO_ROOT"
   if git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
     br=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
-    git -C "$REPO_ROOT" fetch --quiet origin "$br" 2>/dev/null
-    behind=$(git -C "$REPO_ROOT" rev-list --count "HEAD..origin/$br" 2>/dev/null || echo "?")
-    [ "$behind" = "0" ] && ok "branch '$br' up to date with origin" \
-      || wn "branch '$br' is $behind commit(s) behind origin/$br — pull to sync config"
+    # Only fetch+compare when this branch exists on origin. A local-only branch
+    # (or an unreachable origin) otherwise yields a bogus "? commits behind" WARN.
+    if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$br" >/dev/null 2>&1; then
+      git -C "$REPO_ROOT" fetch --quiet origin "$br" 2>/dev/null
+      behind=$(git -C "$REPO_ROOT" rev-list --count "HEAD..origin/$br" 2>/dev/null || echo "?")
+      if [ "$behind" = "0" ]; then
+        ok "branch '$br' up to date with origin"
+      elif [ "$behind" = "?" ]; then
+        wn "branch '$br' sync state undetermined (origin/$br ref unavailable locally)"
+      else
+        wn "branch '$br' is $behind commit(s) behind origin/$br — pull to sync config"
+      fi
+    else
+      wn "branch '$br' not found on origin (local-only branch or origin unreachable) — sync check skipped"
+    fi
   fi
 else
   no "no workspace-hub clone at $REPO_ROOT (set WORKSPACE_HUB=...) — config comparison skipped"
@@ -63,11 +84,15 @@ if [ -e "$SOUL_LINK" ]; then
     wn "~/.hermes/SOUL.md exists but is a COPY, not a symlink (drift risk — prefer install-soul-runtime.sh)"
   fi
   if [ -f "$SOUL_CANON" ]; then
-    if diff -q "$SOUL_LINK" "$SOUL_CANON" >/dev/null 2>&1; then
+    # Compare CRLF-insensitively: on Windows a core.autocrlf checkout can give one
+    # side CRLF and the other LF, which would otherwise report a false DIFFERS.
+    if diff -q <(tr -d '\r' < "$SOUL_LINK") <(tr -d '\r' < "$SOUL_CANON") >/dev/null 2>&1; then
       ok "SOUL runtime matches repo canonical (config/agents/hermes/SOUL.runtime.md)"
     else
       no "SOUL runtime DIFFERS from repo canonical — re-run scripts/agents/build-soul-runtime.sh + install-soul-runtime.sh"
     fi
+  else
+    wn "canonical SOUL not found at $SOUL_CANON — cannot compare (check sparse-checkout / branch)"
   fi
 else
   no "~/.hermes/SOUL.md missing — identity/gates not delivered to Hermes"
@@ -131,8 +156,20 @@ hdr "Scheduled bridges (#2846)"
 SCHED="$REPO_ROOT/config/scheduled-tasks/schedule-tasks.yaml"
 if [ -f "$SCHED" ]; then
   for id in provider-dream-bridge hermes-claude-bridge; do
-    grep -qE "id:\s*${id}\b" "$SCHED" && ok "declared in schedule-tasks.yaml: $id (+ -win variant)" \
-      || wn "not declared: $id"
+    # Confirm BOTH the Linux-cron id and its Windows task-scheduler "-win" variant
+    # are present, rather than asserting the -win variant without checking it.
+    base_ok=0; win_ok=0
+    # Anchor to the YAML list-item form ("- id: <name>") from line start so a
+    # commented "# id: ..." or a longer key like "grid:" can't produce a match.
+    grep -qE "^[[:space:]]*-?[[:space:]]*id:[[:space:]]*${id}([[:space:]]|\$)" "$SCHED" && base_ok=1
+    grep -qE "^[[:space:]]*-?[[:space:]]*id:[[:space:]]*${id}-win([[:space:]]|\$)" "$SCHED" && win_ok=1
+    if [ "$base_ok" = 1 ] && [ "$win_ok" = 1 ]; then
+      ok "declared in schedule-tasks.yaml: $id + ${id}-win"
+    elif [ "$base_ok" = 1 ]; then
+      wn "declared: $id but MISSING Windows variant ${id}-win"
+    else
+      wn "not declared: $id"
+    fi
   done
   echo "  (On Windows, confirm the windows-task-scheduler tasks are actually registered:"
   echo "   PowerShell:  Get-ScheduledTask | Where-Object {\$_.TaskName -like '*dream*' -or \$_.TaskName -like '*hermes*'} )"

--- a/scripts/review/results/2026-05-28-impl-2860-claude-subagent.md
+++ b/scripts/review/results/2026-05-28-impl-2860-claude-subagent.md
@@ -1,0 +1,37 @@
+# Code-stage adversarial review — #2860 Hermes consistency probe
+
+> **Stage:** code/artifact (implementation) · **Issue:** [#2860](https://github.com/vamseeachanta/workspace-hub/issues/2860) · **PR:** #2861 · **Date:** 2026-05-28 · **Complexity:** T1
+> **Artifact:** `scripts/readiness/hermes-consistency-check.sh`
+
+## Provenance / method
+
+Cross-provider Codex/Gemini dispatch is unavailable from a Claude-Code session (`CLAUDECODE=1` trips `submit-to-codex`; Gemini trust-folder gate). Per the documented fallback (`feedback_permission_gate_blocks_cross_review`, SHARED_SOUL "use subagents for parallel work where the runtime supports it"), the code-stage adversarial review was performed by **two independent fresh-context Claude-Code subagents** (no visibility into the author's reasoning), each prompted to hunt defects and default to non-APPROVE. Main session then **empirically verified** every actionable finding before applying fixes (`feedback_verify_subagent_firewall_claims`, subagent-write-phantom hazard).
+
+## Round 1 (initial review)
+
+The first subagent was inadvertently pointed at a **stale untracked copy** of the script in the dirty working tree, not the PR-branch version. It reported 3 BLOCKER/MAJOR comment-blindness findings. Main-session verification (`/tmp` config fixtures) confirmed the *stale copy* was comment-blind — but a diff against the PR branch showed the **PR-branch version already carried the comment-strip fix** (lines 91–100, `CFG_ACTIVE=$(grep -vE '^\s*#' ...)`). Those 3 findings were therefore already resolved on the artifact under review. Lesson recorded: review the merge-target ref, not a working-tree copy.
+
+Findings that **did** apply to the PR-branch version and were fixed:
+
+| # | Sev | Site | Defect | Fix |
+|---|-----|------|--------|-----|
+| 4 | MAJOR | repo-sync | `git fetch origin $br` on a local-only branch → bogus "? commits behind" WARN | Guard on `git ls-remote --exit-code --heads origin "$br"`; distinguish behind=0 / "?" / N / not-on-origin |
+| 5 | MAJOR | color helpers | ANSI escapes with no TTY guard → garbled CI/redirected/Windows output | Gate color on `[ -t 1 ] && [ -z "${NO_COLOR:-}" ]`; `printf '%b'` with empty vars when non-TTY |
+| 7 | MINOR | SOUL section | comparison silently skipped if canonical SOUL absent → falsely-clean section | added `else wn "canonical SOUL not found ..."` |
+| 9 | MINOR | SOUL diff | `diff -q` flags CRLF-vs-LF as DIFFERS on Windows (false FAIL) | CRLF-insensitive `diff <(tr -d '\r' < a) <(tr -d '\r' < b)` |
+| 10 | NIT | bridges | message asserted "+ -win variant" without checking it; `\b` also matched base id inside `-win` | check base AND `-win` explicitly; anchor with `([[:space:]]|$)` |
+| 11 | NIT | header | `hostname` absent on minimal Git Bash | fall back to `$COMPUTERNAME` then "unknown" |
+
+## Round 2 (re-review of the fixed file)
+
+Second subagent re-reviewed the fixed artifact. **Verified all 6 edits functionally correct** (no format-injection via `%b`/positional `%s`; pipefail does not abort on no-match command substitutions; `<(...)` works on Git Bash; ls-remote-success-but-rev-list-fail handled honestly; CRLF compare correct). Found 2 **LOW** items, both in the newly-written bridge grep: not start-anchored, so a commented `# id: ...` or a longer key (`grid:`) could match. Fixed by anchoring to the YAML list-item form `^[[:space:]]*-?[[:space:]]*id:[[:space:]]*<id>([[:space:]]|$)`. Main-session re-verified: anchor matches all four live ids, rejects `# id:` and `grid:` negatives, bridges section still PASS.
+
+## Verification evidence
+
+- `bash -n` clean (both rounds).
+- Live smoke-run on ace-linux-1 (read-only): PASS=15 WARN=3 FAIL=1, exit 1. Colors correctly suppressed when piped. Sync-check correctly WARNs (local-only worktree branch) instead of bogus behind-count. Both bridge `-win` variants detected.
+- **Material downstream finding:** the fixed routing checks report ace-linux-1 routing as **compliant** (no OpenRouter / no `provider: auto` on active lines). Direct inspection of `~/.hermes/config.yaml` confirms *zero* references (not even commented). The handoff's "config.yaml still references OpenRouter + provider:auto" was a **false positive from the pre-fix comment-blind probe** — not a real regression (#2841 step-3 routing item resolved). The SOUL.md copy-not-symlink + DIFFERS drift, by contrast, is **real** and confirmed.
+
+## Verdict
+
+Both rounds' actionable findings applied and re-verified. Read-only guarantee holds (only `git ls-remote`/`fetch` of remote-tracking refs). No secret values printed. **APPROVE for merge** pending owner action.


### PR DESCRIPTION
## Why
Code-stage adversarial review follow-up for [#2860](https://github.com/vamseeachanta/workspace-hub/issues/2860). PR #2861 merged the probe at `03a635981` before these review-found fixes landed (the commit got stranded on the old branch by a silent auto-sync push that didn't re-sync the PR). These fixes complete the code-stage review loop and matter specifically for the **ace-win-1 (Windows Git Bash)** target this probe exists to serve.

## What changed (`scripts/readiness/hermes-consistency-check.sh`)
- **CRLF-safe SOUL diff** — `diff <(tr -d '\r' …)`; a `core.autocrlf` Windows checkout no longer reports a false "SOUL DIFFERS".
- **TTY/NO_COLOR color guard** — ANSI escapes only on an interactive TTY; no escape garble in CI / redirected output / Windows terminals.
- **repo-sync git-fetch guard** — only fetch+compare when the branch exists on origin (`ls-remote --exit-code`); a local-only branch no longer prints a bogus "? commits behind" WARN.
- **bridge `id:` grep anchored** to the YAML list-item form so a commented `# id:` or a `grid:`-style key can't false-match; verifies both base and `-win` variants.
- **no silent skip** when canonical SOUL is absent (now WARNs); hostname falls back to `$COMPUTERNAME` on minimal Git Bash.

## Review evidence
`scripts/review/results/2026-05-28-impl-2860-claude-subagent.md` — two independent fresh-context subagent rounds (Codex/Gemini dispatch unavailable from a Claude-Code session), every finding main-session-verified empirically.

## Verification
`bash -n` clean. Live read-only smoke-run on ace-linux-1: PASS=15 WARN=3 FAIL=1, exit 1. Colors suppressed when piped; bridge `-win` variants detected; routing correctly reports `config.yaml` compliant.

Read-only probe; only `git ls-remote`/`fetch` of remote-tracking refs. No secret values printed.

Related: #2860, #2841, #2846.