### PR TITLE
🔒 URGENT: scrub client member names/IDs from public Deckhand dashboard

### DIFF
--- a/docs/reports/deckhand-dashboard.html
+++ b/docs/reports/deckhand-dashboard.html
@@ -75,7 +75,7 @@
     <span class="badge b-ok">✅ execute_code bypass CLOSED + live: scan_python_source gates hermes_tools/terminal()/re-entry (168 tests)</span>
     <span class="badge b-ok">✅ route B LIVE: acma group -5109954935 + doris group -5211977662 bound (authorize_members); group members get the scope PAT, scope-isolated (verified)</span>
     <span class="badge b-info">activation model (owner decision): gateway stays CLOSED — add members by numeric ID to TELEGRAM_ALLOWED_USERS + group membership routes the scope (no allow-all)</span>
-    <span class="badge b-ok">first member onboarded: Vamsi Galigutta (448087190) → doris (owner-confirmed; scope-isolated verified)</span>
+    <span class="badge b-ok">first member onboarded → doris (owner-confirmed; scope-isolated verified). Named roster → aceengineer-strategy</span>
     <span class="badge b-info">tooling: add-member.sh (allowlist-by-id) + /whoami; 172 tests green; PAT rotation #2936 due 2026-06-08</span>
     <span class="badge b-ok">✅ live rate-limiting (#2938): per-operator/scope write caps + duplicate suppression, fail-closed</span>
     <span class="badge b-ok">✅ PAT hardening: scoped PATs moved out of .env → ~/.hermes/deckhand/secrets.env (chmod 600, shim-only); not in general search/process env; at-rest encryption #2943</span>
@@ -83,7 +83,7 @@
     <span class="badge b-warn">⚠ WhatsApp on owner's PERSONAL number — ban-risk ACCEPTED for now (owner: leave as-is, decide later)</span>
     <span class="badge b-info">📣 GTM direction (leaning, not ratified): Telegram-led demo/marketing; WhatsApp/Signal/Teams demand-driven, client brings own number — strategy now in aceengineer-strategy</span>
     <span class="badge b-ok">📚 Knowledge map + fresh-session runbook: docs/deckhand/README.md (#2944, PR #2946). Routing: workspace-hub=engine · aceengineer-strategy=client/GTM (PR #23) · llm-wiki-&lt;client&gt;=data · Hermes=gateway</span>
-    <span class="badge b-ok">members onboarded → doris: Vamsi Galigutta (448087190), Kedar Kolluri (8882836063); named auto-welcome</span>
+    <span class="badge b-ok">2 members onboarded → doris (named auto-welcome). Named roster lives in aceengineer-strategy (client info)</span>
     <span class="badge b-ok">/scope identity core patch applied; allowed git/gh now run under DECKHAND_PAT_&lt;scope&gt;, not ambient gh</span>
     <span class="badge b-info">acma/doris user-onboarding runbook committed (scripts/review/results)</span>
     <span class="badge b-ok">detective alarm built (Free-plan compensator)</span>


### PR DESCRIPTION
**Security / privacy — please merge promptly.** `workspace-hub` is **PUBLIC**. The Deckhand dashboard (`docs/reports/deckhand-dashboard.html`) currently renders client **member display names + Telegram IDs** in two onboarding badges. This violates the no-client-identifiers-in-workspace-hub rule and exposes client PII publicly.

## Change
Genericized the two badges (counts only; no names/IDs). The named roster already lives in the private `aceengineer-strategy` repo (`strategy/deckhand/onboarded-roster.md`, merged in vamseeachanta/aceengineer-strategy#23) per the 2026-06-02 routing decision.

## Caveat (separate owner decision)
This scrubs **current state** only. The names remain in **git history** of this public repo (prior commits this session). Fully removing them requires a history rewrite (`git filter-repo`/BFG) + force-push — disruptive with the autosync daemon. Flagging for your call; not done here.

Found during post-merge reconciliation of [#2944](https://github.com/vamseeachanta/deckhand/issues/10). Relates [#2931](https://github.com/vamseeachanta/deckhand/issues/1).