### PR TITLE
docs(session-handoff): publish 2026-06-06 Collide→outreach mapping handoff

### DIFF
--- a/docs/session-handoffs/2026-06-06-collide-review-llm-wiki-outreach-mapping.md
+++ b/docs/session-handoffs/2026-06-06-collide-review-llm-wiki-outreach-mapping.md
@@ -1,0 +1,48 @@
+# Session handoff — Collide.io review → llm-wiki ingest → outreach mapping (deckhand-as-surface)
+
+> Session: 2026-06-05/06, ace-linux-1. Owner: VA. Status at handoff: all deliverables verified; one PR open; no unpushed local commits owned by this session.
+
+## What was asked
+
+1. Review collide.io (logged in) — all posts and knowledge.
+2. Strengthen llm-wiki from it.
+3. Derive marketing ideas from the ongoing conversations.
+4. Create aceengineer-strategy issues mapping the work to marketing outreach **with deckhand as our surface** (VA directive 2026-06-06).
+
+## What was done (with verification state)
+
+| # | Deliverable | Where | Verified | Score |
+|---|---|---|---|---|
+| 1 | Collide review: feed + trending + Videos (3,600-video library, named shows) + News + 13-post Day-3 "AI bottleneck" thread + gamification mechanics (Watts/leaderboard/Doghouse/7-day challenge) | chat synthesis 2026-06-05 | content captured via logged-in browser session | 85% (historical feed depth + per-thread comments not exhaustively opened) |
+| 2 | llm-wiki source page: practitioner AI-adoption bottleneck taxonomy (trust/sycophancy, security-compliance-cost, org accountability gap, token-cost governance, output **variance**, overselling/data-ownership, siloing); vendor claims caveated (Azure wireline content-filter incident, TX RRC W-10/G-10/H-10/H-15 95% case study, micro-turbine 83%) | `wikis/trends-and-strategies/wiki/sources/collide-community-2026-ai-adoption-bottlenecks.md` + index/log, **PR llm-wiki#402** | remote branch tip `73d0d5ff` confirmed; PR state OPEN, **MERGEABLE** vs advanced main (2026-06-06) | 95% (pending merge) |
+| 3 | Marketing ideas: VoC→positioning map ("AI that shows its work", "deterministic deliverables", NDA-safe local-first ICP) + Collide playbook tactics (problem-of-the-week, challenge-as-research CTA, provocation proof post) | chat synthesis | mapped 1:1 into issues below | 100% |
+| 4 | Outreach-mapping issues, deckhand as surface | aceengineer-strategy **#42** (decision record — reconciles EXP-003 "do not market it" note), **#43** (VoC messaging + deckhand live-run proof), **#44** (Collide presence track; VA member, 362 Watts), **#45** (due-diligence-consultant ICP; deckhand 5-layer posture as proof artifact), **#46** (invitation copy: question CTA + proof post) | all 5 verified live via `gh issue list` | 100% |
+| 5 | Memory updates | `project_open_deck_outreach_exp003.md` + MEMORY.md index line (merged with concurrent parallel-session updates #47/#48, deckhand#81/#82) | re-read after concurrent edits; both sessions' entries coexist | 100% |
+
+## Cleanup audit (pre-exit)
+
+| Item | Bucket |
+|---|---|
+| llm-wiki local: checkout returned to `main` (behind 25, auto-sync will pull); ingest branch ref had been reset by auto-sync — remote branch + PR #402 unaffected | CLEAN |
+| llm-wiki untracked `.codex/ .gemini/ .planning/*` | EXPECTED (other sessions' residue, untouched) |
+| aceengineer-strategy: on `docs/flywheel-issue-plan` w/ untracked journal file — parallel session's live state | EXPECTED (not touched by this session) |
+| aceengineer-strategy main: 11 commits UNPUSHED (pre-existing; push auto-denied for agents) | EXPECTED — **user must push** |
+| Comment on pre-existing #25 (gating fan-out) auto-denied | EXPECTED — optional one-liner for user |
+
+## Open items / next session
+
+1. **Merge llm-wiki PR #402** (mergeable now; index.md `page_count` may conflict if another trends ingest lands first — union-merge counts).
+2. **#42 decision record** — write it; check against parallel #48 (both touch public bot-promo posture; #48 gates public promo on EXP-002 PASS).
+3. Deck #1 naval-arch due ~2026-06-11 (#31); #43 messaging must land in its copy.
+4. Optional: user pushes aceengineer-strategy main (11 commits) and posts gating fan-out comment on #25.
+5. Collide presence track (#44) can start immediately — it is read/answer activity, not gated outreach.
+
+## Restart prompt (paste into a fresh session)
+
+```
+Continue the Collide→outreach thread (handoff: workspace-hub docs/session-handoffs/2026-06-06-collide-review-llm-wiki-outreach-mapping.md).
+State: llm-wiki PR #402 (Collide AI-bottleneck ingest) was MERGEABLE — merge it (union-merge index.md counts if conflicted).
+Then draft the #42 decision record (deckhand = outreach surface: demo bot / opt-in deck delivery / re-touch channel; amend EXP-003 'do not market it' note + channel-gtm doc; reconcile with parallel #48 which gates public bot-promo on EXP-002 PASS).
+Then start #44 (Collide offshore Problem-of-the-Week #1 aligned to deck #1 naval-arch, due ~06-11) and fold #43 messaging ('AI that shows its work' assumption ledger + 'deterministic deliverables') into deck #1 copy.
+Gating: all outreach inherits aceengineer-strategy #25 (≤3 canaries until deckhand P0s + PAT rotation ~06-08).
+```


### PR DESCRIPTION
Publishes `docs/session-handoffs/2026-06-06-collide-review-llm-wiki-outreach-mapping.md` — it existed only on the local branch `fix/track-fleet-skills-2925-portable` (commit e48fd1330) on ace-linux, so the `gtm-daily-reanalysis` remote routine could never read it (flagged as 'file not found' in its 2026-06-06 run report, aceengineer-strategy#52).

Docs-only; committed server-side via API. Referenced by the routine's Thread C (Collide→outreach: strategy #42–#46, llm-wiki #402 merged, deckhand-as-surface decision PR strategy#60).