### PR TITLE
feat(venue): Telegram-as-venue consistency — single-active lease + absence detector + contract (#2971, F4)

### DIFF
--- a/docs/ops/telegram-venue-contract.md
+++ b/docs/ops/telegram-venue-contract.md
@@ -1,0 +1,221 @@
+# Telegram Venue Consistency Contract (F4)
+
+> Issue: [#2971](https://github.com/vamseeachanta/workspace-hub/issues/2971) (F4) · Parent: [#2967](https://github.com/vamseeachanta/workspace-hub/issues/2967)
+> Depends on: F1 role overlay (`comms-dispatch`), F3 dispatch lease ([#2970](https://github.com/vamseeachanta/workspace-hub/issues/2970), `scripts/operations/dispatch_lease.py`), F3 provider-routing policy.
+> Conformance verifier: [`scripts/operations/venue_audit.py`](../../scripts/operations/venue_audit.py).
+
+## Purpose
+
+Telegram is a **client delivery venue**, not just a control plane. The deckhand bots
+(member-audit, escalation sweep, scope routing, onboarding, WhatsApp bridge) currently
+live on `ace-linux-2`. Client experience must not depend on which host runs the bot.
+
+This document is the **cross-repo contract** the deckhand venue must satisfy for
+**machine-independent, exactly-once delivery**. The contract lives here (workspace-hub);
+deckhand *implements* the send-path against it. The parity verifier
+(`venue_audit.py`) checks a deckhand config for conformance and **fails closed**.
+
+---
+
+## `contract_version: 1`
+
+- This contract is versioned. The current version is **1**.
+- Deckhand **pins** the contract version it implements in its venue config
+  (`config/deckhand/policy.yml` → `venue_contract.contract_version`).
+- The parity verifier **fails closed** on a deckhand config that declares an
+  **older or unknown** contract version (`declared < current` ⇒ gap). A config that
+  declares no version at all is also a gap. Forward declarations (`declared > current`)
+  are *not* a conformance gap for this verifier — this verifier only knows version 1 —
+  but the operator should upgrade the contract doc + verifier in lockstep.
+- Bump the version whenever a normative ("MUST") clause below changes in a way that an
+  older deckhand implementation would silently violate.
+
+---
+
+## 1. Single-active venue (write-side gating)
+
+Exactly one host may run **write-side** venue functions at a time. Write-side functions
+are those that produce externally-visible side effects in the client's view:
+
+- the escalation sweep (mirrors `needs-mirror` issues to Telegram),
+- bot outbound sends (any message the venue emits to a client channel),
+- onboarding let-through actions, scope→channel routing emits.
+
+These run **only on the host that currently holds the `venue-telegram` lease** (F3,
+`scripts/operations/dispatch_lease.py`, ref `refs/heads/dispatch/leases/venue-telegram`).
+A host MUST call `verify_token` (fencing) **immediately before** each externally-visible
+send, and abort if it has been fenced out. This is what guarantees no double-send across
+a failover window even under clock skew or partition.
+
+**Read-only** functions are **not** lease-gated and may run anywhere, anytime:
+
+- member-audit (read membership, report drift),
+- this parity verifier (`venue_audit.py`),
+- any reporting/dashboard read.
+
+Rationale: read-only work has no client-visible side effect, so gating it would only
+reduce availability with no exactly-once benefit.
+
+---
+
+## 2. Ordered delivery state machine
+
+Every client-visible delivery follows this canonical order. **Never** reorder it.
+
+```
+reserve(idempotency_key)  ->  send  ->  record audit  ->  swap label
+```
+
+1. **reserve(idempotency_key)** — claim the per-message idempotency key in a durable
+   dedup store *before* sending. If the key is already in a terminal `sent` state, this
+   message was already delivered: **do not re-send** (skip to step 4 if the label still
+   needs reconciling).
+2. **send** — emit to the client channel. This is the externally-visible side effect;
+   `verify_token` (lease fencing) MUST pass immediately before it.
+3. **record audit** — write the PII-safe audit row (see §5) recording that the send
+   succeeded. The audit/dedup record is the **source of truth** for "was this sent?".
+4. **swap label** — flip the durable mirror-state marker (`needs-mirror -> mirrored`).
+
+### Recovery rules for partial-failure cracks
+
+The dangerous window is *between* steps. Recovery is asymmetric on purpose:
+
+| Crack | State | Recovery |
+|---|---|---|
+| Reserved but not sent | key reserved, no `sent` audit row | retry the **send** (still idempotent — the key is held); the reservation prevents a second concurrent worker from also sending. |
+| **Sent but label not swapped** | `sent` audit/dedup row exists, label still `needs-mirror` | the audit/dedup record is the **source of truth**: the message **was delivered**. **Do NOT re-send.** Retry **only the label swap**. |
+| Audit recorded, label not swapped | same as above | same: retry only the label swap. |
+
+**Invariants:**
+
+- **Never swap the label before the send completes.** A premature swap would mark the
+  message mirrored while it is still un-sent, and the idempotent re-run would then skip
+  it forever (silent drop).
+- **The per-message idempotency key guards the outbound send.** Two workers (or a retry)
+  cannot both pass `reserve` for the same key, so the send happens at most once.
+- **The label remains the durable mirror-state marker.** It is the coarse-grained,
+  GitHub-visible "this issue has been mirrored" signal that makes the sweep re-runnable.
+
+### Reconciliation with deckhand's existing label swap
+
+Deckhand's escalation sweep already has an idempotency mechanism: a GitHub label swap
+`needs-mirror -> mirrored`, so re-running the sweep does not re-mirror. The SLA clock is
+the issue `createdAt`; `sla_hours: 24`.
+
+This contract **keeps that label swap** as the durable, coarse-grained mirror-state
+marker (step 4). It **adds** the finer per-message idempotency key (step 1) that guards
+the actual outbound send. The two are complementary:
+
+- The **label** answers "has this issue been mirrored?" at the issue granularity and
+  survives process restarts because it lives on GitHub.
+- The **key** answers "has this exact message been sent?" at the message granularity and
+  closes the sent-but-label-not-swapped crack that the label alone cannot (a crash
+  between send and swap would, with the label alone, re-send on the next sweep).
+
+A conformant deckhand declares **both**: the escalation label-swap config AND the
+per-message idempotency scheme.
+
+---
+
+## 3. Idempotency key
+
+The idempotency key is:
+
+```
+idempotency_key = client-ref + message-type + monotonic-seq
+```
+
+- **client-ref** — a *non-reversible* reference to the client/channel (an opaque id, not
+  a phone number, handle, or any reversible identifier; see §5).
+- **message-type** — the venue message class (e.g. `escalation`, `onboarding`,
+  `scope-route`).
+- **monotonic-seq** — a per-(client-ref, message-type) monotonically increasing sequence.
+
+**It is NOT a raw content hash.** A content hash would (a) collide two legitimately
+distinct messages that happen to have identical text, suppressing the second, and (b)
+leak content into the key space (the key is logged in the audit row, which must be
+PII-safe). The composite key is stable, content-independent, and safe to persist.
+
+The deckhand config declares this scheme so the verifier can confirm it is
+composite-key-based and not content-hash-based.
+
+---
+
+## 4. Retry and dead-letter
+
+- Outbound sends use **bounded retries** (finite attempt count with backoff) — never an
+  unbounded retry loop.
+- On **terminal failure** (retries exhausted, or a non-retryable error), the message goes
+  to a **dead-letter target** AND an **operator alert** fires.
+- The operator alert is emitted as **JSONL via `scripts/notify.sh`** (the workspace-hub
+  async-notification writer; appends one event to `logs/notifications/YYYY-MM-DD.jsonl`).
+- A dead-lettered message is **not** silently dropped and is **not** auto-retried; it
+  requires operator action. The label is **not** swapped for a dead-lettered message
+  (it was not delivered), so the issue remains visibly `needs-mirror`.
+
+The deckhand config declares a `dead_letter` target so the verifier can confirm one
+exists.
+
+---
+
+## 5. PII-safe audit
+
+Audit rows record **only** the operational fact of delivery, never the payload.
+
+**Each audit row stores ONLY:**
+
+- `host` — which host performed the send (the lease holder at send time),
+- `when` — UTC timestamp of the send,
+- `scope` — the venue scope/channel class (e.g. `escalation`, `onboarding`),
+- `idempotency_key` — the composite key from §3,
+- `result` — `sent` | `dead-letter` | `retry`.
+
+**An audit row MUST NEVER contain:**
+
+- **chat content** (no message body, no quoted text, no attachments metadata),
+- a **reversible client identifier** (no phone number, no Telegram handle/user-id, no
+  email — `client-ref` is opaque and non-reversible),
+- a **content-hash** (a hash is a fingerprint of content and can confirm/guess payloads;
+  it is also why the idempotency key is composite, not a hash — see §3).
+
+**Retention:** audit rows are retained for a bounded window of **90 days**, then purged.
+The window is long enough for delivery-dispute reconciliation and short enough to limit
+exposure.
+
+**Access control:** audit rows are operator-only. They live on the host / in the deckhand
+operator store, are not world-readable, and are never mirrored into a client-visible
+channel. The deckhand `audit` config declares `pii_safe: true` to assert it conforms to
+this section; the verifier treats a missing or false `pii_safe` as a gap (fail closed).
+
+---
+
+## 6. Cross-repo boundary
+
+| Lives here (workspace-hub) | Lives in deckhand |
+|---|---|
+| This contract (normative spec). | The venue config that declares conformance (`config/deckhand/{scopes.yml, policy.yml, routing/*.yaml}`). |
+| The parity verifier (`venue_audit.py`). | The **send-path implementation**: lease-token **fencing** around each send, **retry/dead-letter** machinery, the **audit emitter**. |
+| The `venue-telegram` lease primitive (F3). | The call sites that acquire/verify the lease before write-side work. |
+
+**Deckhand follow-up (not in this repo):** deckhand must implement, in its own repo,
+(a) lease-token fencing immediately before every outbound send, (b) bounded retry +
+dead-letter + `scripts/notify.sh` operator alert, and (c) the PII-safe audit emitter
+writing the row schema in §5. Track that as a deckhand issue referencing this contract
+version. Until deckhand declares conformance in its config, `venue_audit.py` reports
+gaps.
+
+---
+
+## Conformance summary (what `venue_audit.py` checks)
+
+A conformant deckhand venue config declares, at minimum:
+
+1. `venue_contract.contract_version` ≥ this document's `contract_version`.
+2. An **idempotency scheme** that is composite (`client-ref + message-type + monotonic-seq`),
+   not a content hash.
+3. A **dead-letter** target.
+4. An **audit** config with `pii_safe: true`.
+5. The **escalation label-swap** (`needs-mirror -> mirrored`).
+
+Any missing field, an older/unknown contract version, or `pii_safe` not true is a **gap**;
+the verifier exits non-zero.

--- a/scripts/operations/venue_absence_detector.py
+++ b/scripts/operations/venue_absence_detector.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""venue_absence_detector.py — fleet-wide SILENT-STOP detector (issue #2971, F4).
+
+Why this exists
+---------------
+F4 gates the Telegram escalation-sweep behind a single-active-venue lease so that
+at most one host mirrors client escalations. That introduces a fleet-wide
+SILENT-STOP risk: if NO host validly holds the venue lease (CAS loss, clock skew,
+every host no-ops), the client 24h-SLA escalation mirroring quietly stops and
+nobody notices until SLAs breach.
+
+This detector is the safety net. It runs DECOUPLED from the venue lease — it must
+NOT hold or depend on the lease — and it alerts if EITHER:
+  (a) no valid venue holder exists, OR
+  (b) any pending escalation / last-sweep-success heartbeat is staler than a
+      threshold that is strictly BELOW the 24h SLA, so we catch a stall with
+      margin to act before SLA breach.
+
+The decision logic (`evaluate`) is PURE: no IO, no clock, no subprocess. All
+freshness is expressed as ages-in-hours computed by the caller, so the core is
+fully unit-testable and deterministic. The CLI is a thin shell that gathers the
+inputs and routes each alert to `scripts/notify.sh`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+# --------------------------------------------------------------------------- #
+# PURE CORE
+# --------------------------------------------------------------------------- #
+
+
+def evaluate(
+    lease_present: bool,
+    lease_valid: bool,
+    mirror_ages_h: list[float],
+    heartbeat_age_h: float | None,
+    sla_h: float = 24.0,
+    warn_fraction: float = 0.5,
+) -> list[dict]:
+    """Return alert dicts for any silent-stop condition. Empty list == healthy.
+
+    PURE: no IO, no clock. Caller supplies all freshness as ages in hours.
+
+    Args:
+        lease_present:   True if SOME host currently holds the venue lease ref.
+        lease_valid:     True if that held lease is valid (unexpired, well-formed
+                         fencing token, etc.). Both must be true for a holder.
+        mirror_ages_h:   age (hours) of each PENDING escalation awaiting mirror.
+        heartbeat_age_h: age (hours) since the last SUCCESSFUL sweep, or None if
+                         no heartbeat is available to evaluate.
+        sla_h:           the client SLA window in hours (default 24h).
+        warn_fraction:   fraction of the SLA at which staleness becomes an alert
+                         (default 0.5 → alert at 12h, leaving margin before 24h).
+
+    Returns:
+        A list of {"kind", "detail", "severity"} dicts. Alert kinds:
+          - "no-holder"       : not lease_present or not lease_valid
+          - "stale-mirror"    : any mirror age > sla_h * warn_fraction
+          - "stale-heartbeat" : heartbeat_age_h is not None and > threshold
+    """
+    threshold_h = sla_h * warn_fraction
+    alerts: list[dict] = []
+
+    # (a) No valid venue holder — the lease itself has silently stopped.
+    if not lease_present or not lease_valid:
+        if not lease_present:
+            reason = "no host holds the venue lease"
+        else:
+            reason = "venue lease held but invalid (expired/clock-skew/bad-token)"
+        alerts.append(
+            {
+                "kind": "no-holder",
+                "detail": (
+                    f"{reason}; escalation mirroring is unguarded "
+                    f"(sla={sla_h}h)"
+                ),
+                "severity": "critical",
+            }
+        )
+
+    # (b1) A pending escalation has aged past the warn threshold.
+    for age in mirror_ages_h:
+        if age > threshold_h:
+            alerts.append(
+                {
+                    "kind": "stale-mirror",
+                    "detail": (
+                        f"pending escalation un-mirrored for {age:.2f}h "
+                        f"(> {threshold_h:.2f}h = {warn_fraction:.0%} of "
+                        f"{sla_h}h SLA)"
+                    ),
+                    "severity": "critical",
+                }
+            )
+
+    # (b2) The last successful sweep heartbeat is stale.
+    if heartbeat_age_h is not None and heartbeat_age_h > threshold_h:
+        alerts.append(
+            {
+                "kind": "stale-heartbeat",
+                "detail": (
+                    f"last successful sweep was {heartbeat_age_h:.2f}h ago "
+                    f"(> {threshold_h:.2f}h = {warn_fraction:.0%} of "
+                    f"{sla_h}h SLA)"
+                ),
+                "severity": "critical",
+            }
+        )
+
+    return alerts
+
+
+# --------------------------------------------------------------------------- #
+# THIN CLI
+# --------------------------------------------------------------------------- #
+
+
+def _default_notify(alert: dict) -> None:
+    """Real notifier: append a JSONL fail event via scripts/notify.sh."""
+    notify_sh = Path(__file__).resolve().parents[2] / "scripts" / "notify.sh"
+    detail = f"{alert.get('kind', '?')}: {alert.get('detail', '')}"
+    subprocess.run(
+        ["bash", str(notify_sh), "cron", "venue-absence", "fail", detail],
+        check=False,
+    )
+
+
+def _gather_inputs(args: argparse.Namespace) -> dict:
+    """Collect detector inputs. Minimal/stub: prefer --json, else flags.
+
+    Real deployment can replace this with live probes (read the lease ref,
+    list pending escalations, read the last-sweep heartbeat file). The CORE
+    `evaluate` is what carries the safety guarantee and is fully tested.
+    """
+    if args.json:
+        raw = json.loads(Path(args.json).read_text() if Path(args.json).exists() else args.json)
+        return {
+            "lease_present": bool(raw.get("lease_present", False)),
+            "lease_valid": bool(raw.get("lease_valid", False)),
+            "mirror_ages_h": [float(x) for x in raw.get("mirror_ages_h", [])],
+            "heartbeat_age_h": (
+                None if raw.get("heartbeat_age_h") is None
+                else float(raw["heartbeat_age_h"])
+            ),
+            "sla_h": float(raw.get("sla_h", 24.0)),
+            "warn_fraction": float(raw.get("warn_fraction", 0.5)),
+        }
+    return {
+        "lease_present": args.lease_present,
+        "lease_valid": args.lease_valid,
+        "mirror_ages_h": list(args.mirror_age_h or []),
+        "heartbeat_age_h": args.heartbeat_age_h,
+        "sla_h": args.sla_h,
+        "warn_fraction": args.warn_fraction,
+    }
+
+
+def run_cli(
+    args: argparse.Namespace,
+    notify_fn: Callable[[dict], None] = _default_notify,
+) -> int:
+    """Evaluate inputs and fire one notify_fn per alert. Returns exit code.
+
+    Returns 0 when healthy, 1 when any alert fired. notify_fn is injectable so
+    tests can assert call count without shelling out to notify.sh.
+    """
+    inputs = _gather_inputs(args)
+    alerts = evaluate(**inputs)
+    for alert in alerts:
+        notify_fn(alert)
+    if alerts:
+        print(
+            f"venue-absence: {len(alerts)} alert(s) — SILENT-STOP risk",
+            file=sys.stderr,
+        )
+        for alert in alerts:
+            print(f"  [{alert['severity']}] {alert['kind']}: {alert['detail']}",
+                  file=sys.stderr)
+        return 1
+    print("venue-absence: healthy (valid holder, fresh mirrors + heartbeat)")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Venue ABSENCE detector — alerts on escalation silent-stop "
+        "(decoupled from the venue lease)."
+    )
+    p.add_argument("--json", help="JSON file path or inline JSON of inputs.")
+    p.add_argument("--lease-present", action="store_true",
+                   help="A host currently holds the venue lease.")
+    p.add_argument("--lease-valid", action="store_true",
+                   help="The held lease is valid (unexpired/well-formed).")
+    p.add_argument("--mirror-age-h", type=float, action="append", default=[],
+                   help="Age (hours) of a pending escalation; repeatable.")
+    p.add_argument("--heartbeat-age-h", type=float, default=None,
+                   help="Hours since last successful sweep (omit if none).")
+    p.add_argument("--sla-h", type=float, default=24.0,
+                   help="Client SLA window in hours (default 24).")
+    p.add_argument("--warn-fraction", type=float, default=0.5,
+                   help="Fraction of SLA at which staleness alerts (default 0.5).")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return run_cli(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operations/venue_absence_detector.py
+++ b/scripts/operations/venue_absence_detector.py
@@ -69,8 +69,36 @@ def evaluate(
           - "stale-mirror"    : any mirror age > sla_h * warn_fraction
           - "stale-heartbeat" : heartbeat_age_h is not None and > threshold
     """
+    # (0) Input validation — malformed telemetry must FAIL CLOSED, never be read as
+    # healthy (#2971 code-review MAJOR #5).
+    import math
+    if not (isinstance(sla_h, (int, float)) and sla_h > 0):
+        raise ValueError(f"sla_h must be a positive number, got {sla_h!r}")
+    if not (isinstance(warn_fraction, (int, float)) and 0 < warn_fraction <= 1):
+        raise ValueError(f"warn_fraction must be in (0,1], got {warn_fraction!r}")
+    for a in mirror_ages_h or []:
+        if isinstance(a, bool) or not isinstance(a, (int, float)) or math.isnan(a) or a < 0:
+            raise ValueError(f"mirror age must be a non-negative number, got {a!r}")
+    if heartbeat_age_h is not None and (
+        isinstance(heartbeat_age_h, bool)
+        or not isinstance(heartbeat_age_h, (int, float))
+        or math.isnan(heartbeat_age_h) or heartbeat_age_h < 0
+    ):
+        raise ValueError(f"heartbeat_age_h must be None or a non-negative number, got {heartbeat_age_h!r}")
+
     threshold_h = sla_h * warn_fraction
     alerts: list[dict] = []
+
+    # (a0) UNKNOWN telemetry is NOT health (#2971 code-review MAJOR #4): if we have
+    # neither a sweep heartbeat NOR any pending-mirror signal, we cannot prove the
+    # sweep is alive — a dead sweep produces exactly this empty picture. Alert.
+    if heartbeat_age_h is None and not (mirror_ages_h or []):
+        alerts.append({
+            "kind": "unknown-telemetry",
+            "detail": ("no sweep heartbeat and no pending-mirror signal — cannot prove "
+                       "the venue sweep is alive (a dead sweep looks identical)"),
+            "severity": "critical",
+        })
 
     # (a) No valid venue holder — the lease itself has silently stopped.
     if not lease_present or not lease_valid:

--- a/scripts/operations/venue_audit.py
+++ b/scripts/operations/venue_audit.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""venue_audit.py — parity verifier for the Telegram venue contract (#2971, F4).
+
+Checks that a deckhand venue config conforms to the cross-repo venue-consistency
+contract at ``docs/ops/telegram-venue-contract.md``. The contract specifies
+machine-independent, exactly-once delivery; this verifier is the read-only
+conformance gate for it.
+
+Design
+------
+- PURE core: ``verify(deckhand_config: dict, contract_version: int) -> list[dict]``
+  takes plain dicts and returns a list of gaps. No I/O, no network, no ssh.
+- FAIL CLOSED: a missing required field, a non-conformant value, OR a deckhand
+  config that declares a contract_version *older* than the current contract
+  version is a gap. A config that declares no version is a gap.
+- READ-ONLY venue function: per the contract (§1) parity is not lease-gated and
+  may run on any host.
+
+CLI
+---
+``--config <path>`` points at a deckhand venue YAML. If absent, the CLI prints a
+clear message and exits non-zero WITHOUT attempting ssh or any remote fetch —
+this verifier never hard-requires reaching the deckhand host.
+
+Exit codes
+----------
+0  — no gaps (conformant)
+1  — one or more gaps (non-conformant / fail-closed)
+2  — usage / load error (no config provided, file missing, parse error)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+# The contract version this verifier knows about. Keep in lockstep with
+# `contract_version:` in docs/ops/telegram-venue-contract.md.
+CURRENT_CONTRACT_VERSION = 1
+
+
+def required_contract_fields() -> dict:
+    """Schema the deckhand venue config MUST satisfy (derived from the contract).
+
+    Returns a dict describing each required field: where it lives in the deckhand
+    config (a dotted path), a human description, and (where applicable) the
+    constraint the value must meet. This is the machine-readable summary of the
+    "Conformance summary" section of the contract doc.
+
+    Schema shape (per entry)::
+
+        "<dotted.path>": {
+            "detail": <why it is required / what it must be>,
+            # optional constraints used by verify():
+            "min_version": <int>,          # value must be an int >= this
+            "must_equal": <value>,         # value must == this
+            "must_not_contain": [<str>],   # str value must not contain these tokens
+            "present": True,               # field must merely exist (non-empty)
+        }
+    """
+    return {
+        "venue_contract.contract_version": {
+            "detail": (
+                "deckhand must pin the venue contract version it implements; "
+                f"must be an integer >= {CURRENT_CONTRACT_VERSION} (fail closed on "
+                "older/unknown)"
+            ),
+            "min_version": CURRENT_CONTRACT_VERSION,
+        },
+        "venue_contract.idempotency.scheme": {
+            "detail": (
+                "idempotency key must be the composite 'client-ref + message-type "
+                "+ monotonic-seq', NOT a raw content hash"
+            ),
+            "must_equal": "client-ref+message-type+monotonic-seq",
+            "must_not_contain": ["content-hash", "content_hash", "contenthash"],
+        },
+        "venue_contract.dead_letter.target": {
+            "detail": (
+                "bounded retries terminate to a dead-letter target with an "
+                "operator alert (JSONL via scripts/notify.sh)"
+            ),
+            "present": True,
+        },
+        "venue_contract.audit.pii_safe": {
+            "detail": (
+                "audit rows store host/when/scope/idempotency-key/result ONLY; "
+                "config must declare pii_safe: true"
+            ),
+            "must_equal": True,
+        },
+        "venue_contract.escalation.label_swap": {
+            "detail": (
+                "escalation idempotency via GitHub label swap "
+                "'needs-mirror -> mirrored' (durable mirror-state marker)"
+            ),
+            "must_equal": "needs-mirror->mirrored",
+        },
+    }
+
+
+_MISSING = object()
+
+
+def _get_path(config: dict, dotted: str) -> Any:
+    """Walk a dotted path into nested dicts; return _MISSING if any hop absent."""
+    cur: Any = config
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return _MISSING
+        cur = cur[part]
+    return cur
+
+
+def _is_empty(value: Any) -> bool:
+    """A field counts as absent if it is None or an empty string/collection."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict, tuple, set)) and len(value) == 0:
+        return True
+    return False
+
+
+def verify(deckhand_config: dict, contract_version: int) -> list[dict]:
+    """Return the list of conformance gaps. Empty list == conformant.
+
+    PURE: takes a plain dict (the loaded deckhand config) and the current
+    contract version. Each gap is ``{"field": <dotted.path>, "detail": <why>}``.
+
+    FAIL CLOSED:
+      * a required field that is missing/empty is a gap;
+      * a value that violates its constraint is a gap;
+      * specifically, a declared ``contract_version`` < ``contract_version`` (the
+        current contract version passed in) is a gap.
+    """
+    if not isinstance(deckhand_config, dict):
+        return [
+            {
+                "field": "<root>",
+                "detail": (
+                    "deckhand config must be a mapping/dict; got "
+                    f"{type(deckhand_config).__name__}"
+                ),
+            }
+        ]
+
+    gaps: list[dict] = []
+    schema = required_contract_fields()
+
+    for field, spec in schema.items():
+        value = _get_path(deckhand_config, field)
+
+        if value is _MISSING or _is_empty(value):
+            gaps.append({"field": field, "detail": f"missing required field: {spec['detail']}"})
+            continue
+
+        # contract_version: fail closed on older/unknown.
+        if "min_version" in spec:
+            floor = contract_version  # current contract version is authoritative
+            if not isinstance(value, int) or isinstance(value, bool):
+                gaps.append(
+                    {
+                        "field": field,
+                        "detail": (
+                            f"contract_version must be an integer; got {value!r}"
+                        ),
+                    }
+                )
+                continue
+            if value < floor:
+                gaps.append(
+                    {
+                        "field": field,
+                        "detail": (
+                            f"declared contract_version {value} is older than "
+                            f"current {floor} (fail closed)"
+                        ),
+                    }
+                )
+                continue
+
+        if "must_equal" in spec and value != spec["must_equal"]:
+            gaps.append(
+                {
+                    "field": field,
+                    "detail": (
+                        f"expected {spec['must_equal']!r}, got {value!r} — "
+                        f"{spec['detail']}"
+                    ),
+                }
+            )
+            continue
+
+        if "must_not_contain" in spec and isinstance(value, str):
+            lowered = value.lower()
+            bad = [tok for tok in spec["must_not_contain"] if tok in lowered]
+            if bad:
+                gaps.append(
+                    {
+                        "field": field,
+                        "detail": (
+                            f"value {value!r} contains forbidden token(s) {bad} — "
+                            f"{spec['detail']}"
+                        ),
+                    }
+                )
+                continue
+
+    return gaps
+
+
+def _load_config(path: str) -> dict:
+    """Load a YAML deckhand config from ``path``. Raises on failure."""
+    import yaml  # imported lazily so importing the module needs no yaml
+
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"top-level YAML in {path} is not a mapping")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Parity verifier for the Telegram venue contract (#2971, F4). "
+            "Read-only; never reaches the deckhand host."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        metavar="PATH",
+        help=(
+            "path to a deckhand venue YAML (e.g. a copy of "
+            "config/deckhand/policy.yml). If omitted, no remote fetch is "
+            "attempted."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.config:
+        print(
+            "venue_audit: no --config provided.\n"
+            "  This verifier does NOT ssh into the deckhand host. Provide a local\n"
+            "  copy of the deckhand venue config, e.g.:\n"
+            "    venue_audit.py --config /path/to/deckhand/policy.yml\n"
+            f"  Current contract version: {CURRENT_CONTRACT_VERSION} "
+            "(see docs/ops/telegram-venue-contract.md).",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        config = _load_config(args.config)
+    except FileNotFoundError:
+        print(f"venue_audit: config not found: {args.config}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 - surface any load/parse error clearly
+        print(f"venue_audit: failed to load {args.config}: {exc}", file=sys.stderr)
+        return 2
+
+    gaps = verify(config, CURRENT_CONTRACT_VERSION)
+
+    if not gaps:
+        print(
+            f"venue_audit: CONFORMANT — {args.config} satisfies venue contract "
+            f"v{CURRENT_CONTRACT_VERSION}."
+        )
+        return 0
+
+    print(
+        f"venue_audit: {len(gaps)} GAP(S) — {args.config} does NOT conform to "
+        f"venue contract v{CURRENT_CONTRACT_VERSION}:",
+        file=sys.stderr,
+    )
+    for gap in gaps:
+        print(f"  [{gap['field']}] {gap['detail']}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operations/venue_lease.py
+++ b/scripts/operations/venue_lease.py
@@ -121,6 +121,11 @@ def holds_venue(
     # acquire handles both the free-create case and the re-entrant renew case.
     lease = dispatch_lease.acquire(git, name, holder, ttl_s, now, new_token)
     if lease is not None:
+        # Defense-in-depth (#2971 code-review MAJOR #1): never trust a non-None
+        # return as authorization — confirm WE are the holder before allowing a
+        # WRITE. A primitive bug returning another holder's blob must NOT pass.
+        if not _is_our_lease(lease, holder):
+            return {"allowed": False, "reason": "lease not ours after acquire", "lease": None}
         return {"allowed": True, "reason": "acquired", "lease": lease}
 
     # We did not get it via acquire. Inspect why.
@@ -139,9 +144,37 @@ def holds_venue(
             git, name, holder, ttl_s, now, new_token, liveness_fn
         )
         if reclaimed is not None:
+            if not _is_our_lease(reclaimed, holder):
+                return {"allowed": False, "reason": "lease not ours after reclaim", "lease": None}
             return {"allowed": True, "reason": "reclaimed", "lease": reclaimed}
 
     return {"allowed": False, "reason": f"held by {other}", "lease": None}
+
+
+def _is_our_lease(lease: dict, holder: str) -> bool:
+    """A lease authorizes a WRITE only if it actually names us as holder."""
+    return isinstance(lease, dict) and lease.get("holder") == holder
+
+
+def guarded_write(git, capability, holder, ttl_s, now, new_token, side_effect_fn,
+                  *, liveness_fn=None):
+    """Run a client-visible WRITE side effect ONLY while holding the venue lease,
+    fencing immediately before the side effect (#2971 code-review MAJOR #2 — make
+    the fence mandatory by construction, closing the holds_venue→send TOCTOU).
+
+    Returns {"ran": bool, "reason": str, "result": Any}. The side_effect_fn runs
+    iff holds_venue allows AND fence() passes at the last moment; otherwise it is
+    never invoked.
+    """
+    decision = holds_venue(git, capability, holder, ttl_s, now, new_token,
+                           liveness_fn=liveness_fn)
+    if not decision["allowed"]:
+        return {"ran": False, "reason": decision["reason"], "result": None}
+    lease = decision["lease"]
+    # READ capabilities are ungated (lease is None) — no fence needed.
+    if lease is not None and not fence(git, lease["token"]):
+        return {"ran": False, "reason": "fence failed (lease superseded)", "result": None}
+    return {"ran": True, "reason": "ok", "result": side_effect_fn()}
 
 
 def fence(git: Any, token: str) -> bool:

--- a/scripts/operations/venue_lease.py
+++ b/scripts/operations/venue_lease.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""venue_lease.py — single-active-venue lease (issue #2971, F4).
+
+Goal
+----
+Exactly ONE host runs a Telegram venue's WRITE functions (client-visible side
+effects), while READ-only functions are NEVER gated — so a lease problem can
+never silently stop the safe, multi-host-friendly reads. This is the
+Codex-reviewed design: gating is PER-CAPABILITY, not one blanket gate.
+
+Layering
+--------
+This module is a thin policy layer on top of the F3 dispatch lease
+(`dispatch_lease.py`, the versioned-CAS + fencing-token primitive) and its
+real-git adapter (`git_ref_lease.py`). It owns:
+
+  * the venue's capability → criticality map (which functions are WRITE vs READ),
+  * the venue lease name,
+  * the gating decision (`is_gated`),
+  * the host-ownership decision for a capability (`holds_venue`), and
+  * the fencing wrapper a write function must call immediately before its side
+    effect (`fence`).
+
+All git interaction and nondeterminism stay injected exactly as in F3: the
+caller passes a `git` object, `now`, and `new_token`; `holds_venue` optionally
+accepts a `liveness_fn` to enable safe reclaim of an expired+dead holder.
+
+The dependency modules live in `scripts/operations/` and are NOT importable as a
+package, so they are loaded by FILE PATH via importlib (same pattern the F3
+real-git tests use).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# --- importlib-by-path load of the F3 dependencies (same dir, not a package) ---
+_OPS_DIR = Path(__file__).resolve().parent
+
+
+def _load(mod_name: str, file_name: str):
+    path = _OPS_DIR / file_name
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load {mod_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dispatch_lease = _load("dispatch_lease", "dispatch_lease.py")
+git_ref_lease = _load("git_ref_lease", "git_ref_lease.py")
+
+# --- Venue policy -------------------------------------------------------------
+# write = client-visible side effect → MUST be single-host (gated by the lease).
+# read  = safe to run on every host → NEVER gated (so lease trouble can't stop it).
+VENUE_CAPABILITIES: dict[str, str] = {
+    "escalation-sweep": "write",
+    "bot-send": "write",
+    "member-audit": "read",
+    "parity": "read",
+}
+
+VENUE_LEASE_NAME = "venue-telegram"
+
+
+def is_gated(capability: str) -> bool:
+    """True iff ``capability`` is a WRITE capability (and therefore lease-gated).
+
+    Fails CLOSED on an unknown capability: a function we don't recognize might
+    have a client-visible side effect, so we refuse to make a gating decision
+    rather than silently treating it as a safe read.
+    """
+    try:
+        criticality = VENUE_CAPABILITIES[capability]
+    except KeyError:
+        raise ValueError(f"unknown venue capability: {capability!r}")
+    return criticality == "write"
+
+
+def holds_venue(
+    git: Any,
+    capability: str,
+    holder: str,
+    ttl_s: int,
+    now: float,
+    new_token: str,
+    *,
+    liveness_fn: Optional[Callable[[str], bool]] = None,
+) -> dict:
+    """Decide whether ``holder`` may run ``capability`` for the venue right now.
+
+    Returns ``{"allowed": bool, "reason": str, "lease": dict | None}``.
+
+    READ capability
+        Never gated → ``allowed=True``, ``lease=None``, reason ``"read-not-gated"``.
+        No lease is touched, so reads run on every host regardless of lease state.
+
+    WRITE capability
+        Attempt to acquire/renew the venue lease for ``holder``:
+          * Lease free (absent)             → acquire (generation 1) → allowed.
+          * Lease already held by ``holder`` → renew (re-entrant)    → allowed.
+          * Lease held by another FRESH host → allowed=False, reason "held by <h>".
+          * Lease held by an EXPIRED host    → if ``liveness_fn`` is given AND the
+            holder is dead, reclaim (fences the old holder, generation+1) → allowed;
+            otherwise allowed=False (we never steal a possibly-live lease).
+
+    The returned ``lease`` blob carries the fencing ``token`` the caller must
+    later pass to :func:`fence` immediately before the side effect.
+    """
+    if not is_gated(capability):  # READ (or raises ValueError on unknown)
+        return {"allowed": True, "reason": "read-not-gated", "lease": None}
+
+    name = VENUE_LEASE_NAME
+
+    # acquire handles both the free-create case and the re-entrant renew case.
+    lease = dispatch_lease.acquire(git, name, holder, ttl_s, now, new_token)
+    if lease is not None:
+        return {"allowed": True, "reason": "acquired", "lease": lease}
+
+    # We did not get it via acquire. Inspect why.
+    cur = git.read_ref(dispatch_lease.lease_ref(name))
+    if cur is None:
+        # Lost a creation race (someone created it between our read and create).
+        return {"allowed": False, "reason": "lost creation race", "lease": None}
+
+    _sha, blob = cur
+    other = blob["holder"]
+
+    # If the current holder is expired and we were handed a liveness probe, try a
+    # safe reclaim (only succeeds if the holder is also dead; bumps generation).
+    if liveness_fn is not None:
+        reclaimed = dispatch_lease.reclaim(
+            git, name, holder, ttl_s, now, new_token, liveness_fn
+        )
+        if reclaimed is not None:
+            return {"allowed": True, "reason": "reclaimed", "lease": reclaimed}
+
+    return {"allowed": False, "reason": f"held by {other}", "lease": None}
+
+
+def fence(git: Any, token: str) -> bool:
+    """Fencing check for the venue lease — call IMMEDIATELY before a side effect.
+
+    Thin wrapper over :func:`dispatch_lease.verify_token` bound to the venue
+    lease. Returns True iff the venue lease's CURRENT token still equals
+    ``token``. A write function MUST call this just before its client-visible
+    action; on False (the lease was reclaimed by another host and the token
+    rotated) the function MUST abort — guaranteeing no double-execution even if
+    this host still locally believes it holds the lease.
+    """
+    return dispatch_lease.verify_token(git, VENUE_LEASE_NAME, token)

--- a/tests/operations/test_venue_absence_detector.py
+++ b/tests/operations/test_venue_absence_detector.py
@@ -54,10 +54,28 @@ def test_no_holder_when_present_but_invalid():
         lease_present=True,
         lease_valid=False,
         mirror_ages_h=[],
-        heartbeat_age_h=None,
+        heartbeat_age_h=1.0,   # fresh heartbeat → isolates the no-holder condition
     )
     kinds = [a["kind"] for a in alerts]
     assert kinds == ["no-holder"]
+
+
+def test_unknown_telemetry_alerts_when_no_signal():
+    # empty mirrors + no heartbeat = cannot prove the sweep is alive → alert (#2971 MAJOR #4)
+    alerts = vad.evaluate(
+        lease_present=True, lease_valid=True, mirror_ages_h=[], heartbeat_age_h=None,
+    )
+    assert [a["kind"] for a in alerts] == ["unknown-telemetry"]
+
+
+def test_evaluate_rejects_bad_inputs():
+    import pytest
+    for bad in [dict(sla_h=0), dict(warn_fraction=0), dict(warn_fraction=1.5),
+                dict(mirror_ages_h=[-1.0]), dict(heartbeat_age_h=-1.0)]:
+        kw = dict(lease_present=True, lease_valid=True, mirror_ages_h=[], heartbeat_age_h=1.0)
+        kw.update(bad)
+        with pytest.raises(ValueError):
+            vad.evaluate(**kw)
 
 
 def test_stale_mirror_over_threshold():
@@ -106,10 +124,12 @@ def test_stale_heartbeat_over_threshold():
 
 
 def test_none_heartbeat_produces_no_heartbeat_alert():
+    # a None heartbeat must not produce a stale-heartbeat alert; supply a pending
+    # mirror so the unknown-telemetry guard doesn't fire (we have a live signal).
     alerts = vad.evaluate(
         lease_present=True,
         lease_valid=True,
-        mirror_ages_h=[],
+        mirror_ages_h=[1.0],
         heartbeat_age_h=None,
     )
     assert [a["kind"] for a in alerts if a["kind"] == "stale-heartbeat"] == []
@@ -158,7 +178,7 @@ def _args(**overrides):
         lease_present=True,
         lease_valid=True,
         mirror_age_h=[],
-        heartbeat_age_h=None,
+        heartbeat_age_h=1.0,   # fresh heartbeat = genuinely-healthy baseline
         sla_h=24.0,
         warn_fraction=0.5,
     )

--- a/tests/operations/test_venue_absence_detector.py
+++ b/tests/operations/test_venue_absence_detector.py
@@ -1,0 +1,207 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytest"]
+# ///
+"""Tests for the venue ABSENCE detector core + CLI (issue #2971, F4)."""
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the module by path (scripts/ is not a package).
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts" / "operations" / "venue_absence_detector.py"
+)
+_spec = importlib.util.spec_from_file_location("venue_absence_detector", _MODULE_PATH)
+vad = importlib.util.module_from_spec(_spec)
+sys.modules["venue_absence_detector"] = vad
+_spec.loader.exec_module(vad)
+
+
+# --------------------------------------------------------------------------- #
+# PURE CORE: evaluate()
+# --------------------------------------------------------------------------- #
+
+
+def test_healthy_returns_no_alerts():
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[1.0, 5.0],   # under 12h threshold
+        heartbeat_age_h=2.0,        # under 12h threshold
+    )
+    assert alerts == []
+
+
+def test_no_holder_when_lease_absent():
+    alerts = vad.evaluate(
+        lease_present=False,
+        lease_valid=False,
+        mirror_ages_h=[],
+        heartbeat_age_h=None,
+    )
+    kinds = [a["kind"] for a in alerts]
+    assert "no-holder" in kinds
+    assert all(a["severity"] for a in alerts)
+
+
+def test_no_holder_when_present_but_invalid():
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=False,
+        mirror_ages_h=[],
+        heartbeat_age_h=None,
+    )
+    kinds = [a["kind"] for a in alerts]
+    assert kinds == ["no-holder"]
+
+
+def test_stale_mirror_over_threshold():
+    # threshold = 24 * 0.5 = 12h; 13h is stale.
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[13.0],
+        heartbeat_age_h=None,
+    )
+    kinds = [a["kind"] for a in alerts]
+    assert kinds == ["stale-mirror"]
+
+
+def test_no_stale_mirror_under_threshold():
+    # 11.99h is under the 12h threshold → healthy.
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[11.99, 0.5],
+        heartbeat_age_h=None,
+    )
+    assert alerts == []
+
+
+def test_stale_mirror_threshold_is_strict_below_sla():
+    # The warn threshold (12h) must be strictly below the 24h SLA so we alert
+    # with margin to act. Confirm a 12.01h mirror alerts well before 24h.
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[12.01],
+        heartbeat_age_h=None,
+    )
+    assert [a["kind"] for a in alerts] == ["stale-mirror"]
+
+
+def test_stale_heartbeat_over_threshold():
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[],
+        heartbeat_age_h=18.0,
+    )
+    assert [a["kind"] for a in alerts] == ["stale-heartbeat"]
+
+
+def test_none_heartbeat_produces_no_heartbeat_alert():
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[],
+        heartbeat_age_h=None,
+    )
+    assert [a["kind"] for a in alerts if a["kind"] == "stale-heartbeat"] == []
+    assert alerts == []
+
+
+def test_multiple_alerts_compound():
+    alerts = vad.evaluate(
+        lease_present=False,
+        lease_valid=False,
+        mirror_ages_h=[20.0, 1.0],   # one stale, one fresh
+        heartbeat_age_h=30.0,        # stale
+    )
+    kinds = sorted(a["kind"] for a in alerts)
+    # no-holder + one stale-mirror (only the 20h) + stale-heartbeat
+    assert kinds == ["no-holder", "stale-heartbeat", "stale-mirror"]
+
+
+def test_custom_warn_fraction_and_sla():
+    # sla=10h, warn_fraction=0.8 → threshold=8h. 9h mirror is stale.
+    alerts = vad.evaluate(
+        lease_present=True,
+        lease_valid=True,
+        mirror_ages_h=[9.0],
+        heartbeat_age_h=7.0,         # under 8h → fresh
+        sla_h=10.0,
+        warn_fraction=0.8,
+    )
+    assert [a["kind"] for a in alerts] == ["stale-mirror"]
+
+
+def test_evaluate_is_pure_returns_dicts_with_required_keys():
+    alerts = vad.evaluate(False, False, [50.0], 50.0)
+    for a in alerts:
+        assert set(a.keys()) == {"kind", "detail", "severity"}
+
+
+# --------------------------------------------------------------------------- #
+# THIN CLI: run_cli() with injected notify_fn
+# --------------------------------------------------------------------------- #
+
+
+def _args(**overrides):
+    base = dict(
+        json=None,
+        lease_present=True,
+        lease_valid=True,
+        mirror_age_h=[],
+        heartbeat_age_h=None,
+        sla_h=24.0,
+        warn_fraction=0.5,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_cli_healthy_returns_zero_and_no_notify():
+    calls = []
+    rc = vad.run_cli(
+        _args(lease_present=True, lease_valid=True,
+              mirror_age_h=[1.0], heartbeat_age_h=2.0),
+        notify_fn=calls.append,
+    )
+    assert rc == 0
+    assert calls == []
+
+
+def test_cli_calls_notify_once_per_alert_and_returns_nonzero():
+    calls = []
+    rc = vad.run_cli(
+        _args(lease_present=False, lease_valid=False,
+              mirror_age_h=[20.0], heartbeat_age_h=30.0),
+        notify_fn=calls.append,
+    )
+    assert rc == 1
+    # no-holder + stale-mirror + stale-heartbeat = 3 alerts → 3 notify calls.
+    assert len(calls) == 3
+    assert {c["kind"] for c in calls} == {
+        "no-holder", "stale-mirror", "stale-heartbeat",
+    }
+
+
+def test_cli_single_alert_fires_one_notify():
+    calls = []
+    rc = vad.run_cli(
+        _args(lease_present=False, lease_valid=False),
+        notify_fn=calls.append,
+    )
+    assert rc == 1
+    assert len(calls) == 1
+    assert calls[0]["kind"] == "no-holder"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/operations/test_venue_audit.py
+++ b/tests/operations/test_venue_audit.py
@@ -1,0 +1,155 @@
+"""TDD tests for venue_audit.py — Telegram venue parity verifier (#2971, F4)."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "operations" / "venue_audit.py"
+spec = importlib.util.spec_from_file_location("venue_audit", MODULE_PATH)
+assert spec is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["venue_audit"] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+CURRENT = module.CURRENT_CONTRACT_VERSION
+
+
+def _conformant_config(contract_version: int | None = None) -> dict:
+    """A deckhand venue config that fully satisfies the contract."""
+    return {
+        "venue_contract": {
+            "contract_version": CURRENT if contract_version is None else contract_version,
+            "idempotency": {"scheme": "client-ref+message-type+monotonic-seq"},
+            "dead_letter": {"target": "deckhand-dead-letter-queue"},
+            "audit": {"pii_safe": True},
+            "escalation": {"label_swap": "needs-mirror->mirrored"},
+        }
+    }
+
+
+# --- conformant ----------------------------------------------------------------
+
+
+def test_conformant_config_returns_no_gaps():
+    gaps = module.verify(_conformant_config(), CURRENT)
+    assert gaps == []
+
+
+def test_conformant_with_newer_declared_version_is_ok():
+    # declared >= current is fine (fail-closed only triggers on older)
+    gaps = module.verify(_conformant_config(CURRENT + 5), CURRENT)
+    assert gaps == []
+
+
+# --- missing field -------------------------------------------------------------
+
+
+def test_missing_required_field_returns_gap():
+    cfg = _conformant_config()
+    del cfg["venue_contract"]["dead_letter"]
+    gaps = module.verify(cfg, CURRENT)
+    fields = {g["field"] for g in gaps}
+    assert "venue_contract.dead_letter.target" in fields
+    # every gap carries field + detail
+    for g in gaps:
+        assert set(g) == {"field", "detail"}
+
+
+def test_empty_config_returns_all_gaps():
+    gaps = module.verify({}, CURRENT)
+    assert len(gaps) == len(module.required_contract_fields())
+
+
+# --- older contract version (fail closed) -------------------------------------
+
+
+def test_older_declared_contract_version_returns_gap():
+    cfg = _conformant_config(CURRENT - 1)
+    gaps = module.verify(cfg, CURRENT)
+    fields = {g["field"] for g in gaps}
+    assert "venue_contract.contract_version" in fields
+    detail = next(g["detail"] for g in gaps if g["field"] == "venue_contract.contract_version")
+    assert "older" in detail.lower()
+
+
+def test_missing_contract_version_returns_gap():
+    cfg = _conformant_config()
+    del cfg["venue_contract"]["contract_version"]
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.contract_version" in {g["field"] for g in gaps}
+
+
+def test_non_integer_contract_version_returns_gap():
+    cfg = _conformant_config()
+    cfg["venue_contract"]["contract_version"] = "1"  # string, not int
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.contract_version" in {g["field"] for g in gaps}
+
+
+# --- PII-safe audit ------------------------------------------------------------
+
+
+def test_audit_without_pii_safe_true_returns_gap():
+    cfg = _conformant_config()
+    cfg["venue_contract"]["audit"] = {"pii_safe": False}
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.audit.pii_safe" in {g["field"] for g in gaps}
+
+
+def test_audit_missing_pii_safe_returns_gap():
+    cfg = _conformant_config()
+    cfg["venue_contract"]["audit"] = {}  # present but no pii_safe key
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.audit.pii_safe" in {g["field"] for g in gaps}
+
+
+# --- idempotency scheme (no content-hash) -------------------------------------
+
+
+def test_content_hash_idempotency_scheme_returns_gap():
+    cfg = _conformant_config()
+    cfg["venue_contract"]["idempotency"]["scheme"] = "content-hash"
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.idempotency.scheme" in {g["field"] for g in gaps}
+
+
+def test_wrong_label_swap_returns_gap():
+    cfg = _conformant_config()
+    cfg["venue_contract"]["escalation"]["label_swap"] = "open->closed"
+    gaps = module.verify(cfg, CURRENT)
+    assert "venue_contract.escalation.label_swap" in {g["field"] for g in gaps}
+
+
+# --- purity / robustness -------------------------------------------------------
+
+
+def test_verify_does_not_mutate_input():
+    cfg = _conformant_config()
+    snapshot = copy.deepcopy(cfg)
+    module.verify(cfg, CURRENT)
+    assert cfg == snapshot
+
+
+def test_non_dict_config_fails_closed():
+    gaps = module.verify("not-a-dict", CURRENT)
+    assert len(gaps) == 1
+    assert gaps[0]["field"] == "<root>"
+
+
+# --- schema shape --------------------------------------------------------------
+
+
+def test_required_contract_fields_schema_shape():
+    schema = module.required_contract_fields()
+    assert "venue_contract.contract_version" in schema
+    assert "venue_contract.idempotency.scheme" in schema
+    assert "venue_contract.dead_letter.target" in schema
+    assert "venue_contract.audit.pii_safe" in schema
+    assert "venue_contract.escalation.label_swap" in schema
+    for spec in schema.values():
+        assert "detail" in spec

--- a/tests/operations/test_venue_lease.py
+++ b/tests/operations/test_venue_lease.py
@@ -1,0 +1,235 @@
+"""TDD tests for the single-active-venue lease (#2971, F4).
+
+Loads `scripts/operations/venue_lease.py` by file path (it is not an importable
+package). Two git backends are exercised:
+
+  * an in-memory FakeGit implementing the F3 injected interface
+    (read_ref / create_ref / cas_update_ref) with create-only + CAS semantics
+    and a monotonic sha counter, and
+  * a real temp git repo via `git_ref_lease.GitRefLease` for one integration
+    smoke test of the free-venue write path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "operations" / "venue_lease.py"
+spec = importlib.util.spec_from_file_location("venue_lease", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+venue_lease = importlib.util.module_from_spec(spec)
+sys.modules["venue_lease"] = venue_lease
+spec.loader.exec_module(venue_lease)
+
+dispatch_lease = venue_lease.dispatch_lease
+git_ref_lease = venue_lease.git_ref_lease
+
+
+# --- In-memory fake-git: dict name -> (sha, blob); create-only + CAS ----------
+class FakeGit:
+    def __init__(self) -> None:
+        self.refs: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter}"
+
+    def read_ref(self, name: str):
+        return self.refs.get(name)
+
+    def create_ref(self, name: str, blob: dict):
+        if name in self.refs:  # create fails if it already exists
+            return None
+        sha = self._next_sha()
+        self.refs[name] = (sha, dict(blob))
+        return sha
+
+    def cas_update_ref(self, name: str, expected_sha: str, blob: dict):
+        cur = self.refs.get(name)
+        if cur is None or cur[0] != expected_sha:  # CAS only if tip unchanged
+            return None
+        sha = self._next_sha()
+        self.refs[name] = (sha, dict(blob))
+        return sha
+
+
+# --- is_gated ------------------------------------------------------------------
+def test_is_gated_write_capabilities_true():
+    assert venue_lease.is_gated("escalation-sweep") is True
+    assert venue_lease.is_gated("bot-send") is True
+
+
+def test_is_gated_read_capabilities_false():
+    assert venue_lease.is_gated("member-audit") is False
+    assert venue_lease.is_gated("parity") is False
+
+
+def test_is_gated_unknown_capability_raises():
+    with pytest.raises(ValueError):
+        venue_lease.is_gated("delete-everything")
+
+
+# --- holds_venue: READ never gated, no lease acquired -------------------------
+def test_holds_venue_read_allowed_without_lease():
+    git = FakeGit()
+    res = venue_lease.holds_venue(
+        git, "member-audit", holder="hostA", ttl_s=60, now=100.0, new_token="t1"
+    )
+    assert res["allowed"] is True
+    assert res["lease"] is None
+    # No lease ref was created for a read.
+    assert git.refs == {}
+
+
+# --- holds_venue: WRITE on a free venue acquires generation 1 -----------------
+def test_holds_venue_write_free_acquires_gen1():
+    git = FakeGit()
+    res = venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="t1"
+    )
+    assert res["allowed"] is True
+    assert res["lease"]["holder"] == "hostA"
+    assert res["lease"]["generation"] == 1
+    assert res["lease"]["token"] == "t1"
+    assert dispatch_lease.lease_ref(venue_lease.VENUE_LEASE_NAME) in git.refs
+
+
+# --- holds_venue: WRITE blocked when another FRESH host holds it --------------
+def test_holds_venue_write_blocked_by_other_fresh_host():
+    git = FakeGit()
+    a = venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="tA"
+    )
+    assert a["allowed"] is True
+    # hostB tries while hostA's lease is still fresh (now within ttl).
+    b = venue_lease.holds_venue(
+        git, "bot-send", holder="hostB", ttl_s=60, now=110.0, new_token="tB"
+    )
+    assert b["allowed"] is False
+    assert b["reason"] == "held by hostA"
+    assert b["lease"] is None
+
+
+# --- holds_venue: re-entrant (same holder) renews ----------------------------
+def test_holds_venue_write_reentrant_renews():
+    git = FakeGit()
+    a1 = venue_lease.holds_venue(
+        git, "escalation-sweep", holder="hostA", ttl_s=60, now=100.0, new_token="tA1"
+    )
+    assert a1["allowed"] is True
+    a2 = venue_lease.holds_venue(
+        git, "escalation-sweep", holder="hostA", ttl_s=60, now=130.0, new_token="tA2"
+    )
+    assert a2["allowed"] is True
+    # renew keeps the same generation, refreshes renewed_at, rotates the token.
+    assert a2["lease"]["generation"] == 1
+    assert a2["lease"]["renewed_at"] == 130.0
+    assert a2["lease"]["token"] == "tA2"
+
+
+# --- holds_venue: reclaim path (expired + dead holder) -----------------------
+def test_holds_venue_write_reclaims_expired_dead_holder():
+    git = FakeGit()
+    venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="tA"
+    )
+    # hostA's lease is expired (now-renewed_at > ttl) and hostA is dead.
+    res = venue_lease.holds_venue(
+        git,
+        "bot-send",
+        holder="hostB",
+        ttl_s=60,
+        now=200.0,
+        new_token="tB",
+        liveness_fn=lambda h: False,
+    )
+    assert res["allowed"] is True
+    assert res["reason"] == "reclaimed"
+    assert res["lease"]["holder"] == "hostB"
+    assert res["lease"]["generation"] == 2  # fence bump
+    assert res["lease"]["token"] == "tB"
+
+
+def test_holds_venue_write_no_reclaim_when_holder_alive():
+    git = FakeGit()
+    venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="tA"
+    )
+    # Expired but holder still alive → refuse to steal.
+    res = venue_lease.holds_venue(
+        git,
+        "bot-send",
+        holder="hostB",
+        ttl_s=60,
+        now=200.0,
+        new_token="tB",
+        liveness_fn=lambda h: True,
+    )
+    assert res["allowed"] is False
+    assert res["reason"] == "held by hostA"
+
+
+# --- fence: token valid for holder, invalid after reclaim --------------------
+def test_fence_holder_token_true_then_false_after_reclaim():
+    git = FakeGit()
+    a = venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="tA"
+    )
+    a_token = a["lease"]["token"]
+    # hostA's write function fences just before its side effect → still valid.
+    assert venue_lease.fence(git, a_token) is True
+
+    # hostA stalls past ttl and dies; hostB reclaims, bumping the token.
+    b = venue_lease.holds_venue(
+        git,
+        "bot-send",
+        holder="hostB",
+        ttl_s=60,
+        now=200.0,
+        new_token="tB",
+        liveness_fn=lambda h: False,
+    )
+    assert b["allowed"] is True
+    # hostA wakes up and fences with its STALE token → must abort.
+    assert venue_lease.fence(git, a_token) is False
+    # hostB's fresh token still passes.
+    assert venue_lease.fence(git, b["lease"]["token"]) is True
+
+
+def test_fence_absent_lease_false():
+    git = FakeGit()
+    assert venue_lease.fence(git, "anything") is False
+
+
+# --- Real-git integration smoke test (GitRefLease) ----------------------------
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True,
+                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+
+
+def test_holds_venue_write_on_real_git_repo(tmp_path):
+    _init_repo(tmp_path)
+    git = git_ref_lease.GitRefLease(tmp_path)
+    res = venue_lease.holds_venue(
+        git, "bot-send", holder="hostA", ttl_s=60, now=100.0, new_token="t1"
+    )
+    assert res["allowed"] is True
+    assert res["lease"]["generation"] == 1
+    assert res["lease"]["holder"] == "hostA"
+    # Fencing against the real ref works with the granted token.
+    assert venue_lease.fence(git, res["lease"]["token"]) is True
+    # A second host is blocked while the lease is fresh.
+    res2 = venue_lease.holds_venue(
+        git, "bot-send", holder="hostB", ttl_s=60, now=110.0, new_token="t2"
+    )
+    assert res2["allowed"] is False
+    assert res2["reason"] == "held by hostA"

