### PR TITLE
Split llm-wiki-ingest → 2 subdomains (#2878)

### DIFF
--- a/.claude/memory/kanban/boards/repo-llm-wiki-ingest-batch-extraction.yaml
+++ b/.claude/memory/kanban/boards/repo-llm-wiki-ingest-batch-extraction.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-llm-wiki-ingest-batch-extraction
+  display_name: llm-wiki · ingest-batch-extraction
+  tier: domain
+  repo: vamseeachanta/llm-wiki
+  domain: ingest-batch-extraction
+  parent_slug: repo-llm-wiki
+  workspace_path: /mnt/local-analysis/llm-wiki
+  description: 'llm-wiki ingest-batch-extraction subdomain (split from oversized ingest board). Manifested 2026-05-31.
+
+    '
+cards: []

--- a/.claude/memory/kanban/boards/repo-llm-wiki-ingest-corpus-acquisition.yaml
+++ b/.claude/memory/kanban/boards/repo-llm-wiki-ingest-corpus-acquisition.yaml
@@ -1,0 +1,12 @@
+board:
+  slug: repo-llm-wiki-ingest-corpus-acquisition
+  display_name: llm-wiki · ingest-corpus-acquisition
+  tier: domain
+  repo: vamseeachanta/llm-wiki
+  domain: ingest-corpus-acquisition
+  parent_slug: repo-llm-wiki
+  workspace_path: /mnt/local-analysis/llm-wiki
+  description: 'llm-wiki ingest-corpus-acquisition subdomain (split from oversized ingest board). Manifested 2026-05-31.
+
+    '
+cards: []

--- a/.claude/memory/kanban/domains.yaml
+++ b/.claude/memory/kanban/domains.yaml
@@ -57,6 +57,8 @@ repos:
     domains:
       - {name: content,    status: existing}
       - {name: ingest,     status: existing}
+      - {name: ingest-batch-extraction, status: new}
+      - {name: ingest-corpus-acquisition, status: new}
       - {name: governance, status: existing}
       - {name: tooling,    status: existing}
 

--- a/.claude/memory/kanban/manifest.yaml
+++ b/.claude/memory/kanban/manifest.yaml
@@ -132,6 +132,8 @@ manifest:
     - repo-llm-wiki-content
     - repo-llm-wiki-governance
     - repo-llm-wiki-ingest
+    - repo-llm-wiki-ingest-batch-extraction
+    - repo-llm-wiki-ingest-corpus-acquisition
     - repo-llm-wiki-tooling
   - slug: repo-llm-wiki-acma
     tier: repo
@@ -475,6 +477,22 @@ manifest:
     workspace_path: /mnt/local-analysis/llm-wiki
     file: boards/repo-llm-wiki-ingest.yaml
     card_count: 33
+  - slug: repo-llm-wiki-ingest-batch-extraction
+    tier: domain
+    repo: vamseeachanta/llm-wiki
+    domain: ingest-batch-extraction
+    parent_slug: repo-llm-wiki
+    workspace_path: /mnt/local-analysis/llm-wiki
+    file: boards/repo-llm-wiki-ingest-batch-extraction.yaml
+    card_count: 0
+  - slug: repo-llm-wiki-ingest-corpus-acquisition
+    tier: domain
+    repo: vamseeachanta/llm-wiki
+    domain: ingest-corpus-acquisition
+    parent_slug: repo-llm-wiki
+    workspace_path: /mnt/local-analysis/llm-wiki
+    file: boards/repo-llm-wiki-ingest-corpus-acquisition.yaml
+    card_count: 0
   - slug: repo-llm-wiki-tooling
     tier: domain
     repo: vamseeachanta/llm-wiki

--- a/.claude/memory/kanban/migration/2026-05-31-llmwiki-ingest-split-remap.yaml
+++ b/.claude/memory/kanban/migration/2026-05-31-llmwiki-ingest-split-remap.yaml
@@ -1,0 +1,37 @@
+# llm-wiki ingest board split (#2878). relabel removes domain:ingest, adds ingest-<sub>.
+repo: vamseeachanta/llm-wiki
+remap:
+  - {issue: 1, domain: ingest-batch-extraction}
+  - {issue: 2, domain: ingest-batch-extraction}
+  - {issue: 3, domain: ingest-batch-extraction}
+  - {issue: 4, domain: ingest-batch-extraction}
+  - {issue: 5, domain: ingest-batch-extraction}
+  - {issue: 6, domain: ingest-batch-extraction}
+  - {issue: 7, domain: ingest-batch-extraction}
+  - {issue: 8, domain: ingest-batch-extraction}
+  - {issue: 9, domain: ingest-batch-extraction}
+  - {issue: 10, domain: ingest-batch-extraction}
+  - {issue: 11, domain: ingest-batch-extraction}
+  - {issue: 12, domain: ingest-corpus-acquisition}
+  - {issue: 72, domain: ingest-corpus-acquisition}
+  - {issue: 101, domain: ingest-corpus-acquisition}
+  - {issue: 103, domain: ingest-corpus-acquisition}
+  - {issue: 104, domain: ingest-corpus-acquisition}
+  - {issue: 105, domain: ingest-corpus-acquisition}
+  - {issue: 106, domain: ingest-corpus-acquisition}
+  - {issue: 107, domain: ingest-corpus-acquisition}
+  - {issue: 108, domain: ingest-corpus-acquisition}
+  - {issue: 109, domain: ingest-corpus-acquisition}
+  - {issue: 110, domain: ingest-corpus-acquisition}
+  - {issue: 111, domain: ingest-corpus-acquisition}
+  - {issue: 112, domain: ingest-corpus-acquisition}
+  - {issue: 113, domain: ingest-corpus-acquisition}
+  - {issue: 115, domain: ingest-corpus-acquisition}
+  - {issue: 116, domain: ingest-corpus-acquisition}
+  - {issue: 117, domain: ingest-corpus-acquisition}
+  - {issue: 124, domain: ingest-corpus-acquisition}
+  - {issue: 125, domain: ingest-corpus-acquisition}
+  - {issue: 126, domain: ingest-corpus-acquisition}
+  - {issue: 134, domain: ingest-corpus-acquisition}
+  - {issue: 135, domain: ingest-batch-extraction}
+  - {issue: 138, domain: ingest-corpus-acquisition}


### PR DESCRIPTION
Last oversized board. `llm-wiki-ingest` (34 open, all `domain:ingest`) → **ingest-batch-extraction** 12 (bulk OCR/deep-extraction/summarization pipelines) + **ingest-corpus-acquisition** 22 (acquiring/routing publisher/standards corpora). Both ≤30.

INERT scaffold + 34-entry remap → separate `relabel.py --apply` (2 new labels first). After this + the travel split (#2916), **no board in the ecosystem exceeds 30 open** (modulo the marginal 31/32 accepted earlier + pending applies). Refs #2878.