### PR TITLE
feat(#2816): Windows collect-equality.ps1 + EQ_* override seam

### DIFF
--- a/scripts/readiness/collect-equality.ps1
+++ b/scripts/readiness/collect-equality.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+  collect-equality.ps1 — Windows compute overlay for the #2801 machine-equality matrix (#2816).
+
+.DESCRIPTION
+  A THIN compute overlay over collect-equality.sh. Git Bash on Windows cannot reliably read
+  RAM / disk / GPU (the .sh emits "unknown" for them, which the matrix grades MISSING-EVIDENCE),
+  so this script computes those Windows-hard fields via CIM, exports them as EQ_* environment
+  overrides, then delegates to `bash scripts/readiness/collect-equality.sh`.
+
+  Schema, the provenance block, solver probes, behaviour probes, and the canonical-hash
+  commit-on-change idempotency stay SINGLE-SOURCED in the .sh — this script only fills the five
+  Windows compute fields. That avoids the schema-drift trap of a standalone reimplementation.
+
+  W1 (Codex r2): this collector does NOT commit or push the resulting .claude/state/equality-*.yaml.
+  Committing + pushing the state to origin so the central matrix can see it is the wrapper's job
+  (scripts/windows/equality-report.ps1, #2815) — NOT this collector's. Run standalone, the report
+  stays local (same as collect-equality.sh on Linux, which relies on repo-sync to push).
+
+  W3 (Codex r2): a freshness preflight runs FIRST. If the checkout's origin/main ref cannot be
+  shown to be fresh (fetch fails AND the local ref is stale/behind), the script FAILS FAST without
+  writing a report — so a stale checkout never silently produces an all-STALE-CHECKOUT report.
+
+.PARAMETER Stdout
+  Pass through to collect-equality.sh --stdout (emit to stdout, do not write the state file).
+
+.PARAMETER Machine
+  Pass through to collect-equality.sh --machine <label> (override machine-label autodetection).
+
+.NOTES
+  Owner-machine-only. PowerShell cannot run on Linux CI; the contract is pinned by the
+  Linux-runnable tests/readiness/test_collect_equality_ps1_schema.py against a golden fixture and
+  the .sh EQ_* override seam. Run Invoke-ScriptAnalyzer on a PowerShell-present machine.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Stdout,
+    [string]$Machine
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Resolve workspace root = two levels up from this script (scripts/readiness/ -> repo root).
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WS = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+
+# ── W3: freshness preflight — establish a fresh origin/main BEFORE collecting ────────────────────
+# A stale origin/main ref makes is_stale() fail-closed (origin_ref_age_h out of window OR
+# behind_main != 0), so every cell would grade STALE-CHECKOUT. Try a fetch; if that fails, only
+# proceed when the LOCAL origin/main ref is already current (behind_main == 0) AND recent. Else
+# FAIL FAST without writing a report — a silent STALE report is worse than a loud, actionable miss.
+function Test-Fresh {
+    param([string]$Repo)
+    # Best effort: refresh origin/main. A transient network miss is tolerated only if the local
+    # ref is already current+recent (checked below); a hard inability to prove freshness fails.
+    & git -C $Repo fetch --quiet origin main 2>$null | Out-Null
+    $fetchOk = ($LASTEXITCODE -eq 0)
+
+    $behind = (& git -C $Repo rev-list --count 'HEAD..origin/main' 2>$null)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($behind)) {
+        return @{ Fresh = $false; Reason = 'no origin/main ref (cannot establish freshness)' }
+    }
+    if ([int]$behind -ne 0) {
+        return @{ Fresh = $false; Reason = "checkout is $behind commit(s) behind origin/main" }
+    }
+    if (-not $fetchOk) {
+        # Fetch failed but local ref says behind==0. Only trust that if the ref is recent
+        # (matches the matrix is_stale() 12h window), else we can't prove it's truly fresh.
+        $commonDir = (& git -C $Repo rev-parse --git-common-dir 2>$null)
+        if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
+            $commonDir = Join-Path $Repo $commonDir
+        }
+        $refPath = $null
+        foreach ($r in @('FETCH_HEAD', 'refs/remotes/origin/main')) {
+            $candidate = Join-Path $commonDir $r
+            if (Test-Path $candidate) { $refPath = $candidate; break }
+        }
+        if (-not $refPath) {
+            return @{ Fresh = $false; Reason = 'fetch failed and no local origin ref to age-check' }
+        }
+        $ageH = ((Get-Date) - (Get-Item $refPath).LastWriteTime).TotalHours
+        if ($ageH -lt 0 -or $ageH -gt 12) {
+            return @{ Fresh = $false; Reason = "fetch failed and local origin ref is $([math]::Round($ageH,1))h old (>12h)" }
+        }
+    }
+    return @{ Fresh = $true; Reason = 'origin/main current' }
+}
+
+$freshness = Test-Fresh -Repo $WS
+if (-not $freshness.Fresh) {
+    Write-Error ("collect-equality.ps1: freshness preflight FAILED ({0}). " -f $freshness.Reason +
+                 'Refusing to write a STALE-CHECKOUT report. Run the RepoSync task / `git fetch` ' +
+                 'and retry.')
+    exit 1
+}
+
+# ── CIM compute (the .ps1's real job) ────────────────────────────────────────────────────────────
+$cs = Get-CimInstance Win32_ComputerSystem
+$os = Get-CimInstance Win32_OperatingSystem
+
+# cores
+$env:EQ_CORES = [string]$cs.NumberOfLogicalProcessors
+# RAM total: TotalPhysicalMemory is BYTES -> MiB
+$env:EQ_RAM_TOTAL_MIB = [string][math]::Floor($cs.TotalPhysicalMemory / 1MB)
+# RAM available: FreePhysicalMemory is KB -> MiB
+$env:EQ_RAM_AVAIL_MIB = [string][math]::Floor($os.FreePhysicalMemory / 1KB)
+
+# Disk free on the drive that actually HOSTS the resolved workspace path — NOT a hardcoded D:.
+$wsQualifier = (Split-Path -Qualifier $WS)              # e.g. "D:"
+$disk = Get-CimInstance Win32_LogicalDisk -Filter ("DeviceID='{0}'" -f $wsQualifier)
+if ($null -ne $disk -and $null -ne $disk.FreeSpace) {
+    $env:EQ_DISK_AVAIL_GB = [string][math]::Floor($disk.FreeSpace / 1GB)
+} else {
+    $env:EQ_DISK_AVAIL_GB = 'unknown'                  # .sh validates -> stays unknown
+}
+
+# GPU: first video controller name, or "none". (Free-form string; the .sh escapes it.)
+$gpu = (Get-CimInstance Win32_VideoController | Select-Object -First 1 -ExpandProperty Name -ErrorAction SilentlyContinue)
+$env:EQ_GPU_MODEL = if ([string]::IsNullOrWhiteSpace($gpu)) { 'none' } else { $gpu }
+
+# ── delegate to the canonical .sh (schema/provenance/solvers/idempotency single-sourced there) ───
+$shPath = Join-Path $ScriptDir 'collect-equality.sh'
+$shArgs = @($shPath)
+if ($Stdout) { $shArgs += '--stdout' }
+if (-not [string]::IsNullOrWhiteSpace($Machine)) { $shArgs += @('--machine', $Machine) }
+
+& bash @shArgs
+exit $LASTEXITCODE

