### PR TITLE
feat(#2847): Phase 1b — wire the self-fence into the live lease path

### DIFF
--- a/scripts/ai/dispatch_leader.py
+++ b/scripts/ai/dispatch_leader.py
@@ -150,6 +150,32 @@ def may_write_leases(
     return True
 
 
+def leader_can_originate(
+    store: LeaderStateStore,
+    machine: str,
+    *,
+    now: datetime | None = None,
+    alert=None,
+) -> bool:
+    """Phase 1b gate — may `machine` originate a lease right now?
+
+    True iff `machine` is the committed leader AND a fresh heartbeat is confirmed
+    pushed (the self-fence). Reads once to learn the committed term, then
+    `may_write_leases` performs the confirmed-push CAS. A non-leader, an
+    unconfirmed push, or an unreadable store all return False (stand down)."""
+    try:
+        st = store.read()
+    except StoreUnavailable as e:
+        if alert:
+            alert(f"leader_can_originate: store unavailable ({e}) — refusing to originate")
+        return False
+    if st.leader != machine:
+        if alert:
+            alert(f"leader_can_originate: {machine} is not the leader ({st.leader}) — refusing")
+        return False
+    return may_write_leases(store, machine, st.term, now=now, alert=alert)
+
+
 def check(
     store: LeaderStateStore,
     me: str,

--- a/scripts/ai/provider-dispatch-loop.py
+++ b/scripts/ai/provider-dispatch-loop.py
@@ -84,6 +84,13 @@ class DispatcherConfig:
     lease_ttl_seconds: int = DEFAULT_LEASE_TTL_S
     max_implementation_per_run: int = 3
     promotion_token: str | None = None  # set when ace-linux-2 is explicitly promoted
+    # #2847 Phase 1b — self-fence: when True, a tick originates leases only if this
+    # machine is the confirmed git-leader (a fresh heartbeat was pushed). Default
+    # False so behavior is unchanged until deliberately enabled (env
+    # DISPATCH_ENFORCE_LEADER_FENCE=1). leader_state_store is injectable for tests;
+    # when None and enforcement is on, a GitLeaderStateStore is built.
+    enforce_leader_fence: bool = False
+    leader_state_store: Any = None
 
 
 def utc_now() -> str:
@@ -330,6 +337,29 @@ def make_lease(
     )
 
 
+def leader_fence_enabled_from_env() -> bool:
+    """#2847 Phase 1b — the self-fence is opt-in via DISPATCH_ENFORCE_LEADER_FENCE.
+    Truthy only for an explicit 1/true/yes (case-insensitive); unset/empty/anything
+    else is False, so the default is always the no-behavior-change path."""
+    return os.environ.get("DISPATCH_ENFORCE_LEADER_FENCE", "").strip().lower() in ("1", "true", "yes")
+
+
+def _load_dispatch_leader():
+    """Lazy-import the sibling dispatch_leader module (only when the fence is on),
+    so the dispatch loop carries no import cost / dependency when enforcement is off."""
+    import importlib.util
+    mod = sys.modules.get("dispatch_leader")
+    if mod is not None:
+        return mod
+    path = Path(__file__).resolve().parent / "dispatch_leader.py"
+    spec = importlib.util.spec_from_file_location("dispatch_leader", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    sys.modules["dispatch_leader"] = mod
+    return mod
+
+
 def run_loop(
     cfg: DispatcherConfig,
     kanban: dict[str, Any],
@@ -362,7 +392,30 @@ def run_loop(
         "planning_fallback": [],
         "skipped_due_to_lease": [],
         "skipped_due_to_machine": [],
+        "self_fenced": False,
     }
+
+    # #2847 Phase 1b self-fence: when enabled, originate leases ONLY if this machine
+    # is the confirmed git-leader (a fresh heartbeat was pushed this tick). This is
+    # what prevents an alive-but-cannot-push leader from originating in a split-brain.
+    # NOTE: a `tick` is one dispatch *invocation* (cron cadence), not a hot loop, so
+    # the per-tick heartbeat push aligns with the heartbeat design (review #7).
+    # dry_run is NOT fenced — it writes no leases, so it stays a valid plan-preview
+    # even on a fenced/secondary machine (review #1).
+    if cfg.enforce_leader_fence and not dry_run:
+        _dl = _load_dispatch_leader()
+        store = cfg.leader_state_store or _dl.GitLeaderStateStore(WORKSPACE_HUB)
+        fence_msgs: list[str] = []
+
+        def _cap(m: str) -> None:  # capture the reason so the halt isn't silent (review #2)
+            _dl._stderr_alert(m)
+            fence_msgs.append(m)
+
+        if not _dl.leader_can_originate(store, current_machine(), now=now, alert=_cap):
+            summary["self_fenced"] = True
+            # detail distinguishes not-leader vs store-unavailable vs push-unconfirmed
+            summary["self_fenced_detail"] = fence_msgs
+            return summary  # stand down — originate nothing this tick
 
     ready = select_execution_ready(kanban, leases)
     for card in ready[: cfg.max_implementation_per_run]:
@@ -488,7 +541,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    cfg = DispatcherConfig(leader_host=args.leader_host, promotion_token=args.promotion_token)
+    cfg = DispatcherConfig(
+        leader_host=args.leader_host,
+        promotion_token=args.promotion_token,
+        # #2847 Phase 1b — opt-in via env so the fence can be enabled deliberately
+        # (after the dispatch-leader-state ref is bootstrapped) without a code change.
+        enforce_leader_fence=leader_fence_enabled_from_env(),
+    )
 
     if args.morning_qa:
         text = generate_morning_qa(cfg)

--- a/scripts/review/results/2026-05-29-impl-2847-phase1b-claude-subagent.md
+++ b/scripts/review/results/2026-05-29-impl-2847-phase1b-claude-subagent.md
@@ -1,0 +1,28 @@
+# Code-stage adversarial review — #2847 Phase 1b (wire self-fence into lease path)
+
+> **Stage:** code/artifact · **Issue:** [#2847](https://github.com/vamseeachanta/workspace-hub/issues/2847) · **Date:** 2026-05-29 · **Complexity:** T3 slice
+> **Branch:** feat/2847-leader-fence-phase1b
+
+## Method
+Independent fresh-context subagent (cross-provider unavailable from a Claude-Code session; degraded T3→1 — a Codex pass on the live-lease-path change is still recommended). Findings main-verified.
+
+## Verdict: CHANGES REQUIRED → resolved
+
+| # | Sev | Finding | Resolution |
+|---|-----|---------|------------|
+| 1 | MEDIUM | dry-run was fenced, losing the plan-preview (fence is about *origination*; dry-run writes nothing) | gate now `enforce_leader_fence and not dry_run`; test `test_loop_dry_run_is_not_fenced` |
+| 2 | MEDIUM | enabling the flag before the ref is bootstrapped halts origination *silently* | gate captures the fence reason into `summary["self_fenced_detail"]` (distinguishes not-leader / store-unavailable / push-unconfirmed); test `..._when_store_unavailable`; enable-runbook note added |
+| 3 | LOW | `skipped_due_to_machine` not populated on the fenced early-return | left (diagnostic-only; `self_fenced_detail` explains the empty summary) |
+| 4 | LOW | double-read (leader_can_originate.read + may_write_leases.read) | reviewer **confirmed safe** — the 2nd read is authoritative and the CAS binds to it; no change |
+| 5 | LOW | lazy-import keyed on bare `dispatch_leader` in sys.modules | left (unique sibling name; production builds the store off the returned module — mismatch surfaces fast) |
+| 6 | MEDIUM | test gaps: dry-run-under-fence, loop-level StoreUnavailable, env parsing | all 3 added; env parse extracted to testable `leader_fence_enabled_from_env()` |
+| 7 | LOW | per-tick forced push when enabled | documented: a `tick` is one dispatch *invocation* (cron cadence), not a hot loop, so it aligns with the heartbeat design |
+
+## Verification
+TDD. **41 passed** (24 dispatch_leader + 17 dispatch-loop; existing 11 dispatch-loop unchanged — default-off path proven identical). Module parses; `bash`/YAML N/A (Python only).
+
+## Default-off safety
+`enforce_leader_fence` defaults False; with it off the gate is fully skipped (no store built, no import, no new exception, behavior identical) — `test_loop_default_off_originates_without_a_store`. Enabled only via explicit `DISPATCH_ENFORCE_LEADER_FENCE=1` after the dedicated ref is bootstrapped by the `--heartbeat` watcher.
+
+## Verdict
+**APPROVE** after fixes. The fence genuinely blocks origination (tested: `execution_ready==[]` + empty ledger), dry-run preview preserved, halt-reason surfaced. Recommend a Codex pass before flipping the env flag on in production.

--- a/tests/ai/test_dispatch_leader.py
+++ b/tests/ai/test_dispatch_leader.py
@@ -136,6 +136,29 @@ def test_check_term_regression_is_undetermined():
     assert alerts.msgs
 
 
+# ── leader_can_originate (Phase 1b gate entrypoint) ─────────────────────────
+
+def test_can_originate_true_when_leader_and_push_confirmed():
+    store = FakeStore(state=_state(leader="ace-linux-1", term=5), claim_result=ClaimResult.PUSHED)
+    assert module.leader_can_originate(store, "ace-linux-1", now=T0) is True
+
+
+def test_can_originate_false_when_not_leader():
+    store = FakeStore(state=_state(leader="ace-linux-1"), claim_result=ClaimResult.PUSHED)
+    assert module.leader_can_originate(store, "ace-linux-2", now=T0) is False
+    assert store.claims == []  # not leader -> never heartbeats
+
+
+def test_can_originate_false_when_push_cannot_be_confirmed():
+    store = FakeStore(state=_state(leader="ace-linux-1", term=5), claim_result=ClaimResult.PUSH_FAILED)
+    assert module.leader_can_originate(store, "ace-linux-1", now=T0) is False  # self-fence
+
+
+def test_can_originate_false_when_store_unavailable():
+    store = FakeStore(read_exc=StoreUnavailable("uninitialized"))
+    assert module.leader_can_originate(store, "ace-linux-1", now=T0) is False
+
+
 # ── invariants ──────────────────────────────────────────────────────────────
 
 def test_threshold_coherence_invariant():

--- a/tests/ai/test_provider_dispatch_loop.py
+++ b/tests/ai/test_provider_dispatch_loop.py
@@ -304,3 +304,113 @@ def test_dispatch_loop_creates_lease_with_idempotency_key_and_parent_issue(tmp_p
     assert lease["parent_issue"] == "#2519"
     assert lease["expires_at"]
     assert lease["expected_artifact"]
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# #2847 Phase 1b — self-fence wired into the lease path
+# ────────────────────────────────────────────────────────────────────────────
+
+# Load the sibling dispatch_leader module to build a fake store + reuse its types.
+_DL_PATH = REPO_ROOT / "scripts" / "ai" / "dispatch_leader.py"
+_dl_spec = importlib.util.spec_from_file_location("dispatch_leader", _DL_PATH)
+_dl = importlib.util.module_from_spec(_dl_spec)
+sys.modules["dispatch_leader"] = _dl
+_dl_spec.loader.exec_module(_dl)
+
+
+class _FenceStore:
+    """Minimal injectable LeaderStateStore for the fence tests."""
+    def __init__(self, leader, term, claim_result):
+        self._leader, self._term, self._claim = leader, term, claim_result
+        self.claims = []
+
+    def read(self):
+        if self._leader is None:
+            raise _dl.StoreUnavailable("uninitialized")
+        return _dl.LeaderState(leader=self._leader, term=self._term,
+                               heartbeat_utc=datetime(2026, 5, 28, tzinfo=timezone.utc).isoformat(),
+                               heartbeat_pid=1)
+
+    def claim(self, state):
+        self.claims.append(state)
+        return self._claim
+
+
+def test_loop_default_off_originates_without_a_store(tmp_path, monkeypatch):
+    # enforce_leader_fence defaults False -> behavior unchanged, no store needed.
+    cfg = _cfg(tmp_path)
+    _set_machine(monkeypatch, "ace-linux-1")
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8200)]), {})
+    assert summary.get("self_fenced") is False
+    assert len(summary["execution_ready"]) == 1
+
+
+def test_loop_originates_when_confirmed_git_leader(tmp_path, monkeypatch):
+    _set_machine(monkeypatch, "ace-linux-1")
+    cfg = _cfg(tmp_path)
+    cfg.enforce_leader_fence = True
+    cfg.leader_state_store = _FenceStore("ace-linux-1", 7, _dl.ClaimResult.PUSHED)
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8201)]), {})
+    assert summary["self_fenced"] is False
+    assert len(summary["execution_ready"]) == 1
+
+
+def test_loop_self_fences_when_push_not_confirmed(tmp_path, monkeypatch):
+    # Leader is correct but the heartbeat push cannot be confirmed -> stand down.
+    _set_machine(monkeypatch, "ace-linux-1")
+    cfg = _cfg(tmp_path)
+    cfg.enforce_leader_fence = True
+    cfg.leader_state_store = _FenceStore("ace-linux-1", 7, _dl.ClaimResult.PUSH_FAILED)
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8202)]), {})
+    assert summary["self_fenced"] is True
+    assert summary["execution_ready"] == []  # originated NOTHING
+    assert not cfg.lease_ledger_path.exists() or cfg.lease_ledger_path.read_text() == ""
+
+
+def test_loop_self_fences_when_not_the_committed_leader(tmp_path, monkeypatch):
+    # This machine is ace-linux-2 but committed leader is ace-linux-1 (and it
+    # passes the config leader check via promotion_token) -> git-fence still blocks.
+    _set_machine(monkeypatch, "ace-linux-2")
+    cfg = _cfg(tmp_path, promotion_token="tok")  # passes is_leader_machine
+    cfg.enforce_leader_fence = True
+    cfg.leader_state_store = _FenceStore("ace-linux-1", 7, _dl.ClaimResult.PUSHED)
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8203)]), {})
+    assert summary["self_fenced"] is True
+    assert summary["execution_ready"] == []
+
+
+def test_loop_dry_run_is_not_fenced(tmp_path, monkeypatch):
+    # dry-run writes no leases -> it must still produce a plan preview even when the
+    # fence is on and this machine could not originate (review #1).
+    _set_machine(monkeypatch, "ace-linux-1")
+    cfg = _cfg(tmp_path)
+    cfg.enforce_leader_fence = True
+    cfg.leader_state_store = _FenceStore("ace-linux-1", 7, _dl.ClaimResult.PUSH_FAILED)  # would block origination
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8204)]), {}, dry_run=True)
+    assert summary["self_fenced"] is False
+    assert len(summary["execution_ready"]) == 1  # planned (dry-run), not originated
+    assert summary["execution_ready"][0].get("planned") is True
+
+
+def test_loop_self_fences_with_reason_when_store_unavailable(tmp_path, monkeypatch):
+    # Enabling the fence before the ref is bootstrapped halts origination, but the
+    # reason must be surfaced (not silent) (review #2).
+    _set_machine(monkeypatch, "ace-linux-1")
+    cfg = _cfg(tmp_path)
+    cfg.enforce_leader_fence = True
+    cfg.leader_state_store = _FenceStore(None, 0, _dl.ClaimResult.PUSHED)  # read() raises StoreUnavailable
+    summary = module.run_loop(cfg, _kanban_with([_kanban_card(8205)]), {})
+    assert summary["self_fenced"] is True
+    assert summary["execution_ready"] == []
+    assert any("unavailable" in m.lower() for m in summary.get("self_fenced_detail", []))
+
+
+def test_leader_fence_enabled_from_env(monkeypatch):
+    monkeypatch.delenv("DISPATCH_ENFORCE_LEADER_FENCE", raising=False)
+    assert module.leader_fence_enabled_from_env() is False
+    for v in ("1", "true", "TRUE", "yes", " Yes "):
+        monkeypatch.setenv("DISPATCH_ENFORCE_LEADER_FENCE", v)
+        assert module.leader_fence_enabled_from_env() is True
+    for v in ("0", "false", "no", "", "off", "enabled-please"):
+        monkeypatch.setenv("DISPATCH_ENFORCE_LEADER_FENCE", v)
+        assert module.leader_fence_enabled_from_env() is False


