### PR TITLE
docs: route worldenergydata source readiness skill

### DIFF
--- a/.claude/skills/data/worldenergydata-source-readiness/SKILL.md
+++ b/.claude/skills/data/worldenergydata-source-readiness/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: worldenergydata-source-readiness
+description: Route agents to the canonical worldenergydata source-readiness skill and summary script. Use when asked for worldenergydata data completeness, data locations, latest known data dates, scheduler freshness, source-readiness status, or acceptance-criteria inputs across the repo ecosystem.
+---
+
+# WorldEnergyData Source Readiness
+
+## Quick Start
+
+Use the canonical skill and script in the `worldenergydata` checkout:
+
+```bash
+WED_REPO="${WED_REPO:-../worldenergydata}"
+cd "$WED_REPO"
+git fetch origin main
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py
+```
+
+JSON output:
+
+```bash
+WED_REPO="${WED_REPO:-../worldenergydata}"
+cd "$WED_REPO"
+git fetch origin main
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json
+```
+
+If the script is missing, update the `worldenergydata` checkout to a revision at or after PR #461.
+
+## What This Returns
+
+The summary includes:
+
+- data group / module
+- catalog status and freshness status
+- latest known date and whether it came from metadata, file timestamps, or scheduler success
+- repo-local data location
+- external data root, if metadata records one
+- configured scheduler output directory
+- dataset count, record count, file count, and size
+
+## Interpretation Rule
+
+Do not treat `latest_known_date` as source-data vintage unless the row says the basis is an inspected dataset field. Most current rows use metadata refresh, newest file modified date, or scheduler success.
+
+For acceptance criteria, require each Tier-A source to expose:
+
+- `source_data_latest_date`
+- `last_successful_refresh`
+- `data_location`
+- `record_count`
+- `freshness_status`
+- `refresh_cadence`
+- `blocker_issue` or `none`
+
+## Canonical Files
+
+In `worldenergydata`:
+
+- `.claude/skills/worldenergydata-source-readiness/SKILL.md`
+- `.claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py`
+- `data/freshness-scorecard.json`
+- `data/modules/<module>/_metadata.json`
+- `data/modules/<module>/manifest.json`
+- `config/scheduler/scheduler_config.yml`

--- a/logs/orchestrator/hermes/skill-patches.jsonl
+++ b/logs/orchestrator/hermes/skill-patches.jsonl
@@ -923,3 +923,4 @@
 {"ts":"2026-06-01T09:00:26Z","agent":"unknown","action":"modify","skill_path":".claude/skills/workspace-hub/tier1-indexing-scorecard-and-freshness-audit/SKILL.md","commit":"554c978fa2838f480a79f94948d33396559909c5"}
 {"ts":"2026-06-02T23:04:43Z","agent":"unknown","action":"create","skill_path":".claude/skills/coordination/flywheel-closeout/SKILL.md","commit":"0436401198ae1cf3555f67ddae66bf46852253ad"}
 {"ts":"2026-06-08T21:27:17Z","agent":"unknown","action":"modify","skill_path":".claude/skills/coordination/flywheel-closeout/SKILL.md","commit":"359254e613eb296086c64c5b024ce602f02277e3"}
+{"ts":"2026-06-09T15:10:16Z","agent":"unknown","action":"create","skill_path":".claude/skills/data/worldenergydata-source-readiness/SKILL.md","commit":"7e4fafe8194b7f77d1fdbb5e12bac3450507e434"}


### PR DESCRIPTION
## Summary

Adds a shared workspace-hub router skill for worldenergydata source-readiness lookups. This lets agents starting from the repo ecosystem discover the canonical worldenergydata skill and run its bundled summary script quickly.

## Verification

- Frontmatter parsed and description includes `Use when` trigger.
- No `/mnt/`, `/home/`, `TODO`, or `TBD` leakage in the skill file.
- Routed command validated against a temporary `worldenergydata` worktree at `origin/main` containing PR #461.
- `bash scripts/legal/legal-sanity-scan.sh --diff-only` PASS.

## Notes

The router does not duplicate volatile data-source status. It points agents to the canonical source-readiness script in `worldenergydata` and supports `WED_REPO` override for non-sibling worktrees.