### PR TITLE
harness-update: make native update-harness-tools.sh canonical (#2920 dec. A)

### DIFF
--- a/.claude/state/equality-dev-secondary.yaml
+++ b/.claude/state/equality-dev-secondary.yaml
@@ -1,19 +1,19 @@
-generated_at: "2026-05-31T17:49:48"
+generated_at: "2026-05-31T18:28:44"
 schema_version: 3
 machine: "dev-secondary"
 host: "ace-linux-2"
 os: linux
 status: active
 provenance:
-  checkout_sha: "b35573f1b"
-  dirty: true
+  checkout_sha: "10ffa918d"
+  dirty: false
   behind_main: 0
-  ahead_main: 0
+  ahead_main: 1
   origin_ref_age_h: 0
 dimensions:
   compute:
     static: {cores: 32, ram_total_mib: 32040, gpu_model: "NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running."}
-    headroom: {ram_avail_mib: 22371, disk_avail_gb: 885}
+    headroom: {ram_avail_mib: 22665, disk_avail_gb: 885}
   data_access:
     - {repo: assetutilities, mode: sibling}
     - {repo: digitalmodel, mode: sibling}
@@ -41,4 +41,4 @@ dimensions:
   scheduler:
     has_repo_sync: false
     has_parity_review: false
-    job_count: 5
+    job_count: 6

--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -87,7 +87,7 @@ tasks:
     description: Nightly uv.lock freshness, outdated packages, CVE advisories across 5 repos.
 
   - id: harness-update
-    label: AI harness tools daily update (staggered canary)
+    label: AI harness tools daily update (native commands, staggered)
     schedule_by_machine:
       dev-primary: "15 1 * * *"      # 01:15 — canary
       ace-linux-1: "15 1 * * *"
@@ -102,14 +102,17 @@ tasks:
     command: >-
       PATH=$HOME/.local/bin:$HOME/.npm-global/bin:$PATH;
       cd $WORKSPACE_HUB &&
-      bash scripts/cron/harness-update.sh
-      >> $WORKSPACE_HUB/logs/maintenance/harness-update-$(date +\%Y-\%m-\%d).log 2>&1
-    log: logs/maintenance/harness-update-*.log
+      bash scripts/maintenance/update-harness-tools.sh
+      >> $WORKSPACE_HUB/logs/maintenance/update-harness-tools-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/maintenance/update-harness-tools-*.log
     is_claude_task: false
     description: >-
-      Daily AI harness lifecycle — all 7 tools. Staggered canary: dev-primary 01:15,
-      dev-secondary 01:45, Windows 02:15. Health checks, rollback, drift, alerting.
-      Issues: #1668, #1672-#1675.
+      Daily AI harness update via NATIVE updaters — hermes update / claude update /
+      codex update / gemini (npm). Per #2920 decision A: native script is canonical;
+      missing tools are skipped per machine. Staggered: dev-primary 01:15,
+      dev-secondary 01:45, Windows 02:15. NOTE: the prior npm-based
+      scripts/cron/harness-update.sh (health-check/rollback/drift) is retained in-repo
+      but no longer scheduled. Issues: #1668, #1672-#1675, #2920.
 
   - id: comprehensive-learning
     label: Comprehensive learning pipeline

--- a/scripts/memory/bootstrap-machine.sh
+++ b/scripts/memory/bootstrap-machine.sh
@@ -183,6 +183,26 @@ if [[ -f "${KANBAN_AUTOLOAD}" && -n "${GIT_DIR}" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 2.9. Install update-harness-tools symlink into ~/.local/bin (per #2920 dec. A)
+#      Makes `update-harness-tools` runnable from PATH on every machine for
+#      ad-hoc "update now" runs. The same script is the canonical scheduled
+#      updater (schedule-tasks.yaml id: harness-update). Idempotent; only the
+#      symlink target is managed, never the user's other ~/.local/bin entries.
+# ---------------------------------------------------------------------------
+HARNESS_UPDATER="${REPO_ROOT}/scripts/maintenance/update-harness-tools.sh"
+if [[ -f "${HARNESS_UPDATER}" && "${OS}" != "windows" ]]; then
+    mkdir -p "${HOME}/.local/bin"
+    LINK="${HOME}/.local/bin/update-harness-tools"
+    # Only (re)place when missing or pointing elsewhere; never clobber a real file.
+    if [[ -L "${LINK}" || ! -e "${LINK}" ]]; then
+        ln -sfn "${HARNESS_UPDATER}" "${LINK}"
+        echo -e "${CYAN}Installed update-harness-tools symlink → scripts/maintenance/update-harness-tools.sh${NC}"
+    else
+        echo -e "${YELLOW}~/.local/bin/update-harness-tools exists and is not a symlink — leaving it alone.${NC}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 3. Remind about bridge script (Linux/Hermes machines only)
 # ---------------------------------------------------------------------------
 if [[ -d "${HOME}/.hermes" ]]; then


### PR DESCRIPTION
## What

Per the decision-A on #2920, makes the **native** updater canonical for the scheduled `harness-update` task:

- `config/scheduled-tasks/schedule-tasks.yaml` — repoints the `harness-update` command from `scripts/cron/harness-update.sh` (npm-based) to `scripts/maintenance/update-harness-tools.sh` (native: `hermes update` / `claude update` / `codex update` / gemini via npm). Schedules/machines/stagger unchanged.
- `scripts/memory/bootstrap-machine.sh` — new §2.9 installs the `~/.local/bin/update-harness-tools` symlink on every non-Windows machine (idempotent; never clobbers a non-symlink file).

The prior `scripts/cron/harness-update.sh` (health-check / rollback / drift) is **retained in-repo** but no longer scheduled.

## Why native (dec. A)

Per-machine tool coverage varies (no codex on ace-linux-1, no hermes on Windows); the native script skips missing tools gracefully, so one entry is safe everywhere. Simpler than the 28KB npm path.

## Rollout note (manual migration required)

`setup-cron.sh` default mode dedupes by **basename+schedule**, so it will ADD the native line but NOT remove the deprecated `harness-update.sh` line → both would run. Each Linux machine needs a one-time swap (remove old line, add new). Tracked in #2920:
- ace-linux-2: ✅ done (native cron live, tools updated, gemini 0.38.2→0.44.1)
- ace-linux-1: swap applied out-of-band (see #2920)
- Windows (licensed-win-1/2): no SSH — native commands work in git-bash; scheduling stays on existing Windows path, manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)