### PR TITLE
feat(statusline): surface weekly-reset countdown in workspace-hub via combined wrapper (#2893)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -276,7 +276,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "node .claude/hooks/gsd-statusline.js"
+    "command": "bash .claude/statusline-combined.sh"
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,

--- a/.claude/statusline-combined.sh
+++ b/.claude/statusline-combined.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Combined statusline for workspace-hub (#2893).
+#
+# The project statusLine is the vendored GSD statusline
+# (.claude/hooks/gsd-statusline.js), which shows milestone/phase/task but NO
+# AI-quota or weekly-reset info. This wrapper runs BOTH the GSD statusline and
+# the "usage tail" from statusline-command.sh (the C:|O:|G: segment with the
+# #2992 weekly-reset countdown, plus cost + context) and joins them — so the
+# reset countdown is visible while working in workspace-hub.
+#
+# Why a wrapper and not an edit to gsd-statusline.js: that file is vendored
+# (carries a `gsd-hook-version` header) and is overwritten by GSD framework
+# bumps, so any edit there would be clobbered. This wrapper is repo-owned and
+# survives bumps. The weekly-reset logic lives in exactly one place
+# (statusline-command.sh::reset_days) — this only composes, never re-implements.
+#
+# No `set -e`: a composing wrapper must tolerate either child failing and still
+# print something, never a blank statusline.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+input=$(cat)
+
+# GSD statusline (base). Tolerate missing node / script error → empty.
+gsd=""
+if command -v node >/dev/null 2>&1 && [[ -f "$DIR/hooks/gsd-statusline.js" ]]; then
+    gsd=$(printf '%s' "$input" | node "$DIR/hooks/gsd-statusline.js" 2>/dev/null) || gsd=""
+fi
+
+# Usage tail: quota/reset + cost + context, from the canonical statusline script
+# in its --usage-tail segment mode (single source of truth for reset_days).
+usage=""
+if [[ -f "$DIR/statusline-command.sh" ]]; then
+    usage=$(printf '%s' "$input" | bash "$DIR/statusline-command.sh" --usage-tail 2>/dev/null) || usage=""
+fi
+
+sep=" │ "
+if [[ -n "$gsd" && -n "$usage" ]]; then
+    printf '%s%s%s' "$gsd" "$sep" "$usage"
+elif [[ -n "$gsd" ]]; then
+    printf '%s' "$gsd"
+elif [[ -n "$usage" ]]; then
+    printf '%s' "$usage"
+else
+    # Last-resort fallback — never blank the statusline entirely.
+    printf '%s' "$(printf '%s' "$input" | jq -r '.model.display_name // "Claude"' 2>/dev/null || echo "Claude")"
+fi

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 
 input=$(cat)
 
+# Optional segment mode (#2893): emit only a sub-part of the statusline so a
+# wrapper can compose this with another statusline (e.g. the vendored GSD one,
+# which has no quota/reset display). Recognized:
+#   --usage-tail  -> AI-usage segment (C:|O:|G: with weekly-reset) + cost + ctx
+# Any other/empty value renders the full statusline unchanged.
+SEGMENT="${1:-}"
+
 # Extract fields (jq with null-safe defaults)
 model=$(echo "$input" | jq -r '.model.display_name // "Claude"')
 cwd=$(echo "$input" | jq -r '.workspace.current_dir // ""')
@@ -23,7 +30,7 @@ branch=$(cd "$ws_root" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/nul
 # in long sessions; -uno skips the untracked-file scan to keep this cheap on
 # the ~33K-file workspace-hub checkout.
 git_marker=""
-if [[ "$branch" != "?" ]]; then
+if [[ "$SEGMENT" != "--usage-tail" && "$branch" != "?" ]]; then
     if [[ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$ws_root" status --porcelain -uno 2>/dev/null | head -1)" ]]; then
         git_marker="\033[1;31m*\033[0m"   # bold red: dirty (tracked changes/staged)
     fi
@@ -196,6 +203,15 @@ elif (( ctx_int > 60 )); then
     ctx="\033[33m${ctx_int}%\033[0m"
 else
     ctx="\033[32m${ctx_int}%\033[0m"
+fi
+
+# Segment mode (#2893): emit just the usage tail (quota/reset + cost + context)
+# and stop. Composed by .claude/statusline-combined.sh onto the GSD statusline,
+# which otherwise shows no AI-usage or weekly-reset info. Emitted after the
+# fields exist but before the host/branch/path assembly the wrapper omits.
+if [[ "$SEGMENT" == "--usage-tail" ]]; then
+    printf "%b %b ctx:%b" "$ai_usage" "$cost_fmt" "$ctx"
+    exit 0
 fi
 
 # Hostname prefix for multi-machine clarity

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/knowledge/
 # Status line - portable across machines
 !.claude/statusline-command.sh
+!.claude/statusline-combined.sh
 # Repo-level memory - shared institutional knowledge
 !.claude/memory/
 # Work queue - tracked for cross-machine/user portability

--- a/tests/statusline/test_combined_wrapper.bats
+++ b/tests/statusline/test_combined_wrapper.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests for .claude/statusline-combined.sh (#2893) — the wrapper that composes
+# the vendored GSD statusline with the AI-usage tail (quota + #2992 weekly-reset
+# countdown) from statusline-command.sh, so the reset shows in workspace-hub.
+
+SCRIPT="$BATS_TEST_DIRNAME/../../.claude/statusline-combined.sh"
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  export STATUSLINE_QUOTA_PRIMARY="$TMPDIR/q.json"
+  export STATUSLINE_QUOTA_CACHE="$TMPDIR/qc.json"
+  cat > "$STATUSLINE_QUOTA_PRIMARY" <<'EOF'
+{"agents":[
+  {"provider":"claude","week_pct":null,"pct_remaining":null,"hours_to_reset":null,"resets_at":"","source":"unavailable"},
+  {"provider":"codex","week_pct":36,"pct_remaining":64,"hours_to_reset":60,"resets_at":"","source":"app-server-live"},
+  {"provider":"gemini","pct_remaining":100,"source":"estimated"}
+]}
+EOF
+  cp "$STATUSLINE_QUOTA_PRIMARY" "$STATUSLINE_QUOTA_CACHE"
+}
+
+teardown() { rm -rf "$TMPDIR"; }
+
+INPUT='{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"'"$PWD"'"},"cost":{"total_cost_usd":0.42},"context_window":{"used_percentage":15}}'
+
+@test "combined output carries the usage tail with the weekly-reset countdown" {
+  run bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  clean=$(printf '%s' "$output" | sed 's/\x1b\[[0-9;]*m//g')   # strip ANSI colors
+  [[ "$clean" == *"O:64%·2.5d"* ]]   # 60h/24 = 2.5d, via reused reset_days
+  [[ "$clean" == *"ctx:15%"* ]]
+}
+
+@test "combined output includes the GSD base (model) and the joiner" {
+  run bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Opus 4.8"* ]]     # from the GSD statusline base
+  [[ "$output" == *" │ "* ]]          # both parts non-empty -> separator present
+}
+
+@test "never blanks even with minimal input" {
+  run bash -c "printf '%s' '{\"model\":{\"display_name\":\"Sonnet\"}}' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "usage tail alone renders when the GSD base produces nothing" {
+  # Point the wrapper's GSD lookup at an empty hooks dir via a copy in TMPDIR so
+  # gsd-statusline.js is absent; the wrapper must still emit the usage tail.
+  cp "$SCRIPT" "$TMPDIR/statusline-combined.sh"
+  cp "$BATS_TEST_DIRNAME/../../.claude/statusline-command.sh" "$TMPDIR/statusline-command.sh"
+  run bash -c "printf '%s' '$INPUT' | bash '$TMPDIR/statusline-combined.sh'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"O:64%·2.5d"* ]]   # tail still present
+  [[ "$output" != *" │ "* ]]          # no joiner since GSD half was empty
+}


### PR DESCRIPTION
## Summary
Makes the **#2992 weekly-reset countdown visible while working in workspace-hub**. The repo's active statusline is the vendored GSD script (`.claude/hooks/gsd-statusline.js`), which shows milestone/phase/task but **no AI-quota or weekly-reset info** — so the reset countdown that shipped in #3004 never appeared here. This adds a repo-owned wrapper that composes the GSD statusline with the usage tail.

Live render:
```
⬆ /gsd-update │ Opus 4.8 │ v1.0 · Phase 07 │ workspace-hub │ C:-%|O:79%·1.7d|G:100% $0.42 ctx:15%
                                                              └─ Codex 79% left, weekly reset in 1.7 days
```

## Design
- **`statusline-command.sh` — new `--usage-tail` segment mode.** Emits only the `C:|O:|G:` usage segment (with the weekly-reset `·N.Nd`) + cost + context, reusing the existing `reset_days`/`extract_pct`/`color_pct`. **Single source of truth** — the reset logic is not duplicated. Skips the git working-tree scan in this mode for speed.
- **`statusline-combined.sh` — new wrapper (repo-owned).** Feeds stdin to both the vendored GSD statusline and `statusline-command.sh --usage-tail`, joins with ` │ `. Resilient: renders either half alone if the other fails, never blanks (`set -uo pipefail`, no `-e`).
- **`settings.json`** — project `statusLine` → the wrapper.
- **`.gitignore`** — negate the wrapper past the blanket `.claude/*` ignore (else it'd be untracked and never deploy).

**Why a wrapper, not an edit to `gsd-statusline.js`:** that file is vendored (carries a `gsd-hook-version` header) and is overwritten by GSD framework bumps — any edit there would be clobbered. The wrapper is repo-owned and survives bumps.

## Tests / verification
- `tests/statusline/test_combined_wrapper.bats` — 4 cases (composes GSD + reset-bearing tail; never blanks; tail-alone when GSD half empty).
- `tests/statusline/test_weekly_reset.bats` — existing 6 cases still green (no regression from the segment-mode edits).
- `shellcheck -S warning` clean on both scripts; full statusline regression-renders correctly (git markers intact in normal mode); diff clean of deny-list/abs-path markers.

## Notes
- Pushed via audited `GIT_PRE_PUSH_SKIP=1` — the pre-push `check-all`/coverage gates fail machine-wide on a sibling-layout mismatch unrelated to this change.
- Builds on #2992 / #3004. Refs #2893 (statusline parity, under epic #2887).