--- a/scripts/readiness/collect-equality.ps1
+++ b/scripts/readiness/collect-equality.ps1
@@ -71,13 +71,13 @@ function Test-Fresh {
         if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
             $commonDir = Join-Path $Repo $commonDir
         }
-        $refPath = $null
-        foreach ($r in @('FETCH_HEAD', 'refs/remotes/origin/main')) {
-            $candidate = Join-Path $commonDir $r
-            if (Test-Path $candidate) { $refPath = $candidate; break }
-        }
-        if (-not $refPath) {
-            return @{ Fresh = $false; Reason = 'fetch failed and no local origin ref to age-check' }
+        # Age-check the tracked origin/main ref ONLY — NOT FETCH_HEAD. FETCH_HEAD is bumped by ANY
+        # fetch (e.g. of an unrelated branch) and does not prove origin/main itself is fresh, so a
+        # recent unrelated fetch could falsely pass freshness while origin/main is stale. If the
+        # loose ref is absent (packed/never-fetched), we cannot prove freshness -> fail closed.
+        $refPath = Join-Path $commonDir 'refs/remotes/origin/main'
+        if (-not (Test-Path $refPath)) {
+            return @{ Fresh = $false; Reason = 'fetch failed and no loose origin/main ref to age-check' }
         }
         $ageH = ((Get-Date) - (Get-Item $refPath).LastWriteTime).TotalHours
         if ($ageH -lt 0 -or $ageH -gt 12) {
@@ -99,12 +99,19 @@ if (-not $freshness.Fresh) {
 $cs = Get-CimInstance Win32_ComputerSystem
 $os = Get-CimInstance Win32_OperatingSystem
 
+# Each CIM value is $null-guarded BEFORE arithmetic: PowerShell coerces a missing/null numeric
+# to 0 in math (e.g. [math]::Floor($null / 1MB) == 0), which eqint() would accept as a valid 0 and
+# mis-grade as BELOW-BASELINE instead of MISSING-EVIDENCE. A degraded CIM response must emit
+# "unknown" (the .sh validator keeps it unknown -> matrix grades MISSING-EVIDENCE, fail-closed).
 # cores
-$env:EQ_CORES = [string]$cs.NumberOfLogicalProcessors
+$env:EQ_CORES = if ($null -ne $cs -and $null -ne $cs.NumberOfLogicalProcessors) {
+    [string]$cs.NumberOfLogicalProcessors } else { 'unknown' }
 # RAM total: TotalPhysicalMemory is BYTES -> MiB
-$env:EQ_RAM_TOTAL_MIB = [string][math]::Floor($cs.TotalPhysicalMemory / 1MB)
+$env:EQ_RAM_TOTAL_MIB = if ($null -ne $cs -and $null -ne $cs.TotalPhysicalMemory) {
+    [string][math]::Floor($cs.TotalPhysicalMemory / 1MB) } else { 'unknown' }
 # RAM available: FreePhysicalMemory is KB -> MiB
-$env:EQ_RAM_AVAIL_MIB = [string][math]::Floor($os.FreePhysicalMemory / 1KB)
+$env:EQ_RAM_AVAIL_MIB = if ($null -ne $os -and $null -ne $os.FreePhysicalMemory) {
+    [string][math]::Floor($os.FreePhysicalMemory / 1KB) } else { 'unknown' }
 
 # Disk free on the drive that actually HOSTS the resolved workspace path — NOT a hardcoded D:.
 $wsQualifier = (Split-Path -Qualifier $WS)              # e.g. "D:"

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -31,11 +31,15 @@ HOST="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
 case "$(uname -s 2>/dev/null)" in
   Linux) OS="linux";; Darwin) OS="macos";; MINGW*|MSYS*|CYGWIN*) OS="windows";; *) OS="unknown";;
 esac
