### PR TITLE
docs: add issue 2945 completeness report

### DIFF
--- a/docs/reports/2026-06-09-2945-completeness.html
+++ b/docs/reports/2026-06-09-2945-completeness.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Completeness — #2945 [flywheel] Generalize repo-ecosystem work into reusable skills/scripts/tools after every agent wave</title>
+<style>
+body{margin:0;background:#0f1419;color:#e6edf3;font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif}
+.wrap{max-width:920px;margin:0 auto;padding:30px 20px}
+h1{font-size:23px} .muted{color:#9aa7b2;font-size:13px}
+.big{font-size:42px;font-weight:800}
+.pass{color:#3fb950}.fail{color:#f85149}
+table{width:100%;border-collapse:collapse;margin:14px 0}
+td,th{border:1px solid #2d3742;padding:8px 10px;text-align:left}
+code,pre{background:#0b0f14;border:1px solid #2d3742;border-radius:5px;padding:2px 6px;
+ font:12.5px ui-monospace,Menlo,monospace;color:#c9d6e0}
+pre{padding:12px;overflow-x:auto;white-space:pre-wrap}
+</style></head><body><div class="wrap">
+<h1>Completeness — #2945: [flywheel] Generalize repo-ecosystem work into reusable skills/scripts/tools after every agent wave</h1>
+<div class="muted">class: evidence · threshold: 80 · generated 2026-06-09</div>
+<p class="big pass">100% — <span class="pass">PASS</span></p>
+<h2>Evidence</h2>
+<table><thead><tr><th>Item</th></tr></thead><tbody><tr><td>PR #2950 merged with flywheel closeout workflow: met (w=2)</td></tr><tr><td>scripts/workflow/flywheel_closeout.py present on origin/main: met (w=2)</td></tr><tr><td>flywheel-closeout coordination skill present on origin/main: met (w=2)</td></tr><tr><td>flywheel learning issue template present on origin/main: met (w=1)</td></tr><tr><td>llm-wiki canary report and drafts present on origin/main: met (w=2)</td></tr><tr><td>PR verification: flywheel closeout tests 4 passed: met (w=2)</td></tr><tr><td>PR verification: approved canary command generated report: met (w=1)</td></tr><tr><td>PR verification: legal diff scan passed: met (w=1)</td></tr><tr><td>Review gate: initial MAJOR findings fixed; focused re-review MINOR fixed: met (w=2)</td></tr></tbody></table>
+<h2>Authoritative record (gate-read)</h2>
+<pre>```completeness {"completeness_pct": 100, "cls": "evidence", "threshold": 80, "passed": true, "snapshot_sha": null, "issue_number": 2945, "generated_at": "2026-06-09T09:41:05.549691+00:00", "evidence": ["PR #2950 merged with flywheel closeout workflow: met (w=2)", "scripts/workflow/flywheel_closeout.py present on origin/main: met (w=2)", "flywheel-closeout coordination skill present on origin/main: met (w=2)", "flywheel learning issue template present on origin/main: met (w=1)", "llm-wiki canary report and drafts present on origin/main: met (w=2)", "PR verification: flywheel closeout tests 4 passed: met (w=2)", "PR verification: approved canary command generated report: met (w=1)", "PR verification: legal diff scan passed: met (w=1)", "Review gate: initial MAJOR findings fixed; focused re-review MINOR fixed: met (w=2)"]}```</pre>
+<div class="muted">This block is the exact record persisted to the issue + kanban; the close gate reads it.</div>
+</div></body></html>


### PR DESCRIPTION
## Summary

Adds the rendered completeness HTML report for #2945, which was already implemented in PR #2950 and reopened only because the completeness gate required a body record + verification label.

## Verification

- PR #2950 is merged.
- `origin/main` contains `scripts/workflow/flywheel_closeout.py`, `flywheel-closeout` skill, the learning issue template, and the llm-wiki canary report/drafts.
- Computed evidence completeness: 100% / threshold 80.
- `scripts/legal/legal-sanity-scan.sh --diff-only` — passed.

This PR is report-only.
