### PR TITLE
fix(maintenance): re-apply Hermes enforcement patches after `hermes update`

### DIFF
--- a/scripts/maintenance/update-harness-tools.sh
+++ b/scripts/maintenance/update-harness-tools.sh
@@ -9,8 +9,27 @@
 #
 # Each step is independent: a failure is reported but does not abort the rest.
 # Run with --dry-run to print the commands without executing them.
+#
+# Post-hermes-update re-apply (deckhand#63):
+#   `hermes update` discards working-tree changes on its managed clone before
+#   updating ("Discarding working-tree changes on managed clone before
+#   update..."), which silently wipes any locally-applied Hermes enforcement
+#   patches from ~/.hermes/hermes-agent. On any host where the deckhand
+#   installer is present we re-apply those patches immediately after a
+#   successful `hermes update`, and FAIL LOUDLY (non-zero exit) if they cannot
+#   be re-applied so the cron log surfaces the breakage instead of silently
+#   running the gateway without local enforcement.
 
 set -uo pipefail
+
+# Path to the deckhand Hermes-patch installer (idempotent: dry-run checks patch
+# drift with `git apply --check`; `--apply` re-applies and exits non-zero on
+# failure). Override via env for non-standard checkouts. The guard below skips
+# this step entirely on hosts where the installer is absent (multi-machine).
+# The absolute default is a cross-repo machine path (deckhand lives outside this
+# repo, so $(git rev-parse) can't resolve it); it is env-overridable and the
+# step is guarded by an [ -x ] existence check, hence the exemption sentinel.
+DECKHAND_HERMES_INSTALLER="${DECKHAND_HERMES_INSTALLER:-/mnt/local-analysis/deckhand/scripts/deckhand/install-hermes-b2.sh}"  # abs-path-allowed
 
 # Ensure tool dirs are on PATH. Cron and Windows Task Scheduler launch this with a
 # minimal environment, so the npm-global / ~/.local/bin dirs where the CLIs live
@@ -26,6 +45,10 @@ DRY_RUN=0
 # Track results for the summary.
 declare -a NAMES=()
 declare -a STATUS=()
