### PR TITLE
feat(dispatch): wire F3 cores into workstation-dispatch.sh (#2970 residual)

### DIFF
--- a/scripts/operations/workstation-dispatch.sh
+++ b/scripts/operations/workstation-dispatch.sh
@@ -15,6 +15,16 @@
 #
 #   # Force a specific machine:
 #   bash scripts/operations/workstation-dispatch.sh --machine dev-secondary --command "uptime"
+#
+#   # Show provider routing for the selected machine (informational; F3 wiring):
+#   bash scripts/operations/workstation-dispatch.sh --task gsd-researcher --route review --dry-run
+#
+#   # Role-aware selection (honor task roles ∩ machine harness_profile.roles, F3):
+#   bash scripts/operations/workstation-dispatch.sh --task equality-report --role-aware --dry-run
+#
+#   # Acquire an atomic git-ref lease before dispatching so two dispatchers
+#   # can't double-run the same task (F3 headline capability):
+#   bash scripts/operations/workstation-dispatch.sh --task benchmark-regression --lease
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,18 +39,25 @@ COMMAND=""
 MACHINE=""
 DRY_RUN=false
 VERBOSE=false
+ROUTE_TASK_TYPE=""   # F3: --route <task_type> → print provider routing for selected machine
+ROLE_AWARE=false     # F3: --role-aware → honor task roles ∩ machine harness_profile.roles
+USE_LEASE=false      # F3: --lease → acquire an atomic git-ref lease before dispatching
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --task)     TASK_ID="$2"; shift 2 ;;
-    --requires) REQUIRES="$2"; shift 2 ;;
-    --command)  COMMAND="$2"; shift 2 ;;
-    --machine)  MACHINE="$2"; shift 2 ;;
-    --dry-run)  DRY_RUN=true; shift ;;
-    --verbose)  VERBOSE=true; shift ;;
+    --task)       TASK_ID="$2"; shift 2 ;;
+    --requires)   REQUIRES="$2"; shift 2 ;;
+    --command)    COMMAND="$2"; shift 2 ;;
+    --machine)    MACHINE="$2"; shift 2 ;;
+    --route)      ROUTE_TASK_TYPE="$2"; shift 2 ;;
+    --role-aware) ROLE_AWARE=true; shift ;;
+    --lease)      USE_LEASE=true; shift ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --verbose)    VERBOSE=true; shift ;;
     *)
       echo "ERROR: unknown arg: $1" >&2
-      echo "Usage: $0 --task <id> | --requires <caps> --command <cmd> [--machine <name>] [--dry-run]" >&2
+      echo "Usage: $0 --task <id> | --requires <caps> --command <cmd> [--machine <name>]" >&2
+      echo "          [--route <task_type>] [--role-aware] [--lease] [--dry-run] [--verbose]" >&2
       exit 1
       ;;
   esac
