### PR TITLE
Phase 1a: manifest 5 workspace-hub fine-grained domain boards — drains 286 cards off base (#2878)

### DIFF
--- a/.claude/memory/kanban/boards/repo-workspace-hub-document-intelligence.yaml
+++ b/.claude/memory/kanban/boards/repo-workspace-hub-document-intelligence.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-workspace-hub-document-intelligence
+  display_name: workspace-hub · document-intelligence
+  tier: domain
+  repo: vamseeachanta/workspace-hub
+  domain: document-intelligence
+  parent_slug: repo-workspace-hub
+  workspace_path: /mnt/local-analysis/workspace-hub
+  description: 'Document-intelligence pipeline work (indexing, summarization, extraction) tracked in workspace-hub (domain:document-intelligence). Phase-1a board manifested 2026-05-30.
+
+    '
+cards: []

--- a/.claude/memory/kanban/boards/repo-workspace-hub-gtm.yaml
+++ b/.claude/memory/kanban/boards/repo-workspace-hub-gtm.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-workspace-hub-gtm
+  display_name: workspace-hub · gtm
+  tier: domain
+  repo: vamseeachanta/workspace-hub
+  domain: gtm
+  parent_slug: repo-workspace-hub
+  workspace_path: /mnt/local-analysis/workspace-hub
+  description: 'Go-to-market / client-conversion / outreach work tracked in workspace-hub (domain:gtm). Phase-1a board manifested 2026-05-30.
+
+    '
+cards: []

--- a/.claude/memory/kanban/boards/repo-workspace-hub-knowledge-management.yaml
+++ b/.claude/memory/kanban/boards/repo-workspace-hub-knowledge-management.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-workspace-hub-knowledge-management
+  display_name: workspace-hub · knowledge-management
+  tier: domain
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge-management
+  parent_slug: repo-workspace-hub
+  workspace_path: /mnt/local-analysis/workspace-hub
+  description: 'Knowledge-management / llm-wiki / memory work tracked in workspace-hub (domain:knowledge-management). Phase-1a board manifested 2026-05-30.
+
+    '
+cards: []

--- a/.claude/memory/kanban/boards/repo-workspace-hub-marine.yaml
+++ b/.claude/memory/kanban/boards/repo-workspace-hub-marine.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-workspace-hub-marine
+  display_name: workspace-hub · marine
+  tier: domain
+  repo: vamseeachanta/workspace-hub
+  domain: marine
+  parent_slug: repo-workspace-hub
+  workspace_path: /mnt/local-analysis/workspace-hub
+  description: 'Marine/hydrodynamics engineering work tracked in workspace-hub (domain:marine). Phase-1a board manifested 2026-05-30 for the existing domain:marine label.
+
+    '
+cards: []

--- a/.claude/memory/kanban/boards/repo-workspace-hub-workstations.yaml
+++ b/.claude/memory/kanban/boards/repo-workspace-hub-workstations.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-workspace-hub-workstations
+  display_name: workspace-hub · workstations
+  tier: domain
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  parent_slug: repo-workspace-hub
+  workspace_path: /mnt/local-analysis/workspace-hub
+  description: 'Workstation fleet / multi-machine setup / cross-platform parity work tracked in workspace-hub (domain:workstations). Phase-1a board manifested 2026-05-30.
+
+    '
+cards: []

--- a/.claude/memory/kanban/domains.yaml
+++ b/.claude/memory/kanban/domains.yaml
@@ -54,6 +54,13 @@ repos:
       - {name: engineering,      status: existing}
       - {name: harness,          status: existing}
       - {name: ops,              status: existing}
+      # Phase-1a 2026-05-30: manifest existing fine-grained domain: labels as boards
+      # (cards already carry these; reconcile auto-routes them off the base board).
+      - {name: marine,                status: new}
+      - {name: knowledge-management,  status: new}
+      - {name: gtm,                   status: new}
+      - {name: document-intelligence, status: new}
+      - {name: workstations,          status: new}
 
   vamseeachanta/achantas-data:
     board: repo-achantas-data

--- a/.claude/memory/kanban/manifest.yaml
+++ b/.claude/memory/kanban/manifest.yaml
@@ -151,9 +151,14 @@ manifest:
     - repo-workspace-hub-ai-orchestration
     - repo-workspace-hub-business
     - repo-workspace-hub-data
+    - repo-workspace-hub-document-intelligence
     - repo-workspace-hub-engineering
+    - repo-workspace-hub-gtm
     - repo-workspace-hub-harness
+    - repo-workspace-hub-knowledge-management
+    - repo-workspace-hub-marine
     - repo-workspace-hub-ops
+    - repo-workspace-hub-workstations
   - slug: repo-worldenergydata
     tier: repo
     repo: vamseeachanta/worldenergydata
@@ -385,6 +390,46 @@ manifest:
     workspace_path: /mnt/local-analysis/workspace-hub
     file: boards/repo-workspace-hub-ops.yaml
     card_count: 120
+  - slug: repo-workspace-hub-document-intelligence
+    tier: domain
+    repo: vamseeachanta/workspace-hub
+    domain: document-intelligence
+    parent_slug: repo-workspace-hub
+    workspace_path: /mnt/local-analysis/workspace-hub
+    file: boards/repo-workspace-hub-document-intelligence.yaml
+    card_count: 0
+  - slug: repo-workspace-hub-gtm
+    tier: domain
+    repo: vamseeachanta/workspace-hub
+    domain: gtm
+    parent_slug: repo-workspace-hub
+    workspace_path: /mnt/local-analysis/workspace-hub
+    file: boards/repo-workspace-hub-gtm.yaml
+    card_count: 0
+  - slug: repo-workspace-hub-knowledge-management
+    tier: domain
+    repo: vamseeachanta/workspace-hub
+    domain: knowledge-management
+    parent_slug: repo-workspace-hub
+    workspace_path: /mnt/local-analysis/workspace-hub
+    file: boards/repo-workspace-hub-knowledge-management.yaml
+    card_count: 0
+  - slug: repo-workspace-hub-marine
+    tier: domain
+    repo: vamseeachanta/workspace-hub
+    domain: marine
+    parent_slug: repo-workspace-hub
+    workspace_path: /mnt/local-analysis/workspace-hub
+    file: boards/repo-workspace-hub-marine.yaml
+    card_count: 0
+  - slug: repo-workspace-hub-workstations
+    tier: domain
+    repo: vamseeachanta/workspace-hub
+    domain: workstations
+    parent_slug: repo-workspace-hub
+    workspace_path: /mnt/local-analysis/workspace-hub
+    file: boards/repo-workspace-hub-workstations.yaml
+    card_count: 0
   - slug: repo-worldenergydata-gtm
     tier: domain
     repo: vamseeachanta/worldenergydata


### PR DESCRIPTION
## Phase 1a — manifest 5 existing workspace-hub fine-grained domains as boards (#2878)

**INERT scaffolding — zero GitHub labels mutated.** First Phase-1 increment (per the "manifest the fine labels as boards" + "top domains only" decisions).

### Re-baseline (the survey was stale)
The base `repo-workspace-hub` board holds **2727 cards (914 open)** because issues already carry fine-grained `domain:` labels — `marine` (34 open), `knowledge-management`, `gtm`, `document-intelligence`, `workstations`, … — that simply weren't manifested as boards, so they all fall to the base board. **So Phase 1 is mostly scaffolding, not relabeling:** manifest a board for an existing domain value and reconcile auto-routes its cards.

### What's here (inert, 3-file pattern × 5)
5 new domain boards (`cards: []`) + manifest `tier: domain` entries + parent children + `domains.yaml` declarations, for the top-5-by-open-count domains:
`marine`, `knowledge-management`, `gtm`, `document-intelligence`, `workstations`.

### Simulated effect (target_board over the live base cards — no relabel needed)
| New board | total / **open** |
|---|---|
| repo-workspace-hub-marine | 67 / **34** |
| repo-workspace-hub-knowledge-management | 73 / **23** |
| repo-workspace-hub-gtm | 63 / **24** |
| repo-workspace-hub-document-intelligence | 34 / **21** |
| repo-workspace-hub-workstations | 49 / **20** |
| **Total drained off base** | **286 / 122 open** |

All open counts are right-sized (≤34). Merging this + the next cron reconcile moves these cards off the base board automatically — **no `relabel.py --apply` step** (the labels already exist).

### Not in this increment
- The remaining ~21 fine domains + the 557 unlabeled open base cards (future Phase-1 increments / a classification pass).
- The 6 pre-existing empty coarse boards (harness/engineering/…) are now superseded by the fine-grained boards for these domains; cleanup TBD.

Refs #2878 (Phase 1a).
