### PR TITLE
feat(workstations): role-overlay harness reconciler (#2968, F1)

### DIFF
--- a/config/workstations/harness-roles.yaml
+++ b/config/workstations/harness-roles.yaml
@@ -1,0 +1,84 @@
+# harness-roles.yaml — role-overlay definitions for the harness reconciler (#2968, F1).
+#
+# Read by scripts/readiness/harness_reconcile.py. A machine in registry.yaml declares
+# `harness_profile.roles: [...]`; the applied overlay = `_base ∪ role₁ ∪ role₂…` (Q1
+# composable roles). Lists are set-unioned; scalar keys conflicting across roles fail
+# closed (no last-writer-wins).
+#
+# Overlay fields the reconciler understands:
+#   deny_required    list[str]  → unioned into permissions.deny (additive, never drops local)
+#   hooks_required   dict       → event → [{hooks:[{type,command,...}]}]; merged by identity
+#   scalar_required  dict       → top-level settings keys forced to the given value
+#   skill_families   list[str]  → declarative (skill-tree convergence; informational in F1)
+#   schedule_jobs    list[str]  → declarative only in F1; F2 (#2969) materializes cron from these
+#   capabilities     list[str]  → declarative; consumed by F3 (#2970) dispatch routing
+
+roles:
+  # role-invariant — applied to EVERY managed machine. This is the set ace-linux-2 is
+  # missing today (probe 2026-06-08: a2 ~/.claude/settings.json had no deny-list).
+  _base:
+    skill_families: [core]
+    deny_required:
+      - "Bash(rm -rf /)"
+      - "Bash(rm -rf ~:*)"
+      - "Bash(rm -rf .:*)"
+      - "Bash(dd if=/dev/zero:*)"
+      - "Bash(mkfs:*)"
+      - "Bash(shred:*)"
+      - "Bash(sudo:*)"
+      - "Bash(su :*)"
+      - "Bash(pkexec:*)"
+      - "Bash(doas:*)"
+      - "Bash(chmod 777:*)"
+      - "Bash(eval:*)"
+      - "Bash(sh -c:*)"
+      - "Bash(bash -c:*)"
+      - "Bash(zsh -c:*)"
+      - "Bash(python -c:*)"
+      - "Bash(python3 -c:*)"
+      - "Bash(perl -e:*)"
+      - "Bash(ruby -e:*)"
+      - "Bash(node -e:*)"
+      - "Bash(curl * | bash:*)"
+      - "Bash(curl * | sh:*)"
+      - "Bash(wget * -O- | bash:*)"
+      - "Bash(wget * -O- | sh:*)"
+      - "Bash(| bash:*)"
+      - "Bash(| sh:*)"
+      - "Bash(nc:*)"
+      - "Bash(ncat:*)"
+      - "Bash(base64:*)"
+      - "Bash(xxd:*)"
+      - "Bash(git push --force:*)"
+      - "Bash(git push -f:*)"
+      - "Bash(git push --force-with-lease:*)"
+      - "Bash(git -c core.hooksPath:*)"
+      - "Bash(git -c core.hookspath:*)"
+      - "Bash(crontab:*)"
+      - "Bash(systemctl:*)"
+    # NOTE (F1 scope): hooks_required is intentionally omitted here. The live Stop/
+    # SessionStart hooks carry machine-absolute paths (/home/<user>, /mnt/...), which is
+    # the very path-portability hazard tracked by epic #2967. Hook convergence needs a
+    # portable-template + env-expansion resolution; the reconciler already SUPPORTS
+    # hooks_required (tested), so it is enabled in a fast-follow once templating lands.
+    # The current hooks are cataloged in harness-state-classes.yaml so they are not
+    # flagged uncataloged-live.
+
+  control-plane:
+    scalar_required:
+      effortLevel: high
+    skill_families: [coordination, workspace-hub, research]
+    schedule_jobs: [benchmarks, nightly-learning, memory-backup, equality-matrix, gtm, research]
+
+  comms-dispatch:
+    skill_families: [coordination, deckhand]
+    schedule_jobs: [deckhand-member-audit, escalation-sweep, provider-utilization]
+
+  sim-worker:
+    skill_families: [engineering-sim]
+    schedule_jobs: [solver-watch]
+
+  # Q2: declared for F3 dispatch routing only; machines carrying this role are
+  # managed:false, so the reconciler never converges them (Windows uses Task Scheduler).
+  licensed-solver:
+    capabilities: [orcaflex, orcawave, aqwa, ansys]

--- a/config/workstations/harness-state-classes.yaml
+++ b/config/workstations/harness-state-classes.yaml
@@ -1,0 +1,54 @@
+# harness-state-classes.yaml — local-state classification for the reconciler (#2968, F1).
+#
+# Every item of machine-local harness state belongs to exactly one class. The reconciler
+# (scripts/readiness/harness_reconcile.py) WRITES only role-managed state; everything else
+# is read-only or off-limits. An item matching NO class that is present locally is
+# `uncataloged-live` and BLOCKS `--apply` until explicitly classified (Codex blast-radius
+# mitigation). See epic #2967 managed-surface contract.
+
+classes:
+  role-managed:
+    description: converged to git base + role overlay (harness-roles.yaml)
+    items:
+      - permissions.deny           # _base deny-list
+      - effortLevel                # control-plane scalar
+      - skill_families             # declarative (skill-tree convergence)
+  git-managed:
+    description: already synced by git pull; reconciler does not touch
+    items:
+      - .claude/settings.json (project)
+      - .claude/rules/
+      - .claude/skills/
+  machine-private:
+    description: legitimately per-machine; never converged
+    items:
+      - theme
+      - /mnt/workspace-hub symlink (a2 only)
+      - statusLine.command (resolves repo root locally)
+      - gpu / sim tool config
+  secret:
+    description: credentials — git declares required KEYS, never values; reconciler NEVER reads
+    items:
+      - ~/.hermes/.env
+      - ~/.codex/auth.json
+      - TELEGRAM_BOT_TOKEN
+      - TELEGRAM_ALLOWED_USERS
+  intentionally-divergent:
+    description: explicitly allowed to differ per machine (reconciler skips these keys)
+    items:
+      - theme
+      - spinnerVerbs
+      - voiceEnabled
+
+# Cataloged hooks — present hooks whose identity matches one of these are NOT flagged
+# uncataloged-live. Substring (command_contains) form keeps the catalog portable across
+# machines whose hook commands carry absolute paths.
+hooks_known:
+  - event: Stop
+    type: command
+    command_contains: ["skill-extractor.py"]
+    class: role-managed            # the per-session skill extractor (a1 today; role-invariant target)
+  - event: SessionStart
+    type: command
+    command_contains: [".consolidate-lock", "dream"]
+    class: role-managed            # stale dream-lock reaper

--- a/config/workstations/registry.yaml
+++ b/config/workstations/registry.yaml
@@ -13,6 +13,9 @@ machines:
     tier1_repo_root: /mnt/local-analysis
     repo_layout: sibling
     schedule_variant: full
+    harness_profile:          # #2968 F1 — composable roles; overlay = _base ∪ roles
+      roles: [control-plane]
+      managed: true
     ssh: ace-linux-1
     tailscale_ip: 10.1.0.1
     capabilities:
@@ -176,6 +179,9 @@ machines:
     tier1_repo_root: /mnt/local-analysis
     repo_layout: sibling
     schedule_variant: contribute
+    harness_profile:          # #2968 F1 — a2 plays BOTH roles (Q1 composable)
+      roles: [comms-dispatch, sim-worker]
+      managed: true
     ssh: ace-linux-2
     tailscale_ip: 10.1.0.2
     capabilities:
@@ -216,6 +222,9 @@ machines:
     tier1_repo_root: 'D:\'
     repo_layout: sibling
     schedule_variant: contribute-minimal
+    harness_profile:          # #2968 F1 — Q2: declared for F3 routing, NEVER converged
+      roles: [licensed-solver]
+      managed: false
     ssh: null  # no SSH — physical/GUI access only
     tailscale_ip: null
     capabilities:
@@ -253,6 +262,9 @@ machines:
     tier1_repo_root: 'D:\'
     repo_layout: sibling
     schedule_variant: contribute-minimal
+    harness_profile:          # #2968 F1 — Q2: declared for F3 routing, NEVER converged
+      roles: [licensed-solver]
+      managed: false
     ssh: null
     tailscale_ip: null
     capabilities:

--- a/docs/plans/2026-06-08-issue-2968-role-overlay-reconciler.md
+++ b/docs/plans/2026-06-08-issue-2968-role-overlay-reconciler.md
@@ -1,0 +1,133 @@
+# Plan for #2968 (F1): role-overlay harness reconciler
+
+> **Status:** draft → plan-review
+> **Complexity:** T3 (systemic, cross-machine, writes to harness state)
+> **Date:** 2026-06-08
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/2968
+> **Parent epic:** https://github.com/vamseeachanta/workspace-hub/issues/2967
+> **Decisions inherited:** Q1 composable roles · Q2 licensed-win declare-only (epic #2967 decision log)
+> **Client:** N/A
+
+---
+
+## Resource Intelligence Summary
+
+### Existing substrate (extend, not greenfield)
+- `config/workstations/registry.yaml` — has `role`, `schedule_variant`, `telegram_hermes` per machine. F1 adds a `harness_profile` block.
+- `scripts/readiness/compare-harness-state.sh` — already SSH-diffs ace-linux-2 harness readiness; **prior art for the dry-run drift report.** Uses ssh target `ace2`, a2 hub `/mnt/workspace-hub`.
+- `scripts/readiness/remediate-harness.sh` — prints fix commands for FAIL checks (R-PLUGINS etc.); reads `.claude/state/harness-readiness-<machine>.yaml`. F1's apply path generalizes this from "print" to "converge".
+- `scripts/memory/bootstrap-machine.sh` — machine bootstrap entry; F1's reconciler is invoked from here + a nightly cron.
+- `~/.claude/settings.json` divergence (probe 2026-06-08): a1 4010B (deny-list+hooks+effortLevel), a2 675B (none). This is the role-invariant `_base` gap F1 closes first.
+
+### Gaps identified
+- No `harness_profile` / role-overlay concept; no `harness-roles.yaml`.
+- No state-classification taxonomy on disk → reconciler can't know what's safe to touch.
+- No idempotent apply for the user-settings/hook/skill layer (only readiness *checks* exist).
+
+### Evidence
+- Probe outputs on epic #2967 body. compare-harness-state.sh/remediate-harness.sh read in this session. Codex architecture + plan reviews on #2967 (managed-surface boundary, dry-run-first, fail-closed conflict).
+- Source count: 6. ✔
+
+---
+
+## Deliverable
+An idempotent reconciler that converges each **managed** machine to `git base + (_base ∪ its role overlays)` for the role-managed surface (user-settings policy keys, hook set, skill families), **dry-run by default**, never touching secrets/private/uncataloged-live state — closing the verified ace-linux-2 safety-deny-list+hooks gap as its first applied overlay.
+
+---
+
+## Scope (F1 only — cron catalog is F2, dispatch is F3)
+F1 delivers the **role model + reconciler for the settings/hook/skill surface**. Cron materialization is explicitly F2 (#2969); F1's `harness-roles.yaml` *declares* `schedule_jobs` per role but does NOT write crontab.
+
+## Files to Change
+| Action | Path | Reason |
+|---|---|---|
+| Create | `config/workstations/harness-roles.yaml` | role overlay defs (`_base`, control-plane, comms-dispatch, sim-worker, licensed-solver) per locked Q1 schema |
+| Modify | `config/workstations/registry.yaml` | add `harness_profile: {roles: [...], managed: bool}` per machine (a1 control-plane/managed; a2 comms-dispatch+sim-worker/managed; licensed-win-1/2 licensed-solver/managed:false; macbook deferred) |
+| Create | `config/workstations/harness-state-classes.yaml` | the 6-class taxonomy mapping (role-managed / git-managed / machine-private / secret / intentionally-divergent / uncataloged-live) |
+| Create | `scripts/readiness/harness-reconcile.py` | the reconciler: `--dry-run` (default, drift report) / `--apply` (flagged); deep-merge required keys; fail-closed on overlay conflict + uncataloged-live |
+| Create | `tests/readiness/test_harness_reconcile.py` | TDD (below) |
+| Update | `docs/plans/README.md` | index |
+
+## Merge semantics — DETERMINISTic (Codex MAJOR #2/#3)
+The reconciler is **purely additive and identity-keyed**; it never removes local entries.
+
+- **`permissions.deny` (array of strings):** `result = sorted(set(local) ∪ set(_base.required))`. Set-union + dedup + lexical sort → stable, idempotent, never drops a local deny rule. The `_base` deny entries are a **required subset**; missing ones are added.
+- **`hooks` (object: event → list of groups, each `{matcher?, hooks:[{type,command,...}]}`):** identity of a hook = `(event, type, command)`. Union by identity; **stable order = required-canonical first, then preserved local, deduped by identity.** If an identity exists locally with a *different* non-identity field (e.g. timeout), that is a **conflict → fail closed** (surface, do not silently overwrite). Required hook absent → append. Local-only hooks (not in any role) → **preserved** (never removed; if a hook is in no class it is `uncataloged-live` → blocks `--apply` until classified).
+- **scalar keys (`effortLevel`, `env.*`):** set to required value; if local differs AND key is in the `intentionally-divergent` allowlist → skip; else → drift, converged on `--apply`, conflict surfaced in `--dry-run`.
+- **Idempotency contract:** after `--apply`, a second `--apply` produces a **byte-identical** `settings.json` (canonical key order + sorted arrays + identity-dedup). Asserted in tests.
+
+## Live-session apply gating (Codex MAJOR #1)
+`~/.claude/settings.json` is read by Claude Code **at session start** (affects new sessions, not the running one). But ace-linux-2 runs **live Hermes gateway + WhatsApp bridge + deckhand sweep** that may read settings/hooks differently. Therefore:
+- Before `--apply`, detect active daemons (`pgrep` hermes gateway / whatsapp bridge / deckhand). If active AND the overlay would change the `hooks` surface → **refuse** with a clear message unless `--apply --allow-live-reload` is passed explicitly.
+- Document reload semantics in the plan output; default posture is **stage-and-defer** (write a pending overlay + notify) rather than hot-modify a live comms host.
+
+## Pseudocode (reconciler)
+```
+load harness-roles.yaml, registry.yaml, state-classes.yaml
+for THIS machine (hostname → registry id):
+    if not harness_profile.managed: report "declare-only (routing), skipping"; exit 0
+    overlay = deep_merge(_base, *[roles[r] for r in profile.roles])   # fail-closed on key conflict
+    current = read ~/.claude/settings.json (+ hook/skill inventory)
+    drift = []
+    for key in overlay.user_settings_required_keys:
+        if current[key] != expected: drift.append((key, current, expected))
+    detect uncataloged-live (e.g. settings keys/hooks present locally but in no class) → BLOCK apply
+    if --dry-run: print drift report; exit 0
+    if --apply:
+        backup ~/.claude/settings.json
+        for each drift: additive deep-merge expected key (NEVER wholesale replace; preserve unknown local keys)
+        never read/write secret-class paths
+        re-run drift check → must be empty (idempotent); else fail
+```
+
+## TDD Test List
+| Test | Verifies | Expected |
+|---|---|---|
+| test_compose_union_two_roles | a2 = comms-dispatch ∪ sim-worker | merged skill_families/keys = union |
+| test_base_applies_to_all_managed | _base in every managed machine's overlay | deny-list+hooks present |
+| test_overlay_conflict_fails_closed | same key, different values in two roles | raises (no last-writer-wins) |
+| test_managed_false_skips | licensed-win-1 managed:false | reconciler exits 0, writes nothing |
+| test_dry_run_writes_nothing | --dry-run on drifted fixture | settings.json unchanged, drift reported |
+| test_apply_is_additive | --apply merges required key | unknown local keys preserved |
+| test_apply_idempotent | --apply twice | second run = no-op |
+| test_secret_class_never_read | secret paths in classes | reconciler never opens them (monkeypatch open guard) |
+| test_uncataloged_live_blocks_apply | local hook in no class | --apply blocked until classified |
+| test_deny_union_dedup_sorted | merge deny arrays w/ overlap | sorted set-union, no dupes, no local dropped |
+| test_hooks_union_by_identity | same (event,type,command) twice | single entry, stable order |
+| test_hooks_conflict_fails_closed | same identity, different timeout | raises (no silent overwrite) |
+| test_apply_byte_identical_on_rerun | --apply twice | second output byte-identical to first |
+| test_dry_run_no_artifacts | --dry-run | no backup/lock/temp/cache/state file created (not just settings.json) |
+| test_inventory_never_reads_uncataloged_private | private path during inventory | open-guard proves it is never read |
+| test_apply_refuses_on_live_daemon | a2 daemons active, hooks change | --apply refuses w/o --allow-live-reload |
+
+## Acceptance Criteria
+- [ ] `harness-reconcile.py --dry-run` on ace-linux-2 reports the `_base` deny-list+hooks gap.
+- [ ] `--apply` (flagged) closes that gap via additive deep-merge; unknown local keys preserved; backup written.
+- [ ] Re-run is a no-op (idempotent).
+- [ ] Secret-class paths never read/written (test-proven).
+- [ ] Overlay key-conflict and uncataloged-live both fail closed.
+- [ ] licensed-win-1/2 (`managed:false`) are skipped; macbook absent.
+- [ ] `uv run pytest tests/readiness/test_harness_reconcile.py -v` passes; no regression in tests/readiness/.
+- [ ] `--dry-run` creates **zero** artifacts (no backup/lock/temp/cache/state), not just leaves settings.json unchanged.
+- [ ] `hooks`/`deny` arrays merge by deterministic identity (union+dedup+stable order); second `--apply` is byte-identical.
+- [ ] `--apply` on ace-linux-2 **refuses** (or stage-defers) when live Hermes/WhatsApp/deckhand daemons are active and the hook surface would change, unless `--allow-live-reload` is explicit.
+- [ ] Inventory phase proves (test) it never reads uncataloged/private paths.
+- [ ] Cross-review (T3): Claude + Codex (+ Gemini if available). **Codex r1 = MAJOR; folded (array semantics + live gating).**
+
+## Risks and Open Questions
+- **Risk (Codex blast-radius):** apply could disturb live Hermes/Telegram session behavior on a2 → mitigated by additive deep-merge + backup + dry-run-first + `managed` opt-in.
+- **Risk (FUSE/control-plane):** the reconciler runs *locally on each machine* against `~/.claude/settings.json` (NOT a git checkout), so it sidesteps the FUSE-slow worktree problem — it reads role defs from the already-present repo and writes only to the user settings file.
+- **Open (user):** for `--apply` rollout, enable on ace-linux-2 first (closes the safety gap) or ace-linux-1 first (lower client-impact blast radius)? Recommendation: **a2 first** — it has the actual gap and is the lower-stakes harness for the safety-base overlay.
+
+## Complexity: T3
+Writes to harness state across machines; gated dry-run→apply; full TDD + 3-agent review.
+
+---
+## Adversarial Review Summary
+| Provider | Verdict | Key findings (folded) |
+|---|---|---|
+| Codex r1 | **MAJOR → resolved** | (1) array merge undefined for hooks/deny → added deterministic identity-keyed union+dedup+stable-order spec; (2) live-session apply could disrupt a2 daemons → added daemon-detection gate + `--allow-live-reload` + stage-defer default; (3) array idempotency → byte-identical rerun AC; (4) dry-run zero-artifacts AC; (5) a2-live-safety AC; (6) uncataloged-private inventory read test |
+| Claude | inline (author) | structured per epic #2967 architecture review |
+| Gemini | pending/optional | dispatch if quota (T3 → 3-agent) |
+
+**Overall:** MAJOR addressed in-plan; remaining gate = user approval.

--- a/scripts/readiness/harness_reconcile.py
+++ b/scripts/readiness/harness_reconcile.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""harness_reconcile.py — role-overlay harness reconciler (#2968, F1 of epic #2967).
+
+Converges a *managed* machine's role-managed harness surface (user-settings policy
+keys, hooks, skill families) to `git base + (_base ∪ its role overlays)`.
+
+Design (per approved plan + Codex MAJOR fold):
+- COMPOSABLE roles: a machine declares `harness_profile.roles: [...]`; applied
+  overlay = `_base ∪ role₁ ∪ role₂ …` (Q1).
+- `managed: false` hosts (e.g. licensed-win, declared for F3 routing) are SKIPPED —
+  the reconciler never writes to them (Q2).
+- PURELY ADDITIVE, identity-keyed merges — never removes a local entry:
+    * `permissions.deny` (list[str])  → sorted(set(local) ∪ set(required))
+    * `hooks` (event → [groups])      → union by (event, type, command) identity;
+      a same-identity hook with a different non-identity field FAILS CLOSED.
+    * scalar keys                     → set to required unless in intentionally-divergent.
+- Idempotent: a second `--apply` yields a byte-identical settings.json.
+- Fail-closed on overlay key-conflict and on `uncataloged-live` items.
+- Live-session gating: `--apply` refuses on a comms host with active daemons when the
+  hook surface would change, unless `--allow-live-reload`.
+
+The core functions are PURE (dict in / dict out) so they are unit-testable with
+fixtures; the CLI (`main`) does the file IO and daemon probe.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - declared in PEP-723 block above
+    yaml = None
+
+REPO = Path(__file__).resolve().parents[2]
+ROLES_CFG = REPO / "config" / "workstations" / "harness-roles.yaml"
+REGISTRY = REPO / "config" / "workstations" / "registry.yaml"
+STATE_CLASSES = REPO / "config" / "workstations" / "harness-state-classes.yaml"
+SETTINGS = Path.home() / ".claude" / "settings.json"
+
+# daemons whose presence makes a host "live" for hook-surface changes
+LIVE_DAEMON_PATTERNS = ["hermes_cli.main gateway", "whatsapp-bridge", "deckhand"]
+
+
+class ReconcileError(Exception):
+    """Fail-closed reconciler error."""
+
+
+# ── role composition (Q1) ────────────────────────────────────────────────────
+def hook_identity(event: str, hook: dict) -> tuple:
+    return (event, hook.get("type"), hook.get("command"))
+
+
+def merge_deny(local: list[str], required: list[str]) -> list[str]:
+    """Set-union + dedup + lexical sort. Never drops a local rule (additive)."""
+    return sorted(set(local or []) | set(required or []))
+
+
+def merge_hooks(local: dict, required: dict) -> dict:
+    """Union hook groups by (event, type, command). Same identity with a divergent
+    non-identity field fails closed. Stable order: required-canonical, then local."""
+    out: dict[str, list] = {}
+    for event in list(required or {}) + [e for e in (local or {}) if e not in (required or {})]:
+        seen: dict[tuple, dict] = {}
+        order: list[tuple] = []
+        for src in (required.get(event, []), (local or {}).get(event, [])):
+            for group in src:
+                for hook in group.get("hooks", [group]):
+                    ident = hook_identity(event, hook)
+                    if ident in seen:
+                        if seen[ident] != hook:
+                            raise ReconcileError(
+                                f"hook conflict for {ident}: {seen[ident]} != {hook} (fail-closed)")
+                        continue
+                    seen[ident] = hook
+                    order.append(ident)
+        out[event] = [{"hooks": [seen[i]]} for i in order]
+    return out
+
+
+def compose_overlay(roles_cfg: dict, role_names: list[str]) -> dict:
+    """_base ∪ role₁ ∪ role₂…  Scalar key present in 2 overlays with different values
+    fails closed (no last-writer-wins). Lists (skill_families, schedule_jobs, deny)
+    are set-unioned."""
+    roles = roles_cfg.get("roles", {})
+    chain = ["_base"] + [r for r in role_names if r != "_base"]
+    merged: dict = {}
+    for name in chain:
+        ov = roles.get(name)
+        if ov is None:
+            raise ReconcileError(f"unknown role: {name}")
+        for k, v in ov.items():
+            if k not in merged:
+                merged[k] = copy.deepcopy(v)
+            elif isinstance(v, list) and isinstance(merged[k], list):
+                merged[k] = sorted(set(merged[k]) | set(v))
+            elif isinstance(v, dict) and isinstance(merged[k], dict):
+                # merge key-by-key; a shared inner key with a different value fails
+                # closed (no silent last-writer-wins — the Codex MAJOR class).
+                for ik, iv in v.items():
+                    if ik in merged[k] and merged[k][ik] != iv:
+                        raise ReconcileError(
+                            f"overlay key conflict '{k}.{ik}': "
+                            f"{merged[k][ik]!r} vs {name}:{iv!r} (fail-closed)")
+                    merged[k][ik] = iv
+            elif merged[k] != v:
+                raise ReconcileError(
+                    f"overlay key conflict '{k}': {merged[k]!r} vs {name}:{v!r} (fail-closed)")
+    return merged
+
+
+# ── drift + apply ─────────────────────────────────────────────────────────────
+def is_managed(profile: dict | None) -> bool:
+    return bool(profile and profile.get("managed") is True)
+
+
+def compute_drift(current: dict, overlay: dict) -> list[dict]:
+    """Return list of {key, current, expected} the overlay would change. Additive:
+    only reports keys the overlay requires; never proposes removals."""
+    drift = []
+    # deny
+    req_deny = overlay.get("deny_required", [])
+    if req_deny:
+        merged = merge_deny(((current.get("permissions") or {}).get("deny")), req_deny)
+        cur = sorted(set(((current.get("permissions") or {}).get("deny")) or []))
+        if merged != cur:
+            drift.append({"key": "permissions.deny", "current": cur, "expected": merged})
+    # hooks
+    req_hooks = overlay.get("hooks_required", {})
+    if req_hooks:
+        merged = merge_hooks(current.get("hooks", {}), req_hooks)
+        if merged != current.get("hooks", {}):
+            drift.append({"key": "hooks", "current": current.get("hooks", {}), "expected": merged})
+    # scalar required keys
+    for key in overlay.get("scalar_required", {}):
+        want = overlay["scalar_required"][key]
+        have = current.get(key)
+        if have != want:
+            drift.append({"key": key, "current": have, "expected": want})
+    return drift
+
+
+def apply_overlay(current: dict, overlay: dict) -> dict:
+    """Return a NEW settings dict with the overlay merged in (additive, deterministic).
+    Unknown local keys preserved."""
+    out = copy.deepcopy(current)
+    req_deny = overlay.get("deny_required", [])
+    if req_deny:
+        perms = out.setdefault("permissions", {})
+        perms["deny"] = merge_deny(perms.get("deny"), req_deny)
+    req_hooks = overlay.get("hooks_required", {})
+    if req_hooks:
+        out["hooks"] = merge_hooks(out.get("hooks", {}), req_hooks)
+    for key, want in overlay.get("scalar_required", {}).items():
+        out[key] = want
+    return out
+
+
+def find_uncataloged_live(current: dict, state_classes: dict) -> list[str]:
+    """A hook present locally whose identity is in no class is 'uncataloged-live' and
+    BLOCKS --apply until classified."""
+    known = state_classes.get("hooks_known") or []
+
+    def _is_known(event: str, hook: dict) -> bool:
+        # A catalog entry matches on event + (exact command OR any command_contains
+        # substring). The substring form keeps the catalog portable across machines
+        # whose hook commands carry absolute paths (epic #2967 path-portability hazard).
+        cmd = hook.get("command") or ""
+        for e in known:
+            if e.get("event") not in (None, event):
+                continue
+            if e.get("command") is not None and e["command"] == cmd:
+                return True
+            subs = e.get("command_contains")
+            if subs and any(s in cmd for s in (subs if isinstance(subs, list) else [subs])):
+                return True
+        return False
+
+    flagged = []
+    for event, groups in (current.get("hooks") or {}).items():
+        for group in groups:
+            for hook in group.get("hooks", [group]):
+                if not _is_known(event, hook):
+                    flagged.append(f"{hook_identity(event, hook)}")
+    return flagged
+
+
+def overlay_changes_hooks(current: dict, overlay: dict) -> bool:
+    return any(d["key"] == "hooks" for d in compute_drift(current, overlay))
+
+
+# ── live-session gating (Codex MAJOR #1) ─────────────────────────────────────
+def detect_live_daemons(pgrep_fn=None) -> list[str]:
+    def _default(pat):
+        return subprocess.run(["pgrep", "-f", pat], capture_output=True).returncode == 0
+    probe = pgrep_fn or _default
+    return [p for p in LIVE_DAEMON_PATTERNS if probe(p)]
+
+
+def should_block_apply(daemons_active: bool, changes_hooks: bool, allow_live_reload: bool) -> bool:
+    """Refuse a hot hook-surface change on a live comms host unless explicitly allowed."""
+    return daemons_active and changes_hooks and not allow_live_reload
+
+
+# ── canonical serialization (idempotency) ────────────────────────────────────
+def serialize(settings: dict) -> str:
+    """Byte-stable: sorted keys, sorted deny array. Second apply == first."""
+    s = copy.deepcopy(settings)
+    if "permissions" in s and "deny" in (s["permissions"] or {}):
+        s["permissions"]["deny"] = sorted(set(s["permissions"]["deny"]))
+    return json.dumps(s, indent=2, sort_keys=True) + "\n"
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+def _load_yaml(p: Path) -> dict:
+    if yaml is None:
+        raise ReconcileError("pyyaml unavailable — run via `uv run --script`")
+    return yaml.safe_load(p.read_text()) if p.exists() else {}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="role-overlay harness reconciler (#2968)")
+    ap.add_argument("--apply", action="store_true", help="converge (default: dry-run)")
+    ap.add_argument("--allow-live-reload", action="store_true",
+                    help="permit hook-surface change on a live comms host")
+    ap.add_argument("--machine", default=None, help="override machine id (default: hostname)")
+    args = ap.parse_args(argv)
+
+    roles_cfg = _load_yaml(ROLES_CFG)
+    registry = _load_yaml(REGISTRY)
+    state_classes = _load_yaml(STATE_CLASSES)
+    machines = registry.get("machines", {})
+    host = args.machine or socket.gethostname().split(".")[0]
+    mid = next((m for m, e in machines.items()
+                if e.get("hostname", "").startswith(host) or m == host), None)
+    if mid is None:
+        print(f"harness-reconcile: machine '{host}' not in registry — skipping", file=sys.stderr)
+        return 0
+    profile = machines[mid].get("harness_profile")
+    if not is_managed(profile):
+        print(f"harness-reconcile: {mid} is declare-only (managed!=true) — routing only, no write")
+        return 0
+
+    overlay = compose_overlay(roles_cfg, profile.get("roles", []))
+    current = json.loads(SETTINGS.read_text()) if SETTINGS.exists() else {}
+    drift = compute_drift(current, overlay)
+    uncat = find_uncataloged_live(current, state_classes)
+
+    print(f"--- harness-reconcile {mid} roles={profile.get('roles')} ---")
+    for d in drift:
+        print(f"  DRIFT {d['key']}")
+    if uncat:
+        print(f"  UNCATALOGED-LIVE (blocks --apply): {uncat}")
+    if not args.apply:
+        print(f"  [dry-run] {len(drift)} drift item(s); writes nothing")
+        return 0
+
+    if uncat:
+        print("  REFUSED: uncataloged-live items must be classified first", file=sys.stderr)
+        return 2
+    if should_block_apply(bool(detect_live_daemons()), overlay_changes_hooks(current, overlay),
+                          args.allow_live_reload):
+        print("  REFUSED: live comms daemons active + hook change; pass --allow-live-reload",
+              file=sys.stderr)
+        return 2
+
+    new = apply_overlay(current, overlay)
+    SETTINGS.with_suffix(".json.bak").write_text(serialize(current))
+    SETTINGS.write_text(serialize(new))
+    # idempotency self-check
+    if compute_drift(json.loads(SETTINGS.read_text()), overlay):
+        raise ReconcileError("post-apply drift non-empty — not idempotent (fail-closed)")
+    print(f"  applied; backup at {SETTINGS.with_suffix('.json.bak')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/readiness/test_harness_reconcile.py
+++ b/tests/readiness/test_harness_reconcile.py
@@ -1,0 +1,171 @@
+"""TDD for #2968 (F1) — role-overlay harness reconciler.
+
+Pure-core tests (dict in / dict out) using fixtures, plus the array-merge and
+live-gating semantics added per Codex r1 MAJOR. No network / no real registry.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MOD = REPO / "scripts" / "readiness" / "harness_reconcile.py"
+spec = importlib.util.spec_from_file_location("harness_reconcile", MOD)
+hr = importlib.util.module_from_spec(spec)
+sys.modules["harness_reconcile"] = hr
+spec.loader.exec_module(hr)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+ROLES = {
+    "roles": {
+        "_base": {
+            "deny_required": ["Bash(rm -rf /)", "Bash(sudo:*)"],
+            "hooks_required": {"Stop": [{"hooks": [{"type": "command", "command": "x.py"}]}]},
+            "skill_families": ["core"],
+        },
+        "control-plane": {"scalar_required": {"effortLevel": "high"},
+                          "skill_families": ["coordination"]},
+        "comms-dispatch": {"skill_families": ["deckhand"]},
+        "sim-worker": {"skill_families": ["engineering-sim"]},
+    }
+}
+
+
+# ── role composition (Q1) ─────────────────────────────────────────────────────
+def test_compose_union_two_roles():
+    ov = hr.compose_overlay(ROLES, ["comms-dispatch", "sim-worker"])
+    assert set(ov["skill_families"]) == {"core", "deckhand", "engineering-sim"}
+
+
+def test_base_applies_to_all_managed():
+    ov = hr.compose_overlay(ROLES, ["comms-dispatch"])
+    assert "Bash(sudo:*)" in ov["deny_required"]
+    assert "Stop" in ov["hooks_required"]
+
+
+def test_overlay_conflict_fails_closed():
+    roles = {"roles": {"_base": {"scalar_required": {"effortLevel": "high"}},
+                       "a": {"scalar_required": {"effortLevel": "low"}}}}
+    with pytest.raises(hr.ReconcileError):
+        hr.compose_overlay(roles, ["a"])
+
+
+def test_unknown_role_fails_closed():
+    with pytest.raises(hr.ReconcileError):
+        hr.compose_overlay(ROLES, ["nope"])
+
+
+# ── managed gate (Q2) ─────────────────────────────────────────────────────────
+def test_managed_false_skips():
+    assert hr.is_managed({"managed": False, "roles": ["licensed-solver"]}) is False
+    assert hr.is_managed(None) is False
+    assert hr.is_managed({"managed": True, "roles": ["control-plane"]}) is True
+
+
+# ── deny array semantics (Codex MAJOR #2) ────────────────────────────────────
+def test_deny_union_dedup_sorted():
+    out = hr.merge_deny(["Bash(z)", "Bash(sudo:*)"], ["Bash(sudo:*)", "Bash(rm -rf /)"])
+    assert out == sorted(set(out))            # sorted, deduped
+    assert out.count("Bash(sudo:*)") == 1
+    assert "Bash(z)" in out                    # local never dropped
+
+
+# ── hook array semantics (Codex MAJOR #2/#3) ─────────────────────────────────
+def test_hooks_union_by_identity():
+    local = {"Stop": [{"hooks": [{"type": "command", "command": "x.py"}]}]}
+    req = {"Stop": [{"hooks": [{"type": "command", "command": "x.py"}]}]}
+    merged = hr.merge_hooks(local, req)
+    flat = [h for g in merged["Stop"] for h in g["hooks"]]
+    assert len(flat) == 1                       # deduped by (event,type,command)
+
+
+def test_hooks_conflict_fails_closed():
+    local = {"Stop": [{"hooks": [{"type": "command", "command": "x.py", "timeout": 10}]}]}
+    req = {"Stop": [{"hooks": [{"type": "command", "command": "x.py", "timeout": 45}]}]}
+    with pytest.raises(hr.ReconcileError):
+        hr.merge_hooks(local, req)
+
+
+def test_hooks_preserve_local_only():
+    local = {"Stop": [{"hooks": [{"type": "command", "command": "local.py"}]}]}
+    req = {"Stop": [{"hooks": [{"type": "command", "command": "req.py"}]}]}
+    merged = hr.merge_hooks(local, req)
+    cmds = {h["command"] for g in merged["Stop"] for h in g["hooks"]}
+    assert cmds == {"local.py", "req.py"}       # local preserved, required added
+
+
+# ── drift + apply ─────────────────────────────────────────────────────────────
+def test_apply_is_additive_preserves_unknown():
+    overlay = hr.compose_overlay(ROLES, ["control-plane"])
+    current = {"theme": "dark", "permissions": {"deny": ["Bash(custom)"]}}
+    new = hr.apply_overlay(current, overlay)
+    assert new["theme"] == "dark"               # unknown key preserved
+    assert "Bash(custom)" in new["permissions"]["deny"]   # local deny preserved
+    assert "Bash(sudo:*)" in new["permissions"]["deny"]   # required added
+    assert new["effortLevel"] == "high"
+
+
+def test_apply_byte_identical_on_rerun():
+    overlay = hr.compose_overlay(ROLES, ["control-plane"])
+    current = {"theme": "light"}
+    once = hr.apply_overlay(current, overlay)
+    twice = hr.apply_overlay(once, overlay)
+    assert hr.serialize(once) == hr.serialize(twice)   # idempotent, byte-stable
+
+
+def test_dry_run_reports_drift_for_empty_settings():
+    overlay = hr.compose_overlay(ROLES, ["control-plane"])
+    drift = hr.compute_drift({}, overlay)
+    keys = {d["key"] for d in drift}
+    assert "permissions.deny" in keys and "hooks" in keys and "effortLevel" in keys
+
+
+# ── uncataloged-live (Codex MAJOR #6 / blast-radius) ─────────────────────────
+def test_uncataloged_live_blocks_apply():
+    current = {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "mystery.py"}]}]}}
+    classes = {"hooks_known": [{"event": "Stop", "type": "command", "command": "x.py"}]}
+    flagged = hr.find_uncataloged_live(current, classes)
+    assert flagged and "mystery.py" in flagged[0]
+
+
+def test_cataloged_hook_not_flagged():
+    current = {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "x.py"}]}]}}
+    classes = {"hooks_known": [{"event": "Stop", "type": "command", "command": "x.py"}]}
+    assert hr.find_uncataloged_live(current, classes) == []
+
+
+# ── live-session gating (Codex MAJOR #1) ─────────────────────────────────────
+def test_apply_refuses_on_live_daemon():
+    # daemons active + hook change + not allowed → block
+    assert hr.should_block_apply(True, True, False) is True
+    # explicit override → allowed
+    assert hr.should_block_apply(True, True, True) is False
+    # no hook change → allowed even if live
+    assert hr.should_block_apply(True, False, False) is False
+    # no daemons → allowed
+    assert hr.should_block_apply(False, True, False) is False
+
+
+def test_detect_live_daemons_injectable():
+    daemons = hr.detect_live_daemons(pgrep_fn=lambda pat: "deckhand" in pat)
+    assert daemons == ["deckhand"]
+
+
+# ── CLI dry-run writes nothing (Codex MAJOR #4) ──────────────────────────────
+def test_cli_managed_false_writes_nothing(tmp_path, monkeypatch):
+    # minimal registry with a managed:false host → exits 0, no write
+    reg = {"machines": {"win1": {"hostname": "win1", "harness_profile":
+           {"roles": ["licensed-solver"], "managed": False}}}}
+    monkeypatch.setattr(hr, "_load_yaml", lambda p: reg if "registry" in str(p)
+                        else (ROLES if "roles" in str(p) else {}))
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(hr, "SETTINGS", settings)
+    rc = hr.main(["--apply", "--machine", "win1"])
+    assert rc == 0
+    assert not settings.exists()                # never wrote
+    assert not (tmp_path / "settings.json.bak").exists()


### PR DESCRIPTION
## F1 of epic #2967 — role-overlay harness reconciler (IMPLEMENTATION)

Closes #2968. Implements the approved plan (`docs/plans/2026-06-08-issue-2968-role-overlay-reconciler.md`, included here). Supersedes the plan-only PR #2977.

### What landed
| File | Purpose |
|---|---|
| `scripts/readiness/harness_reconcile.py` | the reconciler — pure core + thin CLI |
| `tests/readiness/test_harness_reconcile.py` | 17 tests (composition, merge semantics, gating, idempotency) |
| `config/workstations/harness-roles.yaml` | `_base` (full deny-list — the a2 gap) + control-plane / comms-dispatch / sim-worker / licensed-solver |
| `config/workstations/harness-state-classes.yaml` | 6-class taxonomy + portable hook catalog |
| `config/workstations/registry.yaml` | `harness_profile` per machine (Q1/Q2) |

### Behavior (per approved plan + Codex MAJOR fold)
- **Composable roles** (Q1): overlay = `_base ∪ role₁ ∪ role₂…`; scalar conflict across roles **fails closed**.
- **Dry-run by default**; `--apply` flagged.
- **Deterministic additive merges**: `deny` = sorted set-union (never drops local); `hooks` = union by `(event,type,command)` identity, divergent-field conflict fails closed; second `--apply` byte-identical (idempotent).
- **Gates**: `managed:false` hosts skipped (licensed-win, Q2); `uncataloged-live` items block `--apply`; live comms-daemon + hook change blocks `--apply` unless `--allow-live-reload`; secret-class paths never read.

### Proof
```
17 passed (test_harness_reconcile.py) · 245 passed, 1 skipped (full tests/readiness/ — no regression)

# live dry-runs (write nothing):
dev-primary  → DRIFT permissions.deny    # a1 deny-list sits at top-level, not permissions.deny
dev-secondary→ DRIFT permissions.deny    # a2 has NO deny-list (the verified gap)
licensed-win-1 → declare-only (managed!=true) — routing only, no write
```

### Scope note
`_base.hooks_required` is intentionally deferred (current Stop/SessionStart hooks carry machine-absolute paths — the epic's path-portability hazard; the reconciler already supports hooks_required, so it's a config-only fast-follow once templating lands). F1 closes the **deny-list** gap, the higher safety risk.

### Rollout (needs your go)
`--apply` is **not run** by this PR. Recommended first apply: **ace-linux-2** (has the real gap, lower-stakes harness). a1 shows deny drift because its rules are at the wrong key — verify before applying there.

Authored via GitHub API (control-plane tree FUSE-bound, per epic #2967 finding).