--- a/tests/operations/test_venue_lease.py
+++ b/tests/operations/test_venue_lease.py
@@ -233,3 +233,41 @@ def test_holds_venue_write_on_real_git_repo(tmp_path):
     )
     assert res2["allowed"] is False
     assert res2["reason"] == "held by hostA"
+
+
+# ── #2971 code-review MAJOR fixes ────────────────────────────────────────────
+def test_guarded_write_runs_only_when_held_and_fenced(tmp_path):
+    import importlib.util as _u, sys as _s
+    grl = _s.modules.get("git_ref_lease")
+    if grl is None:
+        spec = _u.spec_from_file_location("git_ref_lease", REPO_ROOT / "scripts" / "operations" / "git_ref_lease.py")
+        grl = _u.module_from_spec(spec); _s.modules["git_ref_lease"] = grl; spec.loader.exec_module(grl)
+    import subprocess
+    subprocess.run(["git","init","-q",str(tmp_path)],check=True)
+    subprocess.run(["git","-C",str(tmp_path),"config","user.email","t@t"],check=True)
+    subprocess.run(["git","-C",str(tmp_path),"config","user.name","t"],check=True)
+    git = grl.GitRefLease(str(tmp_path))
+    ran = []
+    res = venue_lease.guarded_write(git, "escalation-sweep", "host-a", 60, 1000.0, "tok-a",
+                           side_effect_fn=lambda: ran.append(1) or "done")
+    assert res["ran"] is True and res["result"] == "done" and ran == [1]
+
+
+def test_guarded_write_skips_when_not_holder(tmp_path):
+    import importlib.util as _u, sys as _s, subprocess
+    grl = _s.modules["git_ref_lease"]
+    subprocess.run(["git","init","-q",str(tmp_path)],check=True)
+    subprocess.run(["git","-C",str(tmp_path),"config","user.email","t@t"],check=True)
+    subprocess.run(["git","-C",str(tmp_path),"config","user.name","t"],check=True)
+    git = grl.GitRefLease(str(tmp_path))
+    venue_lease.holds_venue(git, "escalation-sweep", "host-a", 60, 1000.0, "tok-a")  # host-a holds
+    ran = []
+    res = venue_lease.guarded_write(git, "escalation-sweep", "host-b", 60, 1001.0, "tok-b",
+                           side_effect_fn=lambda: ran.append(1))
+    assert res["ran"] is False and ran == []   # host-b never runs the side effect
+
+
+def test_is_our_lease_rejects_other_holder():
+    assert venue_lease._is_our_lease({"holder": "me"}, "me") is True
+    assert venue_lease._is_our_lease({"holder": "other"}, "me") is False
+    assert venue_lease._is_our_lease(None, "me") is False


