### PR TITLE
feat(cron): preserved_local class — unblocks F2 a2 cutover (#2988)

### DIFF
--- a/config/workstations/harness-state-classes.yaml
+++ b/config/workstations/harness-state-classes.yaml
@@ -87,3 +87,23 @@ preserved_external:
     fingerprint:
       cwd_contains: /.deckhand-guard
       script_basename: patch-health-check.py
+
+# Preserved-LOCAL crons (#2988, F2 follow-up) — machine-local workspace-hub maintenance
+# crons that are NOT in the role catalog and NOT externally-owned. Functionally identical
+# to preserved_external (the cron reconciler keeps them verbatim, never manages/deletes
+# them), but semantically these are the host's own workspace-hub scripts run with a
+# machine-specific invocation. Match on stable command bits only.
+preserved_local:
+  - owner: ace-linux-2
+    note: >-
+      a2-local model-ID refresh variant (scripts/maintenance/update-model-ids.sh --hub-only).
+      Distinct from the control-plane `model-ids` task (scripts/cron/update-model-ids.sh,
+      a1-only). a2 self-maintains its model registry; keep verbatim.
+    fingerprint:
+      command_contains: scripts/maintenance/update-model-ids.sh
+  - owner: ace-linux-2
+    note: >-
+      a2-local skills-curation variant (raw `claude --skill skills-curation`). Distinct
+      from the control-plane skills-curation task (scripts/cron/skills-curation.sh). Keep verbatim.
+    fingerprint:
+      command_contains: "--skill skills-curation"

--- a/scripts/cron/cron-audit.py
+++ b/scripts/cron/cron-audit.py
@@ -99,11 +99,15 @@ def load_catalog_commands(path: Path = CATALOG_PATH) -> list[str]:
 
 
 def load_external_fingerprints(path: Path = CLASSES_PATH) -> list[dict]:
-    """Read preserved_external fingerprints from harness-state-classes.yaml."""
+    """Read preserved fingerprints from harness-state-classes.yaml.
+
+    Merges preserved_external (other-repo-owned) + preserved_local (this host's own
+    non-catalog workspace-hub crons, #2988) — both are the keep-verbatim bucket.
+    """
     if not path.exists():
         raise FileNotFoundError(f"state-classes file not found at {path}")
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    entries = data.get("preserved_external", []) or []
+    entries = (data.get("preserved_external", []) or []) + (data.get("preserved_local", []) or [])
     fingerprints: list[dict] = []
     for entry in entries:
         fp = entry.get("fingerprint")

--- a/scripts/cron/cron_apply.py
+++ b/scripts/cron/cron_apply.py
@@ -131,7 +131,11 @@ def catalog_commands(catalog: dict) -> list[str]:
 
 
 def external_fingerprints(state_classes: dict) -> list[dict]:
-    return [e.get("fingerprint", {}) for e in (state_classes.get("preserved_external") or [])]
+    # preserved_external (other-repo-owned, e.g. deckhand) + preserved_local (this host's
+    # own non-catalog workspace-hub crons, #2988) — both are the keep-verbatim bucket.
+    entries = (state_classes.get("preserved_external") or []) + \
+              (state_classes.get("preserved_local") or [])
+    return [e.get("fingerprint", {}) for e in entries]
 
 
 # ── the transaction ──────────────────────────────────────────────────────────

--- a/tests/cron/test_cron_audit.py
+++ b/tests/cron/test_cron_audit.py
@@ -117,3 +117,23 @@ def test_stable_command_fragment_prefers_script_path(audit):
         "bash scripts/testing/run-benchmarks.sh >> $WORKSPACE_HUB/logs/x.log 2>&1"
     )
     assert audit.stable_command_fragment(cmd) == "scripts/testing/run-benchmarks.sh"
+
+
+# ── #2988: preserved_local merges into the keep-verbatim bucket ──────────────
+def test_preserved_local_merged_into_fingerprints(tmp_path):
+    import importlib.util as _u, sys as _s
+    spec = _u.spec_from_file_location("cron_audit_x", REPO_ROOT / "scripts" / "cron" / "cron-audit.py") \
+        if "REPO_ROOT" in dir() else None
+    # load module fresh by path
+    from pathlib import Path as _P
+    root = _P(__file__).resolve().parents[2]
+    spec = _u.spec_from_file_location("cron_audit_x", root / "scripts" / "cron" / "cron-audit.py")
+    m = _u.module_from_spec(spec); _s.modules["cron_audit_x"] = m; spec.loader.exec_module(m)
+    classes = tmp_path / "hsc.yaml"
+    classes.write_text(
+        "preserved_external:\n  - fingerprint: {cwd_contains: /deckhand}\n"
+        "preserved_local:\n  - fingerprint: {command_contains: scripts/maintenance/update-model-ids.sh}\n"
+    )
+    fps = m.load_external_fingerprints(classes)
+    assert len(fps) == 2
+    assert any(fp.get("command_contains") == "scripts/maintenance/update-model-ids.sh" for fp in fps)


### PR DESCRIPTION
Closes #2988. F2 (#2969) a2 dry-run fail-closed-blocked on 2 real a2-local maintenance crons (`scripts/maintenance/update-model-ids.sh --hub-only`; raw `claude --skill skills-curation`). Adds a `preserved_local` class (machine-local workspace-hub crons, distinct from deckhand `preserved_external`); cron_apply.py + cron-audit.py merge it into the keep-verbatim bucket. **Verified:** both a2 lines now classify `preserved` (not uncataloged) + deckhand crons still preserved → F2 a2 cutover unblocks, non-destructive. 7 cron-audit tests pass.