+
+# Set to 1 if the deckhand patch re-apply step fails — forces a non-zero exit
+# even though it is not a `run_step`/STATUS entry (deckhand#63).
+REAPPLY_FAILED=0
 
 run_step() {
   local name="$1"; shift
@@ -53,10 +76,77 @@ run_step() {
   fi
 }
 
+# Return the recorded STATUS of a prior run_step by name (empty if not run).
+status_of() {
+  local want="$1" i
+  for i in "${!NAMES[@]}"; do
+    [[ "${NAMES[$i]}" == "$want" ]] && { printf '%s\n' "${STATUS[$i]}"; return; }
+  done
+}
+
+# Re-apply the deckhand Hermes enforcement patches after `hermes update`.
+# `hermes update` discards working-tree changes on the managed clone, wiping the
+# locally-applied patches (deckhand#63). The installer is idempotent: with
+# --apply it drift-checks each patch (`git apply --check`) then applies it,
+# exiting non-zero on any failure. We fail loudly on failure so the cron log and
+# the script exit code surface a gateway that would otherwise restart without
+# local enforcement. (verify-hermes-b2.sh is NOT wired in here: it needs a test
+# session identity + PYTHONPATH + the deckhand python module and asserts ambient
+# GH_TOKEN is unset — assumptions that do not hold in the bare cron env. The
+# installer's own dry-run drift check below is the cron-appropriate verification.)
+reapply_hermes_patches() {
+  echo
+  echo "==> hermes-patches: re-apply deckhand enforcement patches"
+  NAMES+=("hermes-patches")
+
+  if [[ ! -x "$DECKHAND_HERMES_INSTALLER" ]]; then
+    echo "    SKIP: installer not present/executable ($DECKHAND_HERMES_INSTALLER)"
+    STATUS+=("skipped (no installer)")
+    return
+  fi
+
+  local hermes_status
+  hermes_status="$(status_of hermes)"
+  if [[ "$hermes_status" != "ok" ]]; then
+    # Only a successful `hermes update` rewrites the managed clone and wipes the
+    # patches. If hermes was skipped/failed/dry-run, the tree is untouched, so a
+    # re-apply is unnecessary — but it is cheap and idempotent, so still run it
+    # to self-heal any pre-existing drift. In dry-run, only report intent.
+    if (( DRY_RUN )); then
+      echo "    (dry-run, would run: $DECKHAND_HERMES_INSTALLER --apply)"
+      STATUS+=("dry-run")
+      return
+    fi
+    echo "    NOTE: hermes step was '${hermes_status:-not-run}'; running re-apply anyway (idempotent)"
+  fi
+
+  if (( DRY_RUN )); then
+    echo "    (dry-run, would run: $DECKHAND_HERMES_INSTALLER --apply)"
+    STATUS+=("dry-run")
+    return
+  fi
+
+  if "$DECKHAND_HERMES_INSTALLER" --apply; then
+    STATUS+=("ok")
+    # Post-apply drift verification: re-run the installer in dry-run mode. It
+    # exits non-zero if any patch no longer applies cleanly (i.e. did not land).
+    if ! "$DECKHAND_HERMES_INSTALLER" >/dev/null 2>&1; then
+      echo "    ERROR: post-apply drift check failed — patches did not land cleanly"
+      REAPPLY_FAILED=1
+      STATUS[-1]="FAILED (drift)"
+    fi
+  else
+    echo "    ERROR: HERMES LOCAL PATCHES FAILED TO RE-APPLY — gateway restart will lose local enforcement patches"
+    REAPPLY_FAILED=1
+    STATUS+=("FAILED")
+  fi
+}
+
 echo "Harness update — $(date '+%Y-%m-%d %H:%M:%S')"
 (( DRY_RUN )) && echo "(dry-run mode)"
 
 run_step hermes hermes update
+reapply_hermes_patches   # deckhand#63 — re-apply patches wiped by `hermes update`
 run_step claude claude update
 run_step codex  codex  update
 run_step gemini npm install -g @google/gemini-cli@latest
@@ -67,8 +157,14 @@ for i in "${!NAMES[@]}"; do
   printf '  %-8s %s\n' "${NAMES[$i]}" "${STATUS[$i]}"
 done
 
-# Non-zero exit if any step failed.
+# Non-zero exit if any step failed, or if the deckhand patch re-apply failed
+# (deckhand#63 — a wiped enforcement patch must break the run, not pass quietly).
+if (( REAPPLY_FAILED )); then
+  echo
+  echo "ERROR: deckhand Hermes enforcement patches were not re-applied — see above."
+  exit 1
+fi
 for s in "${STATUS[@]}"; do
-  [[ "$s" == "FAILED" ]] && exit 1
+  [[ "$s" == FAILED* ]] && exit 1
 done
 exit 0


### PR DESCRIPTION
## Incident

The 01:45 harness-update cron (`scripts/maintenance/update-harness-tools.sh`, run on the live checkout via the `/mnt/workspace-hub` symlink) runs `hermes update` as its first step. `hermes update` **discards working-tree changes on its managed clone before updating** — it logs:

```
→ Discarding working-tree changes on managed clone before update...
```

That working tree (`~/.hermes/hermes-agent`) is exactly where the locally-applied Hermes enforcement patches live as uncommitted modifications. So every night the cron silently **wipes all 7 deckhand enforcement patches**, and the gateway is restarted by the same `hermes update` run — coming back up **without** local enforcement. Discovered live on 2026-06-05; the 01:45 run had stripped all 7 patches with no error surfaced.

Refs vamseeachanta/deckhand#63.

## Fix

Add a guarded post-`hermes update` step, `reapply_hermes_patches`, that re-applies the patches via the deckhand installer and fails loudly if it can't.

- **Guard (multi-machine):** installer path comes from `DECKHAND_HERMES_INSTALLER` (default `/mnt/local-analysis/deckhand/scripts/deckhand/install-hermes-b2.sh`, env-overridable). The step is gated by an `[ -x ]` existence check, so it's a clean no-op (`skipped (no installer)`) on hosts without the deckhand checkout — consistent with the script's existing per-machine PATH handling.
- **Re-apply after success:** runs `install-hermes-b2.sh --apply` (idempotent — drift-checks each patch with `git apply --check`, then applies; exits non-zero on any failure) immediately after the hermes step.
- **Fail loudly:** on installer failure it prints `ERROR: HERMES LOCAL PATCHES FAILED TO RE-APPLY — gateway restart will lose local enforcement patches`, sets a `REAPPLY_FAILED` flag, and makes the whole script `exit 1` so the cron log shows the failure. No silent continue.
- **Post-apply drift verification:** re-runs the installer in dry-run mode (its default mode = `git apply --check` per patch). If a patch didn't land cleanly, that also trips the fail-loud path. `verify-hermes-b2.sh` is intentionally **not** wired in here — it requires a synthetic Hermes session identity, `PYTHONPATH`, the `deckhand` Python module, and asserts ambient `GH_TOKEN` is unset; none of those hold in the bare cron environment. The installer's own dry-run drift check is the cron-appropriate verification (noted in a code comment).
- **Tie to the hermes step:** re-apply runs right after `run_step hermes`. Because only a *successful* `hermes update` rewrites the managed clone, that's the precise wipe trigger. If hermes was skipped/failed/dry-run, the step still runs (cheap + idempotent) to self-heal pre-existing drift, emitting a `NOTE`. In `--dry-run` it only reports intent.

## Test evidence

Non-destructive only — the real `hermes update` and the real installer were **not** run against the live tree. Logic exercised in isolation with stub tools (fake `$HOME`, minimal `$PATH`) and fake installers:

| Case | Scenario | Result |
|------|----------|--------|
| A | installer `--apply` OK + dry-run drift OK | `hermes-patches ok`, exit 0 |
| B | installer `--apply` fails (drift) | ERROR banner printed, `hermes-patches FAILED`, **exit 1** |
| C | `--apply` OK but post-apply drift check fails | `hermes-patches FAILED (drift)`, **exit 1** |
| D | installer absent (guard) | `skipped (no installer)`, exit 0 |
| E | `--dry-run` | `(dry-run, would run: … --apply)`, no apply, exit 0 |
| G | hermes step skipped (missing) + installer present | `NOTE … running re-apply anyway (idempotent)`, `hermes-patches ok`, exit 0 |

Also: `bash -n` syntax check passes; `scripts/enforcement/check-no-abs-paths.sh` passes (the cross-repo machine-default path carries an `# abs-path-allowed` sentinel — it's env-overridable and `[ -x ]`-guarded); `scripts/legal/legal-sanity-scan.sh --diff-only` → PASS.

## Deployment note

After merge, the **live** checkout must be pulled before tonight's 01:45 run so the fixed script is what cron executes:

```
git -C /mnt/local-analysis/workspace-hub pull --rebase --autostash
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)