### PR DESCRIPTION
Phase 1b of [#2847](https://github.com/vamseeachanta/workspace-hub/issues/2847) (plan-approved). Builds on the merged Phase 1a ([#2870](https://github.com/vamseeachanta/workspace-hub/pull/2870)).

## What
Wires the self-fence primitive into lease origination:
- **`dispatch_leader.leader_can_originate(store, machine)`** — True iff `machine` is the committed leader AND a fresh heartbeat is confirmed pushed (reuses `may_write_leases`).
- **`run_loop`** gates origination **once per tick** on `leader_can_originate` when `DispatcherConfig.enforce_leader_fence` is set; otherwise originates nothing and returns `summary[self_fenced]=True` with a `self_fenced_detail` reason (not-leader / store-unavailable / push-unconfirmed).
- **Opt-in, default OFF** — env `DISPATCH_ENFORCE_LEADER_FENCE=1` (via `leader_fence_enabled_from_env()`). With it off, behavior is provably unchanged (no store, no import, no new exception).

## Safety choices (from code review)
- **dry-run is NOT fenced** — it writes no leases, so it stays a valid plan-preview on any machine.
- **Fail-closed**: enabling before the dedicated ref is bootstrapped → `StoreUnavailable` → self-fence (originate nothing) with the reason surfaced. **Enable runbook:** the `dispatch-leader-watch` `--heartbeat` (Phase 1a) must have bootstrapped the `dispatch-leader-state` ref before flipping the env flag on the leader.
- A `tick` is one dispatch *invocation* (cron cadence), not a hot loop — the per-tick heartbeat push aligns with the heartbeat design.

## Review + tests
Code-stage adversarial review (`scripts/review/results/2026-05-29-impl-2847-phase1b-claude-subagent.md`): CHANGES REQUIRED → resolved (dry-run exempt, halt-reason surfaced, test gaps filled). **41 passed** (24 dispatch_leader + 17 dispatch-loop; existing 11 unchanged — default-off proven identical). 8 new tests incl. blocked-origination (empty ledger), dry-run-not-fenced, store-unavailable-with-reason, env parsing.

## Follow-on
**Phase 2** = auto-promotion (the dedicated-ref CAS proven in 1a is its foundation). Recommend a **Codex pass before flipping `DISPATCH_ENFORCE_LEADER_FENCE` on in production**. Parent: #2841.