### PR TITLE
fix(statusline): guard fallible substitutions under set -euo pipefail (blank statusline)

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -28,7 +28,10 @@ if [[ "$branch" != "?" ]]; then
         git_marker="\033[1;31m*\033[0m"   # bold red: dirty (tracked changes/staged)
     fi
     # ahead/behind vs upstream (rev-list is cheap — no working-tree scan)
-    lr=$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" rev-list --count --left-right '@{u}...HEAD' 2>/dev/null)
+    # `|| true` guards: under set -euo pipefail a failing substitution
+    # (no upstream here; no digits in branch below) silently kills the
+    # script -> blank statusline (same class as review-gate SIGPIPE fix).
+    lr=$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" rev-list --count --left-right '@{u}...HEAD' 2>/dev/null) || true
     if [[ -n "$lr" ]]; then
         behind=${lr%%[[:space:]]*}; ahead=${lr##*[[:space:]]}
         (( ahead  > 0 )) && git_marker="${git_marker}\033[32m↑${ahead}\033[0m"   # green: unpushed
@@ -39,7 +42,7 @@ fi
 # Issue badge — "GitHub issues only" ecosystem: derive the active issue from
 # the branch name (e.g. fix/2795-... -> #2795) instead of local WRK counters.
 issue_seg=""
-issue_num=$(echo "$branch" | grep -oE '[0-9]{3,5}' | head -1)
+issue_num=$(echo "$branch" | grep -oE '[0-9]{3,5}' | head -1) || true
 [[ -n "$issue_num" ]] && issue_seg="\033[36m#${issue_num}\033[0m"
 
 # AI usage remaining percentages


### PR DESCRIPTION
## Problem
Statusline rendered blank on machines/sessions where the cwd is outside a git repo (e.g. `/mnt/local-analysis`) or the branch carries no issue number (e.g. `main`).

## Root cause
`.claude/statusline-command.sh` runs under `set -euo pipefail`. Two unguarded command substitutions kill the script before any output:
- `issue_num=$(echo "$branch" | grep -oE '[0-9]{3,5}' | head -1)` — grep exits 1 on no match (branch `?`/`main`)
- `lr=$(git rev-list --count --left-right '@{u}...HEAD')` — fails when the branch has no upstream

Claude Code hides statusline command errors, so the failure mode is simply an invisible statusline. Same defect class as the review-gate SIGPIPE fix (e0c1e9767).

## Fix
`|| true` guards on both substitutions + explanatory comment.

## Verification
`echo '<statusline JSON>' | bash .claude/statusline-command.sh` exits 0 and renders from: non-git cwd (`/tmp`, `/mnt/local-analysis`), repo cwd on issue-numbered branch, and this worktree off origin/main.