### PR TITLE
docs: add issue 2835 completeness report

### DIFF
--- a/docs/reports/2026-06-09-2835-completeness.html
+++ b/docs/reports/2026-06-09-2835-completeness.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Completeness — #2835 chore(relocation): remove relocated wiki content + retarget wiki_health_cron (llm-wiki#118 hub-side)</title>
+<style>
+body{margin:0;background:#0f1419;color:#e6edf3;font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif}
+.wrap{max-width:920px;margin:0 auto;padding:30px 20px}
+h1{font-size:23px} .muted{color:#9aa7b2;font-size:13px}
+.big{font-size:42px;font-weight:800}
+.pass{color:#3fb950}.fail{color:#f85149}
+table{width:100%;border-collapse:collapse;margin:14px 0}
+td,th{border:1px solid #2d3742;padding:8px 10px;text-align:left}
+code,pre{background:#0b0f14;border:1px solid #2d3742;border-radius:5px;padding:2px 6px;
+ font:12.5px ui-monospace,Menlo,monospace;color:#c9d6e0}
+pre{padding:12px;overflow-x:auto;white-space:pre-wrap}
+</style></head><body><div class="wrap">
+<h1>Completeness — #2835: chore(relocation): remove relocated wiki content + retarget wiki_health_cron (llm-wiki#118 hub-side)</h1>
+<div class="muted">class: evidence · threshold: 80 · generated 2026-06-09</div>
+<p class="big pass">100% — <span class="pass">PASS</span></p>
+<h2>Evidence</h2>
+<table><thead><tr><th>Item</th></tr></thead><tbody><tr><td>PR #2837 merged for #2835: met (w=2)</td></tr><tr><td>Relocated hub content removal verified on origin/main by prior issue comment: met (w=2)</td></tr><tr><td>wiki_health_cron retargeted; script present on origin/main: met (w=2)</td></tr><tr><td>wiki-health reports now under docs/reports/wiki-health on origin/main: met (w=2)</td></tr><tr><td>path guard test present: tests/knowledge/test_wiki_health_cron_paths.py: met (w=1)</td></tr><tr><td>Prior verification recorded 3/3 path tests passing: met (w=1)</td></tr><tr><td>T2 adversarial review: Claude and Codex MINOR, findings resolved: met (w=2)</td></tr><tr><td>Completeness reopen was due missing body record only: met (w=1)</td></tr></tbody></table>
+<h2>Authoritative record (gate-read)</h2>
+<pre>```completeness {"completeness_pct": 100, "cls": "evidence", "threshold": 80, "passed": true, "snapshot_sha": null, "issue_number": 2835, "generated_at": "2026-06-09T09:53:56.238260+00:00", "evidence": ["PR #2837 merged for #2835: met (w=2)", "Relocated hub content removal verified on origin/main by prior issue comment: met (w=2)", "wiki_health_cron retargeted; script present on origin/main: met (w=2)", "wiki-health reports now under docs/reports/wiki-health on origin/main: met (w=2)", "path guard test present: tests/knowledge/test_wiki_health_cron_paths.py: met (w=1)", "Prior verification recorded 3/3 path tests passing: met (w=1)", "T2 adversarial review: Claude and Codex MINOR, findings resolved: met (w=2)", "Completeness reopen was due missing body record only: met (w=1)"]}```</pre>
+<div class="muted">This block is the exact record persisted to the issue + kanban; the close gate reads it.</div>
+</div></body></html>


### PR DESCRIPTION
## Summary

Adds the rendered completeness HTML report for #2835. Implementation already landed in PR #2837; #2835 was reopened only because the completeness gate required a body record plus verification label.

## Verification

- PR #2837 is merged.
- `origin/main` contains `scripts/knowledge/wiki_health_cron.py` and `tests/knowledge/test_wiki_health_cron_paths.py`.
- `origin/main` contains wiki-health outputs under `docs/reports/wiki-health/`.
- Computed evidence completeness: 100% / threshold 80.
- `scripts/legal/legal-sanity-scan.sh --diff-only` — passed.

This PR is report-only.
