### PR TITLE
fix(statusline): accurate Codex quota + headroom/git-state signals

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -18,23 +18,29 @@ ws_root=$(cd "$cwd" 2>/dev/null && git rev-parse --show-superproject-working-tre
 # Git branch
 branch=$(cd "$ws_root" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
 
-# Work queue counts (fast find, no recursion)
-wq="$ws_root/.claude/work-queue"
-if [[ -d "$wq/pending" ]]; then
-    p=$(find "$wq/pending" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-    w=$(find "$wq/working" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-    b=$(find "$wq/blocked" -maxdepth 1 -name "WRK-*.md" 2>/dev/null | wc -l | tr -d ' ')
-else
-    p=0; w=0; b=0
+# Git state markers — surface unpushed/uncommitted risk at a glance.
+# GIT_OPTIONAL_LOCKS=0 avoids the index-lock contention the ecosystem hits
+# in long sessions; -uno skips the untracked-file scan to keep this cheap on
+# the ~33K-file workspace-hub checkout.
+git_marker=""
+if [[ "$branch" != "?" ]]; then
+    if [[ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" status --porcelain -uno 2>/dev/null | head -1)" ]]; then
+        git_marker="\033[1;31m*\033[0m"   # bold red: dirty (tracked changes/staged)
+    fi
+    # ahead/behind vs upstream (rev-list is cheap — no working-tree scan)
+    lr=$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" rev-list --count --left-right '@{u}...HEAD' 2>/dev/null)
+    if [[ -n "$lr" ]]; then
+        behind=${lr%%[[:space:]]*}; ahead=${lr##*[[:space:]]}
+        (( ahead  > 0 )) && git_marker="${git_marker}\033[32m↑${ahead}\033[0m"   # green: unpushed
+        (( behind > 0 )) && git_marker="${git_marker}\033[31m↓${behind}\033[0m"  # red: behind remote
+    fi
 fi
 
-# Active WRK item (from per-machine state file)
-active_wrk=""
-active_wrk_file="$ws_root/.claude/state/active-wrk"
-if [[ -f "$active_wrk_file" ]]; then
-    active_id=$(head -1 "$active_wrk_file" | tr -d '[:space:]')
-    [[ -n "$active_id" ]] && active_wrk=" >${active_id}"
-fi
+# Issue badge — "GitHub issues only" ecosystem: derive the active issue from
+# the branch name (e.g. fix/2795-... -> #2795) instead of local WRK counters.
+issue_seg=""
+issue_num=$(echo "$branch" | grep -oE '[0-9]{3,5}' | head -1)
+[[ -n "$issue_num" ]] && issue_seg="\033[36m#${issue_num}\033[0m"
 
 # AI usage remaining percentages
 # C: uses Claude.ai 7-day subscription quota (from statusline JSON) as primary,
@@ -60,22 +66,37 @@ extract_pct() {
     fi
 }
 
+# Render a "LABEL:NN%" segment colored by remaining headroom so a throttle is
+# glance-able for delegation: red <20%, yellow <40%, green otherwise, dim when
+# the figure is unknown. Emits literal \033 escapes for the final printf %b.
+color_pct() {
+    local label="$1" rem="$2" suffix="${3:-}"
+    if [[ -z "$rem" || "$rem" == "-" ]]; then
+        echo "\033[2m${label}:-%${suffix}\033[0m"   # dim: unknown/unavailable
+        return
+    fi
+    local color='\033[32m'                            # green: ample headroom
+    (( rem < 40 )) && color='\033[33m'                # yellow: getting tight
+    (( rem < 20 )) && color='\033[31m'                # red: near throttle
+    echo "${color}${label}:${rem}%${suffix}\033[0m"
+}
+
 # Claude: prefer 7-day subscription remaining from API (most accurate)
 week_used=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+c_suffix=""
 if [[ -n "$week_used" ]]; then
-    c_display=$(awk -v u="$week_used" 'BEGIN { printf "%d", 100 - u }')"%"
+    c_rem=$(awk -v u="$week_used" 'BEGIN { printf "%d", 100 - u }')
 else
     # Fallback to agent-quota file
-    c_pct=$(extract_pct "claude")
-    c_display="${c_pct:--}%"
+    c_rem=$(extract_pct "claude")
     # Sonnet sub-bucket: show tighter limit with (S) indicator
-    if [[ -f "$quota_primary" ]]; then
+    if [[ -f "$quota_primary" && -n "$c_rem" ]]; then
         s_val=$(jq -r '.agents[] | select(.provider == "claude") | .sonnet_pct // empty' \
             "$quota_primary" 2>/dev/null)
-        if [[ -n "$s_val" && "$s_val" != "null" && -n "$c_pct" ]]; then
+        if [[ -n "$s_val" && "$s_val" != "null" ]]; then
             s_remaining=$(awk -v s="$s_val" 'BEGIN { printf "%d", 100 - s }')
-            if (( s_remaining < c_pct )); then
-                c_display="${s_remaining}%(S)"
+            if (( s_remaining < c_rem )); then
+                c_rem="$s_remaining"; c_suffix="(S)"
             fi
         fi
     fi
@@ -83,7 +104,7 @@ fi
 
 o_pct=$(extract_pct "codex")
 g_pct=$(extract_pct "gemini")
-ai_usage="C:${c_display}|O:${o_pct:--}%|G:${g_pct:--}%"
+ai_usage="$(color_pct C "$c_rem" "$c_suffix")|$(color_pct O "$o_pct")|$(color_pct G "$g_pct")"
 
 # Repo module name (basename of workspace root)
 repo_name=$(basename "$ws_root")
@@ -113,9 +134,9 @@ parts=()
 parts+=("\033[1;33m[${hostname_s}]\033[0m")
 parts+=("\033[1;35m${model}\033[0m")
 parts+=("\033[1;37m${repo_name}\033[0m")
-parts+=("\033[33m${branch}\033[0m")
-parts+=("\033[36mWRK:${p}p/${w}w/${b}b${active_wrk}\033[0m")
-parts+=("\033[35m${ai_usage}\033[0m")
+parts+=("\033[33m${branch}\033[0m${git_marker}")
+[[ -n "$issue_seg" ]] && parts+=("${issue_seg}")
+parts+=("${ai_usage}")
 parts+=("${cost_fmt}")
 parts+=("ctx:${ctx}")
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lib/
 !scripts/coordination/routing/lib/
 !scripts/setup/lib/
 !scripts/review/lib/
+!scripts/ai/assessment/lib/
 !scripts/cron/lib/
 !scripts/improve/lib/
 !scripts/readiness/lib/

--- a/docs/governance/2026-05-26-issue-lifecycle-adversarial-review-hitl.html
+++ b/docs/governance/2026-05-26-issue-lifecycle-adversarial-review-hitl.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue Lifecycle — Adversarial Review &amp; Human-in-the-Loop Gates</title>
+<style>
+  :root { --fg:#1b1f24; --mut:#57606a; --line:#d0d7de; --accent:#0969da;
+          --ok:#1a7f37; --warn:#9a6700; --danger:#cf222e; --bg:#fff; --code:#f6f8fa; }
+  * { box-sizing:border-box; }
+  body { font:15px/1.6 -apple-system,Segoe UI,Helvetica,Arial,sans-serif;
+         color:var(--fg); max-width:1000px; margin:0 auto; padding:32px 24px; background:var(--bg); }
+  h1 { font-size:26px; border-bottom:2px solid var(--line); padding-bottom:8px; }
+  h2 { font-size:20px; margin-top:38px; border-bottom:1px solid var(--line); padding-bottom:5px; }
+  h3 { font-size:16px; margin-top:22px; }
+  code,kbd { background:var(--code); padding:1px 5px; border-radius:5px; font:13px ui-monospace,Menlo,monospace; }
+  pre { background:var(--code); padding:12px 14px; border-radius:8px; overflow:auto; font:12.5px/1.5 ui-monospace,monospace; }
+  table { border-collapse:collapse; width:100%; margin:12px 0; font-size:14px; }
+  th,td { border:1px solid var(--line); padding:7px 10px; text-align:left; vertical-align:top; }
+  th { background:var(--code); }
+  .mut { color:var(--mut); }
+  .lead { color:var(--mut); font-size:15px; }
+  blockquote { border-left:3px solid var(--accent); margin:12px 0; padding:4px 14px; color:var(--mut); background:#f6f8fa; }
+  .pill { display:inline-block; padding:1px 8px; border-radius:11px; font-size:12px; font-weight:600; }
+  .tag { font:12px ui-monospace,monospace; background:#ddf4ff; color:var(--accent); padding:1px 6px; border-radius:5px; }
+
+  /* ---- flowchart ---- */
+  .flow { display:flex; flex-direction:column; align-items:center; margin:24px 0; }
+  .node { width:640px; max-width:100%; border:1.5px solid var(--line); border-radius:10px;
+          padding:11px 16px; background:#fff; position:relative; }
+  .node .lbl { font-size:11px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--mut); }
+  .node .ttl { font-weight:650; font-size:15px; margin-top:1px; }
+  .node .sub { font-size:13px; color:var(--mut); margin-top:3px; }
+  .node .src { font-size:11.5px; color:var(--mut); margin-top:5px; font-style:italic; }
+
+  .arrow { width:2px; height:20px; background:var(--line); position:relative; }
+  .arrow::after { content:""; position:absolute; bottom:0; left:50%; transform:translateX(-50%);
+                  border:5px solid transparent; border-top-color:var(--line); }
+
+  .phase { width:640px; max-width:100%; font-size:12px; font-weight:700; letter-spacing:.05em;
+           text-transform:uppercase; color:var(--mut); margin:6px 0 2px; }
+
+  /* node variants */
+  .process { }
+  .guard   { border-color:var(--accent); background:#f2f8ff; }
+  .review  { border-color:var(--warn); background:#fff8e6; border-width:2px; }
+  .human   { border-color:var(--ok); background:#eafaf0; border-width:2.5px; }
+  .start   { border-color:var(--mut); background:var(--code); border-radius:24px; }
+  .close   { border-color:var(--ok); background:#dafbe1; border-radius:24px; }
+
+  .badge { display:inline-block; font-size:11px; font-weight:700; padding:1px 7px; border-radius:6px; margin-left:6px; vertical-align:middle; }
+  .badge.r { background:#fff1cc; color:var(--warn); border:1px solid #e0b300; }
+  .badge.h { background:#c9f5d8; color:var(--ok); border:1px solid #43c463; }
+
+  .loop { width:640px; max-width:100%; font-size:12.5px; color:var(--danger); text-align:right; margin:3px 0; }
+  .legend { display:flex; flex-wrap:wrap; gap:14px; margin:14px 0; font-size:13px; }
+  .legend span { display:inline-flex; align-items:center; gap:7px; }
+  .sw { width:26px; height:15px; border-radius:4px; border:1.5px solid; display:inline-block; }
+  .sw.guard{ border-color:var(--accent); background:#f2f8ff; }
+  .sw.review{ border-color:var(--warn); background:#fff8e6; }
+  .sw.human{ border-color:var(--ok); background:#eafaf0; }
+  .sw.process{ border-color:var(--line); background:#fff; }
+</style>
+</head>
+<body>
+
+<h1>Issue Lifecycle &mdash; Adversarial Review &amp; Human-in-the-Loop</h1>
+<p class="lead">Governance flowchart &middot; workspace-hub ecosystem &middot; 2026-05-26 &middot;
+synthesized from current session-memory practice (see source-map table at the end).</p>
+
+<blockquote>
+GitHub is the center of record &mdash; every unit of work is a GitHub issue; there are no local task IDs.
+The lifecycle has <strong>two non-negotiable adversarial-review gates</strong> (plan-stage and code-stage)
+and <strong>three human-in-the-loop gates</strong> (plan-approve, PR-merge, completeness-verify/close).
+Reviews are never skipped &mdash; what scales with scope is review <em>depth</em> (T1/T2/T3), not its presence.
+</blockquote>
+
+<div class="legend">
+  <span><i class="sw process"></i> Process step</span>
+  <span><i class="sw guard"></i> Pre-work guard / discovery</span>
+  <span><i class="sw review"></i> Adversarial review gate <i class="badge r">R</i></span>
+  <span><i class="sw human"></i> Human-in-the-loop gate <i class="badge h">H</i></span>
+</div>
+
+<h2>1. The flow</h2>
+<div class="flow">
+
+  <div class="node start"><div class="ttl">Issue opened &middot; <code>gh issue create</code></div>
+    <div class="sub">Added to project board. <code>status:needs-plan</code>. GitHub issues only &mdash; no local IDs.</div></div>
+  <div class="arrow"></div>
+
+  <div class="phase">Phase 1 &middot; Pre-work guards (before any writing)</div>
+
+  <div class="node guard"><div class="lbl">Guard</div>
+    <div class="ttl">Fetch remote &amp; check for an existing fix</div>
+    <div class="sub"><code>git fetch origin</code> + <code>git log --all --grep="#NNNN"</code>. Another machine may have already solved &amp; pushed it.</div>
+    <div class="src">feedback_fetch_remote_before_resolving_issue</div></div>
+  <div class="arrow"></div>
+
+  <div class="node guard"><div class="lbl">Guard</div>
+    <div class="ttl">Check parallel work &middot; claim WIP label</div>
+    <div class="sub">Scan in-flight sessions, worktrees, recent <code>.planning/</code> edits. Claim the WIP label to avoid cross-machine clashes.</div>
+    <div class="src">feedback_check_parallel_work</div></div>
+  <div class="arrow"></div>
+
+  <div class="node guard"><div class="lbl">Guard</div>
+    <div class="ttl">Resource intel &amp; discovery-first pass</div>
+    <div class="sub">Inventory the codebase before writing. For a stale <code>plan-approved</code> issue (&gt;~7d), prior commits may have already done most of the scope &mdash; decide: execute / narrow / close-as-done.</div>
+    <div class="src">feedback_discovery_first_on_stale_plan_approved</div></div>
+  <div class="arrow"></div>
+
+  <div class="phase">Phase 2 &middot; Plan</div>
+
+  <div class="node process"><div class="ttl">Draft the plan</div>
+    <div class="sub">Future tense only (no past-tense artifact claims). Classify scope <strong>T1 / T2 / T3</strong> &mdash; this sets review depth, not whether review happens.</div>
+    <div class="src">feedback_plan_past_tense_artifact_claims</div></div>
+  <div class="arrow"></div>
+
+  <div class="node review"><div class="lbl">Gate &mdash; Adversarial Review A <span class="badge r">R</span></div>
+    <div class="ttl">Adversarial PLAN review</div>
+    <div class="sub">Defect-hunting stance (assume defects, no praise, evidence per finding, empty review = failure). Depth: <strong>T1</strong> 1 provider &middot; <strong>T2</strong> Codex+Gemini &middot; <strong>T3</strong> +3rd Claude pass. Must leave an artifact under <code>scripts/review/results/</code>.</div>
+    <div class="src">adversarial_review_stance &middot; always_adversarial_review_scale_depth &middot; cross_provider_review_payoff</div></div>
+  <div class="loop">&#8617; MAJOR findings &rarr; revise plan &amp; re-review (don't auto-loop &gt;3 rounds &mdash; surface consensus)</div>
+  <div class="arrow"></div>
+
+  <div class="node process"><div class="ttl">Label <code>status:plan-review</code></div>
+    <div class="sub">Present to user: links to plan at a stable commit ref + reviewer artifacts + a CLI one-liner they paste themselves.</div></div>
+  <div class="arrow"></div>
+
+  <div class="node human"><div class="lbl">Human gate 1 <span class="badge h">H</span></div>
+    <div class="ttl">USER APPROVES &rarr; <code>status:plan-approved</code></div>
+    <div class="sub">User sets the label themselves (CLI / web UI). <strong>Never self-approve, never offer "tell me and I'll label it," never pre-authorize via handoff prompt.</strong> Planning is where course-correction is cheapest.</div>
+    <div class="src">feedback_never_offer_to_self_label_plan_approved</div></div>
+  <div class="arrow"></div>
+
+  <div class="phase">Phase 3 &middot; Implement</div>
+
+  <div class="node process"><div class="ttl">Implement (TDD &middot; tests-first)</div>
+    <div class="sub">Mid-build self-corrections are normal but are <em>self-review by the author</em> &mdash; they do NOT satisfy the review gate below.</div></div>
+  <div class="arrow"></div>
+
+  <div class="node review"><div class="lbl">Gate &mdash; Adversarial Review B <span class="badge r">R</span></div>
+    <div class="ttl">Adversarial CODE / artifact review</div>
+    <div class="sub">2+ providers; Codex tends to find contract-vs-shipped-data defects Claude misses (non-overlapping). Spot-verify reviewer claims locally (sandbox can misread untracked-but-present files as "absent"). Leaves an artifact.</div>
+    <div class="src">cross_provider_review_payoff &middot; gemini_sandbox_overlay_blindness</div></div>
+  <div class="loop">&#8617; MAJOR findings &rarr; fix &amp; re-review</div>
+  <div class="arrow"></div>
+
+  <div class="phase">Phase 4 &middot; Completeness &amp; cleanup</div>
+
+  <div class="node process"><div class="ttl">Compute completeness score (0&ndash;100%)</div>
+    <div class="sub">Test-grounded (pass-rate + coverage delta + acceptance-criteria checklist), scored adversarially. Documented in HTML under <code>docs/reports/</code>. Stamp the <code>```completeness {json}```</code> record on the issue body <strong>before</strong> the owner applies the verified label (anti-forgery freshness check).</div>
+    <div class="src">completeness_score_before_closure &middot; completeness_gate_first_close_sequence</div></div>
+  <div class="arrow"></div>
+
+  <div class="node process"><div class="ttl">Pre-completion cleanup audit</div>
+    <div class="sub">5-step audit &rarr; bucket residue CLEAN / EXPECTED / UNEXPECTED. <strong>Block completion if any UNEXPECTED residue.</strong></div>
+    <div class="src">feedback_pre_completion_cleanup_audit_gate</div></div>
+  <div class="arrow"></div>
+
+  <div class="node human"><div class="lbl">Human gate 2 <span class="badge h">H</span></div>
+    <div class="ttl">USER MERGES the PR</div>
+    <div class="sub">Merge is a user action, gated on Review B evidence existing. A green pre-push "review-gate PASS" keys off commit metadata, not a real review artifact &mdash; it does not substitute for the gate.</div>
+    <div class="src">adversarial_review_before_user_approval</div></div>
+  <div class="arrow"></div>
+
+  <div class="node human"><div class="lbl">Human gate 3 <span class="badge h">H</span></div>
+    <div class="ttl">USER reviews % &rarr; owner attests <code>status:completeness-verified</code></div>
+    <div class="sub">Owner confirms score &ge; threshold (default 90%); may override DOWN, never silently up. Set <code>COMPLETENESS_OWNERS</code> repo var first; remove+re-add the label so its timestamp is fresh vs. the body edit. Solo operator may verify+close unless separate-closer is required.</div>
+    <div class="src">completeness_score_before_closure &middot; completeness_gate_first_close_sequence</div></div>
+  <div class="arrow"></div>
+
+  <div class="phase">Phase 5 &middot; Close</div>
+
+  <div class="node process"><div class="ttl">Post summary comment (always)</div>
+    <div class="sub"><code>gh issue comment</code> with commit hash, files changed, what was tested. Non-negotiable for every implemented issue.</div>
+    <div class="src">feedback_gh_issue_comment</div></div>
+  <div class="arrow"></div>
+
+  <div class="node close"><div class="ttl"><code>gh issue close</code></div>
+    <div class="sub">If the issue auto-closed via a <code>Closes #N</code> trailer before your comment lands: reopen &rarr; comment &rarr; close (close drops the comment otherwise).</div>
+    <div class="src">feedback_gh_issue_close_silent_comment_drop</div></div>
+
+</div>
+
+<h2>2. The five gates at a glance</h2>
+<table>
+<tr><th>#</th><th>Gate</th><th>Type</th><th>Pass condition</th><th>Failure mode it prevents</th></tr>
+<tr><td>A</td><td>Adversarial plan review</td><td><span class="pill" style="background:#fff8e6;color:var(--warn)">review</span></td>
+    <td>Defect-hunt artifact exists; MAJORs resolved; depth matches T-class</td>
+    <td>Charitable/rubber-stamp APPROVE; shipping a flawed plan to the approval gate</td></tr>
+<tr><td>1</td><td>User approves plan</td><td><span class="pill" style="background:#eafaf0;color:var(--ok)">human</span></td>
+    <td>User sets <code>status:plan-approved</code> themselves</td>
+    <td>Self-approval / proxy pre-authorization collapsing the cheapest course-correction point</td></tr>
+<tr><td>B</td><td>Adversarial code/artifact review</td><td><span class="pill" style="background:#fff8e6;color:var(--warn)">review</span></td>
+    <td>2+ provider artifact exists; MAJORs fixed; claims spot-verified locally</td>
+    <td>Self-review-only merges; non-overlapping defects a single provider misses</td></tr>
+<tr><td>2</td><td>User merges PR</td><td><span class="pill" style="background:#eafaf0;color:var(--ok)">human</span></td>
+    <td>User merges, with Review B evidence present</td>
+    <td>Green-metadata "PASS" masking the absence of a real review</td></tr>
+<tr><td>3</td><td>User verifies completeness &amp; closes</td><td><span class="pill" style="background:#eafaf0;color:var(--ok)">human</span></td>
+    <td>Score reviewed; owner attests label (fresh timestamp); summary comment posted</td>
+    <td>Agent self-report passed off as owner attestation; closure without objective signal</td></tr>
+</table>
+
+<h2>3. Invariants</h2>
+<ul>
+<li><strong>Review presence is fixed; depth is the dial.</strong> Never surface "skip review" as an option &mdash; only "T1-scoped single provider" vs. "full T2/T3."</li>
+<li><strong>Self-review &ne; adversarial review.</strong> The author finding their own bugs mid-build does not satisfy gate A or B.</li>
+<li><strong>The human gates are load-bearing, not friction.</strong> Provide links + CLI; the user performs the action. This holds even after repeated "continue" authorizations in a session.</li>
+<li><strong>If a provider is unavailable</strong> (Codex stdin-hang, Gemini 429/trust-folder), record it explicitly and proceed with available providers &mdash; never silently downgrade to "no review."</li>
+<li><strong>Discovery before execution.</strong> A <code>plan-approved</code> label is a contract about intent, not current state; verify the corpus first.</li>
+</ul>
+
+<h2>4. Source map</h2>
+<p class="mut">Each lifecycle element traces to a session-memory feedback/project record (under
+<code>~/.claude/projects/&hellip;/memory/</code> and <code>.claude/memory/topics/</code>).</p>
+<table>
+<tr><th>Element</th><th>Memory record</th></tr>
+<tr><td>Both review gates before user approval/merge</td><td><code>feedback_adversarial_review_before_user_approval</code></td></tr>
+<tr><td>Scale depth (T1/T2/T3), never skip</td><td><code>feedback_always_adversarial_review_scale_depth</code></td></tr>
+<tr><td>Defect-hunting reviewer stance contract</td><td><code>feedback_adversarial_review_stance</code></td></tr>
+<tr><td>2+ providers find non-overlapping defects</td><td><code>feedback_cross_provider_review_payoff</code></td></tr>
+<tr><td>User-only plan approval; no proxy pre-auth</td><td><code>feedback_never_offer_to_self_label_plan_approved</code></td></tr>
+<tr><td>Completeness score gates closure (HTML)</td><td><code>feedback_completeness_score_before_closure</code></td></tr>
+<tr><td>Owners-var + stamp-before-verify ordering</td><td><code>feedback_completeness_gate_first_close_sequence</code></td></tr>
+<tr><td>Pre-completion cleanup audit buckets</td><td><code>feedback_pre_completion_cleanup_audit_gate</code></td></tr>
+<tr><td>Discovery-first on stale plan-approved</td><td><code>feedback_discovery_first_on_stale_plan_approved</code></td></tr>
+<tr><td>Fetch remote before resolving</td><td><code>feedback_fetch_remote_before_resolving_issue</code></td></tr>
+<tr><td>Check parallel work / WIP claim</td><td><code>feedback_check_parallel_work</code></td></tr>
+<tr><td>Always comment on the issue</td><td><code>feedback_gh_issue_comment</code></td></tr>
+<tr><td>Close drops comments &rarr; reopen-comment-close</td><td><code>feedback_gh_issue_close_silent_comment_drop</code></td></tr>
+<tr><td>Sandbox file-presence misreads in review</td><td><code>feedback_gemini_sandbox_overlay_blindness</code></td></tr>
+</table>
+
+</body>
+</html>

--- a/scripts/ai/assessment/lib/display.sh
+++ b/scripts/ai/assessment/lib/display.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ABOUTME: Display and logging functions for AI usage reports
+# Requires: utils.sh sourced, providers.sh sourced
+
+bar_graph() {
+    local pct=$1 width=10
+    local filled=$(( pct * width / 100 ))
+    local empty=$(( width - filled ))
+    local bar=""
+    for ((i=0; i<filled; i++)); do bar+="█"; done
+    for ((i=0; i<empty; i++)); do bar+="░"; done
+    echo "$bar"
+}
+
+color_for_pct() {
+    local pct=$1
+    if (( pct > 50 )); then echo "32"
+    elif (( pct > 20 )); then echo "33"
+    else echo "31"; fi
+}
+
+display_summary() {
+    local data="$1"
+    echo ""
+    echo "Agent Credits ($(date +%A) $(date +%Y-%m-%d)):"
+
+    for provider in claude codex gemini; do
+        local entry
+        entry=$(echo "$data" | jq -r --arg p "$provider" '.agents[] | select(.provider == $p)')
+        if [[ -z "$entry" ]]; then
+            printf "  %-8s ░░░░░░░░░░  — (no data)\n" "$provider:"; continue
+        fi
+
+        local pct
+        pct=$(echo "$entry" | jq -r '.pct_remaining // empty' 2>/dev/null || true)
+
+        # No authoritative rate-limit % — keep Claude as N/A until fixed.
+        if [[ -z "$pct" || "$pct" == "null" ]]; then
+            printf "  %-8s ░░░░░░░░░░  N/A (authoritative source unavailable)\n" "$provider:"
+            continue
+        fi
+
+        local msgs limit bar color detail
+        msgs=$(echo "$entry" | jq -r '.week_messages // .today_messages // 0')
+        limit=$(echo "$entry" | jq -r '.weekly_limit // .daily_limit // 0')
+        bar=$(bar_graph "$pct")
+        color=$(color_for_pct "$pct")
+
+        if [[ "$provider" == "claude" ]]; then
+            local approx sessions tools trend icon cost
+            approx=$(echo "$entry" | jq -r '.approx_requests // 0')
+            sessions=$(echo "$entry" | jq -r '.week_sessions // 0')
+            tools=$(echo "$entry" | jq -r '.week_tool_calls // 0')
+            trend=$(echo "$entry" | jq -r '.trend // "stable"')
+            icon=""; case "$trend" in high) icon=" ↑" ;; low) icon=" ↓" ;; esac
+            detail="(~${approx} reqs, ${sessions} sessions, ${tools} tools${icon})"
+            cost=$(echo "$entry" | jq -r '.week_cost_usd // empty' 2>/dev/null || true)
+            [[ -n "$cost" && "$cost" != "0" ]] && detail="\$${cost}/wk equiv, ${detail}"
+        else
+            detail="(${msgs}/${limit} msgs)"
+        fi
+
+        printf "  %-8s \033[%sm%s\033[0m  %d%% remaining %s\n" \
+            "$provider:" "$color" "$bar" "$pct" "$detail"
+    done
+    echo ""
+}
+
+show_weekly_summary() {
+    local week_start
+    week_start=$(last_monday_date)
+    echo "Weekly Usage Summary (since $week_start):"
+    echo ""
+
+    # Claude: authoritative OAuth snapshot only
+    local oauth
+    oauth=$(get_claude_oauth_entry)
+    if [[ -n "$oauth" ]]; then
+        local pct rem five reset
+        pct=$(echo "$oauth" | jq -r '.week_pct // 0')
+        rem=$(awk -v w="$pct" 'BEGIN { printf "%d", 100 - w }')
+        five=$(echo "$oauth" | jq -r '.five_hour_pct // 0')
+        reset=$(echo "$oauth" | jq -r '.hours_to_reset // 0')
+        printf "  %-8s used: %s%%  remaining: %s%%  5h: %s%%  reset in: %sh\n" \
+            "claude:" "$pct" "$rem" "$five" "$reset"
+    else
+        printf "  %-8s N/A  (authoritative source unavailable)\n" "claude:"
+    fi
+
+    # Codex: history.jsonl count
+    local codex_count=0
+    [[ -f "${HOME}/.codex/history.jsonl" ]] && \
+        codex_count=$(uv run --no-project python -c "
+import json, time, os
+h=os.path.expanduser('~/.codex/history.jsonl'); cutoff=time.time()-7*86400; c=0
+try:
+    [c := c+1 for line in open(h) if line.strip() and json.loads(line).get('ts',0) >= cutoff]
+except: pass
+print(c)
+" 2>/dev/null || echo 0)
+    printf "  %-8s week msgs: %s  (limit: %s)\n" \
+        "codex:" "$codex_count" "${CODEX_WEEKLY_MESSAGES:-1400}"
+
+    # Gemini: daily count only (weekly not available)
+    local gemini_count=0
+    [[ -f "${HOME}/.config/gemini/state.json" ]] && \
+        gemini_count=$(jq -r '.dailyRequestCount // 0' "${HOME}/.config/gemini/state.json" 2>/dev/null || echo 0)
+    printf "  %-8s today msgs: %s  (weekly data unavailable from source)\n" \
+        "gemini:" "$gemini_count"
+    echo ""
+}
+
+log_snapshot() {
+    local data="$1" log_file="$2"
+    mkdir -p "$(dirname "$log_file")"
+    jq -cn \
+        --arg ts "$(iso_now)" \
+        --argjson agents "$(echo "$data" | jq -c '.agents')" \
+        '{ timestamp: $ts, agents: $agents }' >> "$log_file"
+}

--- a/scripts/ai/assessment/lib/providers.sh
+++ b/scripts/ai/assessment/lib/providers.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# ABOUTME: AI provider usage query functions (Claude, Codex, Gemini)
+# Requires: utils.sh sourced, REPO_QUOTA_FILE/CLAUDE_MESSAGE_RATIO globals set
+
+# ── Claude ────────────────────────────────────────────────────────────────────
+
+# Returns current-week cost/token data from ccusage (reads session JSONL — always current)
+# Note: auxiliary only; not authoritative for quota percentages.
+get_ccusage_weekly() {
+    command -v npx &>/dev/null || { echo "null"; return; }
+    local since raw
+    since=$(this_monday_yyyymmdd 2>/dev/null || date -d "-7 days" +%Y%m%d)
+    raw=$(NO_COLOR=1 npx ccusage weekly --json --since "$since" 2>/dev/null)
+    [[ -z "$raw" ]] && { echo "null"; return; }
+    echo "$raw" | uv run --no-project python -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    weeks = data.get('weekly', [])
+    if not weeks:
+        print('null'); sys.exit(0)
+    w = weeks[-1]
+    print(json.dumps({
+        'cost_usd':     round(w.get('totalCost', 0), 2),
+        'total_tokens': w.get('totalTokens', 0),
+        'input_tokens': w.get('inputTokens', 0),
+        'output_tokens': w.get('outputTokens', 0),
+        'models':       w.get('modelsUsed', [])
+    }))
+except Exception:
+    print('null')
+" 2>/dev/null || echo "null"
+}
+
+# Returns validated claude entry from REPO_QUOTA_FILE (authoritative only)
+get_claude_oauth_entry() {
+    [[ -f "$REPO_QUOTA_FILE" ]] || return 0
+    local entry
+    entry=$(jq -c '.agents[] | select(.provider == "claude") | select(.source == "oauth-api")' \
+        "$REPO_QUOTA_FILE" 2>/dev/null || true)
+    [[ -z "$entry" ]] && return 0
+    echo "$entry" | jq -e '.week_pct != null' &>/dev/null && echo "$entry"
+}
+
+# Returns weekly stats from ~/.claude/stats-cache.json (local CLI tracker, may be stale)
+query_claude_stats() {
+    local creds="${HOME}/.claude/.credentials.json"
+    local stats="${HOME}/.claude/stats-cache.json"
+    local tier="unknown" weekly_limit=10000
+
+    if [[ -f "$creds" ]]; then
+        tier=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$creds" 2>/dev/null)
+        local rate_tier
+        rate_tier=$(jq -r '.claudeAiOauth.rateLimitTier // ""' "$creds" 2>/dev/null)
+        case "${rate_tier:-$tier}" in
+            pro)                   weekly_limit=2000  ;;
+            max)                   weekly_limit=10000 ;;
+            default_claude_max_20x) weekly_limit=20000 ;;
+            team)                  weekly_limit=3500  ;;
+        esac
+    fi
+
+    local weekly
+    weekly=$(uv run --no-project python - <<PYEOF
+import json, datetime, os
+cache = os.path.expanduser("~/.claude/stats-cache.json")
+try:
+    with open(cache) as f:
+        data = json.load(f)
+    cutoff = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
+    messages = sessions = tools = 0
+    for day in data.get("dailyActivity", []):
+        if day.get("date", "") > cutoff:
+            messages += day.get("messageCount", 0)
+            sessions += day.get("sessionCount", 0)
+            tools    += day.get("toolCallCount", 0)
+    print(messages, sessions, tools)
+except Exception:
+    print(0, 0, 0)
+PYEOF
+)
+    local messages sessions tools
+    read -r messages sessions tools <<< "$weekly"
+    messages=${messages:-0}; sessions=${sessions:-0}; tools=${tools:-0}
+
+    local approx=0 pct_used=0 pct_remaining=100
+    if (( weekly_limit > 0 && messages > 0 )); then
+        approx=$(awk -v m="$messages" -v r="${CLAUDE_MESSAGE_RATIO:-15}" 'BEGIN { printf "%d", m/r }')
+        pct_used=$(awk -v u="$approx" -v l="$weekly_limit" 'BEGIN { printf "%d", (u/l)*100 }')
+        (( pct_used > 100 )) && pct_used=100
+        pct_remaining=$(( 100 - pct_used ))
+    fi
+
+    local avg=0 trend="stable"
+    if [[ -f "$stats" ]]; then
+        avg=$(jq -r '[.dailyActivity[].messageCount] | add / length | floor' "$stats" 2>/dev/null || echo 0)
+        local today_msgs
+        today_msgs=$(jq -r '.dailyActivity[-1].messageCount // 0' "$stats" 2>/dev/null || echo 0)
+        if (( today_msgs > 0 && avg > 0 )); then
+            awk -v t="$today_msgs" -v a="$avg" 'BEGIN { exit !(t/a > 1.5) }' && trend="high"
+            awk -v t="$today_msgs" -v a="$avg" 'BEGIN { exit !(t/a < 0.5) }' && trend="low"
+        fi
+    fi
+
+    jq -n \
+        --arg tier "$tier" \
+        --argjson limit "$weekly_limit" \
+        --argjson messages "$messages" \
+        --argjson approx "$approx" \
+        --argjson sessions "$sessions" \
+        --argjson tools "$tools" \
+        --argjson pct "$pct_remaining" \
+        --argjson avg "$avg" \
+        --arg trend "$trend" \
+        '{provider:"claude", tier:$tier, weekly_limit:$limit,
+          week_messages:$messages, approx_requests:$approx,
+          week_sessions:$sessions, week_tool_calls:$tools,
+          pct_remaining:$pct, avg_daily_messages:$avg,
+          trend:$trend, source:"stats-cache.json"}'
+}
+
+# Merges ccusage token/cost data into a provider JSON entry as auxiliary metadata only.
+# Use this only when the base quota source is authoritative.
+_enrich_with_ccusage() {
+    local entry="$1"
+    local ccusage
+    ccusage=$(get_ccusage_weekly)
+    [[ "$ccusage" == "null" || -z "$ccusage" ]] && { echo "$entry"; return; }
+    echo "$entry" | jq \
+        --argjson cc "$ccusage" \
+        '. + {week_cost_usd: $cc.cost_usd, week_tokens: $cc.total_tokens,
+              week_input_tokens: $cc.input_tokens, week_output_tokens: $cc.output_tokens,
+              models_used: $cc.models}'
+}
+
+# Main claude query: authoritative OAuth snapshot only.
+# If unavailable, surface N/A rather than an estimated quota.
+query_claude() {
+    local oauth
+    oauth=$(get_claude_oauth_entry)
+    if [[ -n "$oauth" ]]; then
+        _enrich_with_ccusage "$oauth"
+        return
+    fi
+
+    local creds="${HOME}/.claude/.credentials.json"
+    local tier="unknown" weekly_limit=10000
+    if [[ -f "$creds" ]]; then
+        tier=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$creds" 2>/dev/null)
+        local rate_tier
+        rate_tier=$(jq -r '.claudeAiOauth.rateLimitTier // ""' "$creds" 2>/dev/null)
+        case "${rate_tier:-$tier}" in
+            pro)                    weekly_limit=2000  ;;
+            max)                    weekly_limit=10000 ;;
+            default_claude_max_20x) weekly_limit=20000 ;;
+            team)                   weekly_limit=3500  ;;
+        esac
+    fi
+
+    local unavailable
+    jq -n \
+        --arg tier "$tier" \
+        --argjson limit "$weekly_limit" \
+        '{
+            provider:"claude",
+            tier:$tier,
+            weekly_limit:$limit,
+            week_pct:null,
+            five_hour_pct:null,
+            pct_remaining:null,
+            hours_to_reset:null,
+            resets_at:"",
+            source:"unavailable"
+        }'
+}
+
+# ── Codex ─────────────────────────────────────────────────────────────────────
+
+query_codex() {
+    local history="${HOME}/.codex/history.jsonl"
+    local messages=0
+    if [[ -f "$history" ]]; then
+        messages=$(uv run --no-project python - <<PYEOF
+import json, time, os
+history = os.path.expanduser("~/.codex/history.jsonl")
+cutoff = time.time() - 7 * 86400
+count = 0
+try:
+    with open(history) as f:
+        for line in f:
+            line = line.strip()
+            if not line: continue
+            try:
+                entry = json.loads(line)
+                if entry.get("ts", 0) >= cutoff:
+                    count += 1
+            except (json.JSONDecodeError, ValueError):
+                pass
+except Exception:
+    pass
+print(count)
+PYEOF
+)
+        messages=${messages:-0}
+    fi
+    local limit="${CODEX_WEEKLY_MESSAGES:-1400}"
+
+    # Authoritative: Codex's own server-reported rate-limit telemetry
+    # (rate_limits.secondary in each session rollout). This matches the
+    # ChatGPT Codex Analytics dashboard exactly. The history.jsonl
+    # message-count below is a coarse estimate that wildly undercounts
+    # (assumes a flat 1400-msg cap, ignores token/tool weighting) and is
+    # used only as a fallback when no session telemetry is available.
+    local assess_dir telemetry
+    assess_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
+    telemetry=$(bash "$assess_dir/query-codex-usage.sh" --json 2>/dev/null || true)
+    if [[ -n "$telemetry" ]] \
+        && echo "$telemetry" | jq -e '.source == "local-session-rate-limits" and .pct_remaining != null' &>/dev/null; then
+        echo "$telemetry" | jq -c \
+            --argjson limit "$limit" \
+            --argjson messages "$messages" \
+            '{provider:"codex", tier:"subscription", weekly_limit:$limit,
+              week_messages:$messages, week_pct:.week_pct,
+              five_hour_pct:.five_hour_pct, pct_remaining:.pct_remaining,
+              hours_to_reset:.hours_to_reset, resets_at:.resets_at,
+              source:"local-session-rate-limits"}'
+        return
+    fi
+
+    # Fallback: coarse message-count estimate (no live rate-limit telemetry).
+    local pct_used=0
+    (( limit > 0 )) && pct_used=$(awk -v u="$messages" -v l="$limit" 'BEGIN { printf "%d", (u/l)*100 }')
+    (( pct_used > 100 )) && pct_used=100
+    jq -n \
+        --argjson limit "$limit" \
+        --argjson messages "$messages" \
+        --argjson pct "$(( 100 - pct_used ))" \
+        '{provider:"codex", tier:"subscription", weekly_limit:$limit,
+          week_messages:$messages, pct_remaining:$pct, source:"history.jsonl-estimate"}'
+}
+
+# ── Gemini ────────────────────────────────────────────────────────────────────
+
+query_gemini() {
+    local state="${HOME}/.config/gemini/state.json"
+    local today messages=0
+    today=$(date +%Y-%m-%d)
+
+    if [[ -f "$state" ]]; then
+        local count
+        count=$(jq -r '.dailyRequestCount // 0' "$state" 2>/dev/null)
+        [[ "$count" != "null" && "$count" != "0" ]] && messages=$count
+    fi
+
+    if (( messages == 0 )); then
+        [[ ! -f /tmp/.gemini-day-marker ]] && touch_midnight /tmp/.gemini-day-marker "$today"
+        messages=$(find "${HOME}/.config/gemini/tmp" -maxdepth 1 \
+            -newer /tmp/.gemini-day-marker -type f 2>/dev/null | wc -l)
+    fi
+
+    local limit="${GEMINI_DAILY_REQUESTS:-1000}"
+    local pct_used=0
+    (( limit > 0 )) && pct_used=$(awk -v u="$messages" -v l="$limit" 'BEGIN { printf "%d", (u/l)*100 }')
+    (( pct_used > 100 )) && pct_used=100
+    jq -n \
+        --argjson limit "$limit" \
+        --argjson messages "$messages" \
+        --argjson pct "$(( 100 - pct_used ))" \
+        '{provider:"gemini", tier:"google_login", daily_limit:$limit,
+          today_messages:$messages, pct_remaining:$pct, source:"estimated"}'
+}

--- a/scripts/ai/assessment/lib/utils.sh
+++ b/scripts/ai/assessment/lib/utils.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ABOUTME: Portable helper functions shared across AI assessment scripts
+
+# Portable file modification time (seconds since epoch)
+file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# Portable ISO-8601 datetime
+iso_now() {
+    date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z
+}
+
+# Monday of the current week in YYYY-MM-DD
+last_monday_date() {
+    local dow days_back
+    dow=$(date +%u 2>/dev/null || date +%w)
+    [[ "$dow" == "0" ]] && dow=7
+    days_back=$(( dow - 1 ))
+    (( days_back == 0 )) && days_back=7
+    date -d "-${days_back} days" +%Y-%m-%d 2>/dev/null && return
+    date -v-${days_back}d +%Y-%m-%d 2>/dev/null && return
+    date -d "-7 days" +%Y-%m-%d 2>/dev/null || date -v-7d +%Y-%m-%d
+}
+
+# Monday of the current week in YYYYMMDD (for ccusage --since)
+this_monday_yyyymmdd() {
+    local dow days_back
+    dow=$(date +%u 2>/dev/null || echo 1)
+    [[ "$dow" == "0" ]] && dow=7
+    days_back=$(( dow - 1 ))
+    date -d "-${days_back} days" +%Y%m%d 2>/dev/null \
+        || date -v-${days_back}d +%Y%m%d 2>/dev/null \
+        || date -d "-7 days" +%Y%m%d
+}
+
+# Portable touch-to-midnight (for day-marker files)
+touch_midnight() {
+    local marker="$1" today="$2"
+    touch -d "${today} 00:00:00" "$marker" 2>/dev/null && return
+    touch -t "$(echo "${today}" | tr -d '-')0000" "$marker" 2>/dev/null || true
+}


### PR DESCRIPTION
## Summary
Recovers the only unpushed local work in workspace-hub (branch `fix/statusline-codex-quota`, which had diverged 146 commits behind main). Cherry-picked the two real commits onto current `main`; **dropped** the bundled `chore(sync): auto-sync 2026-05-26` commit (generated state churn — provider-kanban/scorecard JSON + jsonl signals — already superseded by newer commits on main).

## Changes (6 files, +718/-26)
- **`.claude/statusline-command.sh`** — accurate Codex quota + headroom/git-state signals
- **`scripts/ai/assessment/lib/{providers,display,utils}.sh`** — new quota-query lib (previously swallowed by a bare `lib/` gitignore rule)
- **`.gitignore`** — `!`-negation so the lib is tracked
- **`docs/governance/2026-05-26-issue-lifecycle-adversarial-review-hitl.html`** — issue-lifecycle flowchart (adversarial-review + HITL gates)

Working-tree state churn was intentionally excluded — only committed, deliberate work is here.