### PR TITLE
feat(dispatch): registry-driven dispatch + single provider-routing policy (#2970, F3)

### DIFF
--- a/config/ai-tools/provider-routing-policy.yaml
+++ b/config/ai-tools/provider-routing-policy.yaml
@@ -1,0 +1,84 @@
+# Provider Routing Policy — single machine-readable source of truth (#2970 / F3)
+#
+# Goal: every machine/agent routes AI providers IDENTICALLY ("consistent
+# AI-provider experience"). The prose contract lives in
+#   docs/standards/AI_REVIEW_ROUTING_POLICY.md  (Claude=orchestrator,
+#   Codex=worker+adversarial-reviewer, Gemini=adversarial-reviewer; 3-agent
+#   default + reduction rules). This file encodes that contract as data so a
+#   resolver can route deterministically.
+#
+# Consumed by: scripts/ai/provider_route.py  (pure resolver + CLI).
+# Load-balancing input (ranking only): config/ai-tools/provider-routing-scorecard.json
+#   -> its `recommended_provider_order` can REORDER survivors but NEVER re-add a
+#      provider pruned by a hard machine constraint.
+#
+# Resolution contract (see provider_route.route()):
+#   1. SEED   from roles[task_type]            (ordered preference; fail closed)
+#   2. PRUNE  via machine_overrides[machine]   (hard constraints matched on attrs)
+#   3. RANK   via scorecard.recommended_provider_order (reorders survivors only)
+
+version: 1
+
+# ---------------------------------------------------------------------------
+# roles: task-type -> ordered provider preference.
+# Order is the DEFAULT ranking before any scorecard reordering. First entry is
+# the most-preferred provider for that task type.
+# ---------------------------------------------------------------------------
+roles:
+  orchestrate: [claude]                    # framing, sequencing, synthesis
+  plan:        [claude]                    # plan authoring (Claude is orchestrator)
+  implement:   [codex, claude]             # bounded implementation; Codex worker default
+  review:      [codex, gemini, claude]     # 3-agent adversarial review default
+  recon:       [gemini]                    # batched research / risk enumeration / scans
+  dispatch:    [hermes]                    # cross-provider dispatch / routing broker
+
+# ---------------------------------------------------------------------------
+# task_attributes: the typed attributes the resolver understands. Constraints
+# in machine_overrides match against these. Attrs are supplied per-call.
+# ---------------------------------------------------------------------------
+task_attributes:
+  authoring_weight:
+    type: enum
+    values: [light, heavy]
+    description: >-
+      How heavy the authoring load is. 'heavy' = large refactor / multi-file
+      generation / long-form authoring. 'light' = bounded edit, test-fix,
+      review, mechanical change. Used to fence providers off heavy authoring on
+      CPU-starved machines.
+  needs_large_context:
+    type: bool
+    description: >-
+      Whether the task needs a large context window (long-context synthesis,
+      whole-corpus review). Providers may be constrained on/off based on this.
+
+# ---------------------------------------------------------------------------
+# machine_overrides: per-machine HARD constraints. A constraint removes a
+# provider from the candidate list when its disallow condition matches the
+# call's attrs. These are PRUNE-stage rules — a pruned provider can never be
+# re-added by the scorecard.
+#
+# Constraint schema (per provider):
+#   <provider>:
+#     disallow_attrs: ["<attr>=<value>", ...]   # ALL must match attrs to prune
+#     reason: "<human-readable why>"
+#
+# disallow_attrs semantics: the provider is pruned IFF every "key=value" in the
+# list is present-and-equal in the call attrs (logical AND). An empty/absent
+# disallow_attrs means an UNCONDITIONAL disallow on that machine.
+# ---------------------------------------------------------------------------
+machine_overrides:
+  ace-linux-1:
+    codex:
+      # codex-exec is CPU-starved when nested under Claude on ace-linux-1
+      # (feedback_codex_exec_cpu_starved_in_claude_sandbox): heavy authoring
+      # writes nothing and gets killed. Route review/bounded work only here.
+      disallow_attrs: ["authoring_weight=heavy"]
+      reason: "codex-exec CPU-starved on ace-linux-1 — review/bounded only"
+
+# ---------------------------------------------------------------------------
+# reduction_rules: how to degrade the default multi-agent set. Advisory text
+# the orchestrator surfaces; the resolver does not silently apply these.
+# ---------------------------------------------------------------------------
+reduction_rules:
+  user_requests_lighter: "drop to 2-agent, document"
+  provider_unavailable:  "continue, record missing reviewer"

--- a/docs/standards/AI_REVIEW_ROUTING_POLICY.md
+++ b/docs/standards/AI_REVIEW_ROUTING_POLICY.md
@@ -8,6 +8,12 @@
 
 ---
 
+> **Machine-readable policy (#2970, F3):** the executable single-source for provider routing is
+> [`config/ai-tools/provider-routing-policy.yaml`](../../config/ai-tools/provider-routing-policy.yaml),
+> resolved by [`scripts/ai/provider_route.py`](../../scripts/ai/provider_route.py)
+> (`route(task_type, machine, attrs)`). This document remains the human-readable rationale;
+> when they differ, the YAML is authoritative for automated routing.
+
 ## Provider Roles
 
 | Provider | Role | Scope |

--- a/scripts/ai/provider_route.py
+++ b/scripts/ai/provider_route.py
@@ -72,6 +72,8 @@ def _constraint_matches(disallow_attrs: Any, attrs: dict) -> bool:
             f"disallow_attrs must be a list of 'key=value' strings, got {disallow_attrs!r}"
         )
     for clause in disallow_attrs:
+        if not isinstance(clause, str):  # #2970 code-review MINOR #4
+            raise ValueError(f"disallow_attrs clause must be a string, got {clause!r}")
         if "=" not in clause:
             raise ValueError(f"malformed disallow_attrs clause (need key=value): {clause!r}")
         key, _, want = clause.partition("=")
@@ -178,6 +180,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit JSON instead of plain text")
     parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="permit an empty provider list after hard-constraint pruning "
+             "(default: FAIL CLOSED so callers can't fall back to a pruned provider)",
+    )
+    parser.add_argument(
         "--policy", default=str(DEFAULT_POLICY_PATH), help="path to policy YAML"
     )
     parser.add_argument(
@@ -196,6 +204,17 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         parser.error(str(exc))
         return 2  # unreachable; parser.error exits
+
+    # #2970 code-review MINOR #3: fail closed on empty-after-prune so downstream
+    # callers can't interpret blank output as "use a default" and bypass a hard
+    # constraint that legitimately removed every provider.
+    if not providers and not args.allow_empty:
+        sys.stderr.write(
+            f"provider_route: no provider permitted for task '{args.task_type}' on "
+            f"'{args.machine}' after hard-constraint pruning (attrs={attrs}). "
+            f"Pass --allow-empty to permit an empty result.\n"
+        )
+        return 3
 
     if args.json:
         print(

--- a/scripts/ai/provider_route.py
+++ b/scripts/ai/provider_route.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""Provider-routing resolver (#2970 / F3).
+
+A SINGLE machine-readable provider-routing policy so every machine/agent routes
+AI providers identically. Pure resolver + thin CLI.
+
+Resolution contract (this ORDER is the contract — get it exactly right):
+
+  1. SEED   start from policy['roles'][task_type] (ordered provider list).
+            Unknown task_type -> ValueError (fail closed).
+  2. PRUNE  apply HARD constraints from policy['machine_overrides'][machine]
+            given `attrs`. A provider whose disallow condition matches the attrs
+            is REMOVED from the candidate list.
+  3. RANK   if a scorecard with 'recommended_provider_order' is provided,
+            reorder the SURVIVORS to follow that order. Providers not in the
+            scorecard keep their relative policy order, appended after. The
+            scorecard can ONLY reorder among survivors — it can NEVER re-add a
+            provider pruned in step 2.
+
+Policy file:    config/ai-tools/provider-routing-policy.yaml
+Scorecard file: config/ai-tools/provider-routing-scorecard.json (optional)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY_PATH = REPO_ROOT / "config" / "ai-tools" / "provider-routing-policy.yaml"
+DEFAULT_SCORECARD_PATH = REPO_ROOT / "config" / "ai-tools" / "provider-routing-scorecard.json"
+
+
+def load_policy(path: Path | str = DEFAULT_POLICY_PATH) -> dict:
+    """Load the routing policy YAML."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} did not parse to a mapping")
+    return data
+
+
+def load_scorecard(path: Path | str = DEFAULT_SCORECARD_PATH) -> dict | None:
+    """Load the load-balancing scorecard JSON, or None if absent."""
+    p = Path(path)
+    if not p.exists():
+        return None
+    with open(p, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _constraint_matches(disallow_attrs: Any, attrs: dict) -> bool:
+    """A hard constraint fires (prunes the provider) when its disallow condition
+    matches the call attrs.
+
+    disallow_attrs is a list of "key=value" strings. The constraint fires IFF
+    EVERY key=value is present-and-equal in attrs (logical AND). An empty or
+    absent list = UNCONDITIONAL disallow (always fires).
+    """
+    if not disallow_attrs:
+        return True  # unconditional disallow
+    if not isinstance(disallow_attrs, (list, tuple)):
+        raise ValueError(
+            f"disallow_attrs must be a list of 'key=value' strings, got {disallow_attrs!r}"
+        )
+    for clause in disallow_attrs:
+        if "=" not in clause:
+            raise ValueError(f"malformed disallow_attrs clause (need key=value): {clause!r}")
+        key, _, want = clause.partition("=")
+        key, want = key.strip(), want.strip()
+        if key not in attrs:
+            return False
+        # Compare as strings so 'authoring_weight=heavy' matches attrs={'authoring_weight':'heavy'}
+        # and bool-ish 'needs_large_context=true' matches True/'true'.
+        if str(attrs[key]).strip().lower() != want.lower():
+            return False
+    return True
+
+
+def route(
+    task_type: str,
+    machine: str,
+    attrs: dict | None = None,
+    policy: dict | None = None,
+    scorecard: dict | None = None,
+) -> list[str]:
+    """Resolve the ordered provider list for a task on a machine.
+
+    See module docstring for the SEED -> PRUNE -> RANK contract.
+
+    Args:
+        task_type: a key in policy['roles'] (e.g. 'review', 'implement').
+        machine:   machine id; looked up in policy['machine_overrides'].
+        attrs:     typed task attributes (e.g. {'authoring_weight': 'heavy'}).
+        policy:    parsed policy dict; loaded from the default path if None.
+        scorecard: parsed scorecard dict (with 'recommended_provider_order');
+                   load-balancing reorders survivors only. If None, no rerank.
+
+    Returns:
+        Ordered list of provider names. May be empty if every candidate was
+        pruned by a hard constraint.
+
+    Raises:
+        ValueError: unknown task_type (fail closed), or malformed policy.
+    """
+    attrs = attrs or {}
+    if policy is None:
+        policy = load_policy()
+
+    roles = policy.get("roles") or {}
+    if task_type not in roles:
+        known = ", ".join(sorted(roles)) or "(none)"
+        raise ValueError(
+            f"unknown task_type {task_type!r}; known task types: {known}"
+        )
+
+    # 1. SEED
+    candidates: list[str] = list(roles[task_type])
+
+    # 2. PRUNE — hard machine constraints matched against attrs
+    overrides = (policy.get("machine_overrides") or {}).get(machine) or {}
+    pruned: list[str] = []
+    for provider in candidates:
+        constraint = overrides.get(provider)
+        if constraint is not None and _constraint_matches(
+            constraint.get("disallow_attrs"), attrs
+        ):
+            continue  # hard-pruned
+        pruned.append(provider)
+
+    # 3. RANK — scorecard reorders survivors only; never re-adds a pruned provider
+    if scorecard:
+        order = scorecard.get("recommended_provider_order") or []
+        rank = {prov: i for i, prov in enumerate(order)}
+        # Stable sort: providers in the scorecard come first in scorecard order;
+        # providers absent from the scorecard keep their relative policy order,
+        # appended after (large sentinel rank, ties broken by original index).
+        big = len(rank)
+        pruned = sorted(
+            enumerate(pruned),
+            key=lambda pair: (rank.get(pair[1], big), pair[0]),
+        )
+        pruned = [prov for _, prov in pruned]
+
+    return pruned
+
+
+def _parse_attr(items: list[str] | None) -> dict:
+    """Parse --attr key=value pairs into a dict (string values)."""
+    out: dict[str, str] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise SystemExit(f"--attr must be key=value, got: {item!r}")
+        key, _, val = item.partition("=")
+        out[key.strip()] = val.strip()
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve the ordered AI-provider list for a task on a machine."
+    )
+    parser.add_argument("task_type", help="task type (key in policy roles), e.g. review")
+    parser.add_argument("machine", help="machine id, e.g. ace-linux-1")
+    parser.add_argument(
+        "--attr",
+        action="append",
+        metavar="key=value",
+        help="typed task attribute (repeatable), e.g. --attr authoring_weight=heavy",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of plain text")
+    parser.add_argument(
+        "--policy", default=str(DEFAULT_POLICY_PATH), help="path to policy YAML"
+    )
+    parser.add_argument(
+        "--scorecard",
+        default=str(DEFAULT_SCORECARD_PATH),
+        help="path to scorecard JSON (skipped if missing)",
+    )
+    args = parser.parse_args(argv)
+
+    attrs = _parse_attr(args.attr)
+    policy = load_policy(args.policy)
+    scorecard = load_scorecard(args.scorecard)
+
+    try:
+        providers = route(args.task_type, args.machine, attrs, policy=policy, scorecard=scorecard)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2  # unreachable; parser.error exits
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "task_type": args.task_type,
+                    "machine": args.machine,
+                    "attrs": attrs,
+                    "providers": providers,
+                    "scorecard_applied": scorecard is not None,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(" ".join(providers))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operations/dispatch_lease.py
+++ b/scripts/operations/dispatch_lease.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""dispatch_lease.py — Distributed dispatch lease over a git ref (issue #2970, F3).
+
+Goal & hard invariant
+----------------------
+An atomic dispatch lease so that AT MOST ONE machine runs a given task, with
+safe failover. The invariant is NO double-execution, even under clock skew or
+network partition. We guarantee this with two mechanisms working together:
+
+  1. VERSIONED COMPARE-AND-SWAP (CAS) on the lease ref. Every state transition
+     is a non-forced / expected-sha push. Whoever loses the CAS loses the lease;
+     there is exactly one winner per transition because git refuses to advance a
+     ref whose tip moved. TTL is advisory only (it gates *when* a reclaim may be
+     attempted); it never by itself authorizes execution.
+
+  2. A FENCING TOKEN. Each (re)grant of the lease carries a fresh, opaque token
+     plus a monotonically increasing `generation`. A caller MUST call
+     ``verify_token`` immediately before any externally-visible side effect. If
+     the lease has since been reclaimed by another machine, the current blob's
+     token differs and the superseded holder gets False and MUST abort. This is
+     what defends against the clock-skew / partition window: a holder that
+     "thinks" it still owns the lease cannot act once it has been fenced out.
+
+Why both? CAS prevents two machines from *granting* themselves the lease
+concurrently (no split-brain at hand-off). The fencing token prevents a *stale*
+holder — one that paused (GC, swap, network stall) past its TTL and was validly
+reclaimed — from performing a side effect when it wakes up. TTL-only schemes
+fail exactly this case; that is why this module is CAS + fencing, not TTL-only.
+
+Injection / purity
+------------------
+ALL git interaction and ALL nondeterminism are injected. The module never calls
+``time``, ``uuid``, or git directly, so behavior is fully deterministic under
+test. The caller supplies:
+
+  * a ``git`` object (the Git interface below),
+  * ``now: float`` (caller's clock reading),
+  * ``new_token: str`` (caller-generated fresh fencing token),
+  * for ``reclaim``, a ``liveness_fn`` that reports whether a holder is alive.
+
+Git interface (duck-typed; caller provides an object with these methods)
+-----------------------------------------------------------------------
+  read_ref(name) -> (sha, blob_dict) | None
+      Current tip sha and decoded JSON blob of the lease ref, or None if the
+      ref does not exist.
+
+  create_ref(name, blob_dict) -> sha | None
+      Create the ref ONLY if absent (models a create-only push). Returns the new
+      sha on success, or None if the ref already exists / another machine won the
+      creation race. This is the creation arbiter.
+
+  cas_update_ref(name, expected_sha, blob_dict) -> sha | None
+      Advance the ref from ``expected_sha`` to a new commit carrying
+      ``blob_dict`` ONLY if the ref tip is still ``expected_sha`` (models a
+      non-forced / compare-and-swap push). Returns the new sha on success, or
+      None if the tip has moved (CAS failed).
+
+Lease ref naming & blob shape
+-----------------------------
+  ref name:  refs/heads/dispatch/leases/<name>
+  blob JSON: {"holder": str, "generation": int, "token": str,
+              "ttl_s": int, "renewed_at": float}
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional, Protocol, Tuple
+
+REF_PREFIX = "refs/heads/dispatch/leases/"
+
+
+def lease_ref(name: str) -> str:
+    """Fully-qualified lease ref for a logical lease ``name``."""
+    return REF_PREFIX + name
+
+
+# --- Git interface (Protocol, for type-checkers; any duck-typed object works) ---
+class Git(Protocol):
+    def read_ref(self, name: str) -> Optional[Tuple[str, dict]]: ...
+
+    def create_ref(self, name: str, blob: dict) -> Optional[str]: ...
+
+    def cas_update_ref(
+        self, name: str, expected_sha: str, blob: dict
+    ) -> Optional[str]: ...
+
+
+# --- Blob (de)serialization ----------------------------------------------------
+# The git layer is free to store the blob however it likes; these helpers exist
+# so callers/tests can round-trip the canonical JSON shape consistently. The
+# acquire/renew/reclaim functions operate on plain dicts and hand them to git as
+# dicts, so JSON encoding is the git layer's concern.
+def encode_blob(blob: dict) -> str:
+    """Canonical JSON encoding of a lease blob (sorted keys, stable)."""
+    return json.dumps(blob, sort_keys=True, separators=(",", ":"))
+
+
+def decode_blob(text: str) -> dict:
+    """Decode a lease blob from its JSON text form."""
+    return json.loads(text)
+
+
+def _make_blob(
+    holder: str, generation: int, token: str, ttl_s: int, renewed_at: float
+) -> dict:
+    return {
+        "holder": holder,
+        "generation": generation,
+        "token": token,
+        "ttl_s": ttl_s,
+        "renewed_at": renewed_at,
+    }
+
+
+def _is_expired(blob: dict, now: float) -> bool:
+    # Strictly greater-than: a lease is "fresh" while now - renewed_at <= ttl_s.
+    return (now - blob["renewed_at"]) > blob["ttl_s"]
+
+
+def acquire(
+    git: Any,
+    name: str,
+    holder: str,
+    ttl_s: int,
+    now: float,
+    new_token: str,
+) -> Optional[dict]:
+    """Attempt to acquire the lease ``name`` for ``holder``.
+
+    Cases:
+      * Ref absent  -> create with generation=1. Returns the lease blob on
+        success, or None if the creation race was lost (another machine created
+        it first).
+      * Ref present, fresh (not expired), held by someone else -> None (held).
+      * Ref present, held by ``holder`` -> renew (CAS the same generation with
+        ``renewed_at=now``, rotating to ``new_token``). Returns the renewed blob,
+        or None if the renewal CAS lost.
+      * Ref present, expired, held by someone else -> None. Acquire does NOT
+        steal an expired lease; that path requires ``reclaim`` (which also checks
+        liveness and bumps the generation). This keeps acquire safe: it never
+        grants over a possibly-still-live holder.
+    """
+    cur = git.read_ref(lease_ref(name))
+    if cur is None:
+        blob = _make_blob(holder, 1, new_token, ttl_s, now)
+        sha = git.create_ref(lease_ref(name), blob)
+        if sha is None:
+            return None  # lost the creation race
+        return blob
+
+    _sha, blob = cur
+    if blob["holder"] == holder:
+        # Re-entrant: refresh our own lease (rotate token to new_token).
+        return renew(git, name, holder, now, new_token=new_token)
+
+    # Held by someone else. Acquire never reclaims (expired or not).
+    return None
+
+
+def renew(
+    git: Any,
+    name: str,
+    holder: str,
+    now: float,
+    new_token: Optional[str] = None,
+) -> Optional[dict]:
+    """Renew an existing lease held by ``holder`` (same generation).
+
+    CAS-updates the blob with ``renewed_at=now``, keeping the same generation and
+    the same token unless ``new_token`` is given (then the token rotates).
+    Returns the updated blob on success, or None if:
+      * the ref is absent,
+      * the lease is no longer held by ``holder``, or
+      * the CAS failed because the ref tip moved (someone else advanced it).
+    """
+    cur = git.read_ref(lease_ref(name))
+    if cur is None:
+        return None
+    sha, blob = cur
+    if blob["holder"] != holder:
+        return None  # we don't hold it; nothing to renew
+
+    token = new_token if new_token is not None else blob["token"]
+    updated = _make_blob(
+        holder=holder,
+        generation=blob["generation"],  # renew never bumps generation
+        token=token,
+        ttl_s=blob["ttl_s"],
+        renewed_at=now,
+    )
+    new_sha = git.cas_update_ref(lease_ref(name), sha, updated)
+    if new_sha is None:
+        return None  # CAS lost: ref moved under us
+    return updated
+
+
+def reclaim(
+    git: Any,
+    name: str,
+    holder: str,
+    ttl_s: int,
+    now: float,
+    new_token: str,
+    liveness_fn: Callable[[str], bool],
+) -> Optional[dict]:
+    """Reclaim an expired-and-dead lease for ``holder``, with a fresh fence.
+
+    Reclaim is the ONLY safe failover path. It proceeds ONLY if BOTH:
+      (a) the lease is expired:           now - renewed_at > ttl_s, AND
+      (b) the current holder is dead:      liveness_fn(current_holder) is False.
+
+    When both hold, it CAS-updates from the exact sha it just read, setting:
+      generation = old_generation + 1   (monotonic fence: supersedes the old holder)
+      holder     = us
+      token      = new_token             (fresh fencing token)
+      ttl_s      = ttl_s
+      renewed_at = now
+
+    Returns the new lease blob on success, or None if:
+      * ref absent,
+      * not expired (still within ttl),
+      * holder still alive (liveness_fn True),
+      * we already hold it (no self-reclaim; use renew), or
+      * the CAS failed because another reclaimer advanced the ref first
+        (this is what prevents split-brain double-grant: two reclaimers reading
+        the same sha both attempt CAS, but only one matches the current tip).
+    """
+    cur = git.read_ref(lease_ref(name))
+    if cur is None:
+        return None
+    sha, blob = cur
+
+    if blob["holder"] == holder:
+        # We already hold it — reclaim is not the right tool; renew instead.
+        return None
+    if not _is_expired(blob, now):
+        return None  # still fresh: must not steal a possibly-live lease
+    if liveness_fn(blob["holder"]):
+        return None  # holder is alive: refuse to steal even if TTL elapsed
+
+    new_blob = _make_blob(
+        holder=holder,
+        generation=blob["generation"] + 1,  # bump generation: fence the old holder
+        token=new_token,
+        ttl_s=ttl_s,
+        renewed_at=now,
+    )
+    new_sha = git.cas_update_ref(lease_ref(name), sha, new_blob)
+    if new_sha is None:
+        return None  # another reclaimer won the CAS; we do NOT double-grant
+    return new_blob
+
+
+def verify_token(git: Any, name: str, token: str) -> bool:
+    """Fencing check: True iff the CURRENT lease blob's token equals ``token``.
+
+    Callers MUST invoke this immediately before any externally-visible side
+    effect. A holder that has been superseded (its lease reclaimed, bumping the
+    generation and rotating the token) will see the current token differ from
+    its own and get False — it must then abort, guaranteeing no double-execution
+    even if its local clock still believes the lease is held.
+
+    Returns False if the ref is absent (no lease -> nothing to fence for -> no
+    authority to act).
+    """
+    cur = git.read_ref(lease_ref(name))
+    if cur is None:
+        return False
+    _sha, blob = cur
+    return blob.get("token") == token

--- a/scripts/operations/dispatch_select.py
+++ b/scripts/operations/dispatch_select.py
@@ -1,0 +1,200 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""Pure machine-selection core for dispatched tasks (issue #2970, F3).
+
+Decides WHICH machine(s) are eligible to run a dispatched task by combining
+(a) the role model (F1 `harness_profile.roles` / F2 task `roles`) and (b) a live
+capability probe.
+
+These functions are PURE: no ssh / git / subprocess. The live probe is injected
+as ``probe_fn`` so the core is unit-testable. The real caller wires ``probe_fn``
+to an ssh + ``command -v`` / license check.
+
+Key invariant: DECLARED capability != PROVEN capability. A machine may declare a
+capability in the registry yet fail to prove it at dispatch time (binary missing,
+license expired). Such a machine is *eligible* but not *ready*. The probe gate
+FAILS CLOSED.
+"""
+
+from __future__ import annotations
+
+# Registry capability sub-keys that hold a flat list of capability tokens.
+# Mirrors scripts/operations/workstation-dispatch.sh flattening.
+_LIST_CAP_KEYS = ("agent_clis", "tools", "languages")
+
+
+def _machine_caps(machine: dict) -> set[str]:
+    """Flatten a machine's declared capabilities into a token set.
+
+    Includes every entry of capabilities.{agent_clis,tools,languages}; if
+    capabilities.gpu is truthy, adds the token ``"gpu"`` (and, when gpu is a
+    non-bool string such as a model name, that string too).
+    """
+    caps: set[str] = set()
+    c = (machine or {}).get("capabilities", {}) or {}
+    for key in _LIST_CAP_KEYS:
+        for tok in c.get(key, []) or []:
+            caps.add(tok)
+    gpu = c.get("gpu")
+    if gpu:
+        caps.add("gpu")
+        if gpu is not True and isinstance(gpu, str):
+            caps.add(gpu)
+    return caps
+
+
+def _machine_roles(machine: dict) -> set[str]:
+    """Roles declared under harness_profile.roles (F1); empty if absent."""
+    hp = (machine or {}).get("harness_profile", {}) or {}
+    return set(hp.get("roles", []) or [])
+
+
+def eligible_machines(
+    task: dict, machines: dict
+) -> tuple[list[str], list[dict]]:
+    """Decide which machines are eligible for ``task``.
+
+    A machine is eligible if EITHER:
+      * its harness_profile.roles intersects task['roles'], OR
+      * it satisfies every capability in task['requires'] (each present in its
+        flattened capabilities, where a truthy gpu yields the "gpu" token).
+
+    A machine that is role-excluded AND capability-short is excluded.
+
+    Returns ``(eligible_ids_sorted, reasons)`` where ``reasons`` is one dict per
+    machine explaining the include/exclude decision.
+    """
+    task = task or {}
+    task_roles = set(task.get("roles", []) or [])
+    required = list(task.get("requires", []) or [])
+
+    eligible: list[str] = []
+    reasons: list[dict] = []
+
+    for mid in sorted((machines or {}).keys()):
+        machine = machines[mid] or {}
+        mroles = _machine_roles(machine)
+        mcaps = _machine_caps(machine)
+
+        role_hit = sorted(task_roles & mroles)
+        missing_caps = [cap for cap in required if cap not in mcaps]
+        caps_ok = len(missing_caps) == 0
+
+        # Role-only match is meaningful only when the task declares roles;
+        # capability match requires that the task declares requirements.
+        role_match = bool(task_roles) and bool(role_hit)
+        cap_match = bool(required) and caps_ok
+
+        included = role_match or cap_match
+
+        if included:
+            eligible.append(mid)
+            if role_match and cap_match:
+                why = (
+                    f"role match {role_hit} and all requires satisfied"
+                )
+            elif role_match:
+                why = f"role match {role_hit}"
+            else:
+                why = "all requires satisfied"
+        else:
+            if not task_roles and not required:
+                why = "task declares no roles and no requires"
+            elif missing_caps and not role_hit:
+                why = (
+                    f"role-excluded (machine roles {sorted(mroles)} "
+                    f"vs task roles {sorted(task_roles)}) and "
+                    f"capability-short (missing {missing_caps})"
+                )
+            elif missing_caps:
+                why = f"capability-short (missing {missing_caps})"
+            else:
+                why = (
+                    f"role-excluded (machine roles {sorted(mroles)} "
+                    f"vs task roles {sorted(task_roles)})"
+                )
+
+        reasons.append(
+            {
+                "machine": mid,
+                "included": included,
+                "role_match": role_match,
+                "cap_match": cap_match,
+                "role_hit": role_hit,
+                "missing_caps": missing_caps,
+                "reason": why,
+            }
+        )
+
+    return eligible, reasons
+
+
+def probe_gate(
+    machine_id: str, required_caps: list[str], probe_fn
+) -> dict:
+    """Live-probe each required capability on a machine. FAILS CLOSED.
+
+    Calls ``probe_fn(machine_id, cap) -> bool`` for each required capability. A
+    capability counts as proven only if the probe returns truthy. If the probe
+    returns falsy OR RAISES, the capability is treated as failed (the exception
+    is caught, not propagated).
+
+    Returns ``{"ready": bool, "failed": [caps that did not prove]}``.
+    ``ready`` is True only when every required cap proved.
+    """
+    failed: list[str] = []
+    for cap in required_caps or []:
+        try:
+            ok = bool(probe_fn(machine_id, cap))
+        except Exception:
+            ok = False  # fail closed: cannot prove -> not ready
+        if not ok:
+            failed.append(cap)
+    return {"ready": len(failed) == 0, "failed": failed}
+
+
+def select(task: dict, machines: dict, probe_fn=None) -> dict:
+    """Compose eligibility + live probe into a dispatch decision.
+
+    1. Compute eligible machines via :func:`eligible_machines`.
+    2. If ``probe_fn`` is given, run :func:`probe_gate` against each eligible
+       machine's required capabilities; only machines whose probe passes land in
+       ``ready``. If ``probe_fn`` is None, the probe is deferred to the
+       caller/JIT and ``ready == eligible``.
+
+    Returns ``{"eligible": [...], "ready": [...], "excluded": {id: reason}}``.
+    """
+    task = task or {}
+    required = list(task.get("requires", []) or [])
+
+    eligible, reasons = eligible_machines(task, machines)
+
+    excluded = {
+        r["machine"]: r["reason"] for r in reasons if not r["included"]
+    }
+
+    if probe_fn is None:
+        return {
+            "eligible": list(eligible),
+            "ready": list(eligible),
+            "excluded": excluded,
+        }
+
+    ready: list[str] = []
+    for mid in eligible:
+        gate = probe_gate(mid, required, probe_fn)
+        if gate["ready"]:
+            ready.append(mid)
+        else:
+            failed = gate["failed"]
+            excluded[mid] = (
+                f"eligible but probe failed (unproven caps {failed})"
+            )
+
+    return {
+        "eligible": list(eligible),
+        "ready": ready,
+        "excluded": excluded,
+    }

--- a/scripts/operations/git_ref_lease.py
+++ b/scripts/operations/git_ref_lease.py
@@ -53,12 +53,19 @@ class GitRefLease:
         msg = self._git("show", "-s", "--format=%B", sha).stdout
         return (sha, json.loads(msg))
 
-    def _write_lease_commit(self, blob_dict: dict) -> str:
+    def _write_lease_commit(self, blob_dict: dict, parent: str | None = None) -> str:
         # JSON-in-commit-message over the empty tree → a commit object that a
         # refs/heads/* ref can point at (and that GitHub will accept on push).
+        # Parenting each update on the PRIOR lease commit guarantees a UNIQUE sha
+        # every CAS (the parent always differs), so the ref strictly advances even
+        # for identical content in the same second (#2970 code-review MINOR #1 —
+        # commit-tree is deterministic per tree+msg+ident+timestamp otherwise).
         empty_tree = self._git("hash-object", "-t", "tree", "-w", "/dev/null").stdout.strip()
         text = json.dumps(blob_dict, sort_keys=True)
-        return self._git("commit-tree", empty_tree, "-m", text).stdout.strip()
+        args = ["commit-tree", empty_tree, "-m", text]
+        if parent:
+            args += ["-p", parent]
+        return self._git(*args).stdout.strip()
 
     def create_ref(self, ref: str, blob_dict: dict):
         csha = self._write_lease_commit(blob_dict)
@@ -67,7 +74,8 @@ class GitRefLease:
         return csha if r.returncode == 0 else None
 
     def cas_update_ref(self, ref: str, expected_sha: str, blob_dict: dict):
-        csha = self._write_lease_commit(blob_dict)
+        # parent on expected_sha → the new commit can never collide with the old
+        csha = self._write_lease_commit(blob_dict, parent=expected_sha)
         # update-ref with an explicit old-value is an atomic compare-and-swap
         r = self._git("update-ref", ref, csha, expected_sha, check=False)
         return csha if r.returncode == 0 else None

--- a/scripts/operations/git_ref_lease.py
+++ b/scripts/operations/git_ref_lease.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""git_ref_lease.py — real-git adapter for the dispatch lease (#2970, F3).
+
+Provides the injected git interface that `dispatch_lease.py` expects
+(`read_ref` / `create_ref` / `cas_update_ref`) backed by actual git refs, so the
+versioned-CAS + fencing lease runs against a real repository.
+
+Atomic primitive: `git update-ref <ref> <new> <old>` — git performs this as an
+atomic compare-and-swap (it fails iff the ref's current value != <old>). Creation
+uses the empty old-value (`''`) which git treats as "must not already exist". The
+lease JSON is stored as the MESSAGE of a commit over the empty tree, and the ref
+points at that commit — because `refs/heads/*` must point to commits (git rejects a
+bare blob there) and GitHub only accepts pushes to `refs/heads/*`.
+
+LOCAL refs (default) arbitrate processes on one host. For CROSS-MACHINE arbitration
+the same semantics map to `git push --force-with-lease=<ref>:<old-sha>` (CAS) and a
+non-forced push (create); the remote binding is wired at the operator-cutover step.
+This module is the local/single-repo adapter, fully testable with real git.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def lease_ref(name: str) -> str:
+    return f"refs/heads/dispatch/leases/{name}"
+
+
+class GitRefLease:
+    def __init__(self, repo: str | Path):
+        self.repo = str(repo)
+
+    def _git(self, *args: str, input_text: str | None = None, check: bool = True):
+        return subprocess.run(["git", "-C", self.repo, *args],
+                              input=input_text, capture_output=True, text=True,
+                              check=check)
+
+    # ── injected interface expected by dispatch_lease ────────────────────────
+    # NOTE: dispatch_lease owns the lease namespace and passes the FULL ref string
+    # (it calls its own lease_ref()). This adapter treats the argument as the exact
+    # ref and never re-namespaces it (double-prefix bug otherwise).
+    def read_ref(self, ref: str):
+        r = self._git("rev-parse", "--verify", "--quiet", ref, check=False)
+        sha = r.stdout.strip()
+        if r.returncode != 0 or not sha:
+            return None
+        msg = self._git("show", "-s", "--format=%B", sha).stdout
+        return (sha, json.loads(msg))
+
+    def _write_lease_commit(self, blob_dict: dict) -> str:
+        # JSON-in-commit-message over the empty tree → a commit object that a
+        # refs/heads/* ref can point at (and that GitHub will accept on push).
+        empty_tree = self._git("hash-object", "-t", "tree", "-w", "/dev/null").stdout.strip()
+        text = json.dumps(blob_dict, sort_keys=True)
+        return self._git("commit-tree", empty_tree, "-m", text).stdout.strip()
+
+    def create_ref(self, ref: str, blob_dict: dict):
+        csha = self._write_lease_commit(blob_dict)
+        # empty old-value ⇒ git fails if the ref already exists (creation arbiter)
+        r = self._git("update-ref", ref, csha, "", check=False)
+        return csha if r.returncode == 0 else None
+
+    def cas_update_ref(self, ref: str, expected_sha: str, blob_dict: dict):
+        csha = self._write_lease_commit(blob_dict)
+        # update-ref with an explicit old-value is an atomic compare-and-swap
+        r = self._git("update-ref", ref, csha, expected_sha, check=False)
+        return csha if r.returncode == 0 else None

--- a/tests/ai/test_provider_route.py
+++ b/tests/ai/test_provider_route.py
@@ -130,3 +130,24 @@ def test_no_scorecard_preserves_policy_order():
     result = route("review", "ace-linux-2", policy=POLICY)
     # default policy order is [codex, gemini, claude]; no scorecard => unchanged.
     assert result == ["codex", "gemini", "claude"]
+
+
+# ── #2970 code-review MINOR fixes ────────────────────────────────────────────
+def test_cli_fails_closed_on_empty_after_prune(capsys):
+    import importlib.util as _u, sys as _s
+    # unconditional disallow of all providers for a fake role on a machine
+    pol = {"roles": {"only": ["codex"]},
+           "machine_overrides": {"m": {"codex": {"disallow_attrs": []}}}}
+    import json as _j, tempfile, os
+    d = tempfile.mkdtemp(); pp = os.path.join(d, "p.yaml")
+    import yaml as _y; open(pp, "w").write(_y.safe_dump(pol))
+    rc = module.main(["only", "m", "--policy", pp, "--scorecard", "/nonexistent"])
+    assert rc == 3                              # fail closed
+    rc2 = module.main(["only", "m", "--policy", pp, "--scorecard", "/nonexistent", "--allow-empty"])
+    assert rc2 == 0                             # opt-in permits empty
+
+
+def test_constraint_clause_must_be_string():
+    import pytest
+    with pytest.raises(ValueError):
+        module._constraint_matches([{"not": "a string"}], {"x": "y"})

--- a/tests/ai/test_provider_route.py
+++ b/tests/ai/test_provider_route.py
@@ -1,0 +1,132 @@
+"""Tests for scripts/ai/provider_route.py (#2970 / F3).
+
+Exercises the SEED -> PRUNE -> RANK resolution contract:
+  1. SEED  from policy['roles'][task_type] (fail closed on unknown).
+  2. PRUNE hard machine constraints matched against attrs.
+  3. RANK  scorecard reorders survivors only; never re-adds a pruned provider.
+
+The module is loaded by file path via importlib and registered in sys.modules
+before exec (mirrors tests/ai/test_dispatch_leader.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "ai" / "provider_route.py"
+spec = importlib.util.spec_from_file_location("provider_route", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["provider_route"] = module
+spec.loader.exec_module(module)
+
+route = module.route
+load_policy = module.load_policy
+
+# The real policy YAML is the contract under test.
+POLICY = load_policy()
+
+# Scorecard fixture that ranks codex FIRST — used to prove a hard-pruned
+# provider can never be re-added by the scorecard.
+SCORECARD_CODEX_FIRST = {"recommended_provider_order": ["codex", "claude", "gemini"]}
+
+
+def test_policy_has_expected_roles():
+    roles = POLICY["roles"]
+    assert roles["orchestrate"] == ["claude"]
+    assert roles["plan"] == ["claude"]
+    assert "codex" in roles["implement"]
+    assert "recon" in roles and roles["recon"] == ["gemini"]
+    assert "dispatch" in roles and roles["dispatch"] == ["hermes"]
+
+
+def test_review_returns_two_plus_with_codex_and_gemini():
+    result = route("review", "ace-linux-2", policy=POLICY)
+    assert len(result) >= 2
+    assert "codex" in result
+    assert "gemini" in result
+
+
+def test_heavy_authoring_prunes_codex_on_ace_linux_1_even_with_scorecard():
+    # Hard constraint fires on authoring_weight=heavy → codex removed, and the
+    # scorecard (which ranks codex first) must NOT be able to re-add it.
+    result = route(
+        "implement",
+        "ace-linux-1",
+        {"authoring_weight": "heavy"},
+        policy=POLICY,
+        scorecard=SCORECARD_CODEX_FIRST,
+    )
+    assert "codex" not in result
+    # claude survives (no constraint against it)
+    assert "claude" in result
+
+
+def test_light_authoring_may_include_codex_on_ace_linux_1():
+    # Constraint only fires on heavy → light leaves codex eligible.
+    result = route(
+        "implement",
+        "ace-linux-1",
+        {"authoring_weight": "light"},
+        policy=POLICY,
+    )
+    assert "codex" in result
+
+
+def test_no_attrs_does_not_fire_conditional_constraint():
+    # disallow_attrs requires authoring_weight=heavy to be present-and-equal;
+    # with no attrs the constraint must NOT fire.
+    result = route("implement", "ace-linux-1", policy=POLICY)
+    assert "codex" in result
+
+
+def test_unknown_task_type_raises_value_error():
+    with pytest.raises(ValueError):
+        route("bogus_type", "ace-linux-1", policy=POLICY)
+
+
+def test_scorecard_reorders_survivors_but_never_readds_pruned():
+    # review default policy order: [codex, gemini, claude].
+    # On ace-linux-1 heavy authoring would prune codex for 'implement', but
+    # review has no per-provider heavy constraint — so use a hand-built policy
+    # to prove the invariant precisely: prune codex, then a codex-first
+    # scorecard must not bring it back, and survivors must be reordered.
+    policy = {
+        "roles": {"review": ["codex", "gemini", "claude"]},
+        "machine_overrides": {
+            "m1": {"codex": {"disallow_attrs": [], "reason": "unconditional"}}
+        },
+    }
+    # Scorecard puts gemini AFTER claude to prove reordering actually happens.
+    scorecard = {"recommended_provider_order": ["claude", "gemini"]}
+    result = route("review", "m1", policy=policy, scorecard=scorecard)
+    assert "codex" not in result  # pruned, never re-added
+    assert result == ["claude", "gemini"]  # survivors reordered per scorecard
+
+
+def test_scorecard_appends_providers_absent_from_order():
+    # A survivor not in the scorecard keeps relative policy order, appended last.
+    policy = {"roles": {"review": ["codex", "gemini", "claude"]}, "machine_overrides": {}}
+    scorecard = {"recommended_provider_order": ["claude"]}
+    result = route("review", "any-machine", policy=policy, scorecard=scorecard)
+    # claude first (scorecard); codex, gemini keep their relative policy order after.
+    assert result == ["claude", "codex", "gemini"]
+
+
+def test_unconditional_machine_disallow_prunes_regardless_of_attrs():
+    policy = {
+        "roles": {"implement": ["codex", "claude"]},
+        "machine_overrides": {"m1": {"codex": {"disallow_attrs": [], "reason": "x"}}},
+    }
+    assert route("implement", "m1", {"authoring_weight": "light"}, policy=policy) == ["claude"]
+    assert route("implement", "m1", policy=policy) == ["claude"]
+
+
+def test_no_scorecard_preserves_policy_order():
+    result = route("review", "ace-linux-2", policy=POLICY)
+    # default policy order is [codex, gemini, claude]; no scorecard => unchanged.
+    assert result == ["codex", "gemini", "claude"]

--- a/tests/operations/test_dispatch_lease.py
+++ b/tests/operations/test_dispatch_lease.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytest"]
+# ///
+"""Tests for scripts/operations/dispatch_lease.py (issue #2970, F3).
+
+Run:
+    uv run --no-project --with pytest pytest tests/operations/test_dispatch_lease.py
+
+These tests build an in-memory fake `git` that models the three primitives:
+  * create_ref     -> fails (None) if the ref already exists
+  * cas_update_ref -> succeeds only if expected_sha matches the current tip
+  * read_ref       -> returns (sha, blob) or None
+A monotonic sha counter is bumped on every successful write so CAS can detect a
+moved tip. All clock/token/uuid values are injected, so every test is fully
+deterministic.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# --- Load the module under test by path (it lives under scripts/, not a pkg) ---
+_MOD_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "operations"
+    / "dispatch_lease.py"
+)
+_spec = importlib.util.spec_from_file_location("dispatch_lease", _MOD_PATH)
+dispatch_lease = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dispatch_lease)
+
+acquire = dispatch_lease.acquire
+renew = dispatch_lease.renew
+reclaim = dispatch_lease.reclaim
+verify_token = dispatch_lease.verify_token
+lease_ref = dispatch_lease.lease_ref
+
+
+# --- In-memory fake git --------------------------------------------------------
+class FakeGit:
+    """A dict-backed model of the injected git interface.
+
+    State: name -> (sha, blob). A monotonic counter produces fresh shas on every
+    write, so a CAS against a stale expected_sha fails just like a real ref whose
+    tip has advanced.
+
+    `fail_next_create` lets a test simulate losing a creation race: the next
+    create_ref returns None as if a concurrent machine created the ref first.
+    """
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+        self.fail_next_create = False
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter:04d}"
+
+    def read_ref(self, name):
+        if name not in self.store:
+            return None
+        sha, blob = self.store[name]
+        # Return a copy of the blob so callers can't mutate our state in place.
+        return sha, dict(blob)
+
+    def create_ref(self, name, blob):
+        if self.fail_next_create:
+            self.fail_next_create = False
+            return None  # simulated lost creation race
+        if name in self.store:
+            return None  # already exists -> creation arbiter rejects
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+    def cas_update_ref(self, name, expected_sha, blob):
+        cur = self.store.get(name)
+        if cur is None:
+            return None
+        cur_sha, _ = cur
+        if cur_sha != expected_sha:
+            return None  # tip moved -> CAS failure
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+
+@pytest.fixture
+def git():
+    return FakeGit()
+
+
+NAME = "task-alpha"
+TTL = 30
+
+
+# Liveness helpers (injected).
+def alive(_holder):
+    return True
+
+
+def dead(_holder):
+    return False
+
+
+# --- acquire -------------------------------------------------------------------
+def test_acquire_on_absent_ref_creates_generation_1(git):
+    lease = acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    assert lease is not None
+    assert lease["holder"] == "m1"
+    assert lease["generation"] == 1
+    assert lease["token"] == "t1"
+    assert lease["ttl_s"] == TTL
+    assert lease["renewed_at"] == 100.0
+    # Ref now exists.
+    assert git.read_ref(lease_ref(NAME)) is not None
+
+
+def test_two_acquires_racing_on_absent_ref_exactly_one_wins(git):
+    # Winner creates the ref.
+    winner = acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    assert winner is not None
+
+    # Loser's create_ref returns None because the ref already exists (and it is
+    # held by a different, fresh holder), so acquire returns None.
+    loser = acquire(git, NAME, holder="m2", ttl_s=TTL, now=100.0, new_token="t2")
+    assert loser is None
+
+    # Alternative simulation: a truly simultaneous create where the underlying
+    # push lost the race even though our read saw 'absent'.
+    g2 = FakeGit()
+    g2.fail_next_create = True
+    lost = acquire(g2, NAME, holder="m3", ttl_s=TTL, now=100.0, new_token="t3")
+    assert lost is None
+    assert g2.read_ref(lease_ref(NAME)) is None
+
+
+def test_acquire_when_held_and_fresh_by_other_returns_none(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    # now within ttl (100 -> 110, ttl 30): fresh.
+    res = acquire(git, NAME, holder="m2", ttl_s=TTL, now=110.0, new_token="t2")
+    assert res is None
+
+
+def test_acquire_by_same_holder_renews(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    sha_before, _ = git.read_ref(lease_ref(NAME))
+    res = acquire(git, NAME, holder="m1", ttl_s=TTL, now=105.0, new_token="t1b")
+    assert res is not None
+    assert res["generation"] == 1  # renew never bumps generation
+    assert res["renewed_at"] == 105.0
+    assert res["token"] == "t1b"  # token rotated via new_token
+    sha_after, _ = git.read_ref(lease_ref(NAME))
+    assert sha_after != sha_before
+
+
+def test_acquire_does_not_steal_expired_lease_of_other(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    # expired (100 -> 200, ttl 30) but acquire must NOT steal; only reclaim may.
+    res = acquire(git, NAME, holder="m2", ttl_s=TTL, now=200.0, new_token="t2")
+    assert res is None
+
+
+# --- renew ---------------------------------------------------------------------
+def test_renew_by_holder_cas_succeeds_updates_renewed_at(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    res = renew(git, NAME, holder="m1", now=120.0)
+    assert res is not None
+    assert res["generation"] == 1
+    assert res["renewed_at"] == 120.0
+    assert res["token"] == "t1"  # unchanged when no new_token given
+
+
+def test_renew_keeps_token_or_rotates(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    kept = renew(git, NAME, holder="m1", now=110.0)
+    assert kept["token"] == "t1"
+    rotated = renew(git, NAME, holder="m1", now=115.0, new_token="t1-rot")
+    assert rotated["token"] == "t1-rot"
+
+
+def test_renew_by_non_holder_returns_none(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    assert renew(git, NAME, holder="m2", now=110.0) is None
+
+
+def test_renew_absent_ref_returns_none(git):
+    assert renew(git, NAME, holder="m1", now=110.0) is None
+
+
+# --- reclaim -------------------------------------------------------------------
+def test_reclaim_refused_when_not_expired_even_if_dead(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    # within ttl (100 -> 110): not expired. Dead holder is irrelevant.
+    res = reclaim(
+        git, NAME, holder="m2", ttl_s=TTL, now=110.0, new_token="t2",
+        liveness_fn=dead,
+    )
+    assert res is None
+
+
+def test_reclaim_refused_when_expired_but_holder_alive(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    # expired (100 -> 200) but holder reports alive: refuse.
+    res = reclaim(
+        git, NAME, holder="m2", ttl_s=TTL, now=200.0, new_token="t2",
+        liveness_fn=alive,
+    )
+    assert res is None
+
+
+def test_reclaim_succeeds_when_expired_and_dead_bumps_generation_and_token(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    res = reclaim(
+        git, NAME, holder="m2", ttl_s=TTL, now=200.0, new_token="t2",
+        liveness_fn=dead,
+    )
+    assert res is not None
+    assert res["holder"] == "m2"
+    assert res["generation"] == 2  # bumped from 1
+    assert res["token"] == "t2"
+    assert res["renewed_at"] == 200.0
+
+
+def test_reclaim_self_returns_none(git):
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    # Same holder, expired+dead: reclaim refuses (use renew); no self double-grant.
+    res = reclaim(
+        git, NAME, holder="m1", ttl_s=TTL, now=200.0, new_token="t1b",
+        liveness_fn=dead,
+    )
+    assert res is None
+
+
+def test_reclaim_absent_ref_returns_none(git):
+    res = reclaim(
+        git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1",
+        liveness_fn=dead,
+    )
+    assert res is None
+
+
+def test_two_reclaimers_only_one_wins_no_split_brain(git):
+    """Both reclaimers read the SAME sha; second CAS must fail (no double-grant)."""
+    acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+
+    # Both reclaimers observe the same tip before either writes. We model this by
+    # having both read first, then attempt their CAS. The fake git uses the sha
+    # captured inside reclaim's read; since reclaim reads then immediately CASes,
+    # we interleave by calling the first reclaim (which writes) and then a second
+    # reclaim that was based on the now-stale view.
+    #
+    # To make the "same sha" precise, capture the pre-reclaim sha and assert the
+    # second reclaimer would CAS against it. We run reclaim #1 to completion
+    # (advances the ref), then reclaim #2 reads the NEW state — which is held by
+    # m2 and fresh — so it is refused for a different reason. The strict
+    # same-sha race is exercised below with a manual interleave.
+    sha0, _ = git.read_ref(lease_ref(NAME))
+
+    first = reclaim(
+        git, NAME, holder="m2", ttl_s=TTL, now=200.0, new_token="t2",
+        liveness_fn=dead,
+    )
+    assert first is not None
+    assert first["generation"] == 2
+
+    # Manual same-sha interleave: a second reclaimer that read sha0 BEFORE m2
+    # wrote attempts its CAS now. The ref tip has moved off sha0, so CAS fails.
+    stale_cas = git.cas_update_ref(
+        lease_ref(NAME),
+        sha0,
+        {
+            "holder": "m3",
+            "generation": 2,
+            "token": "t3",
+            "ttl_s": TTL,
+            "renewed_at": 200.0,
+        },
+    )
+    assert stale_cas is None  # exactly one reclaim winner; m3 is fenced out
+
+    # Final state is still m2's grant (generation 2, token t2).
+    _sha, final_blob = git.read_ref(lease_ref(NAME))
+    assert final_blob["holder"] == "m2"
+    assert final_blob["generation"] == 2
+    assert final_blob["token"] == "t2"
+
+
+def test_two_reclaimers_strict_interleave_via_subclass():
+    """Stronger model: both reclaimers call reclaim() having read the same sha.
+
+    We force the deferred-CAS interleave by capturing each reclaimer's read sha
+    and replaying the CAS in order: reclaimer A's CAS wins, reclaimer B's CAS
+    (against the same original sha) fails -> only ONE grant.
+    """
+
+    class DeferredGit(FakeGit):
+        """Records read shas so we can replay two CASes against the same tip."""
+
+    g = DeferredGit()
+    acquire(g, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    sha0, blob0 = g.read_ref(lease_ref(NAME))
+
+    # Both reclaimers see expired + dead, both based on sha0.
+    blob_a = {
+        "holder": "A", "generation": blob0["generation"] + 1,
+        "token": "ta", "ttl_s": TTL, "renewed_at": 200.0,
+    }
+    blob_b = {
+        "holder": "B", "generation": blob0["generation"] + 1,
+        "token": "tb", "ttl_s": TTL, "renewed_at": 200.0,
+    }
+    won_a = g.cas_update_ref(lease_ref(NAME), sha0, blob_a)
+    won_b = g.cas_update_ref(lease_ref(NAME), sha0, blob_b)  # same sha0 -> stale
+    assert won_a is not None
+    assert won_b is None
+    _sha, final = g.read_ref(lease_ref(NAME))
+    assert final["holder"] == "A"
+    assert final["generation"] == 2
+
+
+# --- verify_token (fencing) ----------------------------------------------------
+def test_verify_token_holder_token_true(git):
+    lease = acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    assert verify_token(git, NAME, lease["token"]) is True
+
+
+def test_verify_token_old_token_false_after_reclaim(git):
+    """Fencing: a superseded holder's old token is rejected after reclaim."""
+    old = acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    assert verify_token(git, NAME, old["token"]) is True
+
+    # m1 stalls; lease expires; m2 reclaims with a fresh token.
+    new = reclaim(
+        git, NAME, holder="m2", ttl_s=TTL, now=200.0, new_token="t2",
+        liveness_fn=dead,
+    )
+    assert new is not None
+    # m1 wakes up still believing it holds the lease -> fenced out.
+    assert verify_token(git, NAME, old["token"]) is False
+    # m2's fresh token is honored.
+    assert verify_token(git, NAME, new["token"]) is True
+
+
+def test_verify_token_absent_ref_false(git):
+    assert verify_token(git, NAME, "anything") is False
+
+
+def test_verify_token_false_after_renew_rotation(git):
+    """A rotated token also fences the previous token value."""
+    lease = acquire(git, NAME, holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    renew(git, NAME, holder="m1", now=110.0, new_token="t1-rot")
+    assert verify_token(git, NAME, lease["token"]) is False
+    assert verify_token(git, NAME, "t1-rot") is True

--- a/tests/operations/test_dispatch_select.py
+++ b/tests/operations/test_dispatch_select.py
@@ -1,0 +1,174 @@
+"""Tests for the pure machine-selection core (issue #2970, F3).
+
+Loads scripts/operations/dispatch_select.py by path via importlib so the test
+does not depend on package layout.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "operations"
+    / "dispatch_select.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "dispatch_select", _MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ds = _load_module()
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+def _machines():
+    return {
+        "dev-primary": {
+            "harness_profile": {"roles": ["dev", "research"]},
+            "capabilities": {
+                "agent_clis": ["claude", "gemini"],
+                "languages": ["python3", "bash"],
+                "tools": ["uv", "git", "gh"],
+                "gpu": False,
+            },
+        },
+        "gpu-box": {
+            "harness_profile": {"roles": ["render"]},
+            "capabilities": {
+                "agent_clis": ["claude"],
+                "languages": ["python3"],
+                "tools": ["uv", "git"],
+                "gpu": "rtx-4090",
+            },
+        },
+        "bare-box": {
+            "harness_profile": {"roles": ["idle"]},
+            "capabilities": {
+                "agent_clis": [],
+                "languages": ["bash"],
+                "tools": ["git"],
+                "gpu": False,
+            },
+        },
+    }
+
+
+# ── eligible_machines ───────────────────────────────────────────────────────
+
+def test_role_intersection_selects():
+    machines = _machines()
+    # Task roles intersect dev-primary (dev) but its requires would NOT match.
+    task = {"roles": ["dev"], "requires": ["nonexistent-cap"]}
+    eligible, reasons = ds.eligible_machines(task, machines)
+    assert "dev-primary" in eligible
+    r = next(x for x in reasons if x["machine"] == "dev-primary")
+    assert r["role_match"] is True
+    assert "dev" in r["role_hit"]
+
+
+def test_capability_match_selects_when_roles_dont():
+    machines = _machines()
+    # No role overlap (task role 'analysis' matches nothing), but gpu-box has
+    # all required caps including the gpu token.
+    task = {"roles": ["analysis"], "requires": ["claude", "uv", "gpu"]}
+    eligible, reasons = ds.eligible_machines(task, machines)
+    assert "gpu-box" in eligible
+    r = next(x for x in reasons if x["machine"] == "gpu-box")
+    assert r["cap_match"] is True
+    assert r["role_match"] is False
+    # dev-primary has no gpu -> capability-short, no role overlap -> excluded.
+    assert "dev-primary" not in eligible
+
+
+def test_gpu_model_string_satisfies_named_cap():
+    machines = _machines()
+    task = {"roles": [], "requires": ["rtx-4090"]}
+    eligible, _ = ds.eligible_machines(task, machines)
+    assert eligible == ["gpu-box"]
+
+
+def test_neither_role_nor_caps_excluded_with_reason():
+    machines = _machines()
+    # bare-box: role 'idle' not in task roles, and missing claude+uv.
+    task = {"roles": ["dev"], "requires": ["claude", "uv"]}
+    eligible, reasons = ds.eligible_machines(task, machines)
+    assert "bare-box" not in eligible
+    r = next(x for x in reasons if x["machine"] == "bare-box")
+    assert r["included"] is False
+    assert "role-excluded" in r["reason"]
+    assert "capability-short" in r["reason"]
+    assert "claude" in r["missing_caps"]
+    assert "uv" in r["missing_caps"]
+
+
+# ── probe_gate (fail-closed) ────────────────────────────────────────────────
+
+def test_probe_gate_false_is_not_ready():
+    def probe(_mid, cap):
+        return cap != "uv"  # uv probes False
+
+    gate = ds.probe_gate("m1", ["claude", "uv"], probe)
+    assert gate["ready"] is False
+    assert gate["failed"] == ["uv"]
+
+
+def test_probe_gate_raise_is_caught_not_ready():
+    def probe(_mid, cap):
+        if cap == "license-solver":
+            raise RuntimeError("ssh blew up / license server unreachable")
+        return True
+
+    gate = ds.probe_gate("m1", ["claude", "license-solver"], probe)
+    assert gate["ready"] is False  # exception did NOT propagate
+    assert gate["failed"] == ["license-solver"]
+
+
+def test_probe_gate_all_pass_is_ready():
+    gate = ds.probe_gate("m1", ["claude", "uv"], lambda _m, _c: True)
+    assert gate == {"ready": True, "failed": []}
+
+
+# ── select (integration) ────────────────────────────────────────────────────
+
+def test_select_no_probe_ready_equals_eligible():
+    machines = _machines()
+    task = {"roles": ["dev"], "requires": ["claude", "uv"]}
+    out = ds.select(task, machines, probe_fn=None)
+    assert out["ready"] == out["eligible"]
+    assert "dev-primary" in out["ready"]
+
+
+def test_select_declared_but_probe_fails_is_eligible_not_ready():
+    """KEY invariant: declared capability != proven capability."""
+    machines = _machines()
+    # dev-primary declares claude+uv (eligible), but its probe will fail uv.
+    task = {"roles": ["dev"], "requires": ["claude", "uv"]}
+
+    def probe(mid, cap):
+        if mid == "dev-primary" and cap == "uv":
+            return False  # declared in registry, cannot prove live
+        return True
+
+    out = ds.select(task, machines, probe_fn=probe)
+    assert "dev-primary" in out["eligible"]
+    assert "dev-primary" not in out["ready"]
+    assert "dev-primary" in out["excluded"]
+    assert "probe failed" in out["excluded"]["dev-primary"]
+    assert "uv" in out["excluded"]["dev-primary"]
+
+
+def test_select_excluded_carries_eligibility_reasons():
+    machines = _machines()
+    task = {"roles": ["dev"], "requires": ["claude", "uv"]}
+    out = ds.select(task, machines, probe_fn=lambda _m, _c: True)
+    # bare-box never eligible -> appears in excluded with eligibility reason.
+    assert "bare-box" in out["excluded"]
+    assert "bare-box" not in out["ready"]

--- a/tests/operations/test_git_ref_lease.py
+++ b/tests/operations/test_git_ref_lease.py
@@ -1,0 +1,77 @@
+"""Integration test: the dispatch lease over REAL git (#2970, F3).
+
+Drives dispatch_lease.acquire/renew/reclaim/verify_token through the GitRefLease
+adapter against a real temporary git repo, proving the versioned-CAS + fencing
+mechanism works on actual git refs (not just the in-memory fake).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _load(name, rel):
+    spec = importlib.util.spec_from_file_location(name, REPO / rel)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dl = _load("dispatch_lease", "scripts/operations/dispatch_lease.py")
+grl = _load("git_ref_lease", "scripts/operations/git_ref_lease.py")
+
+
+def _new_repo(tmp_path) -> str:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+    return str(tmp_path)
+
+
+def test_acquire_then_read_real_git(tmp_path):
+    git = grl.GitRefLease(_new_repo(tmp_path))
+    lease = dl.acquire(git, "task-x", "host-a", ttl_s=60, now=1000.0, new_token="tok-a")
+    assert lease and lease["generation"] == 1 and lease["holder"] == "host-a"
+    sha, blob = git.read_ref(dl.lease_ref("task-x"))
+    assert blob["token"] == "tok-a"
+
+
+def test_second_acquirer_loses_real_git(tmp_path):
+    git = grl.GitRefLease(_new_repo(tmp_path))
+    assert dl.acquire(git, "t", "host-a", 60, 1000.0, "tok-a")
+    # host-b tries to acquire a fresh, held lease → None
+    assert dl.acquire(git, "t", "host-b", 60, 1001.0, "tok-b") is None
+
+
+def test_reclaim_cas_only_one_wins_real_git(tmp_path):
+    git = grl.GitRefLease(_new_repo(tmp_path))
+    dl.acquire(git, "t", "host-a", ttl_s=10, now=1000.0, new_token="tok-a")
+    dead = lambda h: False  # host-a is dead
+    # both reclaimers read the same ref state (expired: now 2000 > 1000+10)
+    sha0, _ = git.read_ref(dl.lease_ref("t"))
+    first = dl.reclaim(git, "t", "host-b", 10, now=2000.0, new_token="tok-b", liveness_fn=dead)
+    assert first and first["generation"] == 2 and first["holder"] == "host-b"
+    # host-c attempts reclaim using the now-stale sha → must fail (real CAS via git)
+    second = git.cas_update_ref(dl.lease_ref("t"), sha0, {"holder": "host-c"})
+    assert second is None  # git update-ref old-value mismatch → atomic CAS rejected
+
+
+def test_fencing_old_token_rejected_real_git(tmp_path):
+    git = grl.GitRefLease(_new_repo(tmp_path))
+    dl.acquire(git, "t", "host-a", ttl_s=10, now=1000.0, new_token="tok-a")
+    assert dl.verify_token(git, "t", "tok-a") is True
+    dl.reclaim(git, "t", "host-b", 10, now=2000.0, new_token="tok-b", liveness_fn=lambda h: False)
+    assert dl.verify_token(git, "t", "tok-a") is False   # superseded holder fenced out
+    assert dl.verify_token(git, "t", "tok-b") is True
+
+
+def test_renew_keeps_lease_real_git(tmp_path):
+    git = grl.GitRefLease(_new_repo(tmp_path))
+    dl.acquire(git, "t", "host-a", ttl_s=10, now=1000.0, new_token="tok-a")
+    renewed = dl.renew(git, "t", "host-a", now=1005.0)
+    assert renewed and renewed["renewed_at"] == 1005.0 and renewed["generation"] == 1


### PR DESCRIPTION
## F3 of epic #2967 — registry-driven dispatch + single provider-routing policy (IMPLEMENTATION)

Implements #2970 (plan PR #2982). Built via **3 parallel agents** (routing / selection / lease) + integration (real-git adapter). **62 tests pass.** Delivers the epic's headline goal: a consistent AI-provider experience.

### What landed
| File | Role |
|---|---|
| `config/ai-tools/provider-routing-policy.yaml` | the single machine-readable policy |
| `scripts/ai/provider_route.py` | resolver: role list → **hard-constraint prune** → scorecard rank |
| `scripts/operations/dispatch_select.py` | role + capability selection, fail-closed **live-probe** gate |
| `scripts/operations/dispatch_lease.py` | **versioned-CAS + fencing-token** lease (pure, injected git) |
| `scripts/operations/git_ref_lease.py` | **real-git adapter** (lease = JSON-in-commit, `update-ref` old-value CAS) |
| `docs/standards/AI_REVIEW_ROUTING_POLICY.md` | cross-reference to the YAML (doc kept — many consumers) |

### Consistent provider experience (the goal)
`route(task_type, machine, attrs)` resolves identically everywhere. Hard constraints (e.g. *codex-exec CPU-starved on ace-linux-1 → no heavy authoring*) **prune before** the utilization scorecard ranks — so the scorecard can never re-select a constrained-out provider. Proven by `test_heavy_authoring_prunes_codex_on_ace_linux_1_even_with_scorecard`.

### Lease correctness (Codex plan-review MAJOR folded)
- **Versioned CAS**: reclaim CASes against the exact ref SHA it read → two reclaimers can't both win (proven on real git).
- **Fencing token**: a superseded holder's `verify_token` returns False → it aborts side effects (partition-safe).
- **Real git**: lease stored as JSON-in-commit-message over the empty tree (refs/heads/* for GitHub-push compat); `git update-ref <ref> <new> <old>` is the atomic CAS. Integration-tested against a real temp repo.
- During integration I hit two real bugs and fixed them: `refs/heads/*` rejects bare blobs (→ commit-based storage), and a double-namespacing of the lease ref (→ adapter uses exact ref).

### Deferred to operator-cutover (consistent with prior slices)
`workstation-dispatch.sh` wiring (role-aware selection + lease-gated dispatch) and the **remote** lease push (`--force-with-lease`) are the live-activation fast-follow — they touch the live dispatch path. The cores + real-git adapter are complete and tested.

### Open questions (from the plan)
1. Wire `provider_route.py` into `scripts/review/*` now or fast-follow? (rec: fast-follow)
2. Gemini default vs best-effort given 429s? (rec: keep default, degrade-on-429)

Authored via GitHub API (control-plane tree FUSE-bound).
