### PR TITLE
fix(harness): page owner if hermes update leaves the gateway unpatched (deckhand#162)

### DIFF
--- a/scripts/maintenance/update-harness-tools.sh
+++ b/scripts/maintenance/update-harness-tools.sh
@@ -30,6 +30,12 @@ set -uo pipefail
 # repo, so $(git rev-parse) can't resolve it); it is env-overridable and the
 # step is guarded by an [ -x ] existence check, hence the exemption sentinel.
 DECKHAND_HERMES_INSTALLER="${DECKHAND_HERMES_INSTALLER:-/mnt/local-analysis/deckhand/scripts/deckhand/install-hermes-b2.sh}"  # abs-path-allowed
+# deckhand#162 — gateway-host patch-health guard (stdlib-only; alerts owner if
+# the live gateway is unpatched). Run right after re-apply so a re-apply that
+# FAILED (e.g. a patch needs re-fitting for a new hermes) pages within seconds,
+# instead of only the loud-but-unwatched log + the hourly guard cron. The
+# 2026-06-08 incident ran unpatched for hours because that failure was silent.
+DECKHAND_HEALTH_CHECK="${DECKHAND_HEALTH_CHECK:-/mnt/local-analysis/deckhand/scripts/deckhand/patch-health-check.py}"  # abs-path-allowed
 
 # Ensure tool dirs are on PATH. Cron and Windows Task Scheduler launch this with a
 # minimal environment, so the npm-global / ~/.local/bin dirs where the CLIs live
@@ -147,6 +153,11 @@ echo "Harness update — $(date '+%Y-%m-%d %H:%M:%S')"
 
 run_step hermes hermes update
 reapply_hermes_patches   # deckhand#63 — re-apply patches wiped by `hermes update`
+# deckhand#162 — immediately verify patches landed; alert owner on regression.
+if [[ -f "$DECKHAND_HEALTH_CHECK" ]] && (( ! DRY_RUN )); then
+  echo "==> hermes-patches: verifying gateway is patched (deckhand#162 guard)"
+  python3 "$DECKHAND_HEALTH_CHECK" || true   # read-only; alerts owner if unpatched
+fi
 run_step claude claude update
 run_step codex  codex  update
 run_step gemini npm install -g @google/gemini-cli@latest


### PR DESCRIPTION
## What
Adds one guarded invocation of the Deckhand patch-health guard (`patch-health-check.py`, deckhand#164) to `update-harness-tools.sh`, right after `reapply_hermes_patches`.

## Why
The vamseeachanta/workspace-hub#63 coupling already re-applies the Deckhand hermes patches after `hermes update` and refuses to half-apply, setting `REAPPLY_FAILED` + exiting non-zero on error. But that signal was **a log line + exit code, both unwatched**.

On **2026-06-08**, hermes auto-updated 0.15.1 → 0.16.0; a patch needed re-fitting for the refactored `gateway/run.py`, so re-apply aborted (applied nothing) and the live client gateway ran **unpatched — attachment leak-gate (#28) and PAT-scoping (#01) down — for hours, silently.**

## The fix
After re-apply, run the read-only, stdlib-only vamseeachanta/workspace-hub#162 guard, which **DMs the owner within seconds** if the gateway is unpatched — closing the silent-failure window (previously bounded only by the hourly guard cron). Gateway-host only (guarded by file existence), skipped under `--dry-run`.

Verified: `bash -n` clean; `--dry-run` correctly skips the guard; the guard itself reports `OK` against the (now-remediated) live gateway.

This is the operator-chosen **prevention** for deckhand#162 — couple detection to the update job so a wipe-induced regression can't sit unnoticed. (Re-fit + restore for the 0.16.0 incident already shipped in deckhand#161; the hourly guard cron in deckhand#164.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
