### PR TITLE
refactor(#2817): extract shared label_authority helper (PR1/prerequisite)

### DIFF
--- a/scripts/workflow/completeness_gate_runner.py
+++ b/scripts/workflow/completeness_gate_runner.py
@@ -14,11 +14,9 @@ Hardening:
 """
 from __future__ import annotations
 
-import datetime as _dt
 import json
 import os
 import re
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -26,19 +24,9 @@ from completeness_gate_check import (  # noqa: E402
     OPT_IN_LABEL, PLAN_APPROVED_LABEL, VERIFIED_LABEL,
     body_is_fresh, evaluate_close, gate_applies,
 )
+from label_authority import gh_json, parse_iso, verified_label_event  # noqa: E402
 
 _RECORD_RE = re.compile(r"```completeness\s*(\{.*?\})\s*```", re.DOTALL)
-
-
-def _gh_json(*args: str):
-    out = subprocess.run(["gh", *args], capture_output=True, text=True, check=True).stdout
-    return json.loads(out) if out.strip() else None
-
-
-def _parse_iso(ts: str | None):
-    if not ts:
-        return None
-    return _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
 
 def _parse_record(body: str) -> dict | None:
@@ -51,25 +39,13 @@ def _parse_record(body: str) -> dict | None:
         return None  # fail-closed: unparseable record => no record
 
 
-def _verified_label_event(repo: str, issue: int):
-    """(actor, applied_at) for the most recent application of the verified label."""
-    events = _gh_json("api", f"repos/{repo}/issues/{issue}/timeline",
-                      "--paginate", "-H", "Accept: application/vnd.github+json") or []
-    actor, applied_at = None, None
-    for ev in events:
-        if ev.get("event") == "labeled" and (ev.get("label") or {}).get("name") == VERIFIED_LABEL:
-            actor = (ev.get("actor") or {}).get("login")
-            applied_at = _parse_iso(ev.get("created_at"))
-    return actor, applied_at
-
-
 def main() -> int:
     repo = os.environ.get("GH_REPO") or os.environ.get("REPO", "")
     issue = int(os.environ.get("ISSUE_NUMBER") or sys.argv[1])
     closing_actor = os.environ.get("CLOSING_ACTOR", "")
 
-    data = _gh_json("issue", "view", str(issue), "--repo", repo,
-                    "--json", "body,labels,updatedAt") or {}
+    data = gh_json("issue", "view", str(issue), "--repo", repo,
+                   "--json", "body,labels,updatedAt") or {}
     labels = [l["name"] for l in data.get("labels", [])]
 
     # OPT-IN SCOPE FIRST: the gate only enforces on issues that explicitly opted in
@@ -87,15 +63,15 @@ def main() -> int:
         return 1
 
     record = _parse_record(data.get("body", ""))
-    label_actor, label_at = _verified_label_event(repo, issue)
+    label_actor, label_at = verified_label_event(repo, issue, VERIFIED_LABEL)
     # Freshness anchors on the BODY edit time (lastEditedAt), NOT updatedAt — the close
     # itself bumps updatedAt past the label and would falsely fail freshness (fix #5).
     owner, name = repo.split("/", 1)
-    ts = _gh_json("api", "graphql", "-f", f'query={{repository(owner:"{owner}",name:"{name}")'
+    ts = gh_json("api", "graphql", "-f", f'query={{repository(owner:"{owner}",name:"{name}")'
                   f'{{issue(number:{issue}){{lastEditedAt createdAt}}}}}}') or {}
     issue_ts = (((ts.get("data") or {}).get("repository") or {}).get("issue")) or {}
     body_verified_fresh = body_is_fresh(
-        label_at, _parse_iso(issue_ts.get("lastEditedAt")), _parse_iso(issue_ts.get("createdAt")))
+        label_at, parse_iso(issue_ts.get("lastEditedAt")), parse_iso(issue_ts.get("createdAt")))
 
     require_separate = os.environ.get("COMPLETENESS_REQUIRE_SEPARATE_CLOSER", "").lower() in ("1", "true", "yes")
     decision = evaluate_close(

--- a/scripts/workflow/label_authority.py
+++ b/scripts/workflow/label_authority.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Shared label-actor-authority helpers (#2817).
+
+Generalized — by parameterizing the label name — from #2798's
+``completeness_gate_runner._verified_label_event`` so BOTH the completeness-close gate
+and the plan-approval merge gate resolve "who applied this label, and when" through one
+audited primitive. This module is a pure I/O wrapper + timeline resolver; it makes NO
+policy decisions (authorization / freshness / threshold) — callers own those, so the
+completeness gate's existing behavior is preserved unchanged.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import subprocess
+
+
+def gh_json(*args: str):
+    """Run ``gh <args>`` and return parsed JSON (or None for empty output)."""
+    out = subprocess.run(["gh", *args], capture_output=True, text=True, check=True).stdout
+    return json.loads(out) if out.strip() else None
+
+
+def parse_iso(ts: str | None):
+    """Parse a GitHub ISO-8601 timestamp (``...Z``) to an aware datetime, or None."""
+    if not ts:
+        return None
+    return _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def verified_label_event(repo: str, issue: int, label: str):
+    """``(actor, applied_at)`` for the most recent application of ``label`` on ``issue``.
+
+    Reads the issue **timeline** (audit-attributed). Returns ``(None, None)`` when the label
+    was never applied — callers fail closed on that. ``unlabeled`` events are ignored: only
+    a ``labeled`` event counts as an application. The timeline is chronological, so the last
+    matching ``labeled`` event is the most recent application.
+    """
+    events = gh_json("api", f"repos/{repo}/issues/{issue}/timeline",
+                     "--paginate", "-H", "Accept: application/vnd.github+json") or []
+    actor, applied_at = None, None
+    for ev in events:
+        if ev.get("event") == "labeled" and (ev.get("label") or {}).get("name") == label:
+            actor = (ev.get("actor") or {}).get("login")
+            applied_at = parse_iso(ev.get("created_at"))
+    return actor, applied_at

--- a/tests/workflow/test_label_authority.py
+++ b/tests/workflow/test_label_authority.py
@@ -1,0 +1,74 @@
+"""#2817 PR1: shared label-actor-authority helper, generalized from #2798's
+completeness_gate_runner (`_verified_label_event`). The extraction must be a pure,
+non-regressive move — the same timeline-resolution behavior, parameterized by label name —
+so BOTH the completeness gate and the new plan-approval gate share one audited primitive.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MOD = REPO / "scripts" / "workflow" / "label_authority.py"
+
+spec = importlib.util.spec_from_file_location("label_authority", MOD)
+assert spec is not None and spec.loader is not None
+la = importlib.util.module_from_spec(spec)
+sys.modules["label_authority"] = la  # register before exec (import safety)
+spec.loader.exec_module(la)
+
+
+def test_parse_iso_handles_z_suffix_and_none():
+    dt = la.parse_iso("2026-05-30T04:00:00Z")
+    assert dt is not None and dt.year == 2026 and dt.month == 5 and dt.day == 30
+    assert la.parse_iso(None) is None
+    assert la.parse_iso("") is None
+
+
+def test_verified_label_event_returns_latest_application(monkeypatch):
+    # multiple applications of the SAME label -> the most recent (actor, applied_at) wins
+    events = [
+        {"event": "labeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "alice"}, "created_at": "2026-05-01T00:00:00Z"},
+        {"event": "labeled", "label": {"name": "unrelated"},
+         "actor": {"login": "bob"}, "created_at": "2026-05-02T00:00:00Z"},
+        {"event": "labeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "vamsee"}, "created_at": "2026-05-03T00:00:00Z"},
+    ]
+    monkeypatch.setattr(la, "gh_json", lambda *a: events)
+    actor, at = la.verified_label_event("o/r", 1, "status:plan-approved")
+    assert actor == "vamsee"
+    assert at == la.parse_iso("2026-05-03T00:00:00Z")
+
+
+def test_verified_label_event_parameterized_by_label(monkeypatch):
+    # the SAME timeline yields different results for different label names (the generalization)
+    events = [
+        {"event": "labeled", "label": {"name": "status:completeness-verified"},
+         "actor": {"login": "owner"}, "created_at": "2026-05-03T00:00:00Z"},
+    ]
+    monkeypatch.setattr(la, "gh_json", lambda *a: events)
+    assert la.verified_label_event("o/r", 1, "status:completeness-verified")[0] == "owner"
+    assert la.verified_label_event("o/r", 1, "status:plan-approved") == (None, None)
+
+
+def test_verified_label_event_absent_is_none_pair(monkeypatch):
+    monkeypatch.setattr(la, "gh_json", lambda *a: [])
+    assert la.verified_label_event("o/r", 1, "status:plan-approved") == (None, None)
+    monkeypatch.setattr(la, "gh_json", lambda *a: None)  # gh returned empty
+    assert la.verified_label_event("o/r", 1, "status:plan-approved") == (None, None)
+
+
+def test_verified_label_event_ignores_unlabeled_events(monkeypatch):
+    # an "unlabeled" event for the same name must NOT count as an application
+    events = [
+        {"event": "labeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "vamsee"}, "created_at": "2026-05-03T00:00:00Z"},
+        {"event": "unlabeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "vamsee"}, "created_at": "2026-05-04T00:00:00Z"},
+    ]
+    monkeypatch.setattr(la, "gh_json", lambda *a: events)
+    actor, at = la.verified_label_event("o/r", 1, "status:plan-approved")
+    assert actor == "vamsee" and at == la.parse_iso("2026-05-03T00:00:00Z")


### PR DESCRIPTION
## #2817 PR1 — shared label-authority helper (prerequisite)

First, bounded, **non-regressive** step of the approved #2817 plan (the plan recommends landing the shared-helper refactor as a separate prerequisite PR).

Extracts #2798's `_verified_label_event` / `_gh_json` / `_parse_iso` from `completeness_gate_runner.py` into a new `scripts/workflow/label_authority.py`, **generalized by parameterizing the label name**: `verified_label_event(repo, issue, label)`. The runner now imports it; behavior is identical.

This is the single audited authority primitive both gates will share. Per review finding **R6** (Codex), bot-rejection is NOT baked into this helper — it stays opt-in per caller — so the completeness gate's exact current behavior is preserved.

**Tests:** 6 new helper tests (`tests/workflow/test_label_authority.py` — latest-application, label-parameterization, absent→(None,None), unlabeled-ignored, ISO parsing); existing completeness tests green unchanged. Full `tests/workflow/`: **49 passed**.

Next: PR2 builds the `plan_approval_gate_check.py` server gate on top of this helper (with the R1–R5 review fixes: fail-closed, freshness=plan_revision only, branch/owner-recorded anti-substitution binding, policy-control PAT mitigation, required-status-check).

Refs #2817