@@ -67,6 +84,7 @@ for task in data.get('tasks', []):
     if task.get('id') == '${TASK_ID}':
         print(json.dumps({
             'requires': task.get('requires', []),
+            'roles': task.get('roles', []),
             'command': task.get('command', ''),
             'prefer': task.get('prefer', ''),
             'label': task.get('label', ''),
@@ -82,6 +100,7 @@ print('__NOT_FOUND__')
 
   # Extract fields from JSON
   REQUIRES=$(echo "$TASK_INFO" | uv run --no-project python -c "import sys,json; print(','.join(json.load(sys.stdin)['requires']))" 2>/dev/null)
+  TASK_ROLES=$(echo "$TASK_INFO" | uv run --no-project python -c "import sys,json; print(','.join(json.load(sys.stdin).get('roles', [])))" 2>/dev/null)
   TASK_LABEL=$(echo "$TASK_INFO" | uv run --no-project python -c "import sys,json; print(json.load(sys.stdin)['label'])" 2>/dev/null)
   PREFER=$(echo "$TASK_INFO" | uv run --no-project python -c "import sys,json; print(json.load(sys.stdin)['prefer'])" 2>/dev/null)
   if [[ -z "$COMMAND" ]]; then
@@ -94,6 +113,33 @@ fi
 vlog "Requires: ${REQUIRES:-<none>}"
 vlog "Command: ${COMMAND}"
 
+# ── F3 --role-aware: compute role-aware eligible set via dispatch_select.py ───
+# Default OFF. When ON (and a task is being selected), the task's roles ∩ each
+# machine's harness_profile.roles is honored IN ADDITION to the requires match,
+# via the merged dispatch_select.select() core. The eligible machine ids become
+# an allowlist that further constrains the existing requires-based scorer below;
+# when the allowlist is empty the scorer behaves exactly as before (additive).
+ROLE_ELIGIBLE=""
+if [[ "$ROLE_AWARE" == "true" && -z "$MACHINE" ]]; then
+  ROLE_ELIGIBLE=$(uv run --no-project --with pyyaml python -c "
+import sys
+sys.path.insert(0, '${SCRIPT_DIR}')
+import yaml
+from dispatch_select import select
+with open('${REGISTRY}') as f:
+    reg = yaml.safe_load(f)
+machines = reg.get('machines', {}) or {}
+task = {
+    'requires': '${REQUIRES}'.split(',') if '${REQUIRES}' else [],
+    'roles': '${TASK_ROLES:-}'.split(',') if '${TASK_ROLES:-}' else [],
+}
+# probe_fn=None -> ready == eligible (declared, JIT-probe deferred to dispatch).
+result = select(task, machines)
+print(','.join(result['eligible']))
+" 2>/dev/null)
+  vlog "Role-aware eligible: ${ROLE_ELIGIBLE:-<none>}"
+fi
+
 # ── Find best-fit machine ──────────────────────────────────────────────────
 if [[ -z "$MACHINE" ]]; then
   MACHINE=$(uv run --no-project python -c "
@@ -104,6 +150,7 @@ with open('${REGISTRY}') as f:
 required = set('${REQUIRES}'.split(',')) if '${REQUIRES}' else set()
 prefer = '${PREFER:-}'
 this_host = '${THIS_HOST}'
+role_eligible = set('${ROLE_ELIGIBLE}'.split(',')) if '${ROLE_ELIGIBLE}' else set()
 
 # Flatten each machine's capabilities into a single set
 def get_caps(m):
@@ -129,6 +176,11 @@ for name, m in reg.get('machines', {}).items():
     # Must satisfy all requirements
     caps = get_caps(m)
     if not required.issubset(caps):
+        continue
+    # F3 --role-aware: when an eligibility allowlist was computed, the machine
+    # must also be role-eligible (roles ∩ task roles, or cap-eligible) per the
+    # dispatch_select core. Empty allowlist (default) = no extra constraint.
+    if role_eligible and name not in role_eligible:
         continue
     # Score: prefer hint = +100, local = +10, fewer excess caps = tighter fit
     score = 0
@@ -187,6 +239,33 @@ fi
 
 log "Target: ${MACHINE_NAME} (local=${IS_LOCAL})"
 
+# ── F3 --route: informational provider routing for the selected machine ──────
+# Prints which AI provider(s) should do <task_type> on the selected machine, via
+# the single provider_route.py policy resolver. Informational ONLY — it does not
+# change which machine is selected nor what command runs. The routing machine id
+# is the registry hostname (matches policy machine_overrides keys, e.g.
+# ace-linux-1); unknown machines fall back to the policy seed order.
+if [[ -n "$ROUTE_TASK_TYPE" ]]; then
+  ROUTE_MACHINE=$(uv run --no-project python -c "
+import yaml
+with open('${REGISTRY}') as f:
+    reg = yaml.safe_load(f)
+for name, m in reg.get('machines', {}).items():
+    if name == '${MACHINE_NAME}':
+        print(m.get('hostname') or name)
+        break
+else:
+    print('${MACHINE_NAME}')
+" 2>/dev/null)
+  ROUTE_MACHINE="${ROUTE_MACHINE:-$MACHINE_NAME}"
+  if PROVIDERS=$(uv run --script "${SCRIPT_DIR}/../ai/provider_route.py" "$ROUTE_TASK_TYPE" "$ROUTE_MACHINE" 2>/dev/null) \
+       && [[ -n "$PROVIDERS" ]]; then
+    log "Provider routing (${ROUTE_TASK_TYPE} on ${ROUTE_MACHINE}): ${PROVIDERS}"
+  else
+    log "Provider routing (${ROUTE_TASK_TYPE} on ${ROUTE_MACHINE}): <none — task_type unknown or all providers pruned>"
+  fi
+fi
+
 # ── Dry-run: stop here ─────────────────────────────────────────────────────
 if [[ "$DRY_RUN" == "true" ]]; then
   echo ""
@@ -200,6 +279,75 @@ if [[ -z "$COMMAND" ]]; then
   echo "ERROR: no command to execute (provide --command or --task)" >&2
   exit 1
 fi
+
+# ── F3 --lease: acquire an atomic git-ref lease before dispatching ────────────
+# Default OFF. When ON, acquire a versioned-CAS + fencing lease (dispatch_lease.py
+# over the GitRefLease real-git adapter) named for the task BEFORE executing, so
+# two dispatchers can never double-run the same task. If the lease is held, abort
+# with a clear message. The lease is released (ref deleted, fenced by token) after
+# execution. Reached only post-dry-run, so --dry-run never mutates a lease.
+LEASE_NAME=""
+LEASE_TOKEN=""
+LEASE_REPO=""
+if [[ "$USE_LEASE" == "true" ]]; then
+  # Lease name = task id when dispatching a task, else a hash of the command.
+  if [[ -n "$TASK_ID" ]]; then
+    LEASE_NAME="$TASK_ID"
+  else
+    LEASE_NAME="cmd-$(printf '%s' "$COMMAND" | cksum | cut -d' ' -f1)"
+  fi
+  # Lease arbitration repo: defaults to the WORKSPACE_HUB git toplevel; overridable
+  # via WS_DISPATCH_LEASE_REPO (e.g. a dedicated coordination repo, or a temp repo
+  # for hermetic testing).
+  LEASE_REPO="${WS_DISPATCH_LEASE_REPO:-$(git -C "${WORKSPACE_HUB}" rev-parse --show-toplevel 2>/dev/null || true)}"
+  if [[ -z "$LEASE_REPO" ]] || ! git -C "$LEASE_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "ERROR: --lease requires a git repo (set WS_DISPATCH_LEASE_REPO or run with a git WORKSPACE_HUB)" >&2
+    exit 1
+  fi
+  # Fresh fencing token (caller-generated nondeterminism, per dispatch_lease contract).
+  LEASE_TOKEN="${THIS_HOST}-$$-$(date +%s)-${RANDOM}"
+  log "Acquiring dispatch lease '${LEASE_NAME}' (holder=${THIS_HOST})..."
+  LEASE_RESULT=$(WS_LEASE_REPO="$LEASE_REPO" WS_LEASE_NAME="$LEASE_NAME" \
+    WS_LEASE_HOLDER="$THIS_HOST" WS_LEASE_TOKEN="$LEASE_TOKEN" \
+    uv run --no-project python -c "
+import os, sys, time
+sys.path.insert(0, '${SCRIPT_DIR}')
+from git_ref_lease import GitRefLease
+import dispatch_lease as dl
+git = GitRefLease(os.environ['WS_LEASE_REPO'])
+blob = dl.acquire(
+    git, os.environ['WS_LEASE_NAME'], os.environ['WS_LEASE_HOLDER'],
+    ttl_s=3600, now=time.time(), new_token=os.environ['WS_LEASE_TOKEN'],
+)
+print('ACQUIRED' if blob is not None else 'HELD')
+" 2>/dev/null)
+  if [[ "$LEASE_RESULT" != "ACQUIRED" ]]; then
+    echo "ERROR: dispatch lease '${LEASE_NAME}' is held by another dispatcher; aborting (no double-run)" >&2
+    exit 1
+  fi
+  log "Lease acquired."
+fi
+
+# Release the lease (token-fenced) on any exit once it has been acquired.
+release_lease() {
+  [[ "$USE_LEASE" == "true" && -n "$LEASE_TOKEN" ]] || return 0
+  WS_LEASE_REPO="$LEASE_REPO" WS_LEASE_NAME="$LEASE_NAME" WS_LEASE_TOKEN="$LEASE_TOKEN" \
+    uv run --no-project python -c "
+import os, sys
+sys.path.insert(0, '${SCRIPT_DIR}')
+from git_ref_lease import GitRefLease, lease_ref
+import dispatch_lease as dl, subprocess
+git = GitRefLease(os.environ['WS_LEASE_REPO'])
+# Fence: only delete the ref if WE still hold it (token unchanged). If another
+# machine validly reclaimed it, leave it alone.
+if dl.verify_token(git, os.environ['WS_LEASE_NAME'], os.environ['WS_LEASE_TOKEN']):
+    ref = lease_ref(os.environ['WS_LEASE_NAME'])
+    subprocess.run(['git', '-C', os.environ['WS_LEASE_REPO'], 'update-ref', '-d', ref],
+                   capture_output=True)
+" 2>/dev/null || true
+  log "Lease '${LEASE_NAME}' released."
+}
+trap release_lease EXIT
 
 # Expand $WORKSPACE_HUB in command
 WS_ROOT=$(uv run --no-project python -c "

--- a/scripts/operations/workstation-dispatch.sh
+++ b/scripts/operations/workstation-dispatch.sh
@@ -294,7 +294,9 @@ if [[ "$USE_LEASE" == "true" ]]; then
   if [[ -n "$TASK_ID" ]]; then
     LEASE_NAME="$TASK_ID"
   else
-    LEASE_NAME="cmd-$(printf '%s' "$COMMAND" | cksum | cut -d' ' -f1)"
+    # sha256 (not cksum) — cksum is collision-prone, so unrelated commands could
+    # share a lease name (#2970 wiring review MAJOR #5).
+    LEASE_NAME="cmd-$(printf '%s' "$COMMAND" | sha256sum | cut -c1-16)"
   fi
   # Lease arbitration repo: defaults to the WORKSPACE_HUB git toplevel; overridable
   # via WS_DISPATCH_LEASE_REPO (e.g. a dedicated coordination repo, or a temp repo
@@ -306,9 +308,13 @@ if [[ "$USE_LEASE" == "true" ]]; then
   fi
   # Fresh fencing token (caller-generated nondeterminism, per dispatch_lease contract).
   LEASE_TOKEN="${THIS_HOST}-$$-$(date +%s)-${RANDOM}"
-  log "Acquiring dispatch lease '${LEASE_NAME}' (holder=${THIS_HOST})..."
+  # UNIQUE holder per dispatcher process (#2970 wiring review MAJOR #1): dispatch_lease
+  # renews/returns success when the holder matches, so a bare hostname would let TWO
+  # dispatchers on the same host both acquire+run. host+pid+token is non-reentrant.
+  LEASE_HOLDER="${THIS_HOST}-$$-${LEASE_TOKEN}"
+  log "Acquiring dispatch lease '${LEASE_NAME}' (holder=${LEASE_HOLDER})..."
   LEASE_RESULT=$(WS_LEASE_REPO="$LEASE_REPO" WS_LEASE_NAME="$LEASE_NAME" \
-    WS_LEASE_HOLDER="$THIS_HOST" WS_LEASE_TOKEN="$LEASE_TOKEN" \
+    WS_LEASE_HOLDER="$LEASE_HOLDER" WS_LEASE_TOKEN="$LEASE_TOKEN" \
     uv run --no-project python -c "
 import os, sys, time
 sys.path.insert(0, '${SCRIPT_DIR}')
@@ -338,12 +344,17 @@ sys.path.insert(0, '${SCRIPT_DIR}')
 from git_ref_lease import GitRefLease, lease_ref
 import dispatch_lease as dl, subprocess
 git = GitRefLease(os.environ['WS_LEASE_REPO'])
-# Fence: only delete the ref if WE still hold it (token unchanged). If another
-# machine validly reclaimed it, leave it alone.
-if dl.verify_token(git, os.environ['WS_LEASE_NAME'], os.environ['WS_LEASE_TOKEN']):
-    ref = lease_ref(os.environ['WS_LEASE_NAME'])
-    subprocess.run(['git', '-C', os.environ['WS_LEASE_REPO'], 'update-ref', '-d', ref],
-                   capture_output=True)
+# ATOMIC fenced delete (#2970 wiring review MAJOR #2): read the ref's current sha+blob,
+# and only delete if (a) the token is still ours AND (b) we delete that EXACT sha
+# (git update-ref -d <ref> <oldvalue> is a compare-and-swap). This closes the TOCTOU
+# where another host reclaims between a bare verify and a bare delete.
+cur = git.read_ref(lease_ref(os.environ['WS_LEASE_NAME']))
+if cur is not None:
+    sha, blob = cur
+    if blob.get('token') == os.environ['WS_LEASE_TOKEN']:
+        subprocess.run(['git', '-C', os.environ['WS_LEASE_REPO'],
+                        'update-ref', '-d', lease_ref(os.environ['WS_LEASE_NAME']), sha],
+                       capture_output=True)
 " 2>/dev/null || true
   log "Lease '${LEASE_NAME}' released."
 }
@@ -360,6 +371,24 @@ for name, m in reg.get('machines', {}).items():
         break
 " 2>/dev/null)
 EXPANDED_CMD="${COMMAND//\$WORKSPACE_HUB/$WS_ROOT}"
+
+# PRE-EXEC FENCE (#2970 wiring review MAJOR #3): if leasing, verify we STILL hold the
+# token immediately before the side effect. If the lease was superseded (validly
+# reclaimed by another host) between acquire and now, abort — do NOT execute.
+if [[ "$USE_LEASE" == "true" && -n "$LEASE_TOKEN" ]]; then
+  if [[ "$(WS_LEASE_REPO="$LEASE_REPO" WS_LEASE_NAME="$LEASE_NAME" WS_LEASE_TOKEN="$LEASE_TOKEN" \
+      uv run --no-project python -c "
+import os, sys
+sys.path.insert(0, '${SCRIPT_DIR}')
+from git_ref_lease import GitRefLease
+import dispatch_lease as dl
+git = GitRefLease(os.environ['WS_LEASE_REPO'])
+print('HOLD' if dl.verify_token(git, os.environ['WS_LEASE_NAME'], os.environ['WS_LEASE_TOKEN']) else 'LOST')
+" 2>/dev/null)" != "HOLD" ]]; then
+    echo "ERROR: dispatch lease '${LEASE_NAME}' was superseded before execution; aborting (no double-run)" >&2
+    exit 1
+  fi
+fi
 
 if [[ "$IS_LOCAL" == "True" ]]; then
   log "Executing locally..."

--- a/tests/operations/test_workstation_dispatch_wiring.py
+++ b/tests/operations/test_workstation_dispatch_wiring.py
@@ -1,0 +1,224 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytest"]
+# ///
+"""Wiring tests for workstation-dispatch.sh F3 additions (#2970).
+
+Covers the three additive flags wired into the live dispatcher without changing
+its default behavior:
+
+  * --route <task_type>  -> prints provider routing for the selected machine via
+                            scripts/ai/provider_route.py (informational only).
+  * --role-aware         -> honors task roles ∩ machine harness_profile.roles via
+                            scripts/operations/dispatch_select.py, IN ADDITION to
+                            the existing requires match (default OFF).
+  * --lease              -> acquires an atomic git-ref lease (dispatch_lease.py +
+                            git_ref_lease.py) before dispatching; aborts if held
+                            (default OFF).
+
+Hermetic: every test uses --dry-run (no SSH / no execution) except the lease
+tests, which run against a throwaway temp git repo via WS_DISPATCH_LEASE_REPO and
+never SSH (the selected machine resolves local on the dev host, or the lease is
+acquired before any execution and asserted directly).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "operations" / "workstation-dispatch.sh"
+
+# A task that exists in config/scheduled-tasks/schedule-tasks.yaml.
+KNOWN_TASK = "gsd-researcher"
+# A known policy task_type (key in config/ai-tools/provider-routing-policy.yaml roles).
+KNOWN_TASK_TYPE = "review"
+
+
+def _run(args, env=None, cwd=REPO_ROOT):
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=full_env,
+        timeout=180,
+    )
+
+
+def test_bash_syntax_ok():
+    """(a) `bash -n` must pass on the dispatcher."""
+    r = subprocess.run(
+        ["bash", "-n", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_existing_dry_run_task_no_regression():
+    """(c) Existing `--dry-run --task <id>` still works (no regression)."""
+    r = _run(["--task", KNOWN_TASK, "--dry-run"])
+    assert r.returncode == 0, r.stderr
+    assert "DRY RUN" in r.stdout
+    # No F3 informational lines leak into the default path.
+    assert "Provider routing" not in r.stdout
+    assert "dispatch lease" not in r.stdout.lower()
+
+
+def test_route_prints_nonempty_provider_list():
+    """(b) `--route <task_type>` prints a non-empty provider list (dry-run)."""
+    r = _run(["--task", KNOWN_TASK, "--route", KNOWN_TASK_TYPE, "--dry-run"])
+    assert r.returncode == 0, r.stderr
+    assert "Provider routing" in r.stdout
+    # The routing line lists at least one provider after the colon.
+    route_lines = [ln for ln in r.stdout.splitlines() if "Provider routing" in ln]
+    assert route_lines, r.stdout
+    after_colon = route_lines[0].rsplit("):", 1)[-1].strip()
+    assert after_colon, f"empty provider list in: {route_lines[0]!r}"
+    assert "<none" not in after_colon
+
+
+def test_route_does_not_change_selected_machine():
+    """--route is informational: same target with and without it."""
+    base = _run(["--task", KNOWN_TASK, "--dry-run"])
+    routed = _run(["--task", KNOWN_TASK, "--route", KNOWN_TASK_TYPE, "--dry-run"])
+    assert base.returncode == 0 and routed.returncode == 0
+
+    def target(out):
+        for ln in out.splitlines():
+            if ln.startswith("[dispatch] Target:"):
+                return ln
+        return None
+
+    assert target(base.stdout) == target(routed.stdout)
+
+
+def test_role_aware_selects_a_machine_no_regression():
+    """`--role-aware --dry-run` still resolves a target (role ∩ requires)."""
+    r = _run(["--task", "equality-report", "--role-aware", "--dry-run"])
+    assert r.returncode == 0, r.stderr
+    assert "DRY RUN" in r.stdout
+    assert any(ln.startswith("[dispatch] Target:") for ln in r.stdout.splitlines())
+
+
+def test_unknown_flag_still_rejected():
+    """Arg parser still rejects unknown flags (additive change kept the guard)."""
+    r = _run(["--task", KNOWN_TASK, "--bogus"])
+    assert r.returncode != 0
+    assert "unknown arg" in r.stderr
+
+
+# ── Lease tests: hermetic temp git repo via WS_DISPATCH_LEASE_REPO ───────────
+
+@pytest.fixture()
+def temp_git_repo(tmp_path):
+    repo = tmp_path / "lease-repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "--allow-empty", "-m", "init"],
+        check=True,
+    )
+    yield repo
+
+
+def _lease_refs(repo: Path):
+    r = subprocess.run(
+        ["git", "-C", str(repo), "show-ref"], capture_output=True, text=True
+    )
+    return [ln for ln in r.stdout.splitlines() if "dispatch/leases/" in ln]
+
+
+def _machine_is_local() -> bool:
+    """True iff a registry machine resolves to this host (so --command runs local
+    rather than attempting SSH). Skips lease-execution tests on detached hosts."""
+    host = subprocess.run(
+        ["hostname", "-s"], capture_output=True, text=True
+    ).stdout.strip().lower()
+    return host in {"ace-linux-1", "ace-linux-2"}
+
+
+@pytest.mark.skipif(
+    not _machine_is_local(),
+    reason="lease+execute path needs a registry-local host (no SSH in tests)",
+)
+def test_lease_acquire_run_release(temp_git_repo):
+    """--lease acquires before running a local echo, then releases (ref gone)."""
+    r = _run(
+        ["--machine", "dev-primary", "--command", "echo LEASE_OK", "--lease"],
+        env={"WS_DISPATCH_LEASE_REPO": str(temp_git_repo)},
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "Lease acquired" in r.stdout
+    assert "LEASE_OK" in r.stdout
+    assert "released" in r.stdout
+    # Net-clean: no lease ref remains after a clean release.
+    assert _lease_refs(temp_git_repo) == []
+
+
+def test_lease_aborts_when_held(temp_git_repo):
+    """A pre-held lease for the same name causes a clear abort (no double-run),
+    and the foreign holder's lease is NOT stolen or deleted."""
+    cmd = "echo SHOULD_NOT_RUN"
+    # Compute the lease name the script will use: cmd-<cksum>.
+    cksum = subprocess.run(
+        ["cksum"], input=cmd, capture_output=True, text=True
+    ).stdout.split()[0]
+    name = f"cmd-{cksum}"
+
+    # Pre-hold the lease as a different holder via the real cores.
+    pre = subprocess.run(
+        [
+            "uv", "run", "--no-project", "python", "-c",
+            (
+                "import os,sys,time\n"
+                "sys.path.insert(0,'scripts/operations')\n"
+                "from git_ref_lease import GitRefLease\n"
+                "import dispatch_lease as dl\n"
+                "g=GitRefLease(os.environ['R'])\n"
+                "b=dl.acquire(g,os.environ['N'],'other-host',ttl_s=3600,"
+                "now=time.time(),new_token='tok-other')\n"
+                "print('preheld' if b else 'FAIL')\n"
+            ),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "R": str(temp_git_repo), "N": name},
+    )
+    assert "preheld" in pre.stdout, pre.stderr
+
+    r = _run(
+        ["--machine", "dev-primary", "--command", cmd, "--lease"],
+        env={"WS_DISPATCH_LEASE_REPO": str(temp_git_repo)},
+    )
+    assert r.returncode != 0
+    assert "held by another dispatcher" in r.stderr
+    assert "SHOULD_NOT_RUN" not in r.stdout  # command never executed
+    # Foreign lease still present (token-fencing prevents theft/delete on abort).
+    refs = _lease_refs(temp_git_repo)
+    assert any(name in ln for ln in refs), refs
+
+
+def test_lease_requires_git_repo(tmp_path):
+    """--lease with a non-git lease repo fails closed with a clear message."""
+    non_git = tmp_path / "not-a-repo"
+    non_git.mkdir()
+    r = _run(
+        ["--machine", "dev-primary", "--command", "echo X", "--lease"],
+        env={"WS_DISPATCH_LEASE_REPO": str(non_git)},
+    )
+    assert r.returncode != 0
+    assert "requires a git repo" in r.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/operations/test_workstation_dispatch_wiring.py
+++ b/tests/operations/test_workstation_dispatch_wiring.py
@@ -168,11 +168,12 @@ def test_lease_aborts_when_held(temp_git_repo):
     """A pre-held lease for the same name causes a clear abort (no double-run),
     and the foreign holder's lease is NOT stolen or deleted."""
     cmd = "echo SHOULD_NOT_RUN"
-    # Compute the lease name the script will use: cmd-<cksum>.
-    cksum = subprocess.run(
-        ["cksum"], input=cmd, capture_output=True, text=True
+    # Compute the lease name the script will use: cmd-<sha256[:16]>
+    # (matches `printf '%s' "$COMMAND" | sha256sum | cut -c1-16`).
+    sha = subprocess.run(
+        ["sha256sum"], input=cmd, capture_output=True, text=True
     ).stdout.split()[0]
-    name = f"cmd-{cksum}"
+    name = f"cmd-{sha[:16]}"
 
     # Pre-hold the lease as a different holder via the real cores.
     pre = subprocess.run(
@@ -222,3 +223,28 @@ def test_lease_requires_git_repo(tmp_path):
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# ── #2970 wiring code-review MAJOR fixes ─────────────────────────────────────
+def test_lease_name_uses_sha256_not_cksum():
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parents[2] / "scripts/operations/workstation-dispatch.sh").read_text()
+    assert "sha256sum" in src and "| cksum" not in src   # collision-resistant lease name
+
+def test_unique_holder_per_dispatcher():
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parents[2] / "scripts/operations/workstation-dispatch.sh").read_text()
+    # holder must include pid+token, not be a bare hostname (non-reentrant)
+    assert 'LEASE_HOLDER="${THIS_HOST}-$$-${LEASE_TOKEN}"' in src
+    assert 'WS_LEASE_HOLDER="$LEASE_HOLDER"' in src
+
+def test_pre_exec_fence_present():
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parents[2] / "scripts/operations/workstation-dispatch.sh").read_text()
+    assert "superseded before execution" in src   # verify_token immediately before exec
+
+def test_release_is_cas_fenced_delete():
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parents[2] / "scripts/operations/workstation-dispatch.sh").read_text()
+    # delete must pass the exact sha (CAS), not a bare update-ref -d <ref>
+    assert "update-ref', '-d', lease_ref(os.environ['WS_LEASE_NAME']), sha" in src


### PR DESCRIPTION
The F3 residual build — wires the merged dispatch cores into the live dispatcher, **additively behind opt-in flags** (default behavior unchanged):
- `--route <task_type>` → provider routing via provider_route.py (informational)
- `--role-aware` → honor task `roles` ∩ machine `harness_profile.roles` (dispatch_select.py) in addition to capability match
- `--lease` → atomic versioned-CAS + fencing git-ref lease (dispatch_lease + git_ref_lease) before execute; abort if held (no double-run); EXIT-trap release **fenced** by verify_token

9 tests pass (bash -n; no-regression on legacy --dry-run paths; lease acquire/abort-when-held/non-git fail-closed using a temp repo). Codex code review of the --lease path in progress. Remote lease push (--force-with-lease) remains the operator-cutover step.