### PR TITLE
fix(readiness): equality-matrix cron uses --no-project --with pyyaml (#2894)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -36,7 +36,7 @@ tasks:
       PATH=$HOME/.local/bin:$PATH;
       cd $WORKSPACE_HUB &&
       bash scripts/readiness/collect-equality.sh &&
-      uv run python scripts/readiness/build-equality-matrix.py
+      uv run --no-project --with pyyaml python scripts/readiness/build-equality-matrix.py
       >> $WORKSPACE_HUB/logs/quality/equality-$(date +\%Y-\%m-\%d).log 2>&1
     log: logs/quality/equality-*.log
     is_claude_task: false


### PR DESCRIPTION
## What
One-line fix to the `equality-report` cron command in `config/scheduled-tasks/schedule-tasks.yaml`:
```
- uv run python scripts/readiness/build-equality-matrix.py
+ uv run --no-project --with pyyaml python scripts/readiness/build-equality-matrix.py
```

## Why (a real #0 reliability defect — found during the 2026-05-31 readiness pulse)
Bare `uv run python build-equality-matrix.py` resolves the canonical checkout's project `.venv`, which **lacks `pyyaml`** → `ModuleNotFoundError: No module named 'yaml'` (exit 1). So the weekly **matrix rebuild silently fails even when `collect-equality.sh` succeeds** — evidence gets collected but the matrix HTML never regenerates. This undermines the #0 substrate-revival goal (an always-current, always-available matrix).

`--no-project --with pyyaml` runs the script in a clean ephemeral env with its one external dep, independent of the checkout's venv state.

## Convention alignment
Matches the repo's existing cron patterns — e.g. the `doc-drift` task already uses `uv run --no-project python ...` (`schedule-tasks.yaml`), and `agent-radar` uses `uv run --script ...`. This is not a novel invocation style.

## Validation
- `scripts/cron/validate-schedule.py` → **OK: 47 tasks validated** (fleet-wide cron generation unaffected).
- The fixed command **rebuilds the matrix, exit 0** (`wrote docs/reports/...-machine-equality-matrix.html`).
- Bare command reproduced the failure (`ModuleNotFoundError: yaml`, exit 1) before the fix.

## Scope / gate notes
- Single-line, single-file. T1 change.
- Formal `status:plan-approved` not set on #2894; authorized in-conversation by the user. PR is the review artifact (not auto-merge).
- Pushed via the hook's audited `GIT_PRE_PUSH_SKIP=1` (new-branch guard runs tier-1 repo CI, which can't pass because sibling repos are absent in this environment; change touches only workspace-hub config).

Part of #0 substrate revival (#2894) · epic #2887.
