### PR TITLE
docs(#2814): fix stale context.md repo-layout claim (siblings vs nested)

### DIFF
--- a/.claude/memory/context.md
+++ b/.claude/memory/context.md
@@ -17,19 +17,23 @@
 
 ## Workspace Layout (Linux)
 
-- `/mnt/local-analysis/workspace-hub/` — the real git repo mount
-- `~/workspace-hub` — **sparse overlay** on ace-linux-1; writes may fail silently *stale: 2026-05-24*
+- `/mnt/local-analysis/workspace-hub/` — the real git repo mount (harness / control-plane)
+- `~/workspace-hub` — **sparse overlay** on ace-linux-1; writes may fail silently
   - If a write via tool fails: write to `/tmp/` first, then `mv` via terminal to the real mount
-- `digitalmodel/` — **separate git repo** (vamseeachanta/digitalmodel.git), gitignored by parent *stale: 2026-05-25*
-  - Commits MUST be made from inside `digitalmodel/` — not from workspace-hub root
-- `aceengineer-strategy/` — private GTM strategy repo, nested, gitignored by parent *stale: 2026-05-24*
-- `worldenergydata/` — energy data sub-repo
+- **Tier-1 repos live as SIBLINGS at `/mnt/local-analysis/<repo>` — NOT nested under workspace-hub.**
+  `workspace-hub` is the harness/control-plane, not a parent for tier-1 checkouts. Each is a
+  separate git repo; commit from inside it, never from the workspace-hub root.
+  - `/mnt/local-analysis/digitalmodel/` — separate git repo (vamseeachanta/digitalmodel.git)
+  - `/mnt/local-analysis/worldenergydata/` — separate git repo
+  - `/mnt/local-analysis/assetutilities/` — separate git repo
+  - `/mnt/local-analysis/assethold/` — separate git repo
+  - `/mnt/local-analysis/aceengineer-strategy/` — private GTM strategy repo (sibling, not nested)
 
 ## Windows Path Conventions
 
 - MINGW64 bash: paths use `/d/workspace-hub/` (not `D:\workspace-hub`)
 - `core.symlinks=false` — git treats junctions as dirs; never commit symlinks cross-platform
-- Shell scripts: `#!/usr/bin/env bash`, LF line endings *stale: 2026-05-25*
+- Shell scripts: `#!/usr/bin/env bash`, LF line endings
 
 ## Memory Sync Model
 

--- a/docs/plans/2026-05-27-issue-2814-fix-stale-context-layout.md
+++ b/docs/plans/2026-05-27-issue-2814-fix-stale-context-layout.md
@@ -1,11 +1,13 @@
 # Plan for #2814: docs(harness): fix stale context.md repo-layout claim (siblings vs nested)
 
-> **Status:** draft
+> **Status:** implemented (2026-05-29) — T1 review resolved the `aceengineer-strategy` open question (live-verified sibling); corrected ALL tier-1 siblings + regenerated `context.md` from the template; added anti-drift regression test.
 > **Complexity:** T1
 > **Date:** 2026-05-27
 > **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2814
 > **Client:** N/A
-> **Review artifacts:** scripts/review/results/2026-05-27-plan-2814-claude.md | ...-codex.md | ...-gemini.md
+> **Review artifacts:** scripts/review/results/2026-05-29-2814-claude.md (T1 plan+code; APPROVE)
+>
+> **Implementation note (2026-05-29):** The `aceengineer-strategy` "open question" below is RESOLVED — live `.git` probe confirms it (and `digitalmodel`/`worldenergydata`/`assetutilities`/`assethold`) are all siblings at `/mnt/local-analysis/`. The fix edits the bridge heredoc template and regenerates `context.md` from it (faithful quoted-heredoc extraction — NOT a hand-edit), removing the prior `*stale:*` drift markers. `tests/memory/test_context_md_bridge_sync.py` locks the heredoc↔context.md sync so this drift cannot recur. Scoped to the Linux layout section; Windows (`D:\workspace-hub\`, genuinely nested) untouched.
 
 ---
 

--- a/scripts/memory/bridge-hermes-claude.sh
+++ b/scripts/memory/bridge-hermes-claude.sh
@@ -146,13 +146,17 @@ cat > "${MEMORY_DIR}/context.md" << 'CONTEXT_EOF'
 
 ## Workspace Layout (Linux)
 
-- `/mnt/local-analysis/workspace-hub/` — the real git repo mount
+- `/mnt/local-analysis/workspace-hub/` — the real git repo mount (harness / control-plane)
 - `~/workspace-hub` — **sparse overlay** on ace-linux-1; writes may fail silently
   - If a write via tool fails: write to `/tmp/` first, then `mv` via terminal to the real mount
-- `digitalmodel/` — **separate git repo** (vamseeachanta/digitalmodel.git), gitignored by parent
-  - Commits MUST be made from inside `digitalmodel/` — not from workspace-hub root
-- `aceengineer-strategy/` — private GTM strategy repo, nested, gitignored by parent
-- `worldenergydata/` — energy data sub-repo
+- **Tier-1 repos live as SIBLINGS at `/mnt/local-analysis/<repo>` — NOT nested under workspace-hub.**
+  `workspace-hub` is the harness/control-plane, not a parent for tier-1 checkouts. Each is a
+  separate git repo; commit from inside it, never from the workspace-hub root.
+  - `/mnt/local-analysis/digitalmodel/` — separate git repo (vamseeachanta/digitalmodel.git)
+  - `/mnt/local-analysis/worldenergydata/` — separate git repo
+  - `/mnt/local-analysis/assetutilities/` — separate git repo
+  - `/mnt/local-analysis/assethold/` — separate git repo
+  - `/mnt/local-analysis/aceengineer-strategy/` — private GTM strategy repo (sibling, not nested)
 
 ## Windows Path Conventions
 

--- a/scripts/review/results/2026-05-29-2814-claude.md
+++ b/scripts/review/results/2026-05-29-2814-claude.md
@@ -1,0 +1,17 @@
+# Adversarial Review — #2814 context.md layout fix — Claude (T1, plan + code)
+
+T1 (1 provider) per complexity: doc-truth fix touching a heredoc template + its generated file. Both stages reviewed by Claude, live claims verified. Verdict: **plan MAJOR (1, resolved) → code APPROVE.**
+
+## Plan stage
+- **MAJOR — plan under-corrected `aceengineer-strategy`.** The plan preserved its `nested` description as an open question. Verified live: `/mnt/local-analysis/aceengineer-strategy/.git` exists (sibling); absent under workspace-hub. **Resolution:** the fix corrects it (and all tier-1 siblings) to the real layout, not just `digitalmodel`/`worldenergydata`.
+- **MINOR — managed-file hand-edit hazard.** `context.md` is bridge-generated yet had hand-added `*stale:*` markers (drift). **Resolution:** the fix edits the heredoc template and regenerates `context.md` from it (faithful extraction of the quoted heredoc), not a hand-edit — so the next bridge run is idempotent and the drift markers are removed.
+- **Checked OK:** root-cause locus (the heredoc template, not the generated artifact) is the correct altitude; `agents.md` is the authoritative sibling source and is consistent.
+
+## Code stage (diff review)
+- **Coverage verified empirically** (not assumed): all 5 repos (`digitalmodel`, `worldenergydata`, `assetutilities`, `assethold`, `aceengineer-strategy`) confirmed siblings at `/mnt/local-analysis/` via live `.git` probe.
+- **`context.md` == heredoc:** regenerated via literal extraction of the QUOTED heredoc (no var expansion), so byte-identical to what the bridge's step-4 produces. Locked by a new regression test (`tests/memory/test_context_md_bridge_sync.py`) that asserts the two stay in sync — this would have caught the original drift.
+- **AC1** (context.md reflects real sibling layout): met. **AC2** (no tooling references the stale nested path as authoritative): met — the only `workspace-hub/<repo>` matches are frozen Codex review LOGS using `D:\workspace-hub\` (Windows, where repos are genuinely nested); no active Linux tooling hardcodes the nested assumption. The fix is correctly scoped to the `## Workspace Layout (Linux)` section.
+- **Scope discipline:** Windows path conventions untouched (Windows layout differs and is out of scope); bash syntax of the bridge verified (`bash -n`).
+
+## Verdict
+APPROVE. Plan MAJOR resolved in implementation; doc-truth aligned to live state + authoritative `agents.md`; anti-drift regression test added.

--- a/tests/memory/test_context_md_bridge_sync.py
+++ b/tests/memory/test_context_md_bridge_sync.py
@@ -1,0 +1,54 @@
+"""#2814: context.md must stay in sync with the bridge heredoc, and describe the
+real (sibling) repo layout.
+
+`.claude/memory/context.md` is generated verbatim from the QUOTED heredoc
+(`cat > context.md << 'CONTEXT_EOF' ... CONTEXT_EOF`) in `bridge-hermes-claude.sh` —
+a quoted heredoc does NO variable expansion, so the committed file must be byte-identical
+to the template body. Drift between them (the bridge not re-run after a template edit) is
+exactly the #2814 bug: the committed context.md carried a stale *nested* repo-layout claim
+while the repos are siblings at `/mnt/local-analysis/`.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BRIDGE = REPO / "scripts" / "memory" / "bridge-hermes-claude.sh"
+CONTEXT = REPO / ".claude" / "memory" / "context.md"
+
+TIER1_SIBLINGS = ("digitalmodel", "worldenergydata", "assetutilities", "assethold",
+                  "aceengineer-strategy")
+
+
+def _extract_heredoc(text: str) -> str:
+    """Return the literal body of the `context.md` heredoc in the bridge script."""
+    out, capturing = [], False
+    for ln in text.splitlines():
+        if not capturing:
+            if "context.md" in ln and "<< 'CONTEXT_EOF'" in ln:
+                capturing = True
+            continue
+        if ln == "CONTEXT_EOF":
+            break
+        out.append(ln)
+    return "\n".join(out)
+
+
+def test_context_md_matches_bridge_heredoc():
+    # The generated file must equal its template body — else the bridge wasn't re-run and
+    # context.md is stale (the root-cause drift behind #2814).
+    heredoc = _extract_heredoc(BRIDGE.read_text())
+    assert heredoc, "could not locate the context.md heredoc in bridge-hermes-claude.sh"
+    committed = CONTEXT.read_text().rstrip("\n")
+    assert committed == heredoc.rstrip("\n"), (
+        "context.md has drifted from the bridge heredoc template — regenerate it from the "
+        "template (re-run the bridge or re-extract the heredoc) so they match (#2814)")
+
+
+def test_context_md_layout_is_sibling_not_nested():
+    txt = CONTEXT.read_text()
+    assert "SIBLINGS at `/mnt/local-analysis/<repo>`" in txt
+    for repo in TIER1_SIBLINGS:
+        assert f"/mnt/local-analysis/{repo}/" in txt, f"missing sibling path for {repo}"
+    # the stale nested framing must be gone
+    assert "energy data sub-repo" not in txt
+    assert "private GTM strategy repo, nested" not in txt


### PR DESCRIPTION
## #2814 — fix stale context.md repo-layout claim (siblings vs nested)

`.claude/memory/context.md` claimed `digitalmodel`/`worldenergydata`/`aceengineer-strategy` are nested sub-repos of `workspace-hub`. They are **siblings** at `/mnt/local-analysis/<repo>` — verified live for all five tier-1 repos. Any tooling trusting the nested assumption for data-access resolution would mis-resolve. (Surfaced during the #2801 machine-equality investigation.)

### Fix
- **Root cause = the template, not the artifact.** `context.md` is generated verbatim from a QUOTED heredoc in `scripts/memory/bridge-hermes-claude.sh`. Fixed the heredoc's `## Workspace Layout (Linux)` section to show the real sibling layout with absolute `/mnt/local-analysis/` paths.
- **Regenerated `context.md` from the template** (faithful quoted-heredoc extraction — *not* a hand-edit), which also removes prior hand-added `*stale:*` drift markers. A hand-edit would be reverted on the next bridge run; this stays idempotent.
- **Anti-drift regression test** (`tests/memory/test_context_md_bridge_sync.py`): asserts `context.md` is byte-in-sync with the heredoc + describes siblings not nested. This test would have caught the original drift.

### Review (T1 — 1 provider, both stages)
`scripts/review/results/2026-05-29-2814-claude.md`. The plan-stage review found a MAJOR — the plan under-corrected `aceengineer-strategy` (preserved as an open question). Live `.git` probe resolved it: it's a sibling too. The fix corrects **all five** siblings, not just the two named in the issue.

### Scope / acceptance
- **AC1** context.md reflects real sibling layout — met.
- **AC2** no tooling references the stale nested path as authoritative — met (the only `workspace-hub/<repo>` matches are frozen Codex review *logs* using `D:\workspace-hub\`, i.e. **Windows**, where the repos are genuinely nested). Linux layout section is the correct, sole scope; Windows conventions untouched.
- `tests/memory/` suite: **41 passed**. Bridge `bash -n` clean.

Refs #2814, #2801.
