### PR TITLE
fix(quota): query Codex usage live via app-server RPC (stale O:% in statusline)

### DIFF
--- a/scripts/ai/assessment/lib/providers.sh
+++ b/scripts/ai/assessment/lib/providers.sh
@@ -214,8 +214,10 @@ PYEOF
     local assess_dir telemetry
     assess_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
     telemetry=$(bash "$assess_dir/query-codex-usage.sh" --json 2>/dev/null || true)
+    # Accept either live app-server telemetry (preferred — survives weekly
+    # window rollovers with no recent local session) or session-log telemetry.
     if [[ -n "$telemetry" ]] \
-        && echo "$telemetry" | jq -e '.source == "local-session-rate-limits" and .pct_remaining != null' &>/dev/null; then
+        && echo "$telemetry" | jq -e '(.source == "app-server-live" or .source == "local-session-rate-limits") and .pct_remaining != null' &>/dev/null; then
         echo "$telemetry" | jq -c \
             --argjson limit "$limit" \
             --argjson messages "$messages" \
@@ -223,7 +225,7 @@ PYEOF
               week_messages:$messages, week_pct:.week_pct,
               five_hour_pct:.five_hour_pct, pct_remaining:.pct_remaining,
               hours_to_reset:.hours_to_reset, resets_at:.resets_at,
-              source:"local-session-rate-limits"}'
+              source:.source}'
         return
     fi
 

--- a/scripts/ai/assessment/query-codex-usage.sh
+++ b/scripts/ai/assessment/query-codex-usage.sh
@@ -16,7 +16,7 @@ Usage:
   query-codex-usage.sh --json     Output JSON only
   query-codex-usage.sh --no-live  Skip live app-server query (session logs only)
 
-Env: CODEX_USAGE_NO_LIVE=1 (same as --no-live), CODEX_APPSERVER_WAIT (default 6s)
+Env: CODEX_USAGE_NO_LIVE=1 (same as --no-live), CODEX_APPSERVER_WAIT (default 3s)
 EOF
 }
 
