### PR TITLE
repo-housekeeping: detect merges against origin/main (fix duplicate PRs)

### DIFF
--- a/scripts/maintenance/repo-housekeeping.sh
+++ b/scripts/maintenance/repo-housekeeping.sh
@@ -186,12 +186,29 @@ for dir in "${REPO_DIRS[@]}"; do
   done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
 
   # 2+3) PUSH ahead branches + open PRs --------------------------------------
+  # Integrate against the REMOTE main (origin/main) when available — a stale local
+  # main would otherwise hide already-merged branches and trigger duplicate PRs.
+  base="$mainb"
+  if [[ -n "$has_remote" ]] && git rev-parse --verify --quiet "origin/${mainb}" >/dev/null 2>&1; then
+    base="origin/${mainb}"
+  fi
   if [[ -n "$has_remote" ]]; then
     while IFS= read -r br; do
       [[ -z "$br" || "$br" == "$mainb" || "$br" == "master" ]] && continue
-      # Ahead of main?
-      ahead="$(git rev-list --count "${mainb}..${br}" 2>/dev/null || echo 0)"
+      # Ahead of (remote) main?
+      ahead="$(git rev-list --count "${base}..${br}" 2>/dev/null || echo 0)"
       [[ "$ahead" -gt 0 ]] || continue
+      # Already merged (patch-id equivalent — catches squash/rebase merges where the
+      # branch still shows commits "ahead")? Prune it instead of opening a stale PR.
+      if [[ -z "$(git cherry "$base" "$br" 2>/dev/null | grep '^+')" ]]; then
+        if [[ "$br" == "$cur" ]]; then
+          echo -e "  branch ${br}: already merged into ${base} — ${YELLOW}current branch, not deleting${NC}"
+        else
+          echo -e "  branch ${br}: ${ahead} ahead but all commits already in ${base} — ${GREEN}merged; pruning${NC}"
+          act "git branch -D ${br}" git branch -D "$br" 2>/dev/null && branches_deleted=$((branches_deleted+1))
+        fi
+        continue
+      fi
       # Guard 1: archival/backup branch names → report only, never PR.
       if [[ "$br" =~ $SKIP_BRANCH_RE ]]; then
         echo -e "  branch ${br}: ${ahead} ahead — ${YELLOW}skipped (archival/backup name; --skip-branches / --pr-all to override)${NC}"; continue
@@ -200,7 +217,7 @@ for dir in "${REPO_DIRS[@]}"; do
       if [[ "$ahead" -gt "$MAX_AHEAD" ]]; then
         echo -e "  branch ${br}: ${ahead} ahead — ${YELLOW}skipped (> --max-ahead=${MAX_AHEAD}; review manually or --pr-all)${NC}"; continue
       fi
-      echo "  branch ${br}: ${ahead} commit(s) ahead of ${mainb}"
+      echo "  branch ${br}: ${ahead} commit(s) ahead of ${base}"
       act "git push -u origin ${br}" git push -u origin "$br" 2>/dev/null && pushed=$((pushed+1))
       if (( MAKE_PR )); then
         existing="$(gh pr list --head "$br" --json number --jq '.[0].number' 2>/dev/null || echo '')"
@@ -219,13 +236,15 @@ for dir in "${REPO_DIRS[@]}"; do
     echo "  (no remote — skip push/PR)"
   fi
 
-  # 4) PRUNE stale branches (merged into main, any age) -----------------------
+  # 4) PRUNE stale branches whose tip is an ancestor of (remote) main. The cherry
+  # check above already pruned patch-equivalent (squash/rebase) merges; this catches
+  # plain ancestor merges and is a no-op for branches handled above.
   while IFS= read -r mb; do
     mb="$(echo "$mb" | sed 's/^[* +]*//;s/ *$//')"
     [[ -z "$mb" || "$mb" == "$mainb" || "$mb" == "master" || "$mb" == "$cur" ]] && continue
-    echo "  stale branch (merged into ${mainb}): ${mb}"
+    echo "  stale branch (merged into ${base}): ${mb}"
     act "git branch -d ${mb}" git branch -d "$mb" 2>/dev/null && branches_deleted=$((branches_deleted+1))
-  done < <(git branch --merged "$mainb" 2>/dev/null)
+  done < <(git branch --merged "$base" 2>/dev/null)
 
   # 4b) PRUNE worktrees (merged or missing) -----------------------------------
   if git worktree list >/dev/null 2>&1; then


### PR DESCRIPTION
## Bug

`repo-housekeeping.sh` compared local branches to **local** `main` for both the ahead-count (→ PR) and the merged-prune. Right after a PR merges, local main is behind origin, so already-merged branches show as "ahead" and would get **duplicate PRs** instead of being pruned.

Found while profiling the dry-run for a first `--apply`: 3 of today's merged branches (`chore/repo-housekeeping-script`, `chore/harness-update-windows-scheduling`, `feat/2817-plan-approval-gate`) were queued for duplicate PRs.

## Fix

- Integrate against `origin/<main>` when the remote ref exists (falls back to local main offline).
- Detect already-merged branches with `git cherry` (patch-id) so **squash/rebase** merges — where the branch still shows commits ahead — are recognized and **pruned** (`git branch -D`, safe because all patches are confirmed upstream) rather than re-PR'd.
- Never deletes the current branch.

## Verified (dry-run, workspace-hub)

Before: 4 PRs (3 of them duplicates of merged branches). After: 3 merged branches pruned, **1** PR for the one genuinely-unmerged branch (`codex/ace-linux-2-...`). Backup/archival guards unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)