### PR TITLE
Pilot scaffolding: digitalmodel-hydro-diffraction board for epic #622 cluster (#2878)

### DIFF
--- a/.claude/memory/kanban/boards/repo-digitalmodel-hydro-diffraction.yaml
+++ b/.claude/memory/kanban/boards/repo-digitalmodel-hydro-diffraction.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-digitalmodel-hydro-diffraction
+  display_name: digitalmodel · hydro · diffraction
+  tier: domain
+  repo: vamseeachanta/digitalmodel
+  domain: hydro-diffraction
+  parent_slug: repo-digitalmodel
+  workspace_path: /mnt/local-analysis/digitalmodel
+  description: 'OrcaWave→AQWA output-driven diffraction-domain module (epic #622): mesh pre-flight + auto-copy, self-contained solver packages, MeshPipeline integration, given-mesh CLI, pre-solve QA gates, auxiliary-mesh/QTF handling, convergence/sensitivity, and the canonical spec-to-run workflow — resolve + assume + sanity-check.
+
+    '
+cards: []

--- a/.claude/memory/kanban/domains.yaml
+++ b/.claude/memory/kanban/domains.yaml
@@ -19,6 +19,7 @@ repos:
     board: repo-digitalmodel
     domains:
       - {name: hydro,  status: existing}   # hydrodynamics, naval arch, mooring, fatigue
+      - {name: hydro-diffraction, status: new}  # epic #622 OrcaWave→AQWA diffraction cluster (pilot 2026-05-30)
       - {name: solver, status: existing}   # OrcaWave/AQWA bridges, time-domain integrators
       - {name: codes,  status: existing}   # codes & standards modules
       - {name: subsea, status: existing}   # subsea / pipeline / riser

--- a/.claude/memory/kanban/manifest.yaml
+++ b/.claude/memory/kanban/manifest.yaml
@@ -86,6 +86,7 @@ manifest:
     children:
     - repo-digitalmodel-codes
     - repo-digitalmodel-hydro
+    - repo-digitalmodel-hydro-diffraction
     - repo-digitalmodel-qa
     - repo-digitalmodel-solver
     - repo-digitalmodel-subsea
@@ -248,6 +249,14 @@ manifest:
     workspace_path: /mnt/local-analysis/digitalmodel
     file: boards/repo-digitalmodel-hydro.yaml
     card_count: 44
+  - slug: repo-digitalmodel-hydro-diffraction
+    tier: domain
+    repo: vamseeachanta/digitalmodel
+    domain: hydro-diffraction
+    parent_slug: repo-digitalmodel
+    workspace_path: /mnt/local-analysis/digitalmodel
+    file: boards/repo-digitalmodel-hydro-diffraction.yaml
+    card_count: 0
   - slug: repo-digitalmodel-qa
     tier: domain
     repo: vamseeachanta/digitalmodel

--- a/.claude/memory/kanban/migration/2026-05-30-digitalmodel-hydro-diffraction.yaml
+++ b/.claude/memory/kanban/migration/2026-05-30-digitalmodel-hydro-diffraction.yaml
@@ -1,0 +1,17 @@
+# Pilot remap (workspace-hub#2878) — consolidate epic digitalmodel#622's OrcaWave
+# diffraction cluster onto the new repo-digitalmodel-hydro-diffraction board.
+# Apply with: scripts/kanban/relabel.py <this file> [--apply]
+# All 9 are OrcaWave diffraction-domain issues (epic #622 + its planning-round).
+# #622 currently carries BOTH domain:hydro + domain:solver (one-domain violation,
+# healed here); #500 is domain:solver; #605-#614 are currently UNLABELED (base board).
+repo: vamseeachanta/digitalmodel
+remap:
+  - {issue: 622, domain: hydro-diffraction}   # Epic: output-driven diffraction domain module
+  - {issue: 500, domain: hydro-diffraction}   # mesh pre-flight validation + auto-copy in runner
+  - {issue: 605, domain: hydro-diffraction}   # self-contained solver packages from spec conversion
+  - {issue: 606, domain: hydro-diffraction}   # integrate MeshPipeline into conversion + runner
+  - {issue: 607, domain: hydro-diffraction}   # given-mesh CLI workflow for diffraction setup
+  - {issue: 608, domain: hydro-diffraction}   # mesh quality gates before diffraction solve
+  - {issue: 609, domain: hydro-diffraction}   # auxiliary mesh handling (control surfaces, QTF)
+  - {issue: 612, domain: hydro-diffraction}   # batch mesh convergence + grid sensitivity
+  - {issue: 614, domain: hydro-diffraction}   # docs for canonical spec-to-run workflow


### PR DESCRIPTION
## digitalmodel pilot scaffolding — consolidate epic #622 diffraction cluster (#2878 Phase 0)

**INERT scaffolding only — no GitHub labels are mutated by merging this PR.** It adds the new `repo-digitalmodel-hydro-diffraction` domain sub-board so that a *separately-approved* relabel step can route epic digitalmodel#622's 9-issue OrcaWave diffraction cluster onto one board.

### Why this pilot
Re-baselined from `origin/main` (the earlier survey was read off a clobbered branch): the OrcaWave cluster is currently scattered — #622 mislabeled `domain:hydro`+`domain:solver` (a one-domain violation), #500 on `solver`, and #605–#614 **unlabeled on the 299-card base board**. All 9 are OrcaWave diffraction-domain work (epic #622 = "Output-driven diffraction domain module").

### What's here (4 files, inert)
- `boards/repo-digitalmodel-hydro-diffraction.yaml` — new domain board (`cards: []`)
- `manifest.yaml` — `tier: domain` entry + added to `repo-digitalmodel` children
- `domains.yaml` — `{name: hydro-diffraction, status: new}`
- `migration/2026-05-30-digitalmodel-hydro-diffraction.yaml` — the relabel remap (9 issues → `hydro-diffraction`)

Routing needs **no** edit: `routing-rules.yaml` `domain_family: hydro` (landed in #2895) already routes `hydro-diffraction` → `licensed-win-1`.

### Validated (dry-run)
- Scaffolding: manifest parses, `(digitalmodel, hydro-diffraction)` resolves to the new board, `validate_unmanifested_boards` does not raise.
- `relabel.py --dry-run` (live label fetch) — the exact plan, 9 changes / 0 already-correct:

```
#622 -> domain:hydro-diffraction  +[hydro-diffraction] -[domain:hydro,domain:solver]   # heals one-domain violation
#500 -> domain:hydro-diffraction  +[hydro-diffraction] -[domain:solver]
#605..#614 -> domain:hydro-diffraction  +[hydro-diffraction]                            # assign-missing (off base board)
```

### Next (separate, user-approved)
After this merges to `main`, `scripts/kanban/relabel.py migration/2026-05-30-digitalmodel-hydro-diffraction.yaml --apply` writes the 9 labels (the live mutation); the `*/20` reconcile then moves the 9 cards onto the new board. That apply step is **not** in this PR.

Refs #2878.