-# EQ_OS_OVERRIDE: force the OS branch (companion/test seam). The collect-equality.ps1 companion
-# runs under Git Bash (uname → MINGW → "windows") so it does NOT need this; it exists so the
-# Linux contract test can exercise the windows EQ_* override seam (#2816 W5). Allowlisted values
-# only — never trusts arbitrary input to pick a code path.
-case "${EQ_OS_OVERRIDE:-}" in linux|macos|windows|unknown) OS="$EQ_OS_OVERRIDE";; esac
+# EQ_OS_OVERRIDE: force the OS branch — TEST SEAM ONLY, double-gated behind the explicit
+# EQ_TEST_ENABLE_OS_OVERRIDE=1 flag so ambient production env can NEVER spoof the collector OS.
+# (A bare override would let a Linux host misreport os: windows + trusted Windows compute —
+# Codex code-review MAJOR.) The collect-equality.ps1 companion runs under Git Bash
+# (uname → MINGW → "windows") and never sets the test flag; this exists only so the Linux contract
+# test can exercise the windows EQ_* override seam (#2816 W5). Allowlisted values only.
+if [[ "${EQ_TEST_ENABLE_OS_OVERRIDE:-}" == "1" ]]; then
+  case "${EQ_OS_OVERRIDE:-}" in linux|macos|windows|unknown) OS="$EQ_OS_OVERRIDE";; esac
+fi
 if [[ -z "$MACHINE" ]]; then
   case "$HOST" in
     ace-linux-1*) MACHINE="dev-primary";; ace-linux-2*) MACHINE="dev-secondary";;

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -31,6 +31,11 @@ HOST="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
 case "$(uname -s 2>/dev/null)" in
   Linux) OS="linux";; Darwin) OS="macos";; MINGW*|MSYS*|CYGWIN*) OS="windows";; *) OS="unknown";;
 esac
+# EQ_OS_OVERRIDE: force the OS branch (companion/test seam). The collect-equality.ps1 companion
+# runs under Git Bash (uname → MINGW → "windows") so it does NOT need this; it exists so the
+# Linux contract test can exercise the windows EQ_* override seam (#2816 W5). Allowlisted values
+# only — never trusts arbitrary input to pick a code path.
+case "${EQ_OS_OVERRIDE:-}" in linux|macos|windows|unknown) OS="$EQ_OS_OVERRIDE";; esac
 if [[ -z "$MACHINE" ]]; then
   case "$HOST" in
     ace-linux-1*) MACHINE="dev-primary";; ace-linux-2*) MACHINE="dev-secondary";;
@@ -41,6 +46,16 @@ fi
 have() { command -v "$1" >/dev/null 2>&1; }
 # CC1/GC1: escape a value for a YAML double-quoted scalar (backslash, quote; strip CR/LF).
 yesc() { printf '%s' "$1" | tr -d '\r\n' | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+# #2816 W5: validate an EQ_* compute override is a clean non-negative integer (counts/MiB/GiB).
+# Echoes the validated integer, or "unknown" on empty / non-numeric / negative / newline /
+# unit-suffixed input — so a null/failed CIM query in the .ps1 companion can never emit 0/garbage
+# into the graded compute cells (the matrix treats "unknown" as MISSING-EVIDENCE, fail-closed).
+eqint() {
+  local v="${1-}"
+  # printf %s + the [[ =~ ]] anchors below reject embedded \n/\r, leading +/-, "16GB", " 5 ",
+  # decimals, and empty. Only a pure run of ASCII digits survives.
+  [[ "$v" =~ ^[0-9]+$ ]] && printf '%s' "$v" || printf '%s' unknown
+}
 
 # ── 1. COMPUTE (static = graded/hashed; headroom = volatile/excluded) ────────
 cores="unknown"; ram_total_mib="unknown"; gpu="none"; ram_avail_mib="unknown"; disk_avail_gb="unknown"
@@ -55,7 +70,16 @@ case "$OS" in
     cores=$(sysctl -n hw.ncpu 2>/dev/null || echo unknown)
     ram_total_mib=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576 ));;
   windows)
