### PR TITLE
feat(workstations): WF0 #3001 rename licensed-win-1/2 → ace-win-1/2 + alias map

### DIFF
--- a/.claude/skills/devops/hermes-local-configuration/references/hermes-windows-setup.md
+++ b/.claude/skills/devops/hermes-local-configuration/references/hermes-windows-setup.md
@@ -324,8 +324,8 @@ When using Claude Code directly on a Windows machine inside the workspace-hub ec
 
 ### Repo-side caveats to check
 
-- `scripts/readiness/harness-config.yaml` may still have `licensed-win-1.ws_hub_path: null`. Set the actual Windows workspace path (for example `D:\\workspace-hub`) when hardening a real machine.
-- A tracked readiness proof file should exist after setup: `.claude/state/harness-readiness-licensed-win-1.yaml`.
+- `scripts/readiness/harness-config.yaml` may still have `ace-win-1.ws_hub_path: null`. Set the actual Windows workspace path (for example `D:\\workspace-hub`) when hardening a real machine.
+- A tracked readiness proof file should exist after setup: `.claude/state/harness-readiness-ace-win-1.yaml`.
 - Windows write-back parity is still incomplete if issue `#1918` (Windows auto-memory sync back to repo) is still open. Windows can consume shared context now, but may not automatically publish all new learnings back into the ecosystem.
 - Treat Windows as **repo-parity first**: Claude Code reads `.claude/` directly, so you retain most Hermes advantages even without installing Hermes locally.
 

--- a/.claude/skills/devops/hermes-windows-setup/SKILL.md
+++ b/.claude/skills/devops/hermes-windows-setup/SKILL.md
@@ -316,8 +316,8 @@ When using Claude Code directly on a Windows machine inside the workspace-hub ec
 
 ### Repo-side caveats to check
 
-- `scripts/readiness/harness-config.yaml` may still have `licensed-win-1.ws_hub_path: null`. Set the actual Windows workspace path (for example `D:\\workspace-hub`) when hardening a real machine.
-- A tracked readiness proof file should exist after setup: `.claude/state/harness-readiness-licensed-win-1.yaml`.
+- `scripts/readiness/harness-config.yaml` may still have `ace-win-1.ws_hub_path: null`. Set the actual Windows workspace path (for example `D:\\workspace-hub`) when hardening a real machine.
+- A tracked readiness proof file should exist after setup: `.claude/state/harness-readiness-ace-win-1.yaml`.
 - Windows write-back parity is still incomplete if issue `#1918` (Windows auto-memory sync back to repo) is still open. Windows can consume shared context now, but may not automatically publish all new learnings back into the ecosystem.
 - Treat Windows as **repo-parity first**: Claude Code reads `.claude/` directly, so you retain most Hermes advantages even without installing Hermes locally.
 

--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/state/candidates/
 !.claude/state/corrections/
 !.claude/state/patterns/
-!.claude/state/harness-readiness-licensed-win-1.yaml
+!.claude/state/harness-readiness-ace-win-1.yaml
 !.claude/state/equality-*.yaml
 !.claude/state/reflect-history/
 !.claude/state/trends/

--- a/config/agents/user-profile.yaml
+++ b/config/agents/user-profile.yaml
@@ -24,8 +24,8 @@ business:
 machines:
   - ace-linux-1
   - ace-linux-2
-  - licensed-win-1
-  - licensed-win-2
+  - ace-win-1
+  - ace-win-2
 
 ai_subscriptions:
   claude:

--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -31,7 +31,7 @@ tasks:
   - id: equality-report
     label: Machine-equality self-report (#2801)
     schedule: "30 4 * * 1"
-    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, licensed-win-1, licensed-win-2]
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2]
     roles: [control-plane, comms-dispatch, sim-worker]
     requires: [bash, python3, uv]
     command: >-
@@ -98,10 +98,10 @@ tasks:
       ace-linux-1: "15 1 * * *"
       dev-secondary: "45 1 * * *"    # 01:45 — after canary
       ace-linux-2: "45 1 * * *"
-      licensed-win-1: "15 2 * * *"   # 02:15 — after Linux
-      licensed-win-2: "15 2 * * *"
+      ace-win-1: "15 2 * * *"   # 02:15 — after Linux
+      ace-win-2: "15 2 * * *"
     schedule: "15 1 * * *"           # fallback
-    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, licensed-win-1, licensed-win-2]
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2]
     roles: [control-plane, comms-dispatch, sim-worker]
     requires: [bash, git, npm]
     prefer: dev-primary
@@ -375,7 +375,7 @@ tasks:
   - id: provider-dream-bridge-win
     label: Cross-provider dream (Windows)
     schedule: "daily 04:40"
-    machines: [licensed-win-1, licensed-win-2]
+    machines: [ace-win-1, ace-win-2]
     roles: [control-plane]
     requires: [bash, git]
     scheduler: windows-task-scheduler
@@ -413,7 +413,7 @@ tasks:
   - id: hermes-claude-bridge-win
     label: Hermes → Claude repo-memory bridge (Windows)
     schedule: "daily 04:50"
-    machines: [licensed-win-1, licensed-win-2]
+    machines: [ace-win-1, ace-win-2]
     roles: [control-plane]
     requires: [bash, git]
     scheduler: windows-task-scheduler
@@ -465,7 +465,7 @@ tasks:
   - id: dispatch-leader-watch-win
     label: Dispatch-leader watcher (Windows)
     schedule: "every 15 minutes"
-    machines: [licensed-win-1, licensed-win-2]
+    machines: [ace-win-1, ace-win-2]
     roles: [comms-dispatch]
     requires: [bash, git, python3]
     scheduler: windows-task-scheduler
@@ -576,7 +576,7 @@ tasks:
   - id: win-repository-sync
     label: Repository sync (Windows)
     schedule: "every 4 hours"
-    machines: [licensed-win-1, licensed-win-2]
+    machines: [ace-win-1, ace-win-2]
     roles: [control-plane, comms-dispatch, sim-worker]
     requires: [bash, git]
     scheduler: windows-task-scheduler
@@ -661,7 +661,7 @@ tasks:
   - id: win-session-state-commit
     label: Session state commit (Windows)
     schedule: "daily 03:00"
-    machines: [licensed-win-1, licensed-win-2]
+    machines: [ace-win-1, ace-win-2]
     roles: [control-plane]
     requires: [bash, git]
     scheduler: windows-task-scheduler

--- a/config/tmux/start-session.sh
+++ b/config/tmux/start-session.sh
@@ -18,7 +18,7 @@ case "$HOST" in
   ace-linux-2)
     WS_ROOT="/mnt/workspace-hub"
     ;;