### PR DESCRIPTION
## F4 of epic #2967 — Telegram-as-venue consistency (IMPLEMENTATION) — final slice

Implements #2971 (plan PR #2983, merged). Built via **3 parallel agents**, reusing F3's lease. **40 tests pass.** With this, the epic is structurally complete.

### What landed
| File | Role |
|---|---|
| `scripts/operations/venue_lease.py` | per-CAPABILITY gating: write funcs (escalation-sweep, bot-send) gated + fenced; read funcs (member-audit, parity) **never gated** |
| `scripts/operations/venue_absence_detector.py` | **decoupled** silent-stop guard — alerts on no-holder OR stale-mirror/heartbeat before the 24h SLA |
| `docs/ops/telegram-venue-contract.md` | the contract: single-active, ordered delivery state machine, idempotency key (`client-ref+type+seq`, not content-hash), retry/dead-letter, PII-safe audit, `contract_version` pin |
| `scripts/operations/venue_audit.py` | parity verifier (deckhand config vs contract, fail-closed) |

### Codex plan-review MAJOR folded
Per-capability lease (not blanket) · independent absence detector (no fleet-wide silent-stop) · ordered delivery state machine reconciling the label-swap + per-message key · PII-safe audit (no content/reversible-id/content-hash) · cross-repo version pin.

### Cross-repo boundary
Contract + lease + detector + verifier here. The **deckhand send-path implementation** (lease-token fencing, retry/dead-letter queue, audit emitter) is a deckhand follow-up issue (filed).

### Deferred to operator-cutover (consistent with prior slices)
Moving the live a2 venue crons behind `holds_venue()` is the operator step — a2 runs live client SLA automation (highest-stakes host). Ship contract + lease + detector + verifier; gate the live cutover behind a separate approved step.

Authored via GitHub API (control-plane tree FUSE-bound).