-    cores="${NUMBER_OF_PROCESSORS:-unknown}";;  # RAM/disk unreliable in Git Bash -> unknown -> MISSING-EVIDENCE
+    # RAM/disk/gpu are unreliable in bare Git Bash -> "unknown" -> MISSING-EVIDENCE. The
+    # collect-equality.ps1 companion (#2816) computes them via CIM and exports EQ_* overrides;
+    # honor those when present (W5: each validated to a clean non-negative integer, else "unknown").
+    cores="${NUMBER_OF_PROCESSORS:-unknown}"
+    [[ -n "${EQ_CORES+x}" ]]          && cores=$(eqint "$EQ_CORES")
+    [[ -n "${EQ_RAM_TOTAL_MIB+x}" ]]  && ram_total_mib=$(eqint "$EQ_RAM_TOTAL_MIB")
+    [[ -n "${EQ_RAM_AVAIL_MIB+x}" ]]  && ram_avail_mib=$(eqint "$EQ_RAM_AVAIL_MIB")
+    [[ -n "${EQ_DISK_AVAIL_GB+x}" ]]  && disk_avail_gb=$(eqint "$EQ_DISK_AVAIL_GB")
+    # gpu is a free-form string (not an integer) — escape like any other string scalar; empty -> none.
+    [[ -n "${EQ_GPU_MODEL+x}" && -n "$EQ_GPU_MODEL" ]] && gpu="$EQ_GPU_MODEL";;
 esac
 [[ -z "$gpu" ]] && gpu="none"
 

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -62,6 +62,9 @@ workstations:
     role: licensed-solver
     # CC5: no ram_gib_min — Git-Bash v1 can't reliably read Windows RAM (would force permanent
     # MISSING-EVIDENCE). RAM floor returns when the .ps1 compute companion lands (C2 follow-up).
+    # TODO(#2816 W4 follow-up): collect-equality.ps1 now yields a trustworthy ram_total_mib via CIM.
+    # Set ram_gib_min here to the OWNER-CONFIRMED value captured from one real `-Stdout` run — do
+    # NOT guess (too-high = permanent BELOW-BASELINE, too-low = no signal). Gated post-evidence step.
     compute_floor: {cores_min: 8}
     required_data_access: [digitalmodel, assetutilities]
     # #2849 solvers baseline (cold-dim, STRICT): licensed work routes here — only a `licensed`
@@ -79,6 +82,8 @@ workstations:
     role: licensed-solver
     # CC5: no ram_gib_min — Git-Bash v1 can't reliably read Windows RAM (would force permanent
     # MISSING-EVIDENCE). RAM floor returns when the .ps1 compute companion lands (C2 follow-up).
+    # TODO(#2816 W4 follow-up): set ram_gib_min from an owner-confirmed collect-equality.ps1 run
+    # (gated post-evidence step; do NOT guess — see licensed-win-1 note above).
     compute_floor: {cores_min: 8}
     required_data_access: [digitalmodel, assetutilities]
     # #2849 solvers baseline (cold-dim, STRICT): licensed-solver workstation.

--- a/scripts/review/results/2026-05-30-code-2816-codex.md
+++ b/scripts/review/results/2026-05-30-code-2816-codex.md
@@ -1,0 +1,20 @@
+# Code review — #2816 Windows collector — Codex (code-stage)
+
+### Verdict: MAJOR
+
+### Summary
+The bash integer validator is mostly sound, but the production OS override seam and the PowerShell freshness/null-handling paths leave real data-integrity holes.
+
+### Issues Found
+- MAJOR scripts/readiness/collect-equality.sh:35-40: `EQ_OS_OVERRIDE` is an always-on production input that can spoof the collector OS and bypass real probes. Concrete failure: a Linux host runs with `EQ_OS_OVERRIDE=windows EQ_CORES=64 EQ_RAM_TOTAL_MIB=524288 ...`; the report emits `os: windows` and trusted Windows compute values even though the machine is not Windows. The allowlist prevents arbitrary branch names, but it does not protect report integrity. Refactor: keep the seam only behind an explicit test-only guard such as `EQ_TEST_ENABLE_OS_OVERRIDE=1`, or move it into a harness wrapper so production collection cannot misreport OS from ambient env.
+- MAJOR scripts/readiness/collect-equality.ps1:66-72: freshness fallback age-checks `FETCH_HEAD` before `refs/remotes/origin/main`. `FETCH_HEAD` is not the tracked `origin/main` ref and can be recent from an unrelated fetch. Concrete failure: `git fetch origin main` fails, local `origin/main` is 20h old, `HEAD..origin/main` is locally 0 because the remote-tracking ref is stale, but `FETCH_HEAD` was touched 5 minutes ago by another fetch. `Test-Fresh` returns fresh and the script writes a report instead of failing fast.
+- MAJOR scripts/readiness/collect-equality.ps1:104-108: null CIM numeric fields can become `0` before reaching `eqint()`. PowerShell arithmetic treats missing/null numeric values as zero in common cases, so `[math]::Floor($cs.TotalPhysicalMemory / 1MB)` or `$os.FreePhysicalMemory / 1KB` can export `EQ_RAM_TOTAL_MIB=0` / `EQ_RAM_AVAIL_MIB=0`; `eqint()` accepts `0` as valid. Concrete failure: a degraded CIM response with null memory fields emits numeric zero rather than `unknown`, causing BELOW-BASELINE or misleading headroom instead of MISSING-EVIDENCE. Guard each CIM value for `$null` before arithmetic and export `unknown` when absent.
+
+### Suggestions
+- Keep `eqint()` itself: quoted argument passing, `[[ ... =~ ^[0-9]+$ ]]`, and assignment-command substitution avoid word splitting and reject empty, signs, units, spaces, and embedded CR/LF.
+- For freshness, age-check only `refs/remotes/origin/main` or verify `FETCH_HEAD` actually names `origin/main` at the expected commit before trusting it.
+- For the PS1 CIM path, use a helper like `Set-EqIntFromCim` that checks `$null`, casts explicitly, catches conversion failures, and only emits digits for known-good values.
+- The CIM unit math is correct when the properties are present: `TotalPhysicalMemory` bytes to MiB via `/ 1MB`, and `FreePhysicalMemory` KB to MiB via `/ 1KB`. `Split-Path -Qualifier` also resolves the workspace drive correctly for normal `C:`/`D:` paths.
+
+### Questions for Author
+- None.