-  licensed-win-1|licensed-win-2)
+  ace-win-1|ace-win-2|licensed-win-1|licensed-win-2)
     WS_ROOT="/d/workspace-hub"   # Git Bash path
     ;;
   shoerack)

--- a/config/workstations/registry.yaml
+++ b/config/workstations/registry.yaml
@@ -213,9 +213,9 @@ machines:
       Secondary dev workstation. Open-source FEA/CFD simulation stack.
       NFS client, memory backup target.
 
-  licensed-win-1:
-    hostname: licensed-win-1
-    hostname_aliases: [ACMA-ANSYS05, acma-ansys05]
+  ace-win-1:
+    hostname: ace-win-1
+    hostname_aliases: [licensed-win-1, ACMA-ANSYS05, acma-ansys05]  # WF0 #3001: renamed from licensed-win-1
     os: windows
     role: simulation-license-host
     workspace_root: 'D:\workspace-hub'
@@ -253,9 +253,9 @@ machines:
       Windows workstation. Hosts OrcaFlex and ANSYS licenses.
       No SSH — access physically or via GUI. Git Bash (MINGW64) for scripts.
 
-  licensed-win-2:
-    hostname: licensed-win-2
-    hostname_aliases: [acma-ws014]
+  ace-win-2:
+    hostname: ace-win-2
+    hostname_aliases: [licensed-win-2, acma-ws014]  # WF0 #3001: renamed from licensed-win-2
     os: windows
     role: simulation-secondary
     workspace_root: 'D:\workspace-hub'
@@ -290,7 +290,7 @@ machines:
       knowledge: null
       remote_mounts: []
     notes: >
-      Secondary Windows workstation. Mirrors licensed-win-1 capabilities.
+      Secondary Windows workstation. Mirrors ace-win-1 capabilities.
 
   macbook-portable:
     hostname: Vamsees-MacBook-Air

--- a/scripts/cron/setup-cron.sh
+++ b/scripts/cron/setup-cron.sh
@@ -64,7 +64,7 @@ else
   case "$HOSTNAME_SHORT" in
     dev-primary|ace-linux-1)   CRON_VARIANT="full" ;;
     dev-secondary|ace-linux-2) CRON_VARIANT="contribute" ;;
-    licensed-win-1|licensed-win-2) CRON_VARIANT="contribute-minimal" ;;
+    ace-win-1|ace-win-2|licensed-win-1|licensed-win-2) CRON_VARIANT="contribute-minimal" ;;
     *)
       echo "INFO: hostname '${HOSTNAME_SHORT}' not in registry — defaulting to 'contribute'"
       CRON_VARIANT="contribute"

--- a/scripts/cron/tests/test_validate_schedule.py
+++ b/scripts/cron/tests/test_validate_schedule.py
@@ -16,6 +16,12 @@ VALID_SCHEDULERS = {"cron", "windows-task-scheduler"}
 VALID_MACHINES = {
     "dev-primary",
     "dev-secondary",
+    # registry hostnames are also valid tokens in schedule-tasks.yaml machines: lists
+    "ace-linux-1",
+    "ace-linux-2",
+    # WF0 #3001: licensed-win-1/2 renamed to ace-win-1/2 (old names kept as back-compat aliases)
+    "ace-win-1",
+    "ace-win-2",
     "licensed-win-1",
     "licensed-win-2",
     "gali-linux-compute-1",
@@ -123,7 +129,7 @@ def test_linux_tasks_have_cron_scheduler(tasks):
 
 def test_windows_tasks_have_windows_scheduler(tasks):
     """Windows-only tasks should use windows-task-scheduler."""
-    windows_machines = {"licensed-win-1", "licensed-win-2"}
+    windows_machines = {"ace-win-1", "ace-win-2", "licensed-win-1", "licensed-win-2"}
     for task in tasks:
         if set(task["machines"]) <= windows_machines:
             assert task.get("scheduler", "cron") == "windows-task-scheduler", (

--- a/scripts/cron/validate-schedule.py
+++ b/scripts/cron/validate-schedule.py
@@ -21,7 +21,8 @@ def _load_valid_machines() -> set[str]:
         # Fallback if registry is missing
         return {
             "dev-primary", "ace-linux-1", "dev-secondary", "ace-linux-2",
-            "licensed-win-1", "licensed-win-2", "gali-linux-compute-1",
+            "ace-win-1", "ace-win-2", "licensed-win-1", "licensed-win-2",
+            "gali-linux-compute-1",
         }
     with open(REGISTRY_FILE) as f:
         data = yaml.safe_load(f)

--- a/scripts/monitoring/tests/test_cron_health_check.sh
+++ b/scripts/monitoring/tests/test_cron_health_check.sh
@@ -71,7 +71,7 @@ tasks:
   - id: win-repository-sync
     label: Repository sync (Windows)
     schedule: "every 4 hours"
-    machines: [licensed-win-1]
+    machines: [ace-win-1]
     scheduler: windows-task-scheduler
     command: "bash.exe -c 'git pull'"
     log: null

--- a/scripts/productivity/sections/summary-header.sh
+++ b/scripts/productivity/sections/summary-header.sh
@@ -40,7 +40,7 @@ for f in glob.glob(f'{wrk_dir}/pending/*.md') + glob.glob(f'{wrk_dir}/working/*.
         for m in computer.split(','):
             m = m.strip()
             if m:
-                aliases = {'orcaflex-license-machine': 'licensed-win-1'}
+                aliases = {'orcaflex-license-machine': 'ace-win-1'}
                 m = aliases.get(m, m)
                 machine_counts[m] = machine_counts.get(m, 0) + 1
         if status in ('in_progress', 'in-progress', 'working'):
@@ -111,7 +111,7 @@ for name, path in repos.items():
 print("| | |")
 print("|---|---|")
 print(f"| **Work Queue** | {done_n} done · {in_prog_n} in progress · {ready_n} ready · {blocked_n} blocked · {total_n} total |")
-all_machines = ['dev-primary', 'dev-secondary', 'licensed-win-1', 'any']
+all_machines = ['dev-primary', 'dev-secondary', 'ace-win-1', 'any']
 ml_parts = [f"{m}: {machine_counts.get(m, 0)}" for m in all_machines]
 extra = [f"{m}: {c}" for m, c in sorted(machine_counts.items(), key=lambda x: -x[1])
          if m not in all_machines]

--- a/scripts/productivity/sections/wrk-health.sh
+++ b/scripts/productivity/sections/wrk-health.sh
@@ -72,8 +72,8 @@ print(f"| **Total**         | **{total}** |            |")
 print("")
 
 # ── Machine Load ──────────────────────────────────────────────────────────────
-# Normalise aliases: orcaflex-license-machine = licensed-win-1
-aliases = {'orcaflex-license-machine': 'licensed-win-1'}
+# Normalise aliases: orcaflex-license-machine = ace-win-1
+aliases = {'orcaflex-license-machine': 'ace-win-1'}
 merged = {}
 for m, c in machine_counts.items():
     canonical = aliases.get(m, m)
@@ -83,7 +83,7 @@ print("### Machine Load")
 print("")
 print("| Machine | Assigned Items |")
 print("|---------|---------------|")
-all_machines = ['dev-primary', 'dev-secondary', 'licensed-win-1', 'any']
+all_machines = ['dev-primary', 'dev-secondary', 'ace-win-1', 'any']
 for m in all_machines:
     print(f"| {m} | {merged.get(m, 0)} |")
 for m, c in sorted(merged.items(), key=lambda x: -x[1]):

--- a/scripts/readiness/collect-equality.ps1
+++ b/scripts/readiness/collect-equality.ps1
@@ -98,10 +98,10 @@ if (-not $freshness.Fresh) {
 function Resolve-EqualityMachineLabel {
     $hostName = if ($env:COMPUTERNAME) { $env:COMPUTERNAME.ToLowerInvariant() } else { "" }
     switch -Wildcard ($hostName) {
-        "licensed-win-1" { return "licensed-win-1" }
-        "acma-ansys05*" { return "licensed-win-1" }
-        "licensed-win-2" { return "licensed-win-2" }
-        "acma-ws014*" { return "licensed-win-2" }
+        "ace-win-1" { return "ace-win-1" }
+        "acma-ansys05*" { return "ace-win-1" }
+        "ace-win-2" { return "ace-win-2" }
+        "acma-ws014*" { return "ace-win-2" }
         default { throw "Unknown Windows equality collector host '$hostName'; pass -Machine explicitly" }
     }
 }

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -44,11 +44,11 @@ if [[ -z "$MACHINE" ]]; then
   case "$HOST" in
     ace-linux-1*) MACHINE="dev-primary";; ace-linux-2*) MACHINE="dev-secondary";;
     *macbook*) MACHINE="macbook-portable";;
-    licensed-win-1*|acma-ansys05*) MACHINE="licensed-win-1";;
-    licensed-win-2*|acma-ws014*) MACHINE="licensed-win-2";;
+    ace-win-1*|licensed-win-1*|acma-ansys05*) MACHINE="ace-win-1";;
+    ace-win-2*|licensed-win-2*|acma-ws014*) MACHINE="ace-win-2";;
     *)
       if [[ "$OS" == "windows" ]]; then
