### PR TITLE
feat(harness): self-install missing schedule-tasks.yaml cron entries (#2894)

### DIFF
--- a/scripts/cron/harness-update.sh
+++ b/scripts/cron/harness-update.sh
@@ -608,6 +608,26 @@ send_notification() {
   fi
 }
 
+# ── Crontab self-sync (#2894) ────────────────────────────────────────────────
+# Idempotent: setup-cron.sh only ADDS entries absent from the live crontab
+# (never removes), so every nightly run converges each machine toward
+# schedule-tasks.yaml — closing the gap where a newly-added job (e.g. the
+# equality-matrix self-report) never reaches a machine's crontab. Respects
+# --dry-run. Non-fatal (cron contract is exit-0; failures are logged only).
+sync_crontab() {
+  local installer="${WORKSPACE_HUB}/scripts/cron/setup-cron.sh"
+  [[ -f "$installer" ]] || { log "CRON" "setup-cron.sh absent — skip"; return; }
+  if [[ "$DRY_RUN" == "true" ]]; then
+    local n
+    n=$(bash "$installer" --dry-run 2>/dev/null | grep -cE '^[[:space:]]+[0-9*]' || true)
+    log "CRON" "dry-run: ${n} schedule-tasks.yaml entry/entries would be ensured"
+    return
+  fi
+  local out
+  out=$(bash "$installer" 2>&1) || true
+  log "CRON" "$(printf '%s\n' "$out" | grep -iE 'Installed|Replaced|already present' | tail -1)"
+}
+
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 log "==========================================="
@@ -624,6 +644,8 @@ update_gsd
 update_claude_code
 update_codex
 update_gemini
+
+sync_crontab
 
 print_summary
 send_notification


### PR DESCRIPTION
## What

`harness-update.sh` gains an idempotent `sync_crontab` step that calls `setup-cron.sh` (add-only, **no `--replace`**) on every nightly run, so each machine's live crontab self-converges toward `config/scheduled-tasks/schedule-tasks.yaml`.

## Why (corrected #0 findings)

Part of **#2894** (equality-matrix substrate revival), epic **#2887**. Discovery on dev-primary showed the `equality-report` weekly job was defined in `schedule-tasks.yaml` but **never installed in the live crontab** — `setup-cron.sh` hadn't been re-run since the entry was added. This is a general gap: any newly-added scheduled job silently fails to reach machines until someone manually re-runs the installer. This step closes it via the existing nightly harness-update that already runs on all machines.

> Note: the broader #2894 substrate state was found to be **less dormant** than the issue originally stated — `origin/main` already tracks `equality-dev-primary.yaml` + `equality-dev-secondary.yaml` (2/4 reporting). The original "zero evidence" framing was read off a 181-behind local checkout; #2894's body has context for the re-plan.

## Verification

- `bash -n` syntax check: ✅
- `setup-cron.sh --dry-run | grep -cE '^[[:space:]]+[0-9*]'` probe (used by the dry-run branch): returns a sane positive count ✅
- Placement confirmed: `sync_crontab` defined before `# ── Main`, called after `update_gemini`, before `print_summary` ✅

## Adversarial review (T1 — single-file shell)

| Check | Verdict |
|---|---|
| Idempotent / no churn | ✅ add-only; `setup-cron.sh` skips entries already present |
| Non-destructive | ✅ no `--replace` → never wipes machine-specific manual entries |
| Failure handling | ✅ `\|\| true` + cron exit-0 contract; crontab install is atomic |
| **Known tradeoff** | ⚠️ Re-adds any entry an operator *manually removed* (schedule-tasks.yaml is treated as source of truth). Acceptable per the existing setup-cron contract; flagged for awareness. |

No existing test covers `harness-update.sh` (the `scripts/cron/tests/` suite targets other scripts); a regression harness for it would be disproportionate to this idempotent addition and is noted as a follow-up rather than bundled.

## Gate notes (transparency)

- Formal `status:plan-approved` label is **not** set on #2894; this change was authorized in-conversation by the user. The PR itself is the review artifact — **not** intended for auto-merge.
- Pushed with the hook's sanctioned, audited `GIT_PRE_PUSH_SKIP=1` bypass **by the user**: the new-branch guard runs full tier-1 repo CI, which can't pass because the sibling repos are absent in this environment. The change touches only workspace-hub (`scripts/cron/harness-update.sh`), no tier-1 repo, and the review-evidence gate passed.

Closes part of #2894 · epic #2887
