### PR TITLE
harness-update: Windows Task Scheduler support (#2920 dec. A)

### DIFF
--- a/scripts/maintenance/update-harness-tools.sh
+++ b/scripts/maintenance/update-harness-tools.sh
@@ -12,6 +12,14 @@
 
 set -uo pipefail
 
+# Ensure tool dirs are on PATH. Cron and Windows Task Scheduler launch this with a
+# minimal environment, so the npm-global / ~/.local/bin dirs where the CLIs live
+# are not on PATH by default. Mirrors scripts/cron/harness-update-windows.sh.
+if [[ -n "${APPDATA:-}" ]] && command -v cygpath >/dev/null 2>&1; then
+  PATH="$(cygpath "$APPDATA")/npm:${PATH}"   # Windows npm-global (Git Bash / MINGW64)
+fi
+export PATH="${HOME}/.local/bin:${HOME}/.npm-global/bin:${PATH}"
+
 DRY_RUN=0
 [[ "${1:-}" == "--dry-run" || "${1:-}" == "-n" ]] && DRY_RUN=1
 

--- a/scripts/windows/setup-scheduler-tasks.ps1
+++ b/scripts/windows/setup-scheduler-tasks.ps1
@@ -8,6 +8,7 @@
 #   \Claude\NightlyReadiness           - daily ecosystem readiness
 #   \Claude\RepoSync                   - daily workspace-hub git pull + submodule sync
 #   \Claude\MemoryBridgeSync           - daily repo-tracked memory refresh
+#   \Claude\HarnessUpdate              - daily AI CLI update (claude/codex/gemini) via native updater
 #   \Claude\EqualityReport             - rendered from config/scheduled-tasks/schedule-tasks.yaml
 
 [CmdletBinding()]
@@ -330,6 +331,15 @@ Register-ClaudeTask `
     -ScriptPath "scripts/memory/bridge-hermes-claude.sh" `
     -TaskArguments "--commit" `
     -DailyAt "04:30AM"
+
+# HarnessUpdate — native AI CLI updater (claude/codex/gemini; hermes skipped on Windows).
+# Canonical entry: config/scheduled-tasks/schedule-tasks.yaml id:harness-update
+# (licensed-win-1/2 slot 02:15 per its schedule_by_machine). Per #2920 decision A.
+Register-ClaudeTask `
+    -Name "HarnessUpdate" `
+    -Description "Daily AI harness update via native updaters (claude/codex/gemini). #2920" `
+    -ScriptPath "scripts/maintenance/update-harness-tools.sh" `
+    -DailyAt "02:15AM"
 
 $equalityTask = Get-EqualityReportTask
 $currentMachine = Get-CurrentMachineLabel


### PR DESCRIPTION
## What

Brings the **Windows** boxes (licensed-win-1/2) onto the same native harness updater as the Linux machines, per #2920 decision A.

- **`scripts/maintenance/update-harness-tools.sh`** — prepends tool dirs to PATH (Windows `%APPDATA%\npm` via `cygpath`, plus `~/.local/bin` / `~/.npm-global/bin`) so `claude`/`codex`/`gemini` resolve under the **minimal env** that cron and Task Scheduler hand the process. Harmless on Linux (`cygpath` absent → block skipped). Mirrors the existing `scripts/cron/harness-update-windows.sh` PATH handling.
- **`scripts/windows/setup-scheduler-tasks.ps1`** — registers a `\Claude\HarnessUpdate` scheduled task that runs the native updater via Git Bash at **02:15** (the `licensed-win-1/2` slot from `schedule-tasks.yaml` `schedule_by_machine`). Inherits the installer's idempotent re-register, `-WhatIf`, and `-Remove`.

`hermes` is skipped on Windows (not installed); `claude`/`codex`/`gemini` update.

## Why this shape

Matches the established Windows pattern: fixed `Register-ClaudeTask` calls invoking `.sh` scripts through `bash.exe -c`. The canonical schedule still lives in `schedule-tasks.yaml` (HARD RULE); the PS task references it and uses the same 02:15 slot — no second source of truth.

## Operator steps (per Windows box, after merge)

No SSH to these boxes, so run locally in an **Administrator PowerShell**:

```powershell
cd D:\workspace-hub
git pull
# preview:
powershell -ExecutionPolicy Bypass -File scripts\windows\setup-scheduler-tasks.ps1 -WhatIf
# install:
powershell -ExecutionPolicy Bypass -File scripts\windows\setup-scheduler-tasks.ps1
# verify:
Get-ScheduledTask -TaskPath '\Claude\' | Select TaskName, State
# run once now:
Start-ScheduledTask -TaskName 'HarnessUpdate' -TaskPath '\Claude\'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)