### PR TITLE
Add update-harness-tools.sh: one-shot updater for hermes/claude/codex/gemini

### DIFF
--- a/scripts/maintenance/update-harness-tools.sh
+++ b/scripts/maintenance/update-harness-tools.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# update-harness.sh — Update the key harness CLI programs.
+#
+#   hermes  -> hermes update
+#   claude  -> claude update
+#   codex   -> codex update
+#   gemini  -> npm install -g @google/gemini-cli@latest
+#
+# Each step is independent: a failure is reported but does not abort the rest.
+# Run with --dry-run to print the commands without executing them.
+
+set -uo pipefail
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" || "${1:-}" == "-n" ]] && DRY_RUN=1
+
+# Track results for the summary.
+declare -a NAMES=()
+declare -a STATUS=()
+
+run_step() {
+  local name="$1"; shift
+  echo
+  echo "==> ${name}: $*"
+  NAMES+=("$name")
+
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "    SKIP: '$1' not found on PATH"
+    STATUS+=("skipped (missing)")
+    return
+  fi
+
+  if (( DRY_RUN )); then
+    echo "    (dry-run, not executed)"
+    STATUS+=("dry-run")
+    return
+  fi
+
+  if "$@"; then
+    STATUS+=("ok")
+  else
+    echo "    FAILED (exit $?)"
+    STATUS+=("FAILED")
+  fi
+}
+
+echo "Harness update — $(date '+%Y-%m-%d %H:%M:%S')"
+(( DRY_RUN )) && echo "(dry-run mode)"
+
+run_step hermes hermes update
+run_step claude claude update
+run_step codex  codex  update
+run_step gemini npm install -g @google/gemini-cli@latest
+
+echo
+echo "================ Summary ================"
+for i in "${!NAMES[@]}"; do
+  printf '  %-8s %s\n' "${NAMES[$i]}" "${STATUS[$i]}"
+done
+
+# Non-zero exit if any step failed.
+for s in "${STATUS[@]}"; do
+  [[ "$s" == "FAILED" ]] && exit 1
+done
+exit 0


### PR DESCRIPTION
## What

Adds `scripts/maintenance/update-harness-tools.sh` — one command to update the four key harness CLIs in sequence:

| Tool | Command |
|------|---------|
| hermes | `hermes update` |
| claude | `claude update` |
| codex | `codex update` |
| gemini | `npm install -g @google/gemini-cli@latest` |

## Why

So harness-tool updates are reproducible and **travel with the repo ecosystem** rather than living as ad-hoc commands on one machine.

## Notes

- Each step independent — one failure is reported but does not abort the rest; summary prints at the end.
- Skips any tool not on PATH; `--dry-run`/`-n` prints without executing; exits non-zero on any failure (cron-friendly).
- Symlink to `~/.local/bin/update-harness-tools` for easy invocation (ecosystem rollout tracked in companion issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)