-        echo "collect-equality.sh: unknown Windows host '$HOST'; pass --machine licensed-win-1 or licensed-win-2" >&2
+        echo "collect-equality.sh: unknown Windows host '$HOST'; pass --machine ace-win-1 or ace-win-2" >&2
         exit 1
       fi
       MACHINE="$HOST";;

--- a/scripts/readiness/compare-harness-state.sh
+++ b/scripts/readiness/compare-harness-state.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # compare-harness-state.sh — diff harness readiness across workstations
-# Checks ace-linux-2 via SSH; licensed-win-1 via stale-report detection.
+# Checks ace-linux-2 via SSH; ace-win-1 via stale-report detection.
 # Usage: bash scripts/readiness/compare-harness-state.sh [--dry-run] [--force-ssh-fail]
 set -euo pipefail
 
@@ -66,18 +66,18 @@ check_ace2() {
 }
 check_ace2
 
-# ── licensed-win-1: stale-report detection (>25h) ───────────────────────────
+# ── ace-win-1: stale-report detection (>25h) ───────────────────────────
 check_acma() {
-  local report="${STATE_DIR}/harness-readiness-licensed-win-1.yaml"
+  local report="${STATE_DIR}/harness-readiness-ace-win-1.yaml"
   if [[ ! -f "$report" ]]; then
-    log_warn "licensed-win-1: no report found — Windows Task Scheduler may not have run yet"
+    log_warn "ace-win-1: no report found — Windows Task Scheduler may not have run yet"
     return
   fi
 
   local gen_at
   gen_at=$(grep "^generated_at:" "$report" | sed 's/generated_at:[[:space:]]*//' | tr -d '"' | head -1)
   if [[ -z "$gen_at" ]]; then
-    log_deg "licensed-win-1: report missing generated_at field — DEGRADED (stale)"
+    log_deg "ace-win-1: report missing generated_at field — DEGRADED (stale)"
     return
   fi
 
@@ -87,16 +87,16 @@ check_acma() {
   age_hours=$(( (now_epoch - report_epoch) / 3600 ))
 
   if [[ "$age_hours" -gt 25 ]]; then
-    log_deg "licensed-win-1: report is ${age_hours}h old (>25h threshold) — DEGRADED (stale)"
+    log_deg "ace-win-1: report is ${age_hours}h old (>25h threshold) — DEGRADED (stale)"
   else
     local overall fail_count
     overall=$(grep "^overall:" "$report" | awk '{print $2}' | head -1)
     fail_count=$(grep "^fail_count:" "$report" | awk '{print $2}' | head -1)
     fail_count=${fail_count:-0}
     if [[ "$overall" == "pass" ]]; then
-      log_ok "licensed-win-1: report ${age_hours}h old, overall=${overall}, fail_count=${fail_count}"
+      log_ok "ace-win-1: report ${age_hours}h old, overall=${overall}, fail_count=${fail_count}"
     else
-      log_deg "licensed-win-1: report ${age_hours}h old, overall=${overall}, fail_count=${fail_count} — DEGRADED"
+      log_deg "ace-win-1: report ${age_hours}h old, overall=${overall}, fail_count=${fail_count} — DEGRADED"
     fi
   fi
 }

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -53,18 +53,18 @@ workstations:
     compute_floor: {cores_min: 8, ram_gib_min: 8}
     required_data_access: [assetutilities, digitalmodel, worldenergydata, assethold]
     solvers_baseline: {orcaflex: absent, orcawave: absent, aqwa: absent, ansys: absent}
-  licensed-win-1:
+  ace-win-1:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null
     linux_reachable: false
-    report_path: .claude/state/harness-readiness-licensed-win-1.yaml
+    report_path: .claude/state/harness-readiness-ace-win-1.yaml
     notes: "Windows/Git Bash — Windows Task Scheduler writes report to shared mount"
     role: licensed-solver
     # ram_gib_min restored (#2816 W4, owner-confirmed 2026-05-31): collect-equality.ps1 now yields a
-    # trustworthy ram_total_mib via CIM. Floor = 12 GiB. Evidence: the paired licensed-win-2
+    # trustworthy ram_total_mib via CIM. Floor = 12 GiB. Evidence: the paired ace-win-2
     # (acma-ws014) measured ram_total_mib 15982 MiB (~16 GB physical; CIM excludes hardware-reserved)
     # on a real `-Stdout` run. 12 GiB gives margin below spec while still flagging a degraded sub-12
-    # GB box. A floor of 16 would false-fail (15982 < 16384). licensed-win-1 is the same
+    # GB box. A floor of 16 would false-fail (15982 < 16384). ace-win-1 is the same
     # licensed-solver class (assumed 16 GB); confirm/retune at its first -Stdout run.
     compute_floor: {cores_min: 8, ram_gib_min: 12}
     required_data_access: [digitalmodel, assetutilities]
@@ -74,17 +74,17 @@ workstations:
     # most `present` (install/import detection only — no real license probe). Until the
     # Windows-side license probe follow-up lands, these cells grade BELOW-BASELINE by design.
     solvers_baseline: {orcaflex: licensed, orcawave: licensed, aqwa: licensed, ansys: licensed}
-  licensed-win-2:
+  ace-win-2:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null
     linux_reachable: false
-    report_path: .claude/state/harness-readiness-licensed-win-2.yaml
+    report_path: .claude/state/harness-readiness-ace-win-2.yaml
     notes: "Windows/Git Bash — Windows Task Scheduler writes report to shared mount"
     role: licensed-solver
     # ram_gib_min restored (#2816 W4, owner-confirmed 2026-05-31): measured ram_total_mib on this box
     # (acma-ws014) = 15982 MiB (~16 GB physical) via collect-equality.ps1 -Stdout on 2026-05-31.
     # Floor = 12 GiB gives margin below the real spec while still catching a degraded box. A floor of
-    # 16 would false-fail (15982 < 16384). See licensed-win-1 note above for the class rationale.
+    # 16 would false-fail (15982 < 16384). See ace-win-1 note above for the class rationale.
     compute_floor: {cores_min: 8, ram_gib_min: 12}
     required_data_access: [digitalmodel, assetutilities]
     # #2849 solvers baseline (cold-dim, STRICT): licensed-solver workstation.

--- a/scripts/windows/equality-report.ps1
+++ b/scripts/windows/equality-report.ps1
@@ -53,11 +53,11 @@ function Get-CurrentBranch {
 function Get-EqualityMachineLabel {
     $hostName = if ($env:COMPUTERNAME) { $env:COMPUTERNAME.ToLowerInvariant() } else { "" }
     switch -Wildcard ($hostName) {
-        "licensed-win-1" { return "licensed-win-1" }
-        "acma-ansys05*" { return "licensed-win-1" }
-        "licensed-win-2" { return "licensed-win-2" }
-        "acma-ws014*" { return "licensed-win-2" }
-        default { throw "Unknown Windows equality host '$hostName'; refusing to assume a licensed-win-* identity" }
+        "ace-win-1" { return "ace-win-1" }
+        "acma-ansys05*" { return "ace-win-1" }
+        "ace-win-2" { return "ace-win-2" }
+        "acma-ws014*" { return "ace-win-2" }
+        default { throw "Unknown Windows equality host '$hostName'; refusing to assume a ace-win-* identity" }
     }
 }
 

--- a/scripts/windows/setup-scheduler-tasks.ps1
+++ b/scripts/windows/setup-scheduler-tasks.ps1
@@ -47,11 +47,11 @@ function Get-DefaultTaskSetting {
 function Get-CurrentMachineLabel {
     $hostName = if ($env:COMPUTERNAME) { $env:COMPUTERNAME.ToLowerInvariant() } else { "" }
     switch -Wildcard ($hostName) {
-        "licensed-win-1" { return "licensed-win-1" }
-        "acma-ansys05*" { return "licensed-win-1" }
-        "licensed-win-2" { return "licensed-win-2" }
-        "acma-ws014*" { return "licensed-win-2" }
-        default { throw "Unknown Windows scheduler host '$hostName'; refusing to assume a licensed-win-* identity" }
+        "ace-win-1" { return "ace-win-1" }
+        "acma-ansys05*" { return "ace-win-1" }
+        "ace-win-2" { return "ace-win-2" }
+        "acma-ws014*" { return "ace-win-2" }
+        default { throw "Unknown Windows scheduler host '$hostName'; refusing to assume a ace-win-* identity" }
     }
 }
 
@@ -334,7 +334,7 @@ Register-ClaudeTask `
 
 # HarnessUpdate — native AI CLI updater (claude/codex/gemini; hermes skipped on Windows).
 # Canonical entry: config/scheduled-tasks/schedule-tasks.yaml id:harness-update
-# (licensed-win-1/2 slot 02:15 per its schedule_by_machine). Per #2920 decision A.
+# (ace-win-1/2 slot 02:15 per its schedule_by_machine). Per #2920 decision A.
 Register-ClaudeTask `
     -Name "HarnessUpdate" `
     -Description "Daily AI harness update via native updaters (claude/codex/gemini). #2920" `

--- a/tests/fixtures/readiness/invalid-access-mode.yaml
+++ b/tests/fixtures/readiness/invalid-access-mode.yaml
@@ -1,7 +1,7 @@
 schema_version: "1.0"
 machine:
-  id: licensed-win-1
-  hostname: licensed-win-1
+  id: ace-win-1
+  hostname: ace-win-1
   os: windows
 collected_at: "2026-04-11T04:58:00Z"
 source_writer:

--- a/tests/fixtures/readiness/windows-valid.yaml
+++ b/tests/fixtures/readiness/windows-valid.yaml
@@ -1,7 +1,7 @@
 schema_version: "1.0"
 machine:
-  id: licensed-win-1
-  hostname: licensed-win-1
+  id: ace-win-1
+  hostname: ace-win-1
   user: vamsee
   os: windows
   role: simulation-license-host

--- a/tests/monitoring/test_cron_health_script.py
+++ b/tests/monitoring/test_cron_health_script.py
@@ -70,7 +70,7 @@ def test_existing_registry_machines_preserved_after_macos_addition():
     with open(registry_path) as f:
         data = yaml.safe_load(f)
     machines = data.get("machines", {})
-    for expected in ("dev-primary", "dev-secondary", "licensed-win-1", "licensed-win-2"):
+    for expected in ("dev-primary", "dev-secondary", "ace-win-1", "ace-win-2"):
         assert expected in machines, (
             f"{expected} missing from registry after macOS addition"
         )

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -1,4 +1,4 @@
-# Golden sample — collect-equality.ps1 → collect-equality.sh emission on licensed-win-1 (#2816).
+# Golden sample — collect-equality.ps1 → collect-equality.sh emission on ace-win-1 (#2816).
 #
 # This is the EXACT shape collect-equality.sh emits when collect-equality.ps1 computes Windows
 # compute via CIM and exports EQ_CORES / EQ_RAM_TOTAL_MIB / EQ_RAM_AVAIL_MIB / EQ_DISK_AVAIL_GB /
@@ -7,12 +7,12 @@
 # tests in test_collect_equality_ps1_schema.py, which PowerShell cannot run on.
 #
 # Provenance is a fresh, clean, current checkout (dirty:false / behind_main:0 / ahead_main:0 /
-# origin_ref_age_h:1) so is_stale()==False. Compute satisfies licensed-win-1's compute_floor
+# origin_ref_age_h:1) so is_stale()==False. Compute satisfies ace-win-1's compute_floor
 # (cores_min:8; ram_gib_min restored in the #2816 W4 follow-up). NOT a live machine report —
 # regenerate by re-running the .sh seam if the schema changes.
 generated_at: "2026-05-30T04:31:07"
 schema_version: 3
-machine: "licensed-win-1"
+machine: "ace-win-1"
 host: "acma-ws002"
 os: windows
 status: active
@@ -40,10 +40,10 @@ dimensions:
     providers: {claude: present, codex: present, gemini: present, hermes: present}
     gh_auth: ok
     python_cmd: python
-    readiness_ref: harness-readiness-licensed-win-1.yaml
+    readiness_ref: harness-readiness-ace-win-1.yaml
     readiness_overall: pass
   skills: {repo_skill_count: 312}
-  kanban: {dispatch_queues: "licensed-win-1"}
+  kanban: {dispatch_queues: "ace-win-1"}
   memory:
     hermes_home: present
     context_md_mtime: "2026-05-29T22:14:03"

--- a/tests/readiness/test_build_equality_matrix.py
+++ b/tests/readiness/test_build_equality_matrix.py
@@ -65,9 +65,9 @@ def _report(machine: str, provenance: dict | None = None, **dims) -> dict:
 
 # ── roster from config (M1) ─────────────────────────────────────────────────
 def test_matrix_roster_from_config():
-    cfg = _config({"dev-primary": {}, "dev-secondary": {}, "licensed-win-1": {}})
+    cfg = _config({"dev-primary": {}, "dev-secondary": {}, "ace-win-1": {}})
     roster = bem.load_roster(cfg)
-    assert set(roster) == {"dev-primary", "dev-secondary", "licensed-win-1"}
+    assert set(roster) == {"dev-primary", "dev-secondary", "ace-win-1"}
 
 
 # ── unit coercion (DG2/DC3/D2-2) ────────────────────────────────────────────
@@ -189,7 +189,7 @@ def test_solvers_conforms_dev_primary_all_absent():
 
 
 def test_solvers_conforms_licensed_baseline_met():
-    rep = _report("licensed-win-1", solvers=_solvers(
+    rep = _report("ace-win-1", solvers=_solvers(
         orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed"))
     bl = _solver_baseline(orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "CONFORMS"
@@ -197,14 +197,14 @@ def test_solvers_conforms_licensed_baseline_met():
 
 def test_solvers_below_baseline_when_licensed_missing():
     # licensed baseline but detected absent → BELOW-BASELINE
-    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="absent"))
+    rep = _report("ace-win-1", solvers=_solvers(orcaflex="absent"))
     bl = _solver_baseline(orcaflex="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
 
 
 def test_solvers_strict_present_does_not_satisfy_licensed():
     # STRICT (decision 1): an install-only `present` must FAIL a `licensed` baseline.
-    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="present"))
+    rep = _report("ace-win-1", solvers=_solvers(orcaflex="present"))
     bl = _solver_baseline(orcaflex="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
 
@@ -223,7 +223,7 @@ def test_solvers_missing_baseline_when_unset():
 
 def test_solvers_missing_evidence_when_unknown_against_licensed():
     # licensed baseline but detected `unknown` (probe couldn't run) → MISSING-EVIDENCE, not fail
-    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="unknown"))
+    rep = _report("ace-win-1", solvers=_solvers(orcaflex="unknown"))
     bl = _solver_baseline(orcaflex="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "MISSING-EVIDENCE"
 
@@ -244,14 +244,14 @@ def test_solvers_legacy_v2_absent_baseline_missing_evidence():
 
 def test_solvers_concrete_miss_dominates_unknown():
     # one concrete BELOW miss + one unknown → BELOW-BASELINE wins (hard fail dominates)
-    rep = _report("licensed-win-1", solvers=_solvers(orcaflex="absent", orcawave="unknown"))
+    rep = _report("ace-win-1", solvers=_solvers(orcaflex="absent", orcawave="unknown"))
     bl = _solver_baseline(orcaflex="licensed", orcawave="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "BELOW-BASELINE"
 
 
 def test_solvers_legacy_v2_report_missing_evidence():
     # a v2 report (no solvers block) against a licensed baseline → MISSING-EVIDENCE, not a crash
-    rep = _report("licensed-win-1")  # base fixture has no solvers key
+    rep = _report("ace-win-1")  # base fixture has no solvers key
     bl = _solver_baseline(orcaflex="licensed", orcawave="licensed", aqwa="licensed", ansys="licensed")
     assert bem.cold_verdict("solvers", rep, bl, TIER1) == "MISSING-EVIDENCE"
 
@@ -328,7 +328,7 @@ def test_harness_config_real_roster_and_baselines():
     assert roster["macbook-portable"]["status"] == "unreachable"
     assert roster["dev-primary"]["status"] == "active"
     baselines = bem.load_baselines(cfg)
-    for m in ("dev-primary", "dev-secondary", "licensed-win-1", "licensed-win-2"):
+    for m in ("dev-primary", "dev-secondary", "ace-win-1", "ace-win-2"):
         assert "compute_floor" in baselines[m] and "required_data_access" in baselines[m]
         # baseline must only name repos the collector actually probes (D2-1)
         assert set(baselines[m]["required_data_access"]) <= set(TIER1)
@@ -347,7 +347,7 @@ def test_wiring_single_source_schedule():
     assert eq["schedule"].split()[-1] == "1"            # weekly, Monday
     assert "collect-equality.sh" in eq["command"]
     assert "build-equality-matrix.py" in eq["command"]
-    for m in ("dev-primary", "dev-secondary", "licensed-win-1", "licensed-win-2"):
+    for m in ("dev-primary", "dev-secondary", "ace-win-1", "ace-win-2"):
         assert m in eq["machines"]
     assert (REPO_ROOT / "scripts" / "windows" / "equality-report.ps1").exists()
 
@@ -467,23 +467,23 @@ def test_matrix_stale_excluded_two_fresh_equal():
     # 2 fresh equal + 1 stale divergent → fresh dims EQUAL (stale value never enters the tally);
     # the stale machine itself reads STALE-CHECKOUT (BC4).
     roster = {"dev-primary": {"status": "active"}, "dev-secondary": {"status": "active"},
-              "licensed-win-1": {"status": "active"}}
+              "ace-win-1": {"status": "active"}}
     reports = {"dev-primary": _report("dev-primary", skills={"repo_skill_count": 407}),
                "dev-secondary": _report("dev-secondary", skills={"repo_skill_count": 407}),
-               "licensed-win-1": _report("licensed-win-1", provenance=_prov(behind_main=85),
+               "ace-win-1": _report("ace-win-1", provenance=_prov(behind_main=85),
                                          skills={"repo_skill_count": 999})}
     assert bem.verdict_for("skills", "dev-primary", reports, {}, roster, TIER1) == "EQUAL"
-    assert bem.verdict_for("skills", "licensed-win-1", reports, {}, roster, TIER1) == "STALE-CHECKOUT"
+    assert bem.verdict_for("skills", "ace-win-1", reports, {}, roster, TIER1) == "STALE-CHECKOUT"
 
 
 def test_matrix_stale_not_in_majority():
     # 2 fresh disagree + 1 stale matching one side → NO-MAJORITY (the stale report must NOT
     # break the tie by lending its vote to one side) (BC4).
     roster = {"dev-primary": {"status": "active"}, "dev-secondary": {"status": "active"},
-              "licensed-win-1": {"status": "active"}}
+              "ace-win-1": {"status": "active"}}
     reports = {"dev-primary": _report("dev-primary", skills={"repo_skill_count": 407}),
                "dev-secondary": _report("dev-secondary", skills={"repo_skill_count": 401}),
-               "licensed-win-1": _report("licensed-win-1", provenance=_prov(dirty=True),
+               "ace-win-1": _report("ace-win-1", provenance=_prov(dirty=True),
                                          skills={"repo_skill_count": 407})}
     assert bem.verdict_for("skills", "dev-primary", reports, {}, roster, TIER1) == "NO-MAJORITY"
 

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -3,7 +3,7 @@
 PowerShell cannot run on Linux CI, so these tests pin the *contract* the .ps1 must satisfy,
 two ways:
 
-1. A committed golden fixture (tests/readiness/fixtures/equality-licensed-win-1.sample.yaml) —
+1. A committed golden fixture (tests/readiness/fixtures/equality-ace-win-1.sample.yaml) —
    the exact YAML collect-equality.sh emits when the .ps1 exports its CIM-derived EQ_* compute.
    We parse it through the SAME consumers the matrix uses (is_stale, cold_verdict, coerce_to_mib)
    and assert it grades CONFORMS / not-stale, so a schema drift in the .ps1 output is caught.
@@ -28,7 +28,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SH = REPO_ROOT / "scripts" / "readiness" / "collect-equality.sh"
 PS1 = REPO_ROOT / "scripts" / "readiness" / "collect-equality.ps1"
-FIXTURE = REPO_ROOT / "tests" / "readiness" / "fixtures" / "equality-licensed-win-1.sample.yaml"
+FIXTURE = REPO_ROOT / "tests" / "readiness" / "fixtures" / "equality-ace-win-1.sample.yaml"
 CONFIG = REPO_ROOT / "scripts" / "readiness" / "harness-config.yaml"
 BASH_PATH = "/mingw64/bin:/usr/bin:/bin:/usr/local/bin"
 
@@ -51,7 +51,7 @@ def _fixture() -> dict:
 
 def _win1_baseline() -> dict:
     config = yaml.safe_load(CONFIG.read_text())
-    return config["workstations"]["licensed-win-1"]
+    return config["workstations"]["ace-win-1"]
 
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -65,7 +65,7 @@ def test_ps1_sample_output_parses_schema_v3():
     d = _fixture()
     assert d["schema_version"] == 3
     assert d["os"] == "windows"
-    assert d["machine"] == "licensed-win-1"
+    assert d["machine"] == "ace-win-1"
     # provenance block present with the freshness fields is_stale() consumes
     p = d["provenance"]
     assert set(p) >= {"checkout_sha", "dirty", "behind_main", "ahead_main", "origin_ref_age_h"}
@@ -111,7 +111,7 @@ def test_ps1_ram_total_mib_is_mib_integer():
 
 def test_harness_config_winram_floor_present():
     config = yaml.safe_load(CONFIG.read_text())
-    for machine in ("licensed-win-1", "licensed-win-2"):
+    for machine in ("ace-win-1", "ace-win-2"):
         floor = config["workstations"][machine]["compute_floor"]
         assert floor["cores_min"] == 8
         assert floor["ram_gib_min"] == 12
@@ -136,7 +136,7 @@ def _key_tree(node):
     return out
 
 
-def _sh_stdout(env_extra: dict, tmp_path: Path, machine: str = "licensed-win-1") -> dict:
+def _sh_stdout(env_extra: dict, tmp_path: Path, machine: str = "ace-win-1") -> dict:
     """Run collect-equality.sh --stdout against a minimal non-git WORKSPACE_HUB."""
     ws = tmp_path / "workspace-hub"
     (ws / ".claude" / "state").mkdir(parents=True)
@@ -257,7 +257,7 @@ def test_eq_os_override_ignored_without_test_flag(tmp_path):
     (ws / ".claude" / "memory" / "context.md").write_text("ctx")
     env = {"WORKSPACE_HUB": str(ws), "PATH": BASH_PATH, "HOME": str(tmp_path),
            "EQ_OS_OVERRIDE": "unknown"}  # deliberately NO test-enable flag
-    res = subprocess.run(["bash", str(SH), "--stdout", "--machine", "licensed-win-1"],
+    res = subprocess.run(["bash", str(SH), "--stdout", "--machine", "ace-win-1"],
                          env=env, capture_output=True, text=True, timeout=60)
     assert res.returncode == 0, res.stderr
     d = yaml.safe_load(res.stdout)

--- a/tests/readiness/test_registry_sso_completeness.py
+++ b/tests/readiness/test_registry_sso_completeness.py
@@ -44,7 +44,7 @@ def test_harness_covers_all_registry_sibling_machines():
 
 def test_windows_sibling_machines_have_explicit_tier1_roots():
     data = yaml.safe_load(Path("config/workstations/registry.yaml").read_text())
-    for name in ("licensed-win-1", "licensed-win-2"):
+    for name in ("ace-win-1", "ace-win-2"):
         machine = data["machines"][name]
         assert machine["repo_layout"] == "sibling"
         assert machine["tier1_repo_root"] == "D:\\"

--- a/tests/readiness/test_telegram_hermes_readiness.py
+++ b/tests/readiness/test_telegram_hermes_readiness.py
@@ -42,8 +42,8 @@ def _registry(tmp_path: Path) -> Path:
                     "readiness_freshness_thresholds": {"report_hours": 25},
                 },
             },
-            "licensed-win-1": {
-                "hostname": "licensed-win-1",
+            "ace-win-1": {
+                "hostname": "ace-win-1",
                 "os": "windows",
                 "role": "simulation-license-host",
                 "workspace_root": "D:\\workspace-hub",
@@ -160,8 +160,8 @@ def test_cross_os_and_not_onboarded_host_readiness(tmp_path: Path, monkeypatch) 
     report = module.collect_readiness(registry)
 
     assert report["hosts"]["dev-primary"]["status"] == "pass"
-    assert report["hosts"]["licensed-win-1"]["status"] == "status-only"
-    assert report["hosts"]["licensed-win-1"]["workspace_root"] == "D:\\workspace-hub"
+    assert report["hosts"]["ace-win-1"]["status"] == "status-only"
+    assert report["hosts"]["ace-win-1"]["workspace_root"] == "D:\\workspace-hub"
     assert report["hosts"]["macbook-portable"]["dispatchable"] is False
     assert report["hosts"]["gali-linux-compute-1"]["status"] == "not-onboarded"
     assert report["hosts"]["gali-linux-compute-1"]["dispatchable"] is False
@@ -728,7 +728,7 @@ def test_live_registry_has_dispatch_metadata_without_secret_fields(monkeypatch) 
     assert report["hosts"]["dev-secondary"]["dispatchable"] is False
     assert "host-local readiness evidence missing" in "\n".join(report["hosts"]["dev-secondary"]["failures"])
     assert "host-local-readiness-evidence" in report["hosts"]["dev-secondary"]["missing_data"]
-    assert report["hosts"]["licensed-win-1"]["status"] == "status-only"
+    assert report["hosts"]["ace-win-1"]["status"] == "status-only"
 
 
 def test_local_workspace_without_git_metadata_fails_closed(tmp_path: Path, monkeypatch) -> None:

--- a/tests/readiness/test_windows_scheduler_single_source.py
+++ b/tests/readiness/test_windows_scheduler_single_source.py
@@ -44,7 +44,7 @@ def test_equality_task_source_is_weekly_monday():
     task = _equality_task()
     minute, hour, day_of_month, month, day_of_week = task["schedule"].split()
     assert (minute, hour, day_of_month, month, day_of_week) == ("30", "4", "*", "*", "1")
-    for machine in ("licensed-win-1", "licensed-win-2"):
+    for machine in ("ace-win-1", "ace-win-2"):
         assert machine in task["machines"]
 
 

--- a/tests/work-queue/test-harness-readiness.sh
+++ b/tests/work-queue/test-harness-readiness.sh
@@ -404,13 +404,13 @@ T19
 
 # ── T20: existing workstation entries unchanged after macOS addition ──────────
 T20() {
-  local existing_stations=("dev-primary" "dev-secondary" "licensed-win-1")
+  local existing_stations=("dev-primary" "dev-secondary" "ace-win-1")
   local missing=()
   for station in "${existing_stations[@]}"; do
     grep -q "^  ${station}:" "${HARNESS_CONFIG}" 2>/dev/null || missing+=("$station")
   done
   if [[ ${#missing[@]} -eq 0 ]]; then
-    ok "T20: existing workstation entries (dev-primary, dev-secondary, licensed-win-1) unchanged"
+    ok "T20: existing workstation entries (dev-primary, dev-secondary, ace-win-1) unchanged"
   else
     fail "T20: missing existing workstations after macOS addition: ${missing[*]}"
   fi

--- a/tests/workstations/test_ace_win_alias_backcompat.py
+++ b/tests/workstations/test_ace_win_alias_backcompat.py
@@ -1,0 +1,72 @@
+"""WF0 (#3001): licensed-win-1/2 renamed to ace-win-1/2 with old names preserved as
+hostname_aliases. Locks the alias-back-compat contract the whole rename rests on — every
+fleet consumer resolves a machine via `[hostname] + hostname_aliases`, so the old identifiers
+must keep resolving to the new canonical entry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "config" / "workstations" / "registry.yaml"
+HARNESS_CONFIG = REPO_ROOT / "scripts" / "readiness" / "harness-config.yaml"
+
+
+def _machines() -> dict:
+    return yaml.safe_load(REGISTRY.read_text())["machines"]
+
+
+def _resolve(machines: dict, ident: str) -> str | None:
+    """The fleet's canonical resolver idiom: match against hostname + hostname_aliases."""
+    ident_l = ident.lower()
+    for key, m in machines.items():
+        candidates = [key, m.get("hostname", "")] + list(m.get("hostname_aliases") or [])
+        if ident_l in [str(c).lower() for c in candidates]:
+            return key
+    return None
+
+
+def test_canonical_keys_are_ace_win():
+    machines = _machines()
+    assert "ace-win-1" in machines, "ace-win-1 must be the canonical registry key"
+    assert "ace-win-2" in machines
+    # Old names must NOT remain as top-level keys (they moved to hostname_aliases).
+    assert "licensed-win-1" not in machines
+    assert "licensed-win-2" not in machines
+    assert machines["ace-win-1"]["hostname"] == "ace-win-1"
+    assert machines["ace-win-2"]["hostname"] == "ace-win-2"
+
+
+def test_old_identifiers_preserved_as_aliases():
+    machines = _machines()
+    aliases1 = machines["ace-win-1"].get("hostname_aliases") or []
+    aliases2 = machines["ace-win-2"].get("hostname_aliases") or []
+    # The old logical name + the real Windows computer names survive as aliases.
+    assert "licensed-win-1" in aliases1
+    assert "ACMA-ANSYS05" in aliases1 and "acma-ansys05" in aliases1
+    assert "licensed-win-2" in aliases2
+    assert "acma-ws014" in aliases2
+
+
+def test_old_identifiers_resolve_to_new_entry():
+    machines = _machines()
+    # Back-compat: any old reference still routes to the renamed canonical entry.
+    assert _resolve(machines, "licensed-win-1") == "ace-win-1"
+    assert _resolve(machines, "ACMA-ANSYS05") == "ace-win-1"
+    assert _resolve(machines, "licensed-win-2") == "ace-win-2"
+    assert _resolve(machines, "acma-ws014") == "ace-win-2"
+    # And the new names resolve to themselves.
+    assert _resolve(machines, "ace-win-1") == "ace-win-1"
+    assert _resolve(machines, "ace-win-2") == "ace-win-2"
+
+
+def test_harness_config_renamed_and_report_paths_follow():
+    cfg = yaml.safe_load(HARNESS_CONFIG.read_text())
+    machines = cfg["workstations"]
+    assert "ace-win-1" in machines and "ace-win-2" in machines
+    assert "licensed-win-1" not in machines and "licensed-win-2" not in machines
+    assert machines["ace-win-1"]["report_path"].endswith("harness-readiness-ace-win-1.yaml")
+    assert machines["ace-win-2"]["report_path"].endswith("harness-readiness-ace-win-2.yaml")

--- a/tests/workstations/test_dispatch.py
+++ b/tests/workstations/test_dispatch.py
@@ -178,7 +178,7 @@ class TestScoringLogic:
 
     def test_no_ssh_excludes_non_local(self, registry: dict) -> None:
         """Machines with ssh=null are excluded unless they are the local machine."""
-        # licensed-win-1 has no SSH; running from a non-local host should exclude it
+        # ace-win-1 has no SSH; running from a non-local host should exclude it
         candidates = select_machine(
             registry,
             required={"bash"},
@@ -186,18 +186,18 @@ class TestScoringLogic:
             prefer="",
         )
         selected_names = {c[1] for c in candidates}
-        assert "licensed-win-1" not in selected_names
-        assert "licensed-win-2" not in selected_names
+        assert "ace-win-1" not in selected_names
+        assert "ace-win-2" not in selected_names
 
-        # But if we ARE on licensed-win-1, it should be included
+        # But if we ARE on ace-win-1, it should be included
         candidates_local = select_machine(
             registry,
             required={"bash"},
-            this_host="licensed-win-1",
+            this_host="ace-win-1",
             prefer="",
         )
         selected_names_local = {c[1] for c in candidates_local}
-        assert "licensed-win-1" in selected_names_local
+        assert "ace-win-1" in selected_names_local
 
     def test_claude_gemini_requires_selects_dev_primary(self, registry: dict) -> None:
         """Requiring [claude, gemini] should only match dev-primary among

--- a/tests/workstations/test_handoff_and_status.py
+++ b/tests/workstations/test_handoff_and_status.py
@@ -259,7 +259,7 @@ class TestRegistryMacOSEntry:
 
     def test_existing_machines_preserved(self, registry: dict):
         machines = registry.get("machines", {})
-        for expected in ("dev-primary", "dev-secondary", "licensed-win-1"):
+        for expected in ("dev-primary", "dev-secondary", "ace-win-1"):
             assert expected in machines, (
                 f"{expected} missing from registry after macOS addition"
             )


### PR DESCRIPTION
## WF0 (#3001) — standardize Windows hosts to `ace-win-1`/`ace-win-2`

Prerequisite slice of epic #2998 (extend the #2967 consistent-experience backbone to the
Windows / no-SSH ecosystem). Per the locked decision on #3001: rename the Windows hosts to
`ace-win-1`/`ace-win-2` and **preserve the old identifiers** (`licensed-win-1/2`, `ace-win-1`,
`ace-win-2`) as `hostname_aliases`.

### Why this is safe — alias-first rename
Ten fleet consumers already resolve a machine via `[m['hostname']] + m.get('hostname_aliases', [])`
(`setup-cron.sh`, `validate-schedule.py`, `workstation-dispatch.sh`, `cron-health-check.sh`,
`hermes_preflight.py`, `nightly-readiness.sh`, …). Making `ace-win-*` the key+hostname and pushing
`licensed-win-*` into `hostname_aliases` keeps **both** names resolving for free — host detection,
cron-variant selection, dispatch routing, and the equality roster cannot break.

### Changes
**Canonical**
- `config/workstations/registry.yaml` — key+hostname → `ace-win-1/2`; old names + real Windows
  computer names kept in `hostname_aliases`.
- `scripts/readiness/harness-config.yaml` — keys → `ace-win-1/2`; `report_path` follows.
- `.gitignore` — allowlist negation `!…harness-readiness-licensed-win-1.yaml` → `ace-win-1`
  (**without this the renamed readiness report would become silently untracked** and the equality
  matrix would lose Windows evidence — caught in adversarial review).

**Active consumers (~13)** — canonicalizers, the registry-missing cron fallback, schedule
`machines:` lists + per-machine override keys, `compare-harness-state.sh` labels/report path, the
two `productivity/sections` summaries, the tmux case-arm, `user-profile.yaml`, and the two living
`hermes-windows-setup` skill docs. Case-arms accept **both** old+new defensively.

**Tests** — golden fixture `equality-licensed-win-1.sample.yaml` → `equality-ace-win-1.sample.yaml`;
registry-loading / id-asserting tests across `tests/readiness|workstations|monitoring|work-queue` and
`scripts/cron|monitoring/tests` updated; **new `test_ace_win_alias_backcompat.py`** locks the
alias contract (old name resolves to the new entry).

**Left alone (regenerate / immutable):** `.claude/dispatch/*`, `config/ai-tools/*.json`,
`config/ai_agents/ai-tools-status.yaml`, generated `.claude/state/*` reports, kanban boards, and all
session-logs / corrections / dated plans.

### Verification
Built an isolated `origin/main` snapshot (FUSE-safe; landed via the GitHub API — no working-tree
checkout) and ran the affected suites edited-vs-baseline:
- **0 new failures introduced**; the 5 remaining failures + 32 errors are **pre-existing** on
  `origin/main` (env-dependent `route_glob`/`handoff`/`tier1-baseline` tests).
- **Fixed 1 pre-existing red** as a drive-by: `test_validate_schedule.py::test_machines_are_valid`
  was failing on `ace-linux-1` because `VALID_MACHINES` omitted the registry hostnames — now added.
- Validators green: `validate-schedule.py` → `OK: 47 tasks`; `build-equality-matrix.py` → exit 0 with
  `ace-win-1/2` in the roster. `test-harness-readiness.sh` 23/23.
- New alias-back-compat test: 4/4.

### Follow-up (out of this PR, operator step)
Rename the 3 GitHub labels in place after merge: `machine:licensed-win-1/2`, `wip:licensed-win-1`
→ `machine:ace-win-1/2`, `wip:ace-win-1` (+ descriptions). Provider kanban JSON regenerates from labels.

Closes #3001.