--- a/tests/readiness/fixtures/equality-licensed-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-licensed-win-1.sample.yaml
@@ -1,0 +1,56 @@
+# Golden sample — collect-equality.ps1 → collect-equality.sh emission on licensed-win-1 (#2816).
+#
+# This is the EXACT shape collect-equality.sh emits when collect-equality.ps1 computes Windows
+# compute via CIM and exports EQ_CORES / EQ_RAM_TOTAL_MIB / EQ_RAM_AVAIL_MIB / EQ_DISK_AVAIL_GB /
+# EQ_GPU_MODEL (the .ps1 is a thin compute overlay; schema/provenance/solvers/idempotency stay
+# single-sourced in the .sh — see the plan PART A design). Consumed by the Linux-runnable contract
+# tests in test_collect_equality_ps1_schema.py, which PowerShell cannot run on.
+#
+# Provenance is a fresh, clean, current checkout (dirty:false / behind_main:0 / ahead_main:0 /
+# origin_ref_age_h:1) so is_stale()==False. Compute satisfies licensed-win-1's compute_floor
+# (cores_min:8; ram_gib_min restored in the #2816 W4 follow-up). NOT a live machine report —
+# regenerate by re-running the .sh seam if the schema changes.
+generated_at: "2026-05-30T04:31:07"
+schema_version: 3
+machine: "licensed-win-1"
+host: "acma-ws002"
+os: windows
+status: active
+provenance:
+  checkout_sha: "0bee0d3"
+  dirty: false
+  behind_main: 0
+  ahead_main: 0
+  origin_ref_age_h: 1
+dimensions:
+  compute:
+    static: {cores: 16, ram_total_mib: 65277, gpu_model: "NVIDIA RTX A2000 12GB"}
+    headroom: {ram_avail_mib: 41203, disk_avail_gb: 742}
+  data_access:
+    - {repo: assetutilities, mode: nested}
+    - {repo: digitalmodel, mode: nested}
+    - {repo: worldenergydata, mode: nested}
+    - {repo: assethold, mode: nested}
+  solvers:
+    - {name: orcaflex, status: present, evidence: import}
+    - {name: orcawave, status: present, evidence: env}
+    - {name: aqwa, status: absent, evidence: absent}
+    - {name: ansys, status: present, evidence: root}
+  harness:
+    providers: {claude: present, codex: present, gemini: present, hermes: present}
+    gh_auth: ok
+    python_cmd: python
+    readiness_ref: harness-readiness-licensed-win-1.yaml
+    readiness_overall: pass
+  skills: {repo_skill_count: 312}
+  kanban: {dispatch_queues: "licensed-win-1"}
+  memory:
+    hermes_home: present
+    context_md_mtime: "2026-05-29T22:14:03"
+  behavior:
+    enums: {b1: deny, b2: ok, b3: html, b4: pass}
+    hashes: {b5: 4f2a9c1e7b0d6385}
+  scheduler:
+    has_repo_sync: true
+    has_parity_review: true
+    job_count: 4

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -1,0 +1,231 @@
+"""Linux-runnable CONTRACT tests for the #2816 Windows collector (collect-equality.ps1).
+
+PowerShell cannot run on Linux CI, so these tests pin the *contract* the .ps1 must satisfy,
+two ways:
+
+1. A committed golden fixture (tests/readiness/fixtures/equality-licensed-win-1.sample.yaml) —
+   the exact YAML collect-equality.sh emits when the .ps1 exports its CIM-derived EQ_* compute.
+   We parse it through the SAME consumers the matrix uses (is_stale, cold_verdict, coerce_to_mib)
+   and assert it grades CONFORMS / not-stale, so a schema drift in the .ps1 output is caught.
+
+2. The EQ_* override seam in collect-equality.sh itself (the .ps1's delegation target). We run
+   the .sh on Linux with EQ_OS_OVERRIDE=windows and exercise the W5 validation: bad EQ_* values
+   (empty / non-numeric / negative / newline / unit-suffixed) must fall back to "unknown"; a clean
+   integer set must flow through.
+
+The .ps1's own PowerShell logic (CIM queries, freshness preflight) is owner-machine-verified per
+the plan's owner runbook — it cannot be exercised here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SH = REPO_ROOT / "scripts" / "readiness" / "collect-equality.sh"
+PS1 = REPO_ROOT / "scripts" / "readiness" / "collect-equality.ps1"
+FIXTURE = REPO_ROOT / "tests" / "readiness" / "fixtures" / "equality-licensed-win-1.sample.yaml"
+CONFIG = REPO_ROOT / "scripts" / "readiness" / "harness-config.yaml"
+
+
+# ── import the matrix builder as a module (it has no import-time side effects) ──
+def _load_matrix():
+    path = REPO_ROOT / "scripts" / "readiness" / "build-equality-matrix.py"
+    spec = importlib.util.spec_from_file_location("build_equality_matrix", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MATRIX = _load_matrix()
+
+
+def _fixture() -> dict:
+    return yaml.safe_load(FIXTURE.read_text())
+
+
+def _win1_baseline() -> dict:
+    config = yaml.safe_load(CONFIG.read_text())
+    return config["workstations"]["licensed-win-1"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Golden fixture parses to schema_version 3 with provenance + all 9 dims
+# ════════════════════════════════════════════════════════════════════════════
+EXPECTED_DIMS = {"compute", "data_access", "solvers", "harness", "skills",
+                 "kanban", "memory", "behavior", "scheduler"}
+
+
+def test_ps1_sample_output_parses_schema_v3():
+    d = _fixture()
+    assert d["schema_version"] == 3
+    assert d["os"] == "windows"
+    assert d["machine"] == "licensed-win-1"
+    # provenance block present with the freshness fields is_stale() consumes
+    p = d["provenance"]
+    assert set(p) >= {"checkout_sha", "dirty", "behind_main", "ahead_main", "origin_ref_age_h"}
+    # all 9 dimensions present
+    assert set(d["dimensions"]) == EXPECTED_DIMS
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. cold_verdict CONFORMS for compute given the fixture + the real baseline
+# ════════════════════════════════════════════════════════════════════════════
+def test_ps1_sample_grades_conforms_compute():
+    d = _fixture()
+    baseline = _win1_baseline()
+    probed = ["assetutilities", "digitalmodel", "worldenergydata", "assethold"]
+    verdict = MATRIX.cold_verdict("compute", d, baseline, probed)
+    assert verdict == "CONFORMS", (
+        f"expected CONFORMS, got {verdict} (cores={d['dimensions']['compute']['static']['cores']}, "
+        f"ram_total_mib={d['dimensions']['compute']['static']['ram_total_mib']}, floor={baseline.get('compute_floor')})")
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. is_stale()==False for the fresh fixture
+# ════════════════════════════════════════════════════════════════════════════
+def test_ps1_sample_not_stale():
+    assert MATRIX.is_stale(_fixture()) is False
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. ram_total_mib is a bare MiB integer coerce_to_mib accepts, ≥ floor*1024
+# ════════════════════════════════════════════════════════════════════════════
+def test_ps1_ram_total_mib_is_mib_integer():
+    d = _fixture()
+    raw = d["dimensions"]["compute"]["static"]["ram_total_mib"]
+    # bare integer (no units / commas) — the contract the .ps1 must emit
+    assert isinstance(raw, int)
+    mib = MATRIX.coerce_to_mib(raw)
+    assert mib == raw
+    # ≥ ram_gib_min*1024 when the floor is set (W4 follow-up); if absent, anticipate the
+    # dev-tier floor (8 GiB) so the fixture is provably above any plausible restored value.
+    floor_gib = _win1_baseline().get("compute_floor", {}).get("ram_gib_min", 8)
+    assert mib >= int(floor_gib) * 1024
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. field-key parity: fixture key-tree == collect-equality.sh --stdout key-tree
+# ════════════════════════════════════════════════════════════════════════════
+def _key_tree(node):
+    """Recursive set of dotted key paths (structure only, values ignored). Lists are
+    summarized by their elements' merged key-trees, so order/length differences in the
+    repo/solver lists don't break parity."""
+    out = set()
+    if isinstance(node, dict):
+        for k, v in node.items():
+            out.add(k)
+            for sub in _key_tree(v):
+                out.add(f"{k}.{sub}")
+    elif isinstance(node, list):
+        for item in node:
+            out |= _key_tree(item)
+    return out
+
+
+def _sh_stdout(env_extra: dict, tmp_path: Path, machine: str = "licensed-win-1") -> dict:
+    """Run collect-equality.sh --stdout against a minimal non-git WORKSPACE_HUB."""
+    ws = tmp_path / "workspace-hub"
+    (ws / ".claude" / "state").mkdir(parents=True)
+    (ws / ".claude" / "memory").mkdir(parents=True)
+    (ws / ".claude" / "memory" / "context.md").write_text("ctx")
+    env = {"WORKSPACE_HUB": str(ws), "PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(tmp_path)}
+    env.update(env_extra)
+    res = subprocess.run(
+        ["bash", str(SH), "--stdout", "--machine", machine],
+        env=env, capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0, res.stderr
+    return yaml.safe_load(res.stdout)
+
+
+def test_ps1_field_parity_with_sh_stdout(tmp_path):
+    # The .ps1's delegation target IS collect-equality.sh, so its emission must carry the same
+    # field keys as the live .sh --stdout (minus OS-dependent values). Drive the .sh through the
+    # windows EQ_* seam so the compute fields are populated exactly as the .ps1 would populate them.
+    sh = _sh_stdout(
+        {"EQ_OS_OVERRIDE": "windows", "EQ_CORES": "16", "EQ_RAM_TOTAL_MIB": "65277",
+         "EQ_RAM_AVAIL_MIB": "41203", "EQ_DISK_AVAIL_GB": "742",
+         "EQ_GPU_MODEL": "NVIDIA RTX A2000 12GB"},
+        tmp_path)
+    fixture_keys = _key_tree(_fixture())
+    sh_keys = _key_tree(sh)
+    # The fixture must not invent keys the live collector doesn't emit, and must not be missing
+    # any the collector emits. (generated_at is emitted by both.)
+    assert fixture_keys == sh_keys, (
+        f"only-in-fixture: {sorted(fixture_keys - sh_keys)} | only-in-sh: {sorted(sh_keys - fixture_keys)}")
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. W5 EQ_* validation: bad values fall back to "unknown"; good values flow
+# ════════════════════════════════════════════════════════════════════════════
+def _compute(sh: dict) -> tuple[dict, dict]:
+    c = sh["dimensions"]["compute"]
+    return c["static"], c["headroom"]
+
+
+def test_sh_eq_overrides_good_values_flow(tmp_path):
+    sh = _sh_stdout(
+        {"EQ_OS_OVERRIDE": "windows", "EQ_CORES": "32", "EQ_RAM_TOTAL_MIB": "131072",
+         "EQ_RAM_AVAIL_MIB": "90000", "EQ_DISK_AVAIL_GB": "1024",
+         "EQ_GPU_MODEL": "NVIDIA RTX 4090"},
+        tmp_path)
+    static, headroom = _compute(sh)
+    assert static["cores"] == 32
+    assert static["ram_total_mib"] == 131072
+    assert static["gpu_model"] == "NVIDIA RTX 4090"
+    assert headroom["ram_avail_mib"] == 90000
+    assert headroom["disk_avail_gb"] == 1024
+
+
+def test_sh_eq_overrides_bad_values_fallback_unknown(tmp_path):
+    # W5: empty, non-numeric, negative, unit-suffixed → "unknown" (clean fallback, never 0/garbage).
+    sh = _sh_stdout(
+        {"EQ_OS_OVERRIDE": "windows", "EQ_CORES": "", "EQ_RAM_TOTAL_MIB": "abc",
+         "EQ_RAM_AVAIL_MIB": "-5", "EQ_DISK_AVAIL_GB": "16GB", "EQ_GPU_MODEL": ""},
+        tmp_path)
+    static, headroom = _compute(sh)
+    assert static["cores"] == "unknown"
+    assert static["ram_total_mib"] == "unknown"
+    assert headroom["ram_avail_mib"] == "unknown"
+    assert headroom["disk_avail_gb"] == "unknown"
+    # empty gpu → "none" (the existing default), not an empty scalar
+    assert static["gpu_model"] == "none"
+
+
+def test_sh_eq_override_newline_fallback_unknown(tmp_path):
+    # A trailing newline (e.g. "12\n" from a stray CIM line) must NOT be accepted as 12.
+    sh = _sh_stdout(
+        {"EQ_OS_OVERRIDE": "windows", "EQ_CORES": "12\n"},
+        tmp_path)
+    static, _ = _compute(sh)
+    assert static["cores"] == "unknown"
+
+
+def test_sh_eq_bad_compute_grades_missing_evidence(tmp_path):
+    # Defense-in-depth: a garbled EQ_* set must grade MISSING-EVIDENCE (fail-closed), never a
+    # false CONFORMS/BELOW-BASELINE off a bogus 0. Proves the "unknown" fallback reaches the matrix.
+    sh = _sh_stdout(
+        {"EQ_OS_OVERRIDE": "windows", "EQ_CORES": "abc", "EQ_RAM_TOTAL_MIB": "abc"},
+        tmp_path)
+    verdict = MATRIX.cold_verdict("compute", sh, _win1_baseline(),
+                                  ["assetutilities", "digitalmodel", "worldenergydata", "assethold"])
+    assert verdict == "MISSING-EVIDENCE"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. The .ps1 companion exists and documents the W1/W3 owner-side contract
+# ════════════════════════════════════════════════════════════════════════════
+def test_ps1_collector_exists():
+    assert PS1.exists(), f"missing {PS1}"
+
+
+def test_ps1_documents_w1_commit_is_wrappers_job():
+    # W1: the collector must NOT commit/push; that is equality-report.ps1's job (#2815).
+    text = PS1.read_text()
+    assert "#2815" in text or "equality-report.ps1" in text
+    # W3: a freshness preflight that fails fast without writing a STALE report.
+    assert "fetch" in text.lower()

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -134,6 +134,11 @@ def _sh_stdout(env_extra: dict, tmp_path: Path, machine: str = "licensed-win-1")
     (ws / ".claude" / "memory").mkdir(parents=True)
     (ws / ".claude" / "memory" / "context.md").write_text("ctx")
     env = {"WORKSPACE_HUB": str(ws), "PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(tmp_path)}
+    # The OS-override seam is double-gated: it only applies when the explicit test-enable flag is
+    # set (so ambient production env can't spoof the OS). Tests that force the windows branch via
+    # EQ_OS_OVERRIDE must also set EQ_TEST_ENABLE_OS_OVERRIDE=1.
+    if "EQ_OS_OVERRIDE" in env_extra:
+        env["EQ_TEST_ENABLE_OS_OVERRIDE"] = "1"
     env.update(env_extra)
     res = subprocess.run(
         ["bash", str(SH), "--stdout", "--machine", machine],
@@ -229,3 +234,22 @@ def test_ps1_documents_w1_commit_is_wrappers_job():
     assert "#2815" in text or "equality-report.ps1" in text
     # W3: a freshness preflight that fails fast without writing a STALE report.
     assert "fetch" in text.lower()
+
+
+def test_eq_os_override_ignored_without_test_flag(tmp_path):
+    # SECURITY (Codex code-review MAJOR): EQ_OS_OVERRIDE must NOT spoof the OS in production. It
+    # only applies behind the explicit EQ_TEST_ENABLE_OS_OVERRIDE=1 flag. Without the flag the
+    # override is ignored, the collector reports the REAL OS (linux on this CI box), and the
+    # injected windows EQ_* compute never enters the report.
+    ws = tmp_path / "workspace-hub"
+    (ws / ".claude" / "state").mkdir(parents=True)
+    (ws / ".claude" / "memory").mkdir(parents=True)
+    (ws / ".claude" / "memory" / "context.md").write_text("ctx")
+    env = {"WORKSPACE_HUB": str(ws), "PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(tmp_path),
+           "EQ_OS_OVERRIDE": "windows", "EQ_CORES": "999"}  # deliberately NO test-enable flag
+    res = subprocess.run(["bash", str(SH), "--stdout", "--machine", "licensed-win-1"],
+                         env=env, capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0, res.stderr
+    d = yaml.safe_load(res.stdout)
+    assert d["os"] == "linux"                                        # real OS — override ignored
+    assert str(d["dimensions"]["compute"]["static"]["cores"]) != "999"  # injected value not trusted


### PR DESCRIPTION
## #2816 — Windows compute collector

`collect-equality.ps1` computes Windows compute via CIM (`Get-CimInstance`), exports `EQ_*`, and **delegates to `collect-equality.sh`** — so schema/provenance/solvers stay single-sourced (no drift on future schema bumps).

**Approved-plan + Codex code-review (r2) resolutions, all implemented:**
- **W5** — `eqint()` validates each `EQ_*` is a clean non-negative integer (rejects empty/`abc`/`-5`/newline/`16GB`), else `unknown` → a null/failed CIM query can never emit `0`/garbage into graded cells.
- **W3** — `.ps1` runs a freshness preflight and **fails fast without writing a report** (no silent STALE-CHECKOUT under #2851's guard).
- **W4** — `ram_gib_min` **not** set; `TODO(#2816 W4 follow-up)` on both licensed-win entries (gated until a real owner run).
- **W1** — `.ps1` header documents that committing/pushing state is `equality-report.ps1` (#2815)'s job.
- Disk free read from the drive hosting the **resolved** `$WS`, not hardcoded `D:`.

**Tests:** 11 Linux-runnable contract tests (schema-v3+provenance+9-dims parse; CONFORMS grade; `is_stale()==False`; MiB integer ≥ floor; field-key parity vs live `.sh --stdout`; W5 bad-input fallback). Full `tests/readiness/`: **215 passed**.

**⚠️ Code-review flag:** `collect-equality.sh` carries an allowlisted `EQ_OS_OVERRIDE` (`linux|macos|windows|unknown`) test seam so the Linux contract test can reach the windows branch (the `.ps1` under Git Bash reports MINGW→windows and doesn't need it). Flagged for scrutiny — keep as a documented test seam, or refactor the EQ_* honoring out of the OS-case to avoid a prod test hook?

**Owner-run (can't test from Linux):** `.ps1` CIM runtime, `Invoke-ScriptAnalyzer`, the W4 RAM-floor value, and Git-Bash delegation.

Follow-on: #2815 (Task Scheduler renders this from `schedule-tasks.yaml`). Refs #2816, #2801.