@@ -67,14 +67,18 @@ format_time_left() {
 # while live was 1% used/resets Jun 11).
 # Protocol: JSONL over stdio; stdin must stay open until the response lands
 # (immediate EOF kills the server before it answers), hence printf + sleep.
-# grep -m1 exits on match; the pipeline still waits out the sleep (~6s),
-# which is fine for the 4-hourly cron consumer.
+# The pipeline waits out the full sleep (~3s default) even after grep -m1
+# matches — fine for the 4-hourly cron consumer.
 get_live_rate_limits() {
     [[ "$NO_LIVE" == "1" ]] && return 1
     command -v codex >/dev/null 2>&1 || return 1
     command -v timeout >/dev/null 2>&1 || return 1
 
-    local wait_s="${CODEX_APPSERVER_WAIT:-6}" resp=""
+    # Integer-validate (review nit): bad values would only cost a stderr
+    # line (the || true absorbs the arithmetic abort), but stay quiet.
+    # Responses arrive in ~1s; 3s gives margin without dragging the cron.
+    local wait_s="${CODEX_APPSERVER_WAIT:-3}" resp=""
+    [[ "$wait_s" =~ ^[0-9]+$ ]] || wait_s=3
     resp=$({ printf '%s\n' \
         '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"query-codex-usage","title":"Quota Query","version":"1.0.0"}}}' \
         '{"method":"initialized","params":{}}' \

--- a/scripts/ai/assessment/query-codex-usage.sh
+++ b/scripts/ai/assessment/query-codex-usage.sh
@@ -1,24 +1,29 @@
 #!/usr/bin/env bash
-# ABOUTME: Query Codex weekly usage and reset time from local Codex session logs
-# ABOUTME: Parses latest token_count rate_limits.secondary values from ~/.codex/sessions
+# ABOUTME: Query Codex weekly usage and reset time (live app-server RPC first)
+# ABOUTME: Falls back to token_count rate_limits parsing from ~/.codex/sessions
 
 set -euo pipefail
 
 SESSIONS_DIR="${HOME}/.codex/sessions"
 MAX_FILES=20
 MODE="text"
+NO_LIVE="${CODEX_USAGE_NO_LIVE:-0}"
 
 usage() {
     cat <<'EOF'
 Usage:
-  query-codex-usage.sh         Show weekly Codex usage summary
-  query-codex-usage.sh --json  Output JSON only
+  query-codex-usage.sh            Show weekly Codex usage summary
+  query-codex-usage.sh --json     Output JSON only
+  query-codex-usage.sh --no-live  Skip live app-server query (session logs only)
+
+Env: CODEX_USAGE_NO_LIVE=1 (same as --no-live), CODEX_APPSERVER_WAIT (default 6s)
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --json) MODE="json"; shift ;;
+        --no-live) NO_LIVE=1; shift ;;
         --help|-h) usage; exit 0 ;;
         *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
     esac
@@ -53,6 +58,43 @@ format_time_left() {
     else
         echo "${minutes}m"
     fi
+}
+
+# Live query via `codex app-server` JSON-RPC (account/rateLimits/read).
+# Authoritative even when no Codex session ran recently — session-log parsing
+# (below) freezes at the last session's view and goes stale across weekly
+# window rollovers (observed 2026-06-04: logs said 21% used/resets Jun 7
+# while live was 1% used/resets Jun 11).
+# Protocol: JSONL over stdio; stdin must stay open until the response lands
+# (immediate EOF kills the server before it answers), hence printf + sleep.
+# grep -m1 exits on match; the pipeline still waits out the sleep (~6s),
+# which is fine for the 4-hourly cron consumer.
+get_live_rate_limits() {
+    [[ "$NO_LIVE" == "1" ]] && return 1
+    command -v codex >/dev/null 2>&1 || return 1
+    command -v timeout >/dev/null 2>&1 || return 1
+
+    local wait_s="${CODEX_APPSERVER_WAIT:-6}" resp=""
+    resp=$({ printf '%s\n' \
+        '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"query-codex-usage","title":"Quota Query","version":"1.0.0"}}}' \
+        '{"method":"initialized","params":{}}' \
+        '{"method":"account/rateLimits/read","id":1}'
+        sleep "$wait_s"
+      } | timeout $(( wait_s + 9 )) codex app-server 2>/dev/null \
+        | grep -m1 '"id":1') || true
+    [[ -n "$resp" ]] || return 1
+
+    # Map camelCase RPC fields onto the session-parser entry shape so main()
+    # is source-agnostic. Reject payloads missing the weekly (secondary) lane.
+    echo "$resp" | jq -ce '
+        .result.rateLimits
+        | select(.secondary.usedPercent != null and .secondary.resetsAt != null)
+        | {
+            week_pct: .secondary.usedPercent,
+            resets_at_epoch: .secondary.resetsAt,
+            five_hour_pct: (.primary.usedPercent // 0),
+            five_hour_resets_at_epoch: (.primary.resetsAt // 0)
+        }' 2>/dev/null || return 1
 }
 
 get_latest_rate_limit_entry() {
@@ -115,8 +157,13 @@ manual_fallback() {
 }
 
 main() {
-    local latest
-    latest=$(get_latest_rate_limit_entry || true)
+    local latest source_label="local-session-rate-limits"
+    latest=$(get_live_rate_limits || true)
+    if [[ -n "$latest" ]]; then
+        source_label="app-server-live"
+    else
+        latest=$(get_latest_rate_limit_entry || true)
+    fi
 
     if [[ -z "$latest" ]]; then
         local fallback
@@ -140,7 +187,7 @@ main() {
     resets_at_epoch=$(echo "$latest" | jq -r '.resets_at_epoch')
     five_hour_pct=$(echo "$latest" | jq -r '.five_hour_pct // 0')
     five_hour_resets_at_epoch=$(echo "$latest" | jq -r '.five_hour_resets_at_epoch // 0')
-    source_file=$(echo "$latest" | jq -r '.session_file')
+    source_file=$(echo "$latest" | jq -r '.session_file // "live:codex-app-server"')
 
     local now_epoch pct_remaining seconds_to_reset hours_to_reset
     now_epoch=$(date +%s)
@@ -165,6 +212,7 @@ main() {
         --argjson five_hour_pct "$five_hour_pct" \
         --argjson five_hour_resets_at_epoch "$five_hour_resets_at_epoch" \
         --arg session_file "$source_file" \
+        --arg source_label "$source_label" \
         --arg updated_at "$(date -Iseconds)" \
         '{
             provider: "codex",
@@ -175,7 +223,7 @@ main() {
             hours_to_reset: $hours_to_reset,
             five_hour_pct: $five_hour_pct,
             five_hour_resets_at_epoch: $five_hour_resets_at_epoch,
-            source: "local-session-rate-limits",
+            source: $source_label,
             session_file: $session_file,
             updated_at: $updated_at
         }')


### PR DESCRIPTION
## Problem
Statusline/quota snapshot showed Codex `O:79%` (21% used, resets Jun 7) while live usage was 1% used, resets Jun 11 — the weekly window had rolled but no recent local Codex session existed to refresh the parsed telemetry.

## Root cause
`query-codex-usage.sh` only mined `~/.codex/sessions/*.jsonl` token_count events — a passive trail that freezes at the last session's view of the rate-limit window.

## Fix
- **Live tier**: `codex app-server` JSON-RPC `account/rateLimits/read` (initialize → initialized → read; JSONL over stdio; stdin held open ~6s because immediate EOF kills the server pre-response; `timeout`-guarded). Authoritative regardless of session activity.
- **Fallbacks preserved**: session-log parse → manual file. `--no-live` / `CODEX_USAGE_NO_LIVE=1` for offline.
- `lib/providers.sh` accepts + propagates the new `app-server-live` source label.

## Research
Approach mirrors [CodexBar](https://github.com/steipete/CodexBar/blob/main/docs/codex.md) (app-server RPC primary, `wham/usage` HTTP + session parse as fallbacks) and the official [app-server docs](https://developers.openai.com/codex/app-server).

## Verification
- Live: `{week_pct:1, pct_remaining:99, resets_at:2026-06-11..., source:app-server-live}` in ~6s
- `--no-live`: session parse still works
- End-to-end: `provider-utilization-refresh.sh` exit 0 → `agent-quota-latest.json` updated → statusline renders `O:99%`