### PR TITLE
feat(kanban): domain-coverage guard — keep the one-domain-per-issue invariant from rotting (#2962)

### DIFF
--- a/.github/workflows/domain-coverage.yml
+++ b/.github/workflows/domain-coverage.yml
@@ -1,0 +1,50 @@
+# workspace-hub#2962: warn-only guard that the ecosystem `domain:` label
+# invariant (exactly one taxonomy-known domain per open issue) does not rot.
+# Companion to the */20 kanban-reconcile cron — same App-token mechanism for
+# cross-repo issue reads, plus contents:read to fetch the deckhand taxonomy SoT.
+# Reports to the run summary; never mutates anything.
+name: domain-coverage
+
+on:
+  schedule:
+    - cron: "17 6 * * *"   # daily, offset off the :00/:20 reconcile slots
+  workflow_dispatch:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install pyyaml
+
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.KANBAN_RECONCILE_APP_ID }}
+          private-key: ${{ secrets.KANBAN_RECONCILE_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Reads sibling-repo issues (coverage) + the deckhand taxonomy file.
+          permission-issues: read
+          permission-contents: read
+
+      - name: Fetch taxonomy SoT (best effort)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # The 1:1 crosswalk lives in the private deckhand repo. If unreachable,
+          # the guard still runs zero/multi checks (drift/alias are skipped).
+          gh api repos/${{ github.repository_owner }}/deckhand/contents/routing/taxonomy.yaml \
+            --jq '.content' 2>/dev/null | base64 -d > /tmp/taxonomy.yaml \
+            && echo "taxonomy fetched ($(wc -l < /tmp/taxonomy.yaml) lines)" \
+            || echo "taxonomy unreachable — zero/multi checks only"
+
+      - name: Run domain-coverage guard
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python scripts/kanban/domain_coverage.py --taxonomy /tmp/taxonomy.yaml \
+            | tee "$GITHUB_STEP_SUMMARY"

--- a/scripts/kanban/domain_coverage.py
+++ b/scripts/kanban/domain_coverage.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""domain_coverage.py — warn-only guard on the ecosystem `domain:` label invariant.
+
+On 2026-06-07 every open issue across the repo ecosystem was brought to EXACTLY
+ONE `domain:` label, and deckhand `routing/taxonomy.yaml` established the 1:1
+crosswalk of those labels to llm-wiki nodes (workspace-hub#2962, deckhand#84).
+Without a guard the invariant rots with every new issue. This tool reports, per
+repo, the four ways it can break:
+
+  1. zero    — open issue with NO `domain:` label (unroutable)
+  2. multi   — open issue with >1 `domain:` label (reconcile takes the FIRST;
+               order-dependent placement — the #2878 adversarial finding)
+  3. unknown — a `domain:` value NOT in routing/taxonomy.yaml (crosswalk drift;
+               new domains must go through a taxonomy PR first)
+  4. alias   — use of a synonym label pending staged rename (should shrink, not grow)
+
+Checks 1 and 2 need only GitHub labels and always run. Checks 3 and 4 need the
+canonical label set + aliases from taxonomy.yaml; pass it with --taxonomy. If it
+is absent (e.g. the private SoT is unreachable in CI) those checks are skipped
+with a logged notice rather than failing.
+
+Warn-only by default (exit 0); --strict exits 1 when any violation exists so a
+gate can block. The planning core (`analyze`) is pure; gh calls are isolated
+behind an injectable runner so the whole tool is hermetically testable.
+
+Usage:
+  domain_coverage.py                              report all default repos
+  domain_coverage.py --taxonomy routing/taxonomy.yaml
+  domain_coverage.py --repos repos.txt --strict
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # taxonomy checks degrade gracefully
+
+DOMAIN_PREFIX = "domain:"
+
+# The canonical coverage set: every repo that must keep one-domain-per-issue.
+# Explicit (not manifest-derived) because the kanban manifest is board-scoped —
+# it carries the wrong owner for assethold and omits the client wikis + deckhand.
+DEFAULT_REPOS = [
+    "vamseeachanta/aceengineer-admin",
+    "vamseeachanta/aceengineer-strategy",
+    "vamseeachanta/achantas-data",
+    "vamseeachanta/assetutilities",
+    "vamseeachanta/deckhand",
+    "vamseeachanta/deckhand-sandbox",
+    "vamseeachanta/digitalmodel",
+    "vamseeachanta/hobbies",
+    "vamseeachanta/investments",
+    "vamseeachanta/llm-wiki",
+    "vamseeachanta/llm-wiki-acma",
+    "vamseeachanta/llm-wiki-fdas",
+    "vamseeachanta/sabithaandkrishnaestates",
+    "vamseeachanta/teamresumes",
+    "vamseeachanta/workspace-hub",
+    "vamseeachanta/worldenergydata",
+    "samdansk2/assethold",
+]
+
+
+def domains_of(issue: dict) -> list[str]:
+    """The `domain:`-prefixed label names on an issue, prefix stripped."""
+    return [
+        lbl["name"][len(DOMAIN_PREFIX):]
+        for lbl in issue.get("labels", [])
+        if lbl["name"].startswith(DOMAIN_PREFIX)
+    ]
+
+
+def analyze(issues: list[dict], canonical: set[str] | None, aliases: set[str] | None) -> dict:
+    """Pure core: classify a repo's open issues against the invariant.
+
+    `canonical`/`aliases` None => taxonomy unavailable; checks 3 & 4 skipped.
+    Returns lists of {number, title, domains} (and the offending label for 3/4).
+    """
+    zero, multi, unknown, alias = [], [], [], []
+    for it in issues:
+        ds = domains_of(it)
+        rec = {"number": it["number"], "title": it["title"], "domains": ds}
+        if len(ds) == 0:
+            zero.append(rec)
+            continue
+        if len(ds) > 1:
+            multi.append(rec)
+        # check the first label (the one reconcile actually routes on)
+        first = ds[0]
+        if aliases is not None and first in aliases:
+            alias.append({**rec, "label": first})
+        elif canonical is not None and first not in canonical and (aliases is None or first not in aliases):
+            unknown.append({**rec, "label": first})
+    return {
+        "total": len(issues),
+        "zero": zero,
+        "multi": multi,
+        "unknown": unknown,
+        "alias": alias,
+        "taxonomy_checked": canonical is not None,
+    }
+
+
+def load_taxonomy(path: Path) -> tuple[set[str], set[str]]:
+    """Return (canonical_label_names, alias_label_names) from taxonomy.yaml."""
+    if yaml is None:
+        raise RuntimeError("PyYAML required to read taxonomy.yaml")
+    doc = yaml.safe_load(path.read_text())
+    canonical = set(doc["crosswalk"].keys())
+    aliases = {a["alias"] for a in doc.get("aliases", [])}
+    return canonical, aliases
+
+
+def _gh(repo: str, runner) -> list[dict]:
+    out = runner(
+        ["gh", "issue", "list", "-R", repo, "--state", "open",
+         "--limit", "1000", "--json", "number,title,labels"]
+    )
+    return json.loads(out) if out.strip() else []
+
+
+def _default_runner(args: list[str]) -> str:
+    return subprocess.run(args, capture_output=True, text=True, check=True).stdout
+
+
+def render(report: dict) -> tuple[str, int]:
+    """Markdown report + total violation count."""
+    lines = ["# Domain-coverage guard\n"]
+    if not report["any_taxonomy"]:
+        lines.append("> taxonomy.yaml not provided — crosswalk-drift (unknown) "
+                     "and alias checks skipped; zero/multi still enforced.\n")
+    lines.append("| Repo | Open | Zero | Multi | Unknown | Alias |")
+    lines.append("|---|--:|--:|--:|--:|--:|")
+    total_viol = 0
+    for repo, r in report["repos"].items():
+        n = len(r["zero"]) + len(r["multi"]) + len(r["unknown"]) + len(r["alias"])
+        total_viol += n
+        lines.append(f"| {repo} | {r['total']} | {len(r['zero'])} | "
+                     f"{len(r['multi'])} | {len(r['unknown'])} | {len(r['alias'])} |")
+    lines.append("")
+    for repo, r in report["repos"].items():
+        detail = []
+        for kind in ("zero", "multi", "unknown", "alias"):
+            for rec in r[kind]:
+                tag = f" → `{rec['label']}`" if kind in ("unknown", "alias") else ""
+                doms = ",".join(rec["domains"]) or "—"
+                detail.append(f"- **{kind}** {repo}#{rec['number']} [{doms}]{tag}: {rec['title']}")
+        if detail:
+            lines.append(f"### {repo}")
+            lines.extend(detail)
+            lines.append("")
+    if total_viol == 0:
+        lines.append("✅ Invariant holds: every open issue has exactly one taxonomy-known domain.")
+    return "\n".join(lines), total_viol
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repos", type=Path, help="file with one owner/repo per line (default: built-in list)")
+    ap.add_argument("--taxonomy", type=Path, help="path to routing/taxonomy.yaml for drift/alias checks")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any violation")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    args = ap.parse_args()
+
+    repos = (
+        [l.strip() for l in args.repos.read_text().splitlines() if l.strip() and not l.startswith("#")]
+        if args.repos else DEFAULT_REPOS
+    )
+
+    canonical = aliases = None
+    if args.taxonomy and args.taxonomy.exists():
+        canonical, aliases = load_taxonomy(args.taxonomy)
+    elif args.taxonomy:
+        print(f"notice: {args.taxonomy} not found — skipping drift/alias checks", file=sys.stderr)
+
+    report = {"repos": {}, "any_taxonomy": canonical is not None}
+    for repo in repos:
+        try:
+            issues = _gh(repo, _default_runner)
+        except subprocess.CalledProcessError as e:
+            print(f"warn: {repo}: gh failed ({e.stderr.strip()[:120]}) — skipped", file=sys.stderr)
+            continue
+        report["repos"][repo] = analyze(issues, canonical, aliases)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        total = sum(len(r["zero"]) + len(r["multi"]) + len(r["unknown"]) + len(r["alias"])
+                    for r in report["repos"].values())
+    else:
+        md, total = render(report)
+        print(md)
+
+    return 1 if (args.strict and total) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_domain_coverage.py
+++ b/tests/test_domain_coverage.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for scripts/kanban/domain_coverage.py — the #2962 invariant guard.
+
+The planning core (`analyze`) is pure and fully covered here; the gh shell is
+tested with a fake runner. Hermetic — no live gh.
+
+Run: uv run --with pyyaml pytest tests/test_domain_coverage.py
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARD_PY = REPO_ROOT / "scripts" / "kanban" / "domain_coverage.py"
+
+
+def _import():
+    spec = importlib.util.spec_from_file_location("domain_coverage", GUARD_PY)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dc = _import()
+
+
+def _issue(n, *labels, title="t"):
+    return {"number": n, "title": title, "labels": [{"name": x} for x in labels]}
+
+
+def test_zero_label_flagged():
+    r = dc.analyze([_issue(1, "bug")], canonical={"x"}, aliases=set())
+    assert [i["number"] for i in r["zero"]] == [1]
+    assert r["multi"] == [] and r["unknown"] == [] and r["alias"] == []
+
+
+def test_multi_domain_flagged():
+    r = dc.analyze([_issue(2, "domain:a", "domain:b")], canonical={"a", "b"}, aliases=set())
+    assert [i["number"] for i in r["multi"]] == [2]
+
+
+def test_unknown_domain_flagged_on_first_label():
+    r = dc.analyze([_issue(3, "domain:ghost")], canonical={"a"}, aliases=set())
+    assert r["unknown"] and r["unknown"][0]["label"] == "ghost"
+
+
+def test_alias_flagged_not_unknown():
+    # an alias is a KNOWN synonym pending rename — must land in alias, never unknown
+    r = dc.analyze([_issue(4, "domain:hydro")], canonical={"hydrodynamics"}, aliases={"hydro"})
+    assert r["alias"] and r["alias"][0]["label"] == "hydro"
+    assert r["unknown"] == []
+
+
+def test_exactly_one_known_domain_is_clean():
+    r = dc.analyze([_issue(5, "domain:a")], canonical={"a"}, aliases=set())
+    assert not any(r[k] for k in ("zero", "multi", "unknown", "alias"))
+
+
+def test_taxonomy_absent_skips_drift_checks():
+    # canonical/aliases None => only zero/multi enforced; unknown domain is NOT flagged
+    r = dc.analyze([_issue(6, "domain:whatever")], canonical=None, aliases=None)
+    assert r["unknown"] == [] and r["alias"] == []
+    assert r["taxonomy_checked"] is False
+
+
+def test_multi_and_unknown_compound():
+    # first label unknown AND more than one domain => both flags fire
+    r = dc.analyze([_issue(7, "domain:ghost", "domain:a")], canonical={"a"}, aliases=set())
+    assert [i["number"] for i in r["multi"]] == [7]
+    assert r["unknown"] and r["unknown"][0]["label"] == "ghost"
+
+
+def test_gh_runner_parses_json():
+    calls = []
+
+    def fake(args):
+        calls.append(args)
+        return '[{"number": 9, "title": "z", "labels": [{"name": "domain:a"}]}]'
+
+    issues = dc._gh("o/r", fake)
+    assert issues[0]["number"] == 9
+    assert calls[0][:3] == ["gh", "issue", "list"]
+
+
+def test_gh_runner_handles_empty():
+    assert dc._gh("o/r", lambda a: "") == []
+
+
+def test_render_clean_report_has_check():
+    report = {"any_taxonomy": True, "repos": {
+        "o/r": dc.analyze([_issue(1, "domain:a")], {"a"}, set())}}
+    md, total = dc.render(report)
+    assert total == 0 and "✅" in md


### PR DESCRIPTION
## What

A **warn-only** scheduled guard for the ecosystem `domain:` label invariant established on 2026-06-07 (every open issue in all 17 repos → exactly one `domain:` label) and the 1:1 crosswalk shipped in deckhand routing/taxonomy.yaml (#84). Without it, the invariant rots with every new issue — which already happened: 7 deckhand issues created after the labeling pass had no domain (fixed before this PR).

Closes the maintainability half of the flywheel: routing only works if the label key stays clean.

## Checks (per repo)

| Check | Needs taxonomy? | Meaning |
|---|---|---|
| **zero** | no | open issue with no `domain:` label — unroutable |
| **multi** | no | >1 `domain:` label — reconcile routes the *first* (order-dependent; vamseeachanta/workspace-hub#2878 finding) |
| **unknown** | yes | `domain:` value not in `taxonomy.yaml` — crosswalk drift |
| **alias** | yes | a synonym label pending rename (#2963) — should shrink, not grow |

zero/multi always run. unknown/alias need the taxonomy SoT (private deckhand repo); if unreachable in CI the guard degrades to zero/multi with a logged notice rather than failing.

## Live baseline (2026-06-07, all 17 repos)

```
0 zero · 0 multi · 0 unknown   ← invariant holds, no drift
66 alias  ← exactly the 5 rename-pending synonyms (solver-orcaflex 31,
            pipeline-subsea 19, hydro-rao-seakeeping 8, riser 7, hydro 1)
            tracked by vamseeachanta/workspace-hub#2963 — correctly NOT counted as errors
```

## Design

- `scripts/kanban/domain_coverage.py` — pure `analyze()` core, gh I/O behind an injectable runner (mirrors `relabel.py`). `--strict` to gate, `--json` for machines.
- `tests/test_domain_coverage.py` — 10 hermetic tests (no live gh).
- `.github/workflows/domain-coverage.yml` — daily, reuses the kanban-reconcile App-token (+`contents:read` to fetch the deckhand taxonomy), reports to the run summary, mutates nothing.

### Note
The App token is owner-scoped to `vamseeachanta`, so `samdansk2/assethold` will be skipped in CI (warned, not failed). If you want it covered, the install needs to grant that repo — or run the guard locally where `gh` already has access.

```
$ uv run --with pyyaml pytest tests/test_domain_coverage.py -q
10 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)