### PR TITLE
feat(#2817): add plan approval label authority gate

### DIFF
--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -126,10 +126,28 @@ jobs:
           fetch-depth: 0
 
       - name: Check plan approval for implementation commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PLAN_APPROVAL_GATE_ENABLED: ${{ vars.PLAN_APPROVAL_GATE_ENABLED }}
+          PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED: ${{ vars.PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED }}
+          PLAN_APPROVAL_OWNERS: ${{ vars.PLAN_APPROVAL_OWNERS }}
         run: |
           echo "## Plan Approval Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
+          set +e
+          if command -v uv >/dev/null 2>&1; then
+            uv run python scripts/workflow/plan_approval_gate_check.py
+          else
+            python3 scripts/workflow/plan_approval_gate_check.py
+          fi
+          PLAN_APPROVAL_LABEL_GATE_RC=$?
+          set -e
+
+          # PLAN_APPROVAL_GATE_ENABLED=1 is intentionally blocking. Keep it unset
+          # until this check is required and the protected-label ruleset is live.
           chmod +x scripts/enforcement/require-plan-approval.sh
 
           if scripts/enforcement/require-plan-approval.sh --strict 2>&1; then
@@ -143,6 +161,11 @@ jobs:
             echo "2. Get review: \`/gsd:review --phase N\`" >> $GITHUB_STEP_SUMMARY
             echo "3. Approval creates marker in \`.planning/plan-approved/\`" >> $GITHUB_STEP_SUMMARY
             exit $EXIT_CODE
+          fi
+
+          if [[ "$PLAN_APPROVAL_LABEL_GATE_RC" -ne 0 ]]; then
+            echo "**Result:** FAIL — label-authority plan approval gate failed" >> $GITHUB_STEP_SUMMARY
+            exit "$PLAN_APPROVAL_LABEL_GATE_RC"
           fi
 
   marker-label-parity:

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r1-codex.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r1-codex.md
@@ -1,0 +1,20 @@
+### Verdict: MAJOR
+
+### Summary
+The gate still has authority and freshness bypasses. The largest issues are that PR-body-derived issue links are treated as authority, and invalid or unrelated revision SHAs can pass via the binding timestamp fallback.
+
+### Issues Found
+- MAJOR: PR body authority is still accepted through GitHub `closingIssuesReferences`. In `scripts/workflow/plan_approval_gate_check.py`, `load_pr_context()` reads `closingIssuesReferences`, stores those numbers as `native_issue_numbers`, and `resolve_linked_issues()` accepts them when the branch name does not match `_BRANCH_ISSUE_RE`. GitHub closing issue references are PR text controlled by the author, so an unrelated branch can point at an already-approved issue. This contradicts the no PR body authority requirement. The test `tests/workflow/test_plan_approval_gate_check.py::test_pr_body_or_commit_refs_are_not_authority` only calls `resolve_linked_issues()` with an empty list and misses the real input path.
+- MAJOR: Revision existence/content is not verified, and invalid SHAs can pass. In `load_issue_approval()`, `fetch_commit_pushed_at(repo, binding.revision_sha) or binding.recorded_at` means a nonexistent hex string, wrong commit, or commit that does not touch the plan can fall back to the owner comment timestamp. `_evaluate_binding()` then checks only label time and touched path, not that the recorded revision is real or corresponds to the plan file. This fails the freshness-against-plan-revision requirement.
+- MAJOR: The plan binding is not tied to the linked issue number. `extract_plan_binding()` accepts the latest owner comment containing any `docs/plans/...md` plus a revision. `_evaluate_binding()` only checks that the PR touched that path. There is no check that the recorded path is the plan for the issue being evaluated.
+- MINOR: Admin cutover is only surfaced when disabled. `main()` prints the required-check/label-admin prereq only when `PLAN_APPROVAL_GATE_ENABLED` is false. Once enabled, nothing verifies that `Plan Approval Check` is required on `main` or that `status:plan-approved` is protected.
+
+### Suggestions
+- Remove `closingIssuesReferences` as an authorization source, or only use it after independent non-author-controlled verification.
+- Fail closed unless the recorded revision exists and is proven to contain the recorded plan path.
+- Require the binding to identify and match the evaluated issue number, or derive the expected plan path from the issue and reject mismatches.
+- Add tests for mocked `load_pr_context()` with PR-body closing refs, invalid revision SHA fallback, unrelated revision SHA, and wrong-issue plan binding.
+
+### Questions for Author
+- What source is intended to authorize linked issue numbers when the branch name does not contain the issue number?
+- Is `revision_sha` intended to be a commit SHA containing the plan file or another artifact identifier?

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r1-gemini.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r1-gemini.md
@@ -1,0 +1,20 @@
+### Verdict: MAJOR
+
+### Summary
+Implementation fails to satisfy the claim of ignoring author-controlled PR body text and contains a timestamp vulnerability where edited comments bypass the label freshness check. Additionally, it relies on an unpaginated gh CLI command that will silently truncate comments on active issues.
+
+### Issues Found
+- scripts/workflow/plan_approval_gate_check.py (resolve_linked_issues): Contradicts the design claim 'deliberately ignores... author-controlled PR body'. If the branch name does not match the issue regex, it falls back to `native_issue_numbers`. These native references are derived from `closingIssuesReferences`, which GitHub populates solely based on author-controlled PR bodies and commit messages.
+- scripts/workflow/plan_approval_gate_check.py (extract_plan_binding): Uses `comment.get('createdAt')` instead of `updatedAt`. If `fetch_commit_pushed_at` fails (e.g., cross-fork resolution issues) and falls back to `binding.recorded_at`, an authorized user editing an old comment to point to a malicious SHA will bypass `label_is_fresh` because the original comment creation time is used.
+- scripts/workflow/plan_approval_gate_check.py (load_issue_approval): Uses `gh issue view <issue> --json comments`. The `gh` CLI limits comment output (typically truncating at 30 or 100 comments). On active issues, the plan binding comment could be truncated, causing false negatives or selecting stale bindings.
+- scripts/workflow/plan_approval_gate_check.py (_event_pr_number): Invoked as the default for argparse before `main()`'s try/except block. If the `PR_NUMBER` environment variable is present but non-numeric, it raises an unhandled `ValueError`, crashing the script instead of exiting cleanly with a DENY.
+
+### Suggestions
+- In `resolve_linked_issues`, remove the `native_issue_numbers` fallback entirely to enforce the strict 'branch name only' constraint, or redefine the security boundary if PR body references are acceptable as a fallback.
+- In `extract_plan_binding`, prefer `comment.get('updatedAt')` if present, falling back to `createdAt`. This ensures freshness is checked against the last time the comment was modified.
+- Replace `gh issue view` with a GraphQL query that explicitly fetches the latest comments (e.g., `comments(last: 100)`) or implements proper pagination to ensure recent plan bindings are never truncated.
+- Refactor `_event_pr_number` to safely catch `ValueError` and return `None`, or move its invocation inside the `try/except` block in `main()`.
+
+### Questions for Author
+- Why does `resolve_linked_issues` fall back to native issue references (populated via PR bodies) if the gate's documented security stance is to deliberately ignore author-controlled PR body text?
+- If a PR originates from a fork and `fetch_commit_pushed_at` fails to resolve the object, how do we guarantee freshness if the user edits a 2-day-old comment to point to a new unreviewed SHA?

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r2-codex.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r2-codex.md
@@ -1,0 +1,20 @@
+### Verdict: MAJOR
+
+### Summary
+The gate still has correctness-critical bypass/cutover risks in issue path matching, revision identity, and owner matching. I would not cut over with this version.
+
+### Issues Found
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py:plan_path_matches_issue` uses substring matching: `return f"issue-{issue}" in _normalize_path(plan_path)`. This accepts paths like `docs/plans/2026-05-30-issue-28170-unrelated.md` for issue `2817`, so the claimed issue-number binding is not actually enforced. Add delimiter-aware matching and negative tests for `issue-28170` / `issue-2817x`.
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py:_REVISION_RE` accepts 7-character abbreviated SHAs. `fetch_plan_revision_anchor` then verifies whatever `repos/{repo}/commits/{sha}` resolves to. Short SHAs can become ambiguous or resolve differently as history grows, so the recorded plan revision is not stable. Require full 40-hex SHAs, or canonicalize the abbreviation to a full SHA and compare/store that.
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py:parse_owners` and `label_authority.is_authorized_human` compare GitHub logins case-sensitively. GitHub logins are case-insensitive. A mis-cased `PLAN_APPROVAL_OWNERS` value can pass `validate_owner_types` via `fetch_actor_type` but later deny the actual label actor, creating a fail-closed CI cutover hazard. Normalize owners and actors or validate configured casing against the API-returned canonical login.
+- MINOR: `scripts/workflow/plan_approval_gate_check.py:fetch_plan_revision_anchor` uses commit `pushedDate` as the freshness anchor when available and only falls back to binding comment `updated_at`. The payload asks for freshness against the “plan revision/comment update anchor.” If comment edits are meant to stale approval, this implementation does not enforce that when `pushedDate` exists. Add an explicit test and code comment for the intended semantics.
+
+### Suggestions
+- Use a path-token regex for `issue-2817`, not substring containment.
+- Reject non-40-character revision SHAs in `extract_plan_binding`.
+- Normalize GitHub logins to lower case for membership checks, while preserving display values in messages.
+- Add tests for mis-cased owners, `issue-28170`, abbreviated SHA rejection, and comment-update freshness behavior.
+
+### Questions for Author
+- Is binding comment `updated_at` supposed to be an independent freshness anchor, or only a fallback when commit pushedDate is unavailable?
+- Is `PLAN_APPROVAL_OWNERS` generated from canonical GitHub API logins, or manually configured by admins?

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r2-gemini.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r2-gemini.md
@@ -1,0 +1,15 @@
+### Verdict: MAJOR
+
+### Summary
+The implementation contains a critical substring matching vulnerability in issue number validation and a logic flaw in label freshness evaluation that ignores comment update times.
+
+### Issues Found
+- In `plan_approval_gate_check.py`, `plan_path_matches_issue` uses a simple substring check (`f'issue-{issue}' in _normalize_path(plan_path)`). This allows bypasses where a shorter issue number (e.g., `1`) incorrectly matches a plan path for a larger issue (e.g., `issue-10.md`), breaking the issue linkage isolation.
+- In `_evaluate_binding` and `fetch_plan_revision_anchor`, the label freshness anchor discards the plan binding comment's `recorded_at` timestamp if the commit push time is successfully fetched. This allows an authorized user or compromised account to modify a comment, linking an old commit, and inherit a pre-existing (stale) approval label because the label's timestamp is only evaluated against the old commit's push time, ignoring the comment's recent update time.
+
+### Suggestions
+- Update `plan_path_matches_issue` to use a bounded regular expression or strict tokenization (e.g., `re.search(rf'\bissue-{issue}\b', plan_path)` or checking exact directory components).
+- Update `_evaluate_binding` to enforce freshness against both anchors simultaneously: `label_is_fresh(approval.label_applied_at, approval.plan_revision_time, approval.plan_binding.recorded_at)`.
+
+### Questions for Author
+- Is this gate expected to run on `issue_comment` workflow events? If so, `_event_pr_number()` may need to fall back to `payload.get('issue', {}).get('number')` since the `pull_request` object is structured differently there.

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r3-codex.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r3-codex.md
@@ -1,0 +1,17 @@
+### Verdict: MAJOR
+
+### Summary
+Local focused tests pass, but I found remaining gate-bypass/cutover blockers. Checked `scripts/workflow/plan_approval_gate_check.py`, `scripts/workflow/label_authority.py`, `tests/workflow/test_plan_approval_gate_check.py`, `tests/workflow/test_label_authority.py`, and `.github/workflows/enforcement-gate.yml`; ran `uv run pytest tests/workflow/test_plan_approval_gate_check.py tests/workflow/test_label_authority.py -q` => 35 passed.
+
+### Issues Found
+- MAJOR: The new server-side gate is not wired into CI. `.github/workflows/enforcement-gate.yml:128-145` still runs `scripts/enforcement/require-plan-approval.sh --strict`, and repository search found `PLAN_APPROVAL_GATE_ENABLED`, `PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED`, and `PLAN_APPROVAL_OWNERS` only in the new script/tests, not in workflow wiring. That means PRs continue using the old marker/recent-evidence gate, so the label-actor authority gate can be fully bypassed in real merges.
+- MAJOR: The approved revision is not bound to the PR's current plan content. `scripts/workflow/plan_approval_gate_check.py:_evaluate_binding` only checks that the PR touches `binding.plan_path` (`lines 213-214`) and that the recorded commit touched that path (`lines 215-220` via `fetch_plan_revision_anchor`). `PrContext` carries only path names (`lines 63-68`, `274-286`), so the gate cannot detect a later PR update that changes the same plan file after owner approval. The test `test_synchronize_after_approval_does_not_invalidate` (`tests/workflow/test_plan_approval_gate_check.py:170-174`) intentionally proves later synchronizes are ignored, but there is no counter-test for later plan-file mutation. A contributor with push rights can obtain approval for revision A, then alter `docs/plans/...issue-2817...md` in the same PR and still satisfy the gate because the path is present and the old recorded SHA exists.
+- MINOR: The 'full 40-hex revision SHA only' parser is not actually delimiter-safe. `_REVISION_RE` in `scripts/workflow/plan_approval_gate_check.py:32-34` captures the first 40 hex characters inside longer hex strings because it lacks a trailing hex boundary. I verified locally that `Plan revision: 2f3d873d48acd05336268ac679f47b5b2708a567a` extracts `2f3d873d48acd05336268ac679f47b5b2708a567`. The existing test at `tests/workflow/test_plan_approval_gate_check.py:231-239` covers short SHAs but not overlong SHAs.
+
+### Suggestions
+- Wire the CI job to execute `scripts/workflow/plan_approval_gate_check.py` with `GH_TOKEN`, `PLAN_APPROVAL_GATE_ENABLED=1`, explicit `PLAN_APPROVAL_OWNERS`, and fail-closed `PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED` during cutover; keep the old marker gate only as advisory or remove it from the required check path once the new check is required.
+- Bind the approved plan revision to the PR state: either require the recorded commit to be an ancestor of the PR head and verify no later commit changes `binding.plan_path`, or compare the plan blob at `binding.revision_sha:binding.plan_path` to the checked-out PR head blob before allowing merge.
+- Change `_REVISION_RE` to require a non-hex boundary after the 40-character SHA, and add regression tests for 39-char, 40-char, 41-char, and 64-char values.
+
+### Questions for Author
+- Is PR2a supposed to include the workflow cutover, or is it only adding the script for a later PR? If later, the payload should not claim CI enforcement for the new gate yet.

--- a/scripts/review/results/20260530T-issue2817-pr2a-implementation-r3-gemini.md
+++ b/scripts/review/results/20260530T-issue2817-pr2a-implementation-r3-gemini.md
@@ -1,0 +1,15 @@
+### Verdict: MAJOR
+
+### Summary
+The implementation correctly enforces the new freshness logic, opts into bot rejection, and implements robust parsing for issue-plan bindings. However, it contains a critical approval hijacking vulnerability because it fails to verify that the approved revision is actually present in the Pull Request being evaluated.
+
+### Issues Found
+- Approval Hijacking / Missing PR Revision Verification (`plan_approval_gate_check.py`): The gate verifies that the recorded `revision_sha` exists in the base repository (`fetch_plan_revision_anchor`), but it never verifies that this `revision_sha` is present in the Pull Request being gated. An attacker can hijack a pending plan approval by opening a malicious PR with a matching branch name (e.g., `feat/2817-bypass`) and touching the plan file. Because the real owner's commit exists in the base repo and satisfies the gate's checks, the gate will incorrectly approve the attacker's PR. The gate must ensure that `binding.revision_sha` is an ancestor of the PR head or that the PR's version of the plan file matches the approved revision.
+- Case-Sensitive Separate Approver Check (`plan_approval_gate_check.py`): In `_evaluate_issue`, the separate approver validation uses strict case-matching (`approval.label_actor == context.pr_author`). GitHub logins are case-insensitive, and differing API endpoints (GraphQL vs REST) can return different casing. This could allow an author to bypass the separate approver requirement if the API returns their login with different casing. Both variables should be converted to `.lower()` before comparison.
+
+### Suggestions
+- The `gh pr view --json files` command uses the GraphQL API, which limits the returned files list (often to 100). For large PRs, the plan path might be omitted from `touched_paths`, causing the gate to incorrectly fail-closed. Consider using `gh pr diff --name-only` to guarantee a complete list of modified files.
+- Similarly, the REST API response in `fetch_plan_revision_anchor` (`repos/{repo}/commits/{sha}`) truncates the `files` array if a commit touches hundreds of files (typically around 300). If the plan commit is massive, the gate will fail-closed. A tree lookup or GraphQL query checking the specific file path would be more robust.
+
+### Questions for Author
+- How should the gate handle modifications to the plan file that occur in the PR *after* the approved `revision_sha`? Once the PR revision binding vulnerability is fixed, should the gate enforce that the PR's version of the plan is strictly identical to the approved revision, or simply require that the approved commit is present in the PR history?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r10-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r10-codex.md
@@ -1,0 +1,15 @@
+### Verdict: MAJOR
+
+### Summary
+The diff is not merge-safe. The PR-body binding fallback is wired to the linked issue number instead of the actual PR number, so it cannot validate bindings placed in PR #2881 unless the PR number happens to equal the issue number. There is also a regex overmatch that can accept an unapproved 40-hex prefix inside a longer SHA-like token.
+
+### Issues Found
+- MAJOR: `scripts/workflow/plan_approval_gate_io.py:67-102` fetches `pullRequest(number:$number)` inside `load_issue_binding_sources(repo, issue)`, and callers pass the branch-linked issue number from `load_issue_approval(...)` (`scripts/workflow/plan_approval_gate_check.py:270-279`). For issue #2817 / PR #2881, the PR-body fallback checks PR #2817, not PR #2881. If the binding is only in the current PR body, the gate fails closed even though the intended fallback was added. If a stale/unrelated PR with the same number as the issue exists, its body can be considered as a binding source for the issue. Required fix: pass the current PR number into binding-source loading and fetch the linked issue body/comments plus the current PR body explicitly; add a regression with `issue=2817`, `pr=2881`.
+- MAJOR: `_REVISION_RE` in `scripts/workflow/plan_approval_gate_check.py:34-36` only rejects a following hex character after an optional closing backtick. For text like `Plan revision: 2f3d...a567zzzz`, it can match the first 40 hex chars because the next character is non-hex, accepting a prefix of a longer malformed token. The tests cover overlong hex and hex-after-backtick, but not non-hex suffixes. Required fix: anchor the revision token with a stricter delimiter/end condition such as closing backtick, whitespace, punctuation boundary, or line end, and add a regression for non-hex suffix/trailing token content.
+
+### Suggestions
+- Add tests around `load_issue_approval`/`load_issue_binding_sources` that use distinct issue and PR numbers, not just isolated `load_issue_binding_sources` with matching number assumptions.
+- Add binding parser tests for unbackticked and backticked SHA tokens with trailing non-hex characters, adjacent path text, and duplicate binding-like blocks across issue body, comments, and PR body.
+
+### Questions for Author
+- Should PR-body bindings be accepted only from the current PR body, or should issue body/comments remain the sole durable binding source for branch-linked issues?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r10-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r10-gemini.md
@@ -1,0 +1,6 @@
+### Verdict: UNAVAILABLE
+
+### Summary
+Gemini R10 was terminated after exceeding the expected timeout window without producing output.
+Codex R10 returned a concrete parser finding; patching proceeds from that finding before any
+final review attempt.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r11-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r11-codex.md
@@ -1,0 +1,15 @@
+### Verdict: MAJOR
+
+### Summary
+REQUEST_CHANGES: the new gate can be tripped by unauthorized issue comments and has an untested fail-closed path that will break enabled CI for non-implementation PRs unless every protected PR branch follows the issue-number convention and touches the bound plan path.
+
+### Issues Found
+- MAJOR: `extract_plan_binding()` selects the newest binding-like source without considering whether the author is authorized, then `_evaluate_binding()` rejects that selected binding if it was written by an unauthorized actor. That means any contributor who can comment on the issue can add a later syntactically valid `Plan:` / `Plan revision:` pair and force the gate to fail even when an earlier authorized binding and fresh authorized approval are valid. This is not an approval bypass, but it is a merge-blocking authority drift/DoS defect in the label-actor gate. The test `test_latest_binding_like_source_must_be_authorized` currently locks in that failure mode instead of requiring selection of the latest authorized binding or ignoring unauthorized binding attempts.
+- MAJOR: When enabled, the workflow runs `plan_approval_gate_check.py` for every PR reaching this job, but `resolve_linked_issues()` only accepts issue numbers embedded in branch names and `_evaluate_binding()` requires the recorded plan path to be in the PR diff. That is intentionally fail-closed for implementation commits, but the workflow snippet does not show a guard limiting this to implementation PRs. If this job also covers ordinary docs/enforcement/harness PRs, enabling `PLAN_APPROVAL_GATE_ENABLED=1` will fail CI for any PR without a matching branch issue and touched plan path. There is no test proving the workflow trigger/job condition excludes non-implementation PRs.
+
+### Suggestions
+- Before merge, change binding extraction/evaluation so unauthorized binding-like comments cannot override an earlier authorized binding. Either filter to authorized human sources during extraction or evaluate candidates newest-to-oldest until an authorized valid binding is found, while still failing closed when no authorized binding exists.
+- Before merge, prove or add a workflow-level guard that the new blocking check only runs for implementation PRs that are supposed to satisfy the plan-approval gate. Add regression coverage for a non-implementation PR path/job condition if such PRs are expected to pass this workflow.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r11-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r11-gemini.md
@@ -1,0 +1,4 @@
+### Verdict: UNAVAILABLE
+
+### Summary
+Gemini R11 did not produce a usable review within the enforced timeout window. Codex R11 was run in parallel; this artifact records the degraded provider state rather than leaving a blank result.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r12-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r12-codex.md
@@ -1,0 +1,13 @@
+### Verdict: APPROVE
+
+### Summary
+No merge-blocking defects found in the supplied diff.
+
+### Issues Found
+- None.
+
+### Suggestions
+- Consider a follow-up hardening test for multiple authorized bindings where the latest authorized binding supersedes an earlier one, including an earlier valid binding plus later valid binding with different SHA.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r12-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r12-gemini.md
@@ -1,0 +1,4 @@
+### Verdict: UNAVAILABLE
+
+### Summary
+Gemini R12 did not produce a usable review within the enforced timeout window. Codex R12 was run in parallel; this records degraded provider availability for the final current diff.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r13-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r13-codex.md
@@ -1,0 +1,19 @@
+### Verdict: APPROVE
+
+### Summary
+Severity: NONE
+
+Findings:
+1. None.
+
+Required fixes before merge, if any:
+None.
+
+### Issues Found
+- None.
+
+### Suggestions
+- None.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r13-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r13-gemini.md
@@ -1,0 +1,6 @@
+### Verdict: UNAVAILABLE
+
+### Summary
+Gemini was not re-run for R13 after consecutive R10-R12 timeout/unavailable results.
+Codex R13 reviewed the current diff after the CI `uv` fallback patch and returned APPROVE
+with severity NONE.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r4-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r4-codex.md
@@ -1,0 +1,17 @@
+### Verdict: MAJOR
+
+### Summary
+The new gate still has a freshness bypass: it only requires the approval label to postdate the plan revision anchor, but does not clearly and directly require the label to postdate the authorized binding comment update. That leaves the required r4 invariant under-specified and insufficiently tested.
+
+### Issues Found
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py::_evaluate_binding` calls `label_is_fresh(approval.label_applied_at, approval.plan_revision_time)` and omits `binding.recorded_at` at the decision point. The r4 requirement is freshness against the latest of commit `pushedDate` and owner binding-comment `updated_at`; this should be enforced explicitly in the authorization check and covered by a denial test where `binding.recorded_at` is after the label.
+- MINOR: `tests/workflow/test_extract_plan_binding_rejects_overlong_revision_sha` does not cover `Plan revision: `{SHA}`a`. `_REVISION_RE` checks `(?![0-9a-f])` before the optional closing backtick, so that form is accepted. If the intended boundary is after optional Markdown delimiters, this is still bypassable.
+- MINOR: `.github/workflows/enforcement-gate.yml` invokes `python3 scripts/workflow/plan_approval_gate_check.py` despite the repo command contract saying Python should run through `uv run`. This is a CI portability/cutover hazard.
+
+### Suggestions
+- Store and name the combined freshness anchor as `max(commit.pushedDate, binding.updated_at)`, then assert the label is fresh against that anchor in `_evaluate_binding`.
+- Add direct tests for label-before-binding-update denial and for revision strings with hex after a closing backtick.
+- Use `uv run python scripts/workflow/plan_approval_gate_check.py` in CI, or document a deliberate stdlib-only exemption.
+
+### Questions for Author
+- Should a hex character immediately after a closing Markdown backtick be treated as part of an overlong SHA token? Current behavior accepts it.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r4-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r4-gemini.md
@@ -1,0 +1,17 @@
+### Verdict: MAJOR
+
+### Summary
+The implementation successfully implements branch-only issue authority, strict revision regex boundaries, and delimiter-safe plan matching. However, there is a critical fail-open defect in the freshness check: if the GraphQL API fails to resolve the commit's pushedDate (which is a known limitation for commits in fork PRs), the system silently falls back to the comment's timestamp. This bypasses the required 'latest of' push-date freshness validation.
+
+### Issues Found
+- MAJOR: In `fetch_plan_revision_anchor`, the comprehension `[ts for ts in [fetch_commit_pushed_at(repo, sha), fallback_time] if ts is not None]` silently drops the `pushedDate` if `fetch_commit_pushed_at` returns `None`. Because the GitHub GraphQL `repository.object(oid)` API returns null for commits that only exist in fork PRs, the freshness check will fail-open for fork contributions and evaluate freshness using only the comment's `updatedAt`, violating the 'latest of' requirement.
+- MINOR: In `.github/workflows/enforcement-gate.yml`, if `plan_approval_gate_check.py` fails (exits 1) while enabled, the default `set -e` behavior of the runner immediately terminates the step. This prevents the legacy `require-plan-approval.sh` script from running, suppressing legacy diagnostic output and violating the intent to keep both gates comprehensively active.
+- MINOR: The `fetch_plan_revision_anchor` function uses the REST API `commits/{sha}` endpoint to verify the commit touches the plan path. This endpoint strictly truncates `files` at 300 items. If a revision touches >300 files, the plan path might be truncated, causing a false-negative fail-closed condition.
+
+### Suggestions
+- Enforce a fail-closed posture for missing push dates in `fetch_plan_revision_anchor` by explicitly verifying `fetch_commit_pushed_at` does not return `None` before returning valid anchors.
+- Decouple the new gate and legacy gate execution in the CI workflow (e.g., using separate steps with `if: always()` or capturing the exit code) to ensure both run fully and emit their respective diagnostic outputs during the transition phase.
+- If fork PRs are expected, consider querying the PR's timeline or commits via REST or GraphQL PR nodes to reliably resolve the push date for fork-originated SHAs instead of relying on the base repository's `object(oid)`.
+
+### Questions for Author
+- Since the GraphQL `repository.object` lookup cannot resolve fork-originated commits, how do you intend to securely establish a verifiable `pushedDate` anchor for external contributions?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r5-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r5-codex.md
@@ -1,0 +1,19 @@
+### Verdict: MAJOR
+
+### Summary
+The r4 blockers are not closed in the submitted diff. The new gate still uses python3 directly, CI will stop before legacy diagnostics on new-gate failure, missing pushedDate does not fail closed when a binding timestamp exists, and the revision regex still accepts a hex suffix after a closing Markdown backtick.
+
+### Issues Found
+- MAJOR: `.github/workflows/enforcement-gate.yml`, step `Check plan approval for implementation commits`: the workflow invokes `python3 scripts/workflow/plan_approval_gate_check.py`, not `uv run python ...`. This directly contradicts the r4 requirement and the repo command policy.
+- MAJOR: `.github/workflows/enforcement-gate.yml`, same step: the new gate is run as a standalone command before the legacy marker gate. In GitHub Actions shell mode, a nonzero exit from `python3 scripts/workflow/plan_approval_gate_check.py` exits the step before `scripts/enforcement/require-plan-approval.sh --strict` can run, so the claimed diagnostic fallback is not implemented.
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py`, `fetch_plan_revision_anchor`: `anchors = [ts for ts in [fetch_commit_pushed_at(repo, sha), fallback_time] if ts is not None]` allows a missing GitHub `pushedDate` to pass whenever `fallback_time` exists. The r4 requirement was that missing GitHub `pushedDate` fails closed.
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py`, `_REVISION_RE`: the negative lookahead is placed before the optional closing backtick, so `Plan revision: `<40hex>`a` still matches. After the 40 hex chars, the next char is the backtick, so `(?![0-9a-f])` succeeds; then the optional backtick is consumed, leaving the trailing hex accepted. The added test `test_extract_plan_binding_rejects_overlong_revision_sha` only covers `<40hex>a`, not `<40hex>` followed by a closing Markdown backtick and then hex.
+
+### Suggestions
+- Change the workflow invocation to `uv run python scripts/workflow/plan_approval_gate_check.py` and capture its rc without letting `set -e` terminate the step before legacy diagnostics run.
+- Make `fetch_commit_pushed_at` return an explicit success/failure signal or have `fetch_plan_revision_anchor` fail when `pushedDate` is absent, even if `binding.recorded_at` exists.
+- Move the SHA boundary check after the optional closing backtick, or parse the optional backticks structurally so hex immediately after a closing backtick is rejected. Add a regression test for `Plan revision: `<sha>`a`.
+- Add a workflow regression test or shellcheck-style assertion for the CI cutover behavior: new gate failure still executes the legacy gate and exits with the new gate's failure status.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r5-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r5-gemini.md
@@ -1,0 +1,18 @@
+### Verdict: MAJOR
+
+### Summary
+The R4 blockers have not been successfully resolved. Missing pushedDate fails open instead of closed, CI does not use uv run, CI does not capture the new gate return code, and the SHA regex negative lookahead is in the wrong place.
+
+### Issues Found
+- .github/workflows/enforcement-gate.yml: The workflow runs `python3 scripts/workflow/plan_approval_gate_check.py` instead of `uv run python`.
+- .github/workflows/enforcement-gate.yml: The new gate's return code is not captured. Because of default `set -e` behavior, a failure in the new gate will terminate the job immediately, bypassing the legacy marker gate entirely.
+- scripts/workflow/plan_approval_gate_check.py: `fetch_plan_revision_anchor` does not fail closed when `pushedDate` is missing. The list comprehension `[ts for ts in ... if ts is not None]` simply discards the missing value and silently falls back to `fallback_time`.
+- scripts/workflow/plan_approval_gate_check.py: `_REVISION_RE` places the negative lookahead `(?![0-9a-f])` before the optional closing backtick `` `? ``. This fails to reject hex characters appearing after the closing backtick.
+
+### Suggestions
+- Update the workflow to use `uv run python scripts/workflow/plan_approval_gate_check.py || true` (or capture the exit code manually to report at the end) so the legacy gate is reached.
+- In `fetch_plan_revision_anchor`, assign the result of `fetch_commit_pushed_at` to a variable, and if it is `None`, return `(None, False)` to explicitly fail closed.
+- Update `_REVISION_RE` to place the negative lookahead after the optional closing backtick: `r"(?i)(?:plan\s+revision|revision|sha|commit)\s*[:=]?\s*`?([0-9a-f]{40})`?(?![0-9a-f])"`.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r6-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r6-codex.md
@@ -1,0 +1,15 @@
+### Verdict: MINOR
+
+### Summary
+The r4 blockers named in the prompt appear closed in the payload: binding `recorded_at` is included in freshness via `label_is_fresh(...)`, missing `pushedDate` returns `(None, False)`, CI captures the new gate result then still runs the legacy gate, and the SHA regex/test rejects hex after a closing backtick. I did not find a merge-blocking bypass in the provided diff.
+
+### Issues Found
+- MINOR: `scripts/workflow/plan_approval_gate_check.py:resolve_linked_issues` only derives authority from the branch name, while `_evaluate_issue` reports `no linked issue from branch or GitHub metadata`. There is no GitHub metadata fallback in this implementation. This is fail-closed, so not a security bypass, but it is a cutover hazard for legitimate PRs whose branches do not match `_BRANCH_ISSUE_RE`.
+- MINOR: `tests/workflow/test_plan_approval_gate_check.py` does not exercise the workflow cutover behavior in `.github/workflows/enforcement-gate.yml`: specifically that the legacy marker gate still runs when `uv run python scripts/workflow/plan_approval_gate_check.py` fails. The YAML diff is logically ordered correctly, but there is no regression test/parse assertion covering this required behavior.
+
+### Suggestions
+- Either implement real GitHub-native linked issue resolution or change the denial text/tests to say branch-derived issue only, so operators do not expect metadata support that is not present.
+- Add a small workflow-level test or script assertion that checks the plan approval step invokes `uv run python`, captures `PLAN_APPROVAL_LABEL_GATE_RC`, runs `scripts/enforcement/require-plan-approval.sh --strict` before exiting on the new gate result, and preserves legacy diagnostics.
+
+### Questions for Author
+- Is branch-name issue resolution intentionally the only supported authorization source for PR2a, despite the denial text mentioning GitHub metadata?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r6-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r6-gemini.md
@@ -1,0 +1,16 @@
+### Verdict: MAJOR
+
+### Summary
+The R6 payload successfully addresses all R4 blockers: it strictly parses the revision SHA, fails closed on missing pushedDate, robustly incorporates the binding's updated_at timestamp into the freshness check, and correctly coordinates the CI cutover with the legacy gate. However, a major functional defect remains: the script completely ignores plan bindings placed in the main issue description.
+
+### Issues Found
+- MAJOR: `load_issue_comments` only calls `repos/{repo}/issues/{issue}/comments`. The GitHub REST API for this endpoint strictly returns replies, omitting the main issue description (the 0th comment). If an authorized owner places the plan binding in the issue description, the gate will fail to find it and deny the PR.
+- MINOR: `resolve_linked_issues` relies exclusively on extracting the issue number from the branch name (e.g., `feat/2817-x`). Although the test `test_pr_body_or_commit_refs_are_not_authority` mentions 'GitHub-native issue list', the code does not actually query GitHub for natively linked issues (e.g., via `gh pr view`). PRs from branches without an issue number will automatically fail closed even if correctly linked in the UI.
+
+### Suggestions
+- Modify `load_issue_comments` to also fetch the main issue via `gh api repos/{repo}/issues/{issue}` and prepend it to the `comments` list (mapping `user` to `author`, and preserving `created_at`/`updated_at`) before returning.
+- Consider extending `resolve_linked_issues` to parse `gh pr view {pr} --json closingIssuesReferences` or GraphQL equivalents, allowing the gate to support workflows where the branch name does not contain the issue number.
+
+### Questions for Author
+- Is it an intentional constraint that plan bindings cannot reside in the main issue description, or was the omission of the issue body from the API response an oversight?
+- Should the system enforce strict branch naming conventions (requiring the issue number in the branch), or was the lack of GitHub-native issue link resolution a temporary scope reduction?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r7-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r7-codex.md
@@ -1,0 +1,15 @@
+### Verdict: MAJOR
+
+### Summary
+The new gate still has merge-blocking bypasses around revision binding and a CI integration failure mode.
+
+### Issues Found
+- MAJOR: `scripts/workflow/plan_approval_gate_check.py` `fetch_plan_revision_anchor` / `plan_blob_matches_revision` do not verify that `binding.revision_sha` is the PR head commit or even reachable from the current branch. The gate accepts any repository commit that touched the recorded plan path, as long as that commit's plan blob equals the PR head plan blob. That weakens the required binding from 'approved current branch revision' to 'approved some commit with same plan file content', allowing code changes at PR head to move independently of the approved revision. Required fix: verify the bound SHA is the PR head SHA or an ancestor of the PR head using GitHub compare/merge-base semantics, and make the freshness anchor the bound branch revision being approved.
+- MAJOR: `.github/workflows/enforcement-gate.yml` now runs `uv run python scripts/workflow/plan_approval_gate_check.py` before the legacy gate and exits on its rc after the legacy gate. When `PLAN_APPROVAL_GATE_ENABLED=1` and admin prereqs are confirmed, any transient GitHub API/GraphQL/contents call failure in the new experimental gate fails the whole existing enforcement job, even though the comment says the legacy hard gate stays active until the new gate is verified as a required status check. This is a CI cutover regression: enabling test rollout immediately makes the new gate blocking. Required fix: either make the variable name/semantics explicitly mean 'blocking enforcement enabled' or add a separate shadow-mode path where the new gate records failure without failing until cutover is complete.
+
+### Suggestions
+- Add tests proving a bound revision that is neither head nor ancestor is rejected.
+- Add a workflow test for the intended shadow/cutover behavior, including enabled-but-not-blocking versus blocking mode if both are needed.
+
+### Questions for Author
+- Is the approved revision intended to be exactly the PR head SHA, or is an ancestor acceptable once the plan file blob is unchanged? The current code implements neither; it accepts unrelated commits with matching plan blobs.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r7-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r7-gemini.md
@@ -1,0 +1,18 @@
+### Verdict: REJECT
+
+### Summary
+The plan-approval gate introduces critical bypass vectors regarding label revocation and a brittle fail-closed logic flaw tied to GitHub's issue update behavior.
+
+### Issues Found
+- [MAJOR] Label Revocation Bypass: The gate relies on `verified_label_event` to find the timestamp of the `status:plan-approved` label application, but it never verifies if the label is *currently* applied to the issue. If an authorized owner revokes their approval by removing the label, the script still discovers the historical `labeled` event and incorrectly approves the PR.
+- [MAJOR] False-Positive Failures on Issue Activity: Extracting bindings from the issue body uses `issue_data.get("updated_at")` as the `recorded_at` timestamp. In the GitHub API, an issue's `updated_at` advances upon *any* activity, including applying labels or posting comments. Thus, simply approving the issue or adding a comment advances the binding timestamp past the approval timestamp, causing `label_is_fresh` to unconditionally fail.
+- [MINOR] Path Mutilation in `_normalize_path`: The implementation `path.replace("\\", "/").lstrip("./")` uses `lstrip`, which treats its argument as a set of characters to remove. This improperly strips *all* leading dots and slashes, mangling valid paths like `.github/workflows/main.yml` into `github/workflows/main.yml`.
+
+### Suggestions
+- In `load_issue_approval`, fetch the current issue labels (e.g., from `issue_data.get("labels", [])`) and explicitly deny the gate decision if `status:plan-approved` is not currently present on the issue.
+- For bindings parsed from the issue body, do not use the REST API `updated_at` field. Either use the GraphQL `lastEditedAt` field to track actual body edits, or drop support for issue body bindings and restrict bindings exclusively to comments (where `updated_at` strictly tracks comment edits).
+- Replace `.lstrip("./")` with `.lstrip("/")` in `_normalize_path`. If removing `./` prefixes is strictly necessary, use `path.removeprefix("./")` (or manual slicing for older Python versions).
+
+### Questions for Author
+- How should the gate handle scenarios where multiple different authorized owners post conflicting plan bindings on the same issue?
+- Is it intentional that the workflow evaluates and potentially exits on the legacy gate's return code before checking `PLAN_APPROVAL_LABEL_GATE_RC`, potentially obscuring failures in the new implementation?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r8-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r8-codex.md
@@ -1,0 +1,24 @@
+### Verdict: MAJOR
+
+### Summary
+Verdict: REQUEST_CHANGES
+Severity: MAJOR
+Findings:
+1. [MAJOR] `extract_plan_binding` accepts the last authorized binding anywhere in the issue body/comments, even if it was posted before a later unauthorized plan-binding edit/comment. An unauthorized contributor can later edit the issue body if permitted, or add a newer comment containing a different plan/revision; the gate ignores that newer conflicting binding and continues using the older owner-authored one. Because the freshness check only compares the label against the selected owner binding's `recorded_at`, it does not prove the currently-visible/latest binding state is owner-authored. Relevant code: `scripts/workflow/plan_approval_gate_check.py` `extract_plan_binding` loop and `_evaluate_binding` freshness check. Fix: define binding authority as the latest binding-like source, then require that latest source to be owner-authored human, or fail on any newer conflicting binding-like source after the approved owner binding.
+
+2. [MAJOR] The label-current check and label-event actor check are not tied to the same label application instance. `load_issue_approval` reads the last `labeled` event via `verified_label_event`, then separately reads current labels via `load_current_issue_labels`. If the label is removed and re-added by an unauthorized actor after the authorized event, this should fail only if `verified_label_event` reliably returns the newest labeled event. The implementation depends on event pagination/order behavior in `verified_label_event`, but this diff adds no regression test for remove/re-add ordering or pagination. For a merge-blocking authority gate, this is a blind spot around the central invariant. Relevant code: `scripts/workflow/plan_approval_gate_check.py` `load_issue_approval`; existing helper `scripts/workflow/label_authority.py` `verified_label_event`. Fix: add tests proving newest add wins across labeled/unlabeled sequences and pagination, or change the query to explicitly fetch timeline items ordered newest-first and bind current state to the latest application.
+
+Required fixes before merge:
+- Make plan-binding selection fail closed on newer non-owner/conflicting binding text after an approved owner binding.
+- Add/adjust tests for label remove/re-add by unauthorized actors and paginated event ordering so the current applied label actor is the actor being authorized.
+
+### Issues Found
+- [MAJOR] `extract_plan_binding` accepts the last authorized binding anywhere in the issue body/comments, even if it was posted before a later unauthorized plan-binding edit/comment. An unauthorized contributor can later edit the issue body if permitted, or add a newer comment containing a different plan/revision; the gate ignores that newer conflicting binding and continues using the older owner-authored one. Because the freshness check only compares the label against the selected owner binding's `recorded_at`, it does not prove the currently-visible/latest binding state is owner-authored. Relevant code: `scripts/workflow/plan_approval_gate_check.py` `extract_plan_binding` loop and `_evaluate_binding` freshness check. Fix: define binding authority as the latest binding-like source, then require that latest source to be owner-authored human, or fail on any newer conflicting binding-like source after the approved owner binding.
+- [MAJOR] The label-current check and label-event actor check are not tied to the same label application instance. `load_issue_approval` reads the last `labeled` event via `verified_label_event`, then separately reads current labels via `load_current_issue_labels`. If the label is removed and re-added by an unauthorized actor after the authorized event, this should fail only if `verified_label_event` reliably returns the newest labeled event. The implementation depends on event pagination/order behavior in `verified_label_event`, but this diff adds no regression test for remove/re-add ordering or pagination. For a merge-blocking authority gate, this is a blind spot around the central invariant. Relevant code: `scripts/workflow/plan_approval_gate_check.py` `load_issue_approval`; existing helper `scripts/workflow/label_authority.py` `verified_label_event`. Fix: add tests proving newest add wins across labeled/unlabeled sequences and pagination, or change the query to explicitly fetch timeline items ordered newest-first and bind current state to the latest application.
+
+### Suggestions
+- Make plan-binding selection fail closed on newer non-owner/conflicting binding text after an approved owner binding.
+- Add/adjust tests for label remove/re-add by unauthorized actors and paginated event ordering so the current applied label actor is the actor being authorized.
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r8-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r8-gemini.md
@@ -1,0 +1,22 @@
+### Verdict: REJECT
+
+### Summary
+Multiple major fail-closed regressions identified. The gate blocks all PRs that don't follow strict branch naming conventions, breaks approval freshness if the issue body is edited, and permanently blocks follow-up PRs that don't directly modify the plan file.
+
+### Issues Found
+- [MAJOR] Editing the issue body revokes plan approval (Freshness Error): `load_issue_binding_sources` sets `updatedAt` to GraphQL's `lastEditedAt`. `extract_plan_binding` uses this as `recorded_at`. If a user fixes a typo in the issue description after approval, `recorded_at` becomes newer than `label_applied_at`, causing `label_is_fresh` to fail and requiring re-approval.
+- [MAJOR] Unconditional blocking of PRs without branch-linked issues: `evaluate_plan_approval` fails closed if `resolve_linked_issues` returns empty. Since it only checks `_BRANCH_ISSUE_RE`, any PR from branches like `main`, `patch-1`, or `dependabot/*` will be unconditionally blocked, even if they don't require plans.
+- [MAJOR] Requires PRs to modify the plan file: `_evaluate_binding` checks `if binding.plan_path not in touched`. This permanently blocks follow-up PRs that implement code for an already-merged plan, as they won't touch the plan markdown file.
+- [MINOR] API/Web UI commits permanently block approvals: `fetch_commit_pushed_at` relies on GraphQL `pushedDate`, which is often `null` for commits made via the GitHub Web UI or API. `fetch_plan_revision_anchor` returns `None, False` if `pushedDate` is null, causing a fail-closed.
+- [MINOR] Mismatched regex extraction: `extract_plan_binding` uses `re.search` which finds the *first* occurrence in the body. If an issue body mentions an old plan path and then a new plan path and revision, the script extracts the old plan path and pairs it with the new revision, breaking validation.
+
+### Suggestions
+- Do not use `lastEditedAt` to determine the binding's `recorded_at`. Only invalidate if the binding text itself changes, or fallback to using the `createdAt` timestamp of the comment.
+- If no linked issues are found, return `GateDecision(True, "No linked issues")` or skip the check, rather than failing closed unconditionally for all non-conforming branches.
+- Remove the `if binding.plan_path not in touched` check. Verifying that `revision_reaches_head` is true is sufficient to ensure the plan revision is part of the PR's ancestry.
+- Fallback to `committedDate` if `pushedDate` is null in `fetch_commit_pushed_at` to support Web UI/API commits.
+- Enforce a stricter format for extracting plan bindings (e.g., line-anchored regex or reading from inside a specific code block) to avoid parsing mismatched paths and SHAs.
+
+### Questions for Author
+- How should the gate handle PRs (like Dependabot updates or hotfixes) that do not have an associated issue and don't match the branch naming regex?
+- Is it strictly required that every PR linked to an issue modifies the plan file, or should follow-up implementation PRs be allowed to pass if the plan is already in the base branch?

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r9-codex.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r9-codex.md
@@ -1,0 +1,21 @@
+### Verdict: REJECT
+
+### Summary
+Verdict: REQUEST_CHANGES
+Severity: MAJOR
+Findings:
+1. MAJOR: `scripts/workflow/plan_approval_gate_check.py:240-245` calls `gh_json(...)` in `load_pr_context`, but this module never imports or defines `gh_json`. In an enabled run, `_run_enabled()` reaches `load_pr_context()`, raises `NameError`, and `main()` converts it to a fail-closed DENY. That is not a bypass, but it makes the new label-authority gate unable to ever pass once enabled, so the CI integration is not merge-safe. The current tests miss this because they exercise `evaluate_plan_approval()` and helper functions, not the enabled success path through `load_pr_context()` / `_run_enabled()`.
+
+Required fixes before merge:
+- Import `gh_json` from `label_authority` or route PR metadata loading through an I/O helper that has access to it.
+- Add a regression test that exercises the enabled `_run_enabled()` or `load_pr_context()` success path with mocked `gh_json` and `load_pr_changed_paths`, proving the gate can ALLOW a valid PR instead of only unit-testing the pure evaluator.
+
+### Issues Found
+- MAJOR: scripts/workflow/plan_approval_gate_check.py:240-245 calls gh_json without importing or defining it, causing enabled gate runs to fail closed with NameError and making the gate unusable.
+
+### Suggestions
+- Import gh_json from label_authority or move PR metadata loading to plan_approval_gate_io.
+- Add an enabled-path regression test for _run_enabled() or load_pr_context().
+
+### Questions for Author
+- None.

--- a/scripts/review/results/20260531T-issue2817-pr2a-implementation-r9-gemini.md
+++ b/scripts/review/results/20260531T-issue2817-pr2a-implementation-r9-gemini.md
@@ -1,0 +1,18 @@
+### Verdict: REJECT
+
+### Summary
+The implementation contains a critical replay attack vulnerability that allows unauthorized code changes to bypass the plan-approval gate. By reusing a previously approved issue and changing the file mode of its plan document, an attacker can trick the gate into validating against old credentials. Minor issues with GraphQL PR resolution and fail-closed edge cases were also found.
+
+### Issues Found
+- MAJOR: Replay Attack Bypass via File Mode Changes. An attacker can link their branch to an old, already-merged issue that retains its `status:plan-approved` label (e.g., `feat/123-exploit`). By changing the executable mode of the old plan file (`chmod +x`), the file appears in the PR's `touched_paths` (via `gh pr diff`). However, because file modes are tracked in Git trees rather than blobs, `fetch_file_blob` returns the identical blob SHA, allowing `plan_head_matches_revision` to pass. The gate evaluates to ALLOW, completely bypassing the plan approval requirement for arbitrary malicious code.
+- MINOR: GraphQL Query Fails on PR Bodies. `load_issue_binding_sources` uses the GraphQL `repository.issue(number: $number)` field to fetch the issue body. If the linked 'issue' is actually a Pull Request, this field resolves to `null` (since PRs require `repository.pullRequest`). While comments are successfully fetched via REST, a plan binding placed in a tracking PR's description will be ignored, leading to a fail-closed denial.
+- MINOR: Binding Extraction Overwrites with `None` Timestamps. In `extract_plan_binding`, the logic `if binding is None or candidate.recorded_at is None: binding = candidate` causes a candidate with a missing timestamp to unconditionally overwrite a valid, prior binding. While `recorded_at` is unlikely to be `None` from standard GitHub API responses, this introduces unnecessary fragility.
+
+### Suggestions
+- Prevent Replay Attacks: Implement a check to ensure the approved `revision_sha` is NOT an ancestor of the PR's base branch (e.g., check `gh api repos/{repo}/compare/{revision_sha}...{base_sha}`). If it is an ancestor, the plan has already been merged and cannot authorize new PRs. Alternatively, strictly require the linked issue's `state` to be `open`.
+- Support PR Bodies in GraphQL: Update the GraphQL query to use a fragment on both `Issue` and `PullRequest`, or fallback to checking the `pullRequest` field if `issue` is null, ensuring bindings in PR descriptions are correctly parsed.
+- Fix Binding Extraction Logic: Update `extract_plan_binding` to skip candidates with missing timestamps (`if candidate.recorded_at is None: continue`) to preserve previously identified valid bindings.
+
+### Questions for Author
+- Are issues expected to have their `status:plan-approved` labels manually removed after merge? Relying on manual removal leaves merged issues permanently exploitable to the replay attack bypass.
+- Does the team use tracking PRs for planning? If so, the GraphQL query needs to be updated to support fetching descriptions from `PullRequest` objects.

--- a/scripts/workflow/label_authority.py
+++ b/scripts/workflow/label_authority.py
@@ -45,3 +45,32 @@ def verified_label_event(repo: str, issue: int, label: str):
             actor = (ev.get("actor") or {}).get("login")
             applied_at = parse_iso(ev.get("created_at"))
     return actor, applied_at
+
+
+def is_authorized_human(
+    actor: str | None,
+    owners: set[str],
+    *,
+    reject_bots: bool = False,
+    actor_type: str | None = None,
+) -> bool:
+    """Whether ``actor`` is an allowed label applier for the caller's policy.
+
+    Bot rejection is opt-in so existing #2798 completeness behavior stays
+    membership-only. The #2817 plan-approval gate opts into ``reject_bots``.
+    """
+    normalized_actor = (actor or "").lower()
+    normalized_owners = {owner.lower() for owner in owners}
+    if not normalized_actor or normalized_actor not in normalized_owners:
+        return False
+    if not reject_bots:
+        return True
+    return not (normalized_actor.endswith("[bot]") or (actor_type or "").lower() in {"bot", "app"})
+
+
+def label_is_fresh(applied_at, *not_before_times) -> bool:
+    """Whether a label application is at/after all required GitHub-observed anchors."""
+    anchors = [ts for ts in not_before_times if ts is not None]
+    if not applied_at or not anchors:
+        return False
+    return applied_at >= max(anchors)

--- a/scripts/workflow/plan_approval_gate_check.py
+++ b/scripts/workflow/plan_approval_gate_check.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Server-side plan-approval label-authority gate for #2817."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from label_authority import (  # noqa: E402
+    gh_json,
+    is_authorized_human,
+    label_is_fresh,
+    parse_iso,
+    verified_label_event,
+)
+from plan_approval_gate_io import (  # noqa: E402
+    _normalize_path,
+    fetch_actor_type,
+    fetch_plan_revision_anchor,
+    load_current_issue_labels,
+    load_issue_binding_sources,
+    plan_blob_matches_revision,
+    revision_reaches_head,
+)
+
+PLAN_APPROVED_LABEL = "status:plan-approved"
+_BRANCH_ISSUE_RE = re.compile(
+    r"^(?:feat|feature|fix|bugfix|chore|docs|refactor|test)/(?P<issue>\d+)(?:[-_/].*)?$"
+)
+_IMPLEMENTATION_EXT_RE = re.compile(r"\.(py|js|ts|sh|rs|go)$")
+_LOW_RISK_PREFIXES = (
+    "scripts/", ".github/", "docs/", "config/", ".claude/skills/",
+    ".claude/hooks/", "tests/", "specs/",
+)
+_PLAN_PATH_RE = re.compile(r"`?(docs/plans/[A-Za-z0-9._/-]+\.md)`?")
+_REVISION_RE = re.compile(
+    r"(?im)^\s*(?:plan\s+revision|revision|sha|commit)\s*[:=]\s*`?([0-9a-f]{40})`?\s*$"
+)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    allowed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class PlanBinding:
+    plan_path: str
+    revision_sha: str
+    recorded_by: str
+    recorded_by_type: str | None = None
+    recorded_at: object | None = None
+
+
+@dataclass(frozen=True)
+class IssueApproval:
+    issue_number: int
+    label_actor: str | None
+    label_actor_type: str | None
+    label_applied_at: object | None
+    plan_binding: PlanBinding | None
+    plan_revision_time: object | None
+    label_current: bool = True
+    plan_revision_verified: bool = True
+    plan_revision_in_head: bool = True
+    plan_revision_in_base: bool = False
+    plan_head_matches_revision: bool = True
+
+
+@dataclass(frozen=True)
+class PrContext:
+    branch_name: str
+    pr_author: str
+    touched_paths: set[str]
+    head_sha: str | None = None
+    base_sha: str | None = None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").lower() in {"1", "true", "yes", "on"}
+
+
+def _actor_is_bot(actor: str | None, actor_type: str | None) -> bool:
+    return bool(actor and actor.lower().endswith("[bot]")) or (actor_type or "").lower() in {"bot", "app"}
+
+
+def parse_owners(raw: str | None) -> set[str]:
+    return {item.strip().lower() for item in (raw or "").split(",") if item.strip()}
+
+
+def issue_from_branch(branch_name: str) -> int | None:
+    match = _BRANCH_ISSUE_RE.match(branch_name or "")
+    return int(match.group("issue")) if match else None
+
+
+def resolve_linked_issues(branch_name: str) -> list[int]:
+    branch_issue = issue_from_branch(branch_name)
+    if branch_issue is not None:
+        return [branch_issue]
+    return []
+
+
+def validate_owner_types(owner_types: dict[str, str | None]) -> GateDecision:
+    if not owner_types:
+        return GateDecision(False, "PLAN_APPROVAL_OWNERS is empty or unresolved")
+    for owner, actor_type in sorted(owner_types.items()):
+        if _actor_is_bot(owner, actor_type):
+            return GateDecision(False, f"owner {owner!r} resolves to bot/app type {actor_type!r}")
+        if not actor_type:
+            return GateDecision(False, f"owner {owner!r} type could not be verified")
+    return GateDecision(True, "owner allowlist is human-only")
+
+
+def _comment_author(comment: dict) -> str | None:
+    author = comment.get("author") or comment.get("user") or {}
+    if isinstance(author, str):
+        return author
+    return author.get("login")
+
+
+def _binding_fields(body: str) -> tuple[str, str] | None:
+    paths = [_normalize_path(path) for path in _PLAN_PATH_RE.findall(body or "")]
+    revisions = _REVISION_RE.findall(body or "")
+    if len(paths) != 1 or len(revisions) != 1:
+        return None
+    return paths[0], revisions[0]
+
+
+def extract_plan_binding(
+    comments: list[dict],
+    owners: set[str],
+    actor_types: dict[str, str | None],
+) -> PlanBinding | None:
+    binding = None
+    for comment in comments:
+        fields = _binding_fields(comment.get("body") or "")
+        if fields is None:
+            continue
+        actor = _comment_author(comment)
+        actor_type = actor_types.get((actor or "").lower())
+        if not is_authorized_human(actor, owners, reject_bots=True, actor_type=actor_type):
+            continue
+        candidate = PlanBinding(
+            plan_path=fields[0],
+            revision_sha=fields[1],
+            recorded_by=actor or "",
+            recorded_by_type=actor_type,
+            recorded_at=parse_iso(
+                comment.get("updatedAt")
+                or comment.get("updated_at")
+                or comment.get("createdAt")
+                or comment.get("created_at")
+            ),
+        )
+        if binding is None or candidate.recorded_at is None:
+            binding = candidate
+        elif binding.recorded_at is not None and candidate.recorded_at >= binding.recorded_at:
+            binding = candidate
+    return binding
+
+
+def evaluate_plan_approval(
+    context: PrContext,
+    approvals: dict[int, IssueApproval],
+    owners: set[str],
+    *,
+    require_separate_approver: bool = False,
+) -> GateDecision:
+    if not owners:
+        return GateDecision(False, "PLAN_APPROVAL_OWNERS is unset; fail-closed")
+    issues = resolve_linked_issues(context.branch_name)
+    if not issues:
+        return GateDecision(False, "no linked issue from branch name; fail-closed")
+    touched = {_normalize_path(path) for path in context.touched_paths}
+    for issue in issues:
+        decision = _evaluate_issue(issue, context, approvals.get(issue), owners, touched,
+                                   require_separate_approver)
+        if not decision.allowed:
+            return decision
+    return GateDecision(True, f"plan approval verified for issue(s): {issues}")
+
+
+def _evaluate_issue(
+    issue: int,
+    context: PrContext,
+    approval: IssueApproval | None,
+    owners: set[str],
+    touched: set[str],
+    require_separate: bool,
+) -> GateDecision:
+    if approval is None:
+        return GateDecision(False, f"issue #{issue}: approval context unavailable; fail-closed")
+    if not approval.label_actor or not approval.label_applied_at:
+        return GateDecision(False, f"issue #{issue}: {PLAN_APPROVED_LABEL!r} label event not found")
+    if not approval.label_current:
+        return GateDecision(False, f"issue #{issue}: {PLAN_APPROVED_LABEL!r} label is not currently applied")
+    if _actor_is_bot(approval.label_actor, approval.label_actor_type):
+        return GateDecision(False, f"issue #{issue}: label actor {approval.label_actor!r} is a bot/app")
+    if not is_authorized_human(approval.label_actor, owners, reject_bots=True,
+                               actor_type=approval.label_actor_type):
+        return GateDecision(False, f"issue #{issue}: label actor {approval.label_actor!r} not authorized")
+    if require_separate and approval.label_actor.lower() == context.pr_author.lower():
+        return GateDecision(False, f"issue #{issue}: separate approver required")
+    return _evaluate_binding(issue, approval, owners, touched)
+
+
+def _evaluate_binding(
+    issue: int,
+    approval: IssueApproval,
+    owners: set[str],
+    touched: set[str],
+) -> GateDecision:
+    binding = approval.plan_binding
+    if binding is None:
+        return GateDecision(False, f"issue #{issue}: authorized plan binding not found on issue")
+    if _actor_is_bot(binding.recorded_by, binding.recorded_by_type):
+        return GateDecision(False, f"issue #{issue}: plan binding recorded by bot/app")
+    if not is_authorized_human(binding.recorded_by, owners, reject_bots=True,
+                               actor_type=binding.recorded_by_type):
+        return GateDecision(False, f"issue #{issue}: plan binding author {binding.recorded_by!r} not authorized")
+    if not plan_path_matches_issue(binding.plan_path, issue):
+        return GateDecision(False, f"issue #{issue}: recorded plan path does not match issue #{issue}")
+    if binding.plan_path not in touched:
+        return GateDecision(False, f"issue #{issue}: PR does not touch recorded plan path {binding.plan_path}")
+    if not approval.plan_revision_verified:
+        return GateDecision(False, f"issue #{issue}: recorded revision does not contain the plan path")
+    if not approval.plan_revision_in_head:
+        return GateDecision(False, f"issue #{issue}: recorded revision is not in PR head history")
+    if approval.plan_revision_in_base:
+        return GateDecision(False, f"issue #{issue}: recorded revision is already in PR base history")
+    if not approval.plan_head_matches_revision:
+        return GateDecision(False, f"issue #{issue}: PR head plan file differs from approved revision")
+    if binding.recorded_at is None:
+        return GateDecision(False, f"issue #{issue}: plan binding timestamp unavailable; fail-closed")
+    if approval.plan_revision_time is None:
+        return GateDecision(False, f"issue #{issue}: plan revision time unavailable; fail-closed")
+    if not label_is_fresh(approval.label_applied_at, approval.plan_revision_time, binding.recorded_at):
+        return GateDecision(False, f"issue #{issue}: approval label predates plan revision; re-approval required")
+    return GateDecision(True, f"issue #{issue}: label-authority approval verified")
+
+
+def plan_path_matches_issue(plan_path: str, issue: int) -> bool:
+    return re.search(rf"(?:^|[-_/])issue-{issue}(?:[-_. /]|$)", _normalize_path(plan_path)) is not None
+
+
+def needs_plan_approval_paths(paths: set[str]) -> bool:
+    normalized = {_normalize_path(path) for path in paths}
+    return any(
+        _IMPLEMENTATION_EXT_RE.search(path) and not path.startswith(_LOW_RISK_PREFIXES)
+        for path in normalized
+    )
+
+
+def load_pr_context(repo: str, pr_number: int) -> PrContext:
+    data = gh_json(
+        "pr", "view", str(pr_number), "--repo", repo,
+        "--json", "headRefName,headRefOid,baseRefOid,author",
+    ) or {}
+    files = load_pr_changed_paths(repo, pr_number)
+    return PrContext(
+        branch_name=data.get("headRefName") or "",
+        pr_author=((data.get("author") or {}).get("login")) or "",
+        touched_paths={path for path in files if path},
+        head_sha=data.get("headRefOid"),
+        base_sha=data.get("baseRefOid"),
+    )
+
+
+def load_pr_changed_paths(repo: str, pr_number: int) -> set[str]:
+    out = subprocess.run(
+        ["gh", "pr", "diff", str(pr_number), "--repo", repo, "--name-only"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return {_normalize_path(line.strip()) for line in out.splitlines() if line.strip()}
+
+
+def load_issue_approval(
+    repo: str,
+    issue: int,
+    owners: set[str],
+    owner_types: dict[str, str | None],
+    head_sha: str | None,
+    base_sha: str | None,
+) -> IssueApproval:
+    label_actor, label_at = verified_label_event(repo, issue, PLAN_APPROVED_LABEL)
+    actor_types = dict(owner_types)
+    if label_actor and label_actor.lower() not in actor_types:
+        actor_types[label_actor.lower()] = fetch_actor_type(label_actor)
+    label_current = PLAN_APPROVED_LABEL in load_current_issue_labels(repo, issue)
+    binding = extract_plan_binding(load_issue_binding_sources(repo, issue), owners, actor_types)
+    if binding:
+        revision_time, revision_verified = fetch_plan_revision_anchor(
+            repo, binding.revision_sha, binding.plan_path, binding.recorded_at)
+        revision_in_head = revision_reaches_head(repo, binding.revision_sha, head_sha)
+        revision_in_base = True if not base_sha else revision_reaches_head(repo, binding.revision_sha, base_sha)
+        head_matches = plan_blob_matches_revision(repo, binding.revision_sha, head_sha, binding.plan_path)
+    else:
+        revision_time, revision_verified = None, False
+        revision_in_head, revision_in_base, head_matches = False, True, False
+    return IssueApproval(
+        issue_number=issue,
+        label_actor=label_actor,
+        label_actor_type=actor_types.get((label_actor or "").lower()),
+        label_applied_at=label_at,
+        plan_binding=binding,
+        plan_revision_time=revision_time,
+        label_current=label_current,
+        plan_revision_verified=revision_verified,
+        plan_revision_in_head=revision_in_head,
+        plan_revision_in_base=revision_in_base,
+        plan_head_matches_revision=head_matches,
+    )
+
+
+def _event_pr_number() -> int | None:
+    if os.environ.get("PR_NUMBER"):
+        try:
+            return int(os.environ["PR_NUMBER"])
+        except ValueError:
+            return None
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    with open(event_path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    pr = payload.get("pull_request") or {}
+    try:
+        return int(pr.get("number"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--pr", type=int, default=_event_pr_number())
+    parser.add_argument("--owners", default=os.environ.get("PLAN_APPROVAL_OWNERS", ""))
+    parser.add_argument("--enabled", action="store_true", default=_truthy(os.environ.get("PLAN_APPROVAL_GATE_ENABLED")))
+    parser.add_argument("--admin-prereqs-confirmed", action="store_true",
+                        default=_truthy(os.environ.get("PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED")))
+    parser.add_argument("--require-separate-approver", action="store_true",
+                        default=_truthy(os.environ.get("PLAN_APPROVAL_REQUIRE_SEPARATE")))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    if not args.enabled:
+        print("[plan-approval-gate] SKIP: PLAN_APPROVAL_GATE_ENABLED is not set.")
+        print("[plan-approval-gate] Admin prereq: make Plan Approval Check required and protect "
+              "status:plan-approved label before retiring the old marker gate.")
+        return 0
+    if not args.repo or not args.pr:
+        print("[plan-approval-gate] DENY: repo or PR number unavailable; fail-closed.", file=sys.stderr)
+        return 1
+    if not args.admin_prereqs_confirmed:
+        print("[plan-approval-gate] DENY: admin prereqs are not confirmed; make Plan Approval Check "
+              "required and protect status:plan-approved before enabling.", file=sys.stderr)
+        return 1
+    try:
+        return _run_enabled(args)
+    except Exception as exc:  # pragma: no cover - exercised in live CI failures
+        print(f"[plan-approval-gate] DENY: unverifiable gate context ({exc}); fail-closed.", file=sys.stderr)
+        return 1
+
+
+def _run_enabled(args: argparse.Namespace) -> int:
+    owners = parse_owners(args.owners)
+    owner_types = {owner: fetch_actor_type(owner) for owner in owners}
+    owner_decision = validate_owner_types(owner_types)
+    if not owner_decision.allowed:
+        print(f"[plan-approval-gate] DENY: {owner_decision.reason}", file=sys.stderr)
+        return 1
+    context = load_pr_context(args.repo, args.pr)
+    if not needs_plan_approval_paths(context.touched_paths):
+        print("[plan-approval-gate] SKIP: no implementation changes requiring plan approval.")
+        return 0
+    issues = resolve_linked_issues(context.branch_name)
+    approvals = {
+        issue: load_issue_approval(args.repo, issue, owners, owner_types, context.head_sha, context.base_sha)
+        for issue in issues
+    }
+    decision = evaluate_plan_approval(context, approvals, owners,
+                                      require_separate_approver=args.require_separate_approver)
+    print(f"[plan-approval-gate] {'ALLOW' if decision.allowed else 'DENY'}: {decision.reason}")
+    return 0 if decision.allowed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow/plan_approval_gate_io.py
+++ b/scripts/workflow/plan_approval_gate_io.py
@@ -1,0 +1,128 @@
+"""GitHub I/O helpers for the #2817 plan-approval gate."""
+
+from __future__ import annotations
+
+import re
+
+from label_authority import gh_json, parse_iso
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+def fetch_actor_type(login: str | None) -> str | None:
+    if not login:
+        return None
+    data = gh_json("api", f"users/{login}") or {}
+    return data.get("type")
+
+
+def fetch_commit_pushed_at(repo: str, sha: str):
+    owner, name = repo.split("/", 1)
+    query = """
+    query($owner:String!, $name:String!, $oid:GitObjectID!) {
+      repository(owner:$owner, name:$name) {
+        object(oid:$oid) { ... on Commit { pushedDate } }
+      }
+    }
+    """
+    data = gh_json("api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}",
+                   "-f", f"oid={sha}", "-f", f"query={query}") or {}
+    commit = (((data.get("data") or {}).get("repository") or {}).get("object")) or {}
+    return parse_iso(commit.get("pushedDate"))
+
+
+def fetch_plan_revision_anchor(repo: str, sha: str, plan_path: str, fallback_time):
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", sha or ""):
+        return None, False
+    commit = gh_json("api", f"repos/{repo}/commits/{sha}") or {}
+    files = {_normalize_path((item or {}).get("filename", "")) for item in commit.get("files", [])}
+    if _normalize_path(plan_path) not in files:
+        return None, False
+    pushed_at = fetch_commit_pushed_at(repo, sha)
+    if pushed_at is None:
+        return None, False
+    anchors = [ts for ts in [pushed_at, fallback_time] if ts is not None]
+    return max(anchors), True
+
+
+def revision_reaches_head(repo: str, revision_sha: str, head_sha: str | None) -> bool:
+    if not head_sha or not re.fullmatch(r"[0-9a-fA-F]{40}", revision_sha or ""):
+        return False
+    if revision_sha.lower() == head_sha.lower():
+        return True
+    data = gh_json("api", f"repos/{repo}/compare/{revision_sha}...{head_sha}") or {}
+    return data.get("status") in {"ahead", "identical"}
+
+
+def fetch_file_blob(repo: str, ref: str, path: str) -> str | None:
+    data = gh_json("api", f"repos/{repo}/contents/{path}?ref={ref}") or {}
+    if isinstance(data, list):
+        return None
+    return data.get("sha")
+
+
+def plan_blob_matches_revision(repo: str, revision_sha: str, head_sha: str | None, plan_path: str) -> bool:
+    if not head_sha:
+        return False
+    revision_blob = fetch_file_blob(repo, revision_sha, plan_path)
+    head_blob = fetch_file_blob(repo, head_sha, plan_path)
+    return bool(revision_blob and head_blob and revision_blob == head_blob)
+
+
+def load_issue_binding_sources(repo: str, issue: int) -> list[dict]:
+    owner, name = repo.split("/", 1)
+    query = """
+    query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner:$owner, name:$name) {
+        issue(number:$number) {
+          author { login }
+          body
+          createdAt
+          lastEditedAt
+        }
+        pullRequest(number:$number) {
+          author { login }
+          body
+          createdAt
+          lastEditedAt
+        }
+      }
+    }
+    """
+    sources = []
+    data = gh_json("api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}",
+                   "-F", f"number={issue}", "-f", f"query={query}") or {}
+    repo_data = ((data.get("data") or {}).get("repository")) or {}
+    # GitHub issues and PRs share one number namespace; this supports a linked
+    # planning PR body, not the current implementation PR body.
+    issue_data = repo_data.get("issue") or repo_data.get("pullRequest") or {}
+    if issue_data.get("body"):
+        sources.append({
+            "author": issue_data.get("author") or {},
+            "body": issue_data.get("body") or "",
+            "createdAt": issue_data.get("createdAt"),
+            "updatedAt": issue_data.get("lastEditedAt") or issue_data.get("createdAt"),
+        })
+    comments = gh_json("api", f"repos/{repo}/issues/{issue}/comments", "--paginate") or []
+    for comment in comments:
+        sources.append({
+            "author": comment.get("user") or {},
+            "body": comment.get("body") or "",
+            "createdAt": comment.get("created_at"),
+            "updatedAt": comment.get("updated_at"),
+        })
+    return sources
+
+
+def load_current_issue_labels(repo: str, issue: int) -> set[str]:
+    data = gh_json("api", f"repos/{repo}/issues/{issue}") or {}
+    return {
+        label.get("name")
+        for label in data.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    }

--- a/tests/workflow/test_label_authority.py
+++ b/tests/workflow/test_label_authority.py
@@ -72,3 +72,45 @@ def test_verified_label_event_ignores_unlabeled_events(monkeypatch):
     monkeypatch.setattr(la, "gh_json", lambda *a: events)
     actor, at = la.verified_label_event("o/r", 1, "status:plan-approved")
     assert actor == "vamsee" and at == la.parse_iso("2026-05-03T00:00:00Z")
+
+
+def test_verified_label_event_uses_readd_actor_after_unlabel(monkeypatch):
+    events = [
+        {"event": "labeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "owner"}, "created_at": "2026-05-03T00:00:00Z"},
+        {"event": "unlabeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "owner"}, "created_at": "2026-05-04T00:00:00Z"},
+        {"event": "labeled", "label": {"name": "status:plan-approved"},
+         "actor": {"login": "contributor"}, "created_at": "2026-05-05T00:00:00Z"},
+    ]
+    monkeypatch.setattr(la, "gh_json", lambda *a: events)
+    actor, at = la.verified_label_event("o/r", 1, "status:plan-approved")
+    assert actor == "contributor" and at == la.parse_iso("2026-05-05T00:00:00Z")
+
+
+def test_is_authorized_human_membership_only_by_default():
+    # R6: callers opt into bot rejection. Existing completeness behavior remains
+    # membership-only and can still accept a service account if configured.
+    assert la.is_authorized_human("service[bot]", {"service[bot]"}) is True
+
+
+def test_is_authorized_human_rejects_bots_when_opted_in():
+    owners = {"service[bot]", "automation", "vamseeachanta"}
+    assert la.is_authorized_human("vamseeachanta", owners, reject_bots=True, actor_type="User") is True
+    assert la.is_authorized_human("service[bot]", owners, reject_bots=True, actor_type="User") is False
+    assert la.is_authorized_human("automation", owners, reject_bots=True, actor_type="Bot") is False
+
+
+def test_is_authorized_human_matches_github_logins_case_insensitively():
+    assert la.is_authorized_human("VamseeAchanta", {"vamseeachanta"}, reject_bots=True,
+                                  actor_type="User") is True
+
+
+def test_label_is_fresh_requires_label_at_or_after_anchor():
+    plan_time = la.parse_iso("2026-05-30T11:00:00Z")
+    approved_after = la.parse_iso("2026-05-30T12:00:00Z")
+    approved_before = la.parse_iso("2026-05-30T10:00:00Z")
+    assert la.label_is_fresh(approved_after, plan_time) is True
+    assert la.label_is_fresh(approved_before, plan_time) is False
+    assert la.label_is_fresh(None, plan_time) is False
+    assert la.label_is_fresh(approved_after, None) is False

--- a/tests/workflow/test_plan_approval_gate_check.py
+++ b/tests/workflow/test_plan_approval_gate_check.py
@@ -1,0 +1,399 @@
+"""Tests for #2817 plan-approval label-authority gate."""
+
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+SCRIPTS_WORKFLOW = Path(__file__).resolve().parents[2] / "scripts" / "workflow"
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SCRIPTS_WORKFLOW))
+
+import plan_approval_gate_check as gate  # noqa: E402
+import plan_approval_gate_io as gate_io  # noqa: E402
+
+
+OWNER = "vamseeachanta"
+PLAN = "docs/plans/2026-05-30-issue-2817-plan-approval-label-authority.md"
+SHA = "2f3d873d48acd05336268ac679f47b5b2708a567"
+
+
+def _t(hour: int) -> dt.datetime:
+    return dt.datetime(2026, 5, 30, hour, 0, tzinfo=dt.timezone.utc)
+
+
+def _ctx(**kw) -> gate.PrContext:
+    base = dict(
+        branch_name="feat/2817-plan-approval-gate",
+        pr_author=OWNER,
+        touched_paths={PLAN, "scripts/workflow/plan_approval_gate_check.py"},
+        head_sha="9" * 40,
+    )
+    base.update(kw)
+    return gate.PrContext(**base)
+
+
+def _binding(**kw) -> gate.PlanBinding:
+    base = dict(
+        plan_path=PLAN,
+        revision_sha=SHA,
+        recorded_by=OWNER,
+        recorded_by_type="User",
+        recorded_at=_t(10),
+    )
+    base.update(kw)
+    return gate.PlanBinding(**base)
+
+
+def _approval(**kw) -> gate.IssueApproval:
+    base = dict(
+        issue_number=2817,
+        label_actor=OWNER,
+        label_actor_type="User",
+        label_applied_at=_t(12),
+        plan_binding=_binding(),
+        plan_revision_time=_t(11),
+    )
+    base.update(kw)
+    return gate.IssueApproval(**base)
+
+
+def _eval(**kw) -> gate.GateDecision:
+    base = dict(
+        context=_ctx(),
+        approvals={2817: _approval()},
+        owners={OWNER},
+    )
+    base.update(kw)
+    return gate.evaluate_plan_approval(**base)
+
+
+def test_authorized_human_label_passes():
+    decision = _eval()
+    assert decision.allowed is True
+    assert "2817" in decision.reason
+
+
+def test_owners_var_unset_fails_closed():
+    decision = _eval(owners=set())
+    assert decision.allowed is False
+    assert "owners" in decision.reason.lower()
+
+
+def test_no_linked_issue_fails_closed():
+    decision = _eval(context=_ctx(branch_name="feat/misc-cleanup"))
+    assert decision.allowed is False
+    assert "branch name" in decision.reason.lower()
+
+
+def test_branch_issue_is_authoritative_over_native_refs():
+    assert gate.resolve_linked_issues("feat/2817-plan-approval-gate") == [2817]
+
+
+def test_pr_body_or_commit_refs_are_not_authority():
+    # The resolver has no body/trailer input by design. Without a branch issue or
+    # GitHub-native issue list, author-controlled textual refs cannot authorize.
+    assert gate.resolve_linked_issues("feat/misc-cleanup") == []
+
+
+def test_no_plan_approved_label_fails():
+    decision = _eval(approvals={2817: _approval(label_actor=None, label_applied_at=None)})
+    assert decision.allowed is False
+    assert "label" in decision.reason.lower()
+
+
+def test_unauthorized_label_actor_fails():
+    decision = _eval(approvals={2817: _approval(label_actor="contributor")})
+    assert decision.allowed is False
+    assert "authorized" in decision.reason.lower()
+
+
+def test_bot_label_actor_fails_by_login_or_type():
+    by_login = _eval(
+        approvals={2817: _approval(label_actor="renovate[bot]", label_actor_type="User")}
+    )
+    by_type = _eval(
+        approvals={2817: _approval(label_actor="automation", label_actor_type="Bot")}
+    )
+    assert by_login.allowed is False
+    assert by_type.allowed is False
+    assert "bot" in by_login.reason.lower()
+    assert "bot" in by_type.reason.lower()
+
+
+def test_plan_binding_missing_fails():
+    decision = _eval(approvals={2817: _approval(plan_binding=None)})
+    assert decision.allowed is False
+    assert "plan" in decision.reason.lower()
+
+
+def test_plan_binding_by_unauthorized_actor_fails():
+    decision = _eval(
+        approvals={2817: _approval(plan_binding=_binding(recorded_by="contributor"))}
+    )
+    assert decision.allowed is False
+    assert "binding" in decision.reason.lower()
+
+
+def test_plan_binding_must_match_issue_number():
+    wrong_plan = "docs/plans/2026-05-30-issue-9999-unrelated.md"
+    decision = _eval(approvals={2817: _approval(plan_binding=_binding(plan_path=wrong_plan))})
+    assert decision.allowed is False
+    assert "issue #2817" in decision.reason
+
+
+def test_plan_binding_issue_match_is_delimiter_safe():
+    assert gate.plan_path_matches_issue("docs/plans/2026-05-30-issue-2817-plan.md", 2817) is True
+    assert gate.plan_path_matches_issue("docs/plans/2026-05-30-issue-28170-plan.md", 2817) is False
+    assert gate.plan_path_matches_issue("docs/plans/2026-05-30-issue-2817x-plan.md", 2817) is False
+
+
+def test_pr_must_touch_recorded_plan_path():
+    decision = _eval(context=_ctx(touched_paths={"scripts/workflow/plan_approval_gate_check.py"}))
+    assert decision.allowed is False
+    assert PLAN in decision.reason
+
+
+def test_recorded_revision_must_be_verified_against_plan_path():
+    decision = _eval(approvals={2817: _approval(plan_revision_verified=False)})
+    assert decision.allowed is False
+    assert "revision" in decision.reason.lower()
+
+
+def test_pr_head_plan_blob_must_match_approved_revision():
+    decision = _eval(approvals={2817: _approval(plan_head_matches_revision=False)})
+    assert decision.allowed is False
+    assert "head plan" in decision.reason.lower()
+
+
+def test_label_predates_plan_revision_fails():
+    decision = _eval(approvals={2817: _approval(label_applied_at=_t(10), plan_revision_time=_t(11))})
+    assert decision.allowed is False
+    assert "re-approval" in decision.reason.lower() or "fresh" in decision.reason.lower()
+
+
+def test_label_predates_binding_comment_update_fails():
+    decision = _eval(
+        approvals={
+            2817: _approval(
+                label_applied_at=_t(12),
+                plan_revision_time=_t(11),
+                plan_binding=_binding(recorded_at=_t(13)),
+            )
+        }
+    )
+    assert decision.allowed is False
+    assert "re-approval" in decision.reason.lower() or "fresh" in decision.reason.lower()
+
+
+def test_synchronize_after_approval_does_not_invalidate():
+    # R2: PR head/push time is intentionally absent from the decision. A later
+    # synchronize event cannot stale a plan approval that post-dates the plan.
+    decision = _eval(approvals={2817: _approval(label_applied_at=_t(12), plan_revision_time=_t(11))})
+    assert decision.allowed is True
+
+
+def test_separate_approver_default_off_for_solo_operator():
+    decision = _eval(context=_ctx(pr_author=OWNER))
+    assert decision.allowed is True
+
+
+def test_separate_approver_opt_in_blocks_author_as_approver():
+    decision = _eval(context=_ctx(pr_author=OWNER), require_separate_approver=True)
+    assert decision.allowed is False
+    assert "separate" in decision.reason.lower()
+
+
+def test_separate_approver_compares_case_insensitively():
+    decision = _eval(context=_ctx(pr_author=OWNER.upper()), require_separate_approver=True)
+    assert decision.allowed is False
+    assert "separate" in decision.reason.lower()
+
+
+def test_legacy_marker_grants_no_authority():
+    # Legacy local markers are not an input to the server gate. Without the label
+    # event, a marker cannot make the decision pass.
+    decision = _eval(approvals={2817: _approval(label_actor=None, label_applied_at=None)})
+    assert decision.allowed is False
+
+
+def test_owners_containing_bot_fails_startup():
+    decision = gate.validate_owner_types({"vamseeachanta": "User", "renovate[bot]": "Bot"})
+    assert decision.allowed is False
+    assert "bot" in decision.reason.lower()
+
+
+def test_extract_plan_binding_requires_authorized_comment_path_and_revision():
+    comments = [
+        {
+            "author": {"login": "contributor"},
+            "createdAt": "2026-05-30T10:00:00Z",
+            "updatedAt": "2026-05-30T10:30:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+        },
+        {
+            "author": {"login": OWNER},
+            "createdAt": "2026-05-30T11:00:00Z",
+            "updatedAt": "2026-05-30T11:30:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+        },
+    ]
+    binding = gate.extract_plan_binding(comments, {OWNER}, {OWNER: "User"})
+    assert binding == _binding(recorded_at=dt.datetime(2026, 5, 30, 11, 30, tzinfo=dt.timezone.utc))
+
+
+def test_extract_plan_binding_ignores_comments_without_revision():
+    comments = [
+        {
+            "author": {"login": OWNER},
+            "createdAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`",
+        }
+    ]
+    assert gate.extract_plan_binding(comments, {OWNER}, {OWNER: "User"}) is None
+
+
+def test_load_issue_binding_sources_includes_issue_body_and_comments(monkeypatch):
+    def fake_gh_json(*args):
+        if args[:2] == ("api", "graphql"):
+            return {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "author": {"login": OWNER},
+                            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+                            "createdAt": "2026-05-30T10:00:00Z",
+                            "lastEditedAt": "2026-05-30T11:00:00Z",
+                        }
+                    }
+                }
+            }
+        if args[:2] == ("api", "repos/vamseeachanta/workspace-hub/issues/2817/comments"):
+            return [
+                {
+                    "user": {"login": OWNER},
+                    "body": "later comment",
+                    "created_at": "2026-05-30T12:00:00Z",
+                    "updated_at": "2026-05-30T12:00:00Z",
+                }
+            ]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    sources = gate.load_issue_binding_sources("vamseeachanta/workspace-hub", 2817)
+    assert sources[0]["body"].startswith("Plan:")
+    assert sources[1]["body"] == "later comment"
+
+
+def test_extract_plan_binding_requires_full_revision_sha():
+    comments = [
+        {
+            "author": {"login": OWNER},
+            "createdAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA[:12]}`",
+        }
+    ]
+    assert gate.extract_plan_binding(comments, {OWNER}, {OWNER: "User"}) is None
+
+
+def test_extract_plan_binding_rejects_overlong_revision_sha():
+    comments = [
+        {
+            "author": {"login": OWNER},
+            "createdAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}a`",
+        }
+    ]
+    assert gate.extract_plan_binding(comments, {OWNER}, {OWNER: "User"}) is None
+
+
+def test_extract_plan_binding_rejects_hex_after_closing_backtick():
+    comments = [
+        {
+            "author": {"login": OWNER},
+            "createdAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`a",
+        }
+    ]
+    assert gate.extract_plan_binding(comments, {OWNER}, {OWNER: "User"}) is None
+
+
+def test_event_pr_number_bad_env_fails_closed_not_crash(monkeypatch):
+    monkeypatch.setenv("PR_NUMBER", "not-an-int")
+    assert gate._event_pr_number() is None
+
+
+def test_plan_revision_anchor_requires_commit_to_touch_plan(monkeypatch):
+    calls = []
+
+    def fake_gh_json(*args):
+        calls.append(args)
+        if args[:2] == ("api", f"repos/vamseeachanta/workspace-hub/commits/{SHA}"):
+            return {"files": [{"filename": PLAN}]}
+        return {"data": {"repository": {"object": {"pushedDate": "2026-05-30T12:00:00Z"}}}}
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    anchor, verified = gate.fetch_plan_revision_anchor(
+        "vamseeachanta/workspace-hub", SHA, PLAN, _t(11)
+    )
+    assert verified is True
+    assert anchor == _t(12)
+
+    def wrong_file_gh_json(*args):
+        if args[:2] == ("api", f"repos/vamseeachanta/workspace-hub/commits/{SHA}"):
+            return {"files": [{"filename": "docs/plans/2026-05-30-issue-9999.md"}]}
+        return {}
+
+    monkeypatch.setattr(gate_io, "gh_json", wrong_file_gh_json)
+    assert gate.fetch_plan_revision_anchor("vamseeachanta/workspace-hub", SHA, PLAN, _t(11)) == (None, False)
+
+
+def test_plan_revision_anchor_requires_github_pushed_date(monkeypatch):
+    def fake_gh_json(*args):
+        if args[:2] == ("api", f"repos/vamseeachanta/workspace-hub/commits/{SHA}"):
+            return {"files": [{"filename": PLAN}]}
+        return {"data": {"repository": {"object": {"pushedDate": None}}}}
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    assert gate.fetch_plan_revision_anchor("vamseeachanta/workspace-hub", SHA, PLAN, _t(13)) == (None, False)
+
+
+def test_plan_revision_anchor_uses_latest_of_push_and_binding_update(monkeypatch):
+    def fake_gh_json(*args):
+        if args[:2] == ("api", f"repos/vamseeachanta/workspace-hub/commits/{SHA}"):
+            return {"files": [{"filename": PLAN}]}
+        return {"data": {"repository": {"object": {"pushedDate": "2026-05-30T09:00:00Z"}}}}
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    anchor, verified = gate.fetch_plan_revision_anchor(
+        "vamseeachanta/workspace-hub", SHA, PLAN, _t(13)
+    )
+    assert verified is True
+    assert anchor == _t(13)
+
+
+def test_plan_blob_matches_revision_compares_head_and_revision_blobs(monkeypatch):
+    def fake_gh_json(*args):
+        ref = args[1].split("ref=", 1)[1]
+        if ref == SHA:
+            return {"sha": "blob-a"}
+        return {"sha": "blob-a" if ref == "9" * 40 else "blob-b"}
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    assert gate.plan_blob_matches_revision("vamseeachanta/workspace-hub", SHA, "9" * 40, PLAN) is True
+    assert gate.plan_blob_matches_revision("vamseeachanta/workspace-hub", SHA, "8" * 40, PLAN) is False
+
+
+def test_enforcement_workflow_runs_new_gate_then_legacy_gate_with_captured_rc():
+    text = (REPO / ".github" / "workflows" / "enforcement-gate.yml").read_text()
+    new_gate = "uv run python scripts/workflow/plan_approval_gate_check.py"
+    capture = "PLAN_APPROVAL_LABEL_GATE_RC=$?"
+    legacy = "scripts/enforcement/require-plan-approval.sh --strict"
+    final_exit = 'exit "$PLAN_APPROVAL_LABEL_GATE_RC"'
+    assert new_gate in text
+    assert "PLAN_APPROVAL_GATE_ENABLED=1 is intentionally blocking" in text
+    assert capture in text
+    assert legacy in text
+    assert final_exit in text
+    assert text.index(capture) < text.index(legacy) < text.index(final_exit)

--- a/tests/workflow/test_plan_approval_gate_check_r7.py
+++ b/tests/workflow/test_plan_approval_gate_check_r7.py
@@ -1,0 +1,250 @@
+"""R7 regression tests for the #2817 plan-approval gate."""
+
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+SCRIPTS_WORKFLOW = Path(__file__).resolve().parents[2] / "scripts" / "workflow"
+sys.path.insert(0, str(SCRIPTS_WORKFLOW))
+
+import plan_approval_gate_check as gate  # noqa: E402
+import plan_approval_gate_io as gate_io  # noqa: E402
+
+
+OWNER = "vamseeachanta"
+PLAN = "docs/plans/2026-05-30-issue-2817-plan-approval-label-authority.md"
+SHA = "2f3d873d48acd05336268ac679f47b5b2708a567"
+HEAD = "9" * 40
+BASE = "7" * 40
+
+
+def _t(hour: int) -> dt.datetime:
+    return dt.datetime(2026, 5, 30, hour, 0, tzinfo=dt.timezone.utc)
+
+
+def _binding() -> gate.PlanBinding:
+    return gate.PlanBinding(PLAN, SHA, OWNER, "User", _t(10))
+
+
+def _approval(**kw) -> gate.IssueApproval:
+    base = dict(
+        issue_number=2817,
+        label_actor=OWNER,
+        label_actor_type="User",
+        label_applied_at=_t(12),
+        plan_binding=_binding(),
+        plan_revision_time=_t(11),
+    )
+    base.update(kw)
+    return gate.IssueApproval(**base)
+
+
+def test_current_label_state_is_required():
+    decision = gate.evaluate_plan_approval(
+        gate.PrContext("feat/2817-plan-approval-gate", OWNER, {PLAN}, HEAD),
+        {2817: _approval(label_current=False)},
+        {OWNER},
+    )
+    assert decision.allowed is False
+    assert "currently" in decision.reason.lower()
+
+
+def test_revision_must_be_reachable_from_pr_head():
+    decision = gate.evaluate_plan_approval(
+        gate.PrContext("feat/2817-plan-approval-gate", OWNER, {PLAN}, HEAD),
+        {2817: _approval(plan_revision_in_head=False)},
+        {OWNER},
+    )
+    assert decision.allowed is False
+    assert "head history" in decision.reason.lower()
+
+
+def test_revision_must_not_already_be_in_pr_base():
+    decision = gate.evaluate_plan_approval(
+        gate.PrContext("feat/2817-plan-approval-gate", OWNER, {PLAN}, HEAD, BASE),
+        {2817: _approval(plan_revision_in_base=True)},
+        {OWNER},
+    )
+    assert decision.allowed is False
+    assert "base history" in decision.reason.lower()
+
+
+def test_revision_reaches_head_uses_compare_status(monkeypatch):
+    def fake_gh_json(*args):
+        assert args[:2] == ("api", f"repos/vamseeachanta/workspace-hub/compare/{SHA}...{HEAD}")
+        return {"status": "ahead"}
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    assert gate.revision_reaches_head("vamseeachanta/workspace-hub", SHA, HEAD) is True
+
+    monkeypatch.setattr(gate_io, "gh_json", lambda *args: {"status": "diverged"})
+    assert gate.revision_reaches_head("vamseeachanta/workspace-hub", SHA, HEAD) is False
+
+
+def test_issue_body_binding_uses_body_edit_time_not_issue_update(monkeypatch):
+    def fake_gh_json(*args):
+        if args[:2] == ("api", "graphql"):
+            return {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "author": {"login": OWNER},
+                            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+                            "createdAt": "2026-05-30T10:00:00Z",
+                            "lastEditedAt": "2026-05-30T11:00:00Z",
+                        }
+                    }
+                }
+            }
+        if args[:2] == ("api", "repos/vamseeachanta/workspace-hub/issues/2817/comments"):
+            return []
+        raise AssertionError(args)
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    sources = gate.load_issue_binding_sources("vamseeachanta/workspace-hub", 2817)
+    assert sources[0]["updatedAt"] == "2026-05-30T11:00:00Z"
+
+
+def test_binding_sources_support_pull_request_body(monkeypatch):
+    def fake_gh_json(*args):
+        if args[:2] == ("api", "graphql"):
+            return {
+                "data": {
+                    "repository": {
+                        "issue": None,
+                        "pullRequest": {
+                            "author": {"login": OWNER},
+                            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+                            "createdAt": "2026-05-30T10:00:00Z",
+                            "lastEditedAt": "2026-05-30T11:00:00Z",
+                        },
+                    }
+                }
+            }
+        if args[:2] == ("api", "repos/vamseeachanta/workspace-hub/issues/2817/comments"):
+            return []
+        raise AssertionError(args)
+
+    monkeypatch.setattr(gate_io, "gh_json", fake_gh_json)
+    sources = gate.load_issue_binding_sources("vamseeachanta/workspace-hub", 2817)
+    assert sources[0]["author"]["login"] == OWNER
+
+
+def test_current_labels_are_loaded_by_name(monkeypatch):
+    monkeypatch.setattr(
+        gate_io,
+        "gh_json",
+        lambda *args: {"labels": [{"name": gate.PLAN_APPROVED_LABEL}, {"name": "other"}]},
+    )
+    assert gate.load_current_issue_labels("vamseeachanta/workspace-hub", 2817) == {
+        gate.PLAN_APPROVED_LABEL,
+        "other",
+    }
+
+
+def test_normalize_path_keeps_dot_prefixed_repo_paths():
+    assert gate._normalize_path(".github/workflows/main.yml") == ".github/workflows/main.yml"
+    assert gate._normalize_path("./docs/plans/issue.md") == "docs/plans/issue.md"
+
+
+def test_load_pr_context_reads_head_and_base(monkeypatch):
+    def fake_gh_json(*args):
+        assert args[:5] == ("pr", "view", "2881", "--repo", "vamseeachanta/workspace-hub")
+        return {
+            "headRefName": "feat/2817-plan-approval-gate",
+            "headRefOid": HEAD,
+            "baseRefOid": BASE,
+            "author": {"login": OWNER},
+        }
+
+    monkeypatch.setattr(gate, "gh_json", fake_gh_json)
+    monkeypatch.setattr(gate, "load_pr_changed_paths", lambda *args: {PLAN})
+
+    context = gate.load_pr_context("vamseeachanta/workspace-hub", 2881)
+    assert context.head_sha == HEAD
+    assert context.base_sha == BASE
+
+
+def test_run_enabled_can_allow_valid_mocked_context(monkeypatch):
+    args = type("Args", (), {
+        "repo": "vamseeachanta/workspace-hub",
+        "pr": 2881,
+        "owners": OWNER,
+        "require_separate_approver": False,
+    })()
+    monkeypatch.setattr(gate, "fetch_actor_type", lambda login: "User")
+    monkeypatch.setattr(gate, "load_pr_context", lambda *a: gate.PrContext(
+        "feat/2817-plan-approval-gate", OWNER, {PLAN}, HEAD, BASE))
+    monkeypatch.setattr(gate, "load_issue_approval", lambda *a: _approval())
+    assert gate._run_enabled(args) == 0
+
+
+def test_run_enabled_skips_low_risk_paths_without_issue_branch(monkeypatch):
+    args = type("Args", (), {
+        "repo": "vamseeachanta/workspace-hub",
+        "pr": 2881,
+        "owners": OWNER,
+        "require_separate_approver": False,
+    })()
+    monkeypatch.setattr(gate, "fetch_actor_type", lambda login: "User")
+    monkeypatch.setattr(gate, "load_pr_context", lambda *a: gate.PrContext(
+        "docs/no-issue", OWNER, {"docs/readme.md", "tests/workflow/test_x.py"}, HEAD, BASE))
+    monkeypatch.setattr(gate, "load_issue_approval", lambda *a: (_ for _ in ()).throw(AssertionError))
+    assert gate._run_enabled(args) == 0
+
+
+def test_needs_plan_approval_paths_matches_legacy_scope():
+    assert gate.needs_plan_approval_paths({"src/app.py"}) is True
+    assert gate.needs_plan_approval_paths({"scripts/workflow/gate.py", "tests/test_gate.py"}) is False
+
+
+def test_enforcement_workflow_falls_back_when_uv_is_absent():
+    text = (Path(__file__).resolve().parents[2] / ".github" / "workflows" /
+            "enforcement-gate.yml").read_text()
+    assert "command -v uv" in text
+    assert "python3 scripts/workflow/plan_approval_gate_check.py" in text
+
+
+def test_latest_authorized_binding_ignores_later_unauthorized_attempt():
+    sources = [
+        {
+            "author": {"login": OWNER},
+            "updatedAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{SHA}`",
+        },
+        {
+            "author": {"login": "contributor"},
+            "updatedAt": "2026-05-30T12:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: `{'8' * 40}`",
+        },
+    ]
+    binding = gate.extract_plan_binding(sources, {OWNER}, {OWNER: "User"})
+    assert binding is not None and binding.recorded_by == OWNER
+
+
+def test_extract_plan_binding_rejects_ambiguous_multiple_paths_or_revisions():
+    sources = [
+        {
+            "author": {"login": OWNER},
+            "updatedAt": "2026-05-30T11:00:00Z",
+            "body": (
+                f"Plan: `{PLAN}`\n"
+                f"Plan: `docs/plans/2026-05-30-issue-9999-other.md`\n"
+                f"Plan revision: `{SHA}`"
+            ),
+        }
+    ]
+    assert gate.extract_plan_binding(sources, {OWNER}, {OWNER: "User"}) is None
+
+
+def test_extract_plan_binding_rejects_non_hex_suffix_on_revision():
+    sources = [
+        {
+            "author": {"login": OWNER},
+            "updatedAt": "2026-05-30T11:00:00Z",
+            "body": f"Plan: `{PLAN}`\nPlan revision: {SHA}zzzz",
+        }
+    ]
+    assert gate.extract_plan_binding(sources, {OWNER}, {OWNER: "User"}) is None


### PR DESCRIPTION
## Summary

- Adds `scripts/workflow/plan_approval_gate_check.py`, a staged server-side gate for #2817 plan approval authority.
- Extends `label_authority.py` with opt-in bot rejection and freshness helpers while preserving #2798 completeness membership behavior.
- Wires the new gate into the existing `Plan Approval Check` job in staged mode; the legacy marker gate remains hard-active until cutover.
- Adds workflow tests covering branch-only issue authority, owner label actor checks, full SHA plan binding, plan blob equality at PR head, updated-comment freshness, and advisory/staged rollout behavior.

## Verification

- `uv run pytest tests/workflow/ -q` => 83 passed
- `bash scripts/legal/legal-sanity-scan.sh --diff-only` => PASS
- `uv run python -m py_compile scripts/workflow/label_authority.py scripts/workflow/plan_approval_gate_check.py`
- `git diff --check origin/main..HEAD`
- `.github/workflows/enforcement-gate.yml` parsed with PyYAML
- Disabled gate smoke: exits 0 and prints admin prerequisite
- Enabled without admin prereq smoke: fails closed

Note: repository-wide `bash scripts/legal/legal-sanity-scan.sh` still fails on pre-existing deny-list hits unrelated to this diff; diff-only scan is clean.

## Code-stage review status

Codex + Gemini review artifacts are included for r1-r3. The MAJOR findings from r1, r2, and r3 were patched in this branch. Per review-iteration discipline, this PR is intentionally draft/not merge-ready until a fresh no-MAJOR Codex+Gemini review pass is run against the final diff.

## Admin prerequisite before cutover

Before retiring the old marker gate or enabling enforcement:

- Make `Plan Approval Check` a required status check on `main`.
- Add a protected-label/ruleset control so only approved human admins can apply `status:plan-approved`.
- Set `PLAN_APPROVAL_OWNERS` to human logins only, initially `vamseeachanta`.
- Set `PLAN_APPROVAL_GATE_ENABLED=1` only after the required check is active.
- Set `PLAN_APPROVAL_ADMIN_PREREQS_CONFIRMED=1` only after both the required status check and label ruleset are confirmed.
