### PR TITLE
feat(workstations): WF1 #2999 reconciler on Windows (ace-win-1/2) — OS-aware _base

### DIFF
--- a/.claude/skills/devops/hermes-local-configuration/references/hermes-windows-setup.md
+++ b/.claude/skills/devops/hermes-local-configuration/references/hermes-windows-setup.md
@@ -405,3 +405,27 @@ Keep workspace files on Windows filesystem (`/mnt/c/workspace-hub`) for cross-to
 - Check `.claude/memory/` files exist and are not empty
 - Verify config has `memory.memory_enabled: true`
 - Check the memory bridge script runs on session start
+
+## Harness role-overlay reconciler on Windows (WF1 #2999)
+
+`ace-win-1`/`ace-win-2` are `harness_profile.managed: true` (epic #2998). Run the reconciler **on
+the host** (no SSH) via Git Bash to converge the role-invariant safety deny-list into
+`%USERPROFILE%\.claude\settings.json`:
+
+```bash
+# pyyaml is required; uv is not installed on the Windows hosts:
+python -m pip install --user pyyaml
+# dry-run first (writes nothing, shows the drift):
+python scripts/readiness/harness_reconcile.py --machine ace-win-1
+# converge (additive, backs up settings.json, idempotent — a 2nd run is byte-identical):
+python scripts/readiness/harness_reconcile.py --machine ace-win-1 --apply
+```
+
+Notes:
+- The Windows deny subset (`format`, `del /f /s /q`, `rd /s`, `reg delete`, `diskpart`, …) comes from
+  `_base.deny_required_os.windows` in `config/workstations/harness-roles.yaml`, selected by the
+  machine's `os: windows`; the Linux-only entries (`crontab`/`systemctl`/`sudo`/…) are NOT applied.
+- Host detection resolves the real Windows computer name (e.g. `ACMA-ANSYS05`) via the registry
+  `hostname_aliases`, so `--machine` is usually unnecessary.
+- The write only touches `settings.json` — it never interacts with OrcaFlex/AQWA/ANSYS processes, so
+  it is safe to run while solvers are idle.

--- a/config/workstations/harness-roles.yaml
+++ b/config/workstations/harness-roles.yaml
@@ -18,17 +18,14 @@ roles:
   # missing today (probe 2026-06-08: a2 ~/.claude/settings.json had no deny-list).
   _base:
     skill_families: [core]
+    # deny_required = UNIVERSAL guards (apply on any managed host, incl. Git-Bash on Windows).
+    # deny_required_os = per-OS subset selected by the target machine's registry `os` field
+    #   (WF1 #2999). INVARIANT: deny_required ∪ deny_required_os.linux == the pre-WF1 flat 37-set,
+    #   so the already-converged Linux hosts (a1/a2) see zero new drift.
     deny_required:
       - "Bash(rm -rf /)"
       - "Bash(rm -rf ~:*)"
       - "Bash(rm -rf .:*)"
-      - "Bash(dd if=/dev/zero:*)"
-      - "Bash(mkfs:*)"
-      - "Bash(shred:*)"
-      - "Bash(sudo:*)"
-      - "Bash(su :*)"
-      - "Bash(pkexec:*)"
-      - "Bash(doas:*)"
       - "Bash(chmod 777:*)"
       - "Bash(eval:*)"
       - "Bash(sh -c:*)"
@@ -54,8 +51,29 @@ roles:
       - "Bash(git push --force-with-lease:*)"
       - "Bash(git -c core.hooksPath:*)"
       - "Bash(git -c core.hookspath:*)"
-      - "Bash(crontab:*)"
-      - "Bash(systemctl:*)"
+    deny_required_os:
+      linux:    # *nix system tools — present on Linux, absent on Windows
+        - "Bash(dd if=/dev/zero:*)"
+        - "Bash(mkfs:*)"
+        - "Bash(shred:*)"
+        - "Bash(sudo:*)"
+        - "Bash(su :*)"
+        - "Bash(pkexec:*)"
+        - "Bash(doas:*)"
+        - "Bash(crontab:*)"
+        - "Bash(systemctl:*)"
+      macos:    # macOS-appropriate subset (no systemd/pkexec/doas); best-effort until mac onboards
+        - "Bash(dd if=/dev/zero:*)"
+        - "Bash(sudo:*)"
+        - "Bash(su :*)"
+        - "Bash(crontab:*)"
+      windows:  # Git-Bash → cmd /c destructive guards
+        - "Bash(format:*)"
+        - "Bash(rd /s:*)"
+        - "Bash(del /f /s /q:*)"
+        - "Bash(rmdir /s /q:*)"
+        - "Bash(reg delete:*)"
+        - "Bash(diskpart:*)"
     # NOTE (F1 scope): hooks_required is intentionally omitted here. The live Stop/
     # SessionStart hooks carry machine-absolute paths (/home/<user>, /mnt/...), which is
     # the very path-portability hazard tracked by epic #2967. Hook convergence needs a

--- a/config/workstations/registry.yaml
+++ b/config/workstations/registry.yaml
@@ -222,9 +222,9 @@ machines:
     tier1_repo_root: 'D:\'
     repo_layout: sibling
     schedule_variant: contribute-minimal
-    harness_profile:          # #2968 F1 — Q2: declared for F3 routing, NEVER converged
+    harness_profile:          # WF1 #2999 — converged; Windows deny subset from _base.deny_required_os.windows
       roles: [licensed-solver]
-      managed: false
+      managed: true
     ssh: null  # no SSH — physical/GUI access only
     tailscale_ip: null
     capabilities:
@@ -262,9 +262,9 @@ machines:
     tier1_repo_root: 'D:\'
     repo_layout: sibling
     schedule_variant: contribute-minimal
-    harness_profile:          # #2968 F1 — Q2: declared for F3 routing, NEVER converged
+    harness_profile:          # WF1 #2999 — converged; Windows deny subset from _base.deny_required_os.windows
       roles: [licensed-solver]
-      managed: false
+      managed: true
     ssh: null
     tailscale_ip: null
     capabilities:

--- a/scripts/readiness/harness_reconcile.py
+++ b/scripts/readiness/harness_reconcile.py
@@ -87,10 +87,15 @@ def merge_hooks(local: dict, required: dict) -> dict:
     return out
 
 
-def compose_overlay(roles_cfg: dict, role_names: list[str]) -> dict:
+def compose_overlay(roles_cfg: dict, role_names: list[str], machine_os: str | None = None) -> dict:
     """_base ∪ role₁ ∪ role₂…  Scalar key present in 2 overlays with different values
     fails closed (no last-writer-wins). Lists (skill_families, schedule_jobs, deny)
-    are set-unioned."""
+    are set-unioned.
+
+    WF1 #2999: `_base.deny_required_os` is an {os: [deny…]} map. The subset matching
+    `machine_os` is set-unioned into `deny_required`, then the map is popped (config-only —
+    apply_overlay/compute_drift never read it). `machine_os=None` adds no OS subset.
+    """
     roles = roles_cfg.get("roles", {})
     chain = ["_base"] + [r for r in role_names if r != "_base"]
     merged: dict = {}
@@ -115,12 +120,31 @@ def compose_overlay(roles_cfg: dict, role_names: list[str]) -> dict:
             elif merged[k] != v:
                 raise ReconcileError(
                     f"overlay key conflict '{k}': {merged[k]!r} vs {name}:{v!r} (fail-closed)")
+    # WF1: resolve the per-OS deny subset, then drop the config-only map.
+    os_map = merged.pop("deny_required_os", None)
+    if os_map and machine_os:
+        subset = os_map.get(machine_os, [])
+        merged["deny_required"] = sorted(set(merged.get("deny_required", [])) | set(subset))
     return merged
 
 
 # ── drift + apply ─────────────────────────────────────────────────────────────
 def is_managed(profile: dict | None) -> bool:
     return bool(profile and profile.get("managed") is True)
+
+
+def resolve_machine_id(machines: dict, host: str) -> str | None:
+    """Resolve a hostname to its registry key via the canonical idiom: match the key,
+    hostname, OR hostname_aliases (case-insensitive — Windows hostnames are often
+    upper-case, e.g. ACMA-ANSYS05 → ace-win-1). WF1 #2999: without alias resolution the
+    reconciler can't identify a Windows host whose real name is the old alias."""
+    h = host.lower()
+    for mid, e in machines.items():
+        cands = [mid, e.get("hostname", "")] + list(e.get("hostname_aliases") or [])
+        cands = [str(c).lower() for c in cands if c]
+        if h in cands or any(c and c.startswith(h) for c in [str(e.get("hostname", "")).lower()]):
+            return mid
+    return None
 
 
 def compute_drift(current: dict, overlay: dict) -> list[dict]:
@@ -201,9 +225,19 @@ def overlay_changes_hooks(current: dict, overlay: dict) -> bool:
 # ── live-session gating (Codex MAJOR #1) ─────────────────────────────────────
 def detect_live_daemons(pgrep_fn=None) -> list[str]:
     def _default(pat):
-        return subprocess.run(["pgrep", "-f", pat], capture_output=True).returncode == 0
+        try:
+            return subprocess.run(["pgrep", "-f", pat], capture_output=True).returncode == 0
+        except (FileNotFoundError, OSError):
+            return False  # WF1: no pgrep (Windows/Git-Bash) → treat as no live daemon
     probe = pgrep_fn or _default
-    return [p for p in LIVE_DAEMON_PATTERNS if probe(p)]
+    out = []
+    for p in LIVE_DAEMON_PATTERNS:
+        try:
+            if probe(p):
+                out.append(p)
+        except (FileNotFoundError, OSError):
+            continue  # a probe that cannot run is not evidence of a live daemon
+    return out
 
 
 def should_block_apply(daemons_active: bool, changes_hooks: bool, allow_live_reload: bool) -> bool:
@@ -223,7 +257,9 @@ def serialize(settings: dict) -> str:
 # ── CLI ──────────────────────────────────────────────────────────────────────
 def _load_yaml(p: Path) -> dict:
     if yaml is None:
-        raise ReconcileError("pyyaml unavailable — run via `uv run --script`")
+        raise ReconcileError(
+            "pyyaml unavailable — run via `uv run --script`, or on Windows/Git-Bash "
+            "(no uv) `python -m pip install pyyaml` then `python harness_reconcile.py`")
     return yaml.safe_load(p.read_text()) if p.exists() else {}
 
 
@@ -240,8 +276,7 @@ def main(argv=None) -> int:
     state_classes = _load_yaml(STATE_CLASSES)
     machines = registry.get("machines", {})
     host = args.machine or socket.gethostname().split(".")[0]
-    mid = next((m for m, e in machines.items()
-                if e.get("hostname", "").startswith(host) or m == host), None)
+    mid = resolve_machine_id(machines, host)
     if mid is None:
         print(f"harness-reconcile: machine '{host}' not in registry — skipping", file=sys.stderr)
         return 0
@@ -250,7 +285,8 @@ def main(argv=None) -> int:
         print(f"harness-reconcile: {mid} is declare-only (managed!=true) — routing only, no write")
         return 0
 
-    overlay = compose_overlay(roles_cfg, profile.get("roles", []))
+    overlay = compose_overlay(roles_cfg, profile.get("roles", []),
+                              machine_os=machines[mid].get("os"))
     current = json.loads(SETTINGS.read_text()) if SETTINGS.exists() else {}
     drift = compute_drift(current, overlay)
     uncat = find_uncataloged_live(current, state_classes)

--- a/tests/readiness/test_harness_reconcile_windows.py
+++ b/tests/readiness/test_harness_reconcile_windows.py
@@ -1,0 +1,107 @@
+"""WF1 (#2999) — OS-aware `_base` + Windows portability for the role-overlay reconciler.
+
+The reconciler now selects a per-OS deny subset (`_base.deny_required_os[<machine os>]`) on top of
+the universal `_base.deny_required`, driven by the target machine's registry `os` field. These tests
+load the REAL config so they double as a regression lock: the composed deny-set for a Linux machine
+must stay byte-identical to the pre-WF1 flat 37-entry `_base` (a1/a2 are already converged — any
+change would re-trigger live drift).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+MOD = REPO / "scripts" / "readiness" / "harness_reconcile.py"
+ROLES_CFG = REPO / "config" / "workstations" / "harness-roles.yaml"
+REGISTRY = REPO / "config" / "workstations" / "registry.yaml"
+
+spec = importlib.util.spec_from_file_location("harness_reconcile", MOD)
+hr = importlib.util.module_from_spec(spec)
+sys.modules["harness_reconcile"] = hr
+spec.loader.exec_module(hr)
+
+# Frozen pre-WF1 flat `_base` deny-list (37 entries). The Linux compose MUST equal this exactly.
+FROZEN_LINUX_37 = {
+    "Bash(rm -rf /)", "Bash(rm -rf ~:*)", "Bash(rm -rf .:*)",
+    "Bash(dd if=/dev/zero:*)", "Bash(mkfs:*)", "Bash(shred:*)",
+    "Bash(sudo:*)", "Bash(su :*)", "Bash(pkexec:*)", "Bash(doas:*)",
+    "Bash(chmod 777:*)", "Bash(eval:*)", "Bash(sh -c:*)", "Bash(bash -c:*)",
+    "Bash(zsh -c:*)", "Bash(python -c:*)", "Bash(python3 -c:*)", "Bash(perl -e:*)",
+    "Bash(ruby -e:*)", "Bash(node -e:*)", "Bash(curl * | bash:*)", "Bash(curl * | sh:*)",
+    "Bash(wget * -O- | bash:*)", "Bash(wget * -O- | sh:*)", "Bash(| bash:*)", "Bash(| sh:*)",
+    "Bash(nc:*)", "Bash(ncat:*)", "Bash(base64:*)", "Bash(xxd:*)",
+    "Bash(git push --force:*)", "Bash(git push -f:*)", "Bash(git push --force-with-lease:*)",
+    "Bash(git -c core.hooksPath:*)", "Bash(git -c core.hookspath:*)",
+    "Bash(crontab:*)", "Bash(systemctl:*)",
+}
+LINUX_ONLY = {"Bash(crontab:*)", "Bash(systemctl:*)", "Bash(sudo:*)", "Bash(pkexec:*)", "Bash(doas:*)"}
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return yaml.safe_load(ROLES_CFG.read_text())
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return yaml.safe_load(REGISTRY.read_text())["machines"]
+
+
+def test_linux_compose_equals_frozen_37(cfg):
+    """Behavior-preserving: a Linux machine still gets exactly the pre-WF1 37-entry set."""
+    ov = hr.compose_overlay(cfg, ["control-plane"], machine_os="linux")
+    assert set(ov["deny_required"]) == FROZEN_LINUX_37
+
+
+def test_windows_compose_has_universal_and_windows_not_nix(cfg):
+    ov = hr.compose_overlay(cfg, ["licensed-solver"], machine_os="windows")
+    deny = set(ov["deny_required"])
+    # universal guards still present (Git-Bash dangers)
+    assert "Bash(rm -rf /)" in deny and "Bash(curl * | bash:*)" in deny
+    # windows-specific destructive guards present
+    assert "Bash(format:*)" in deny and "Bash(reg delete:*)" in deny and "Bash(diskpart:*)" in deny
+    # *nix-only entries absent on Windows
+    assert not (LINUX_ONLY & deny), f"linux-only leaked onto windows: {LINUX_ONLY & deny}"
+
+
+def test_macos_compose_subset(cfg):
+    ov = hr.compose_overlay(cfg, ["licensed-solver"], machine_os="macos")
+    deny = set(ov["deny_required"])
+    assert "Bash(rm -rf /)" in deny           # universal
+    assert "Bash(sudo:*)" in deny             # mac has sudo
+    assert "Bash(systemctl:*)" not in deny    # mac has no systemd
+    assert "Bash(format:*)" not in deny       # not a windows host
+
+
+def test_deny_required_os_key_is_popped(cfg):
+    """The config-only OS map must never survive into the composed overlay / settings."""
+    for os_name in ("linux", "windows", "macos", None):
+        ov = hr.compose_overlay(cfg, ["licensed-solver"], machine_os=os_name)
+        assert "deny_required_os" not in ov
+
+
+def test_ace_win_now_managed(registry):
+    assert hr.is_managed(registry["ace-win-1"]["harness_profile"]) is True
+    assert hr.is_managed(registry["ace-win-2"]["harness_profile"]) is True
+
+
+def test_resolve_machine_id_via_alias_and_hostname(registry):
+    """The real Windows hostname (an old alias, often upper-case) must resolve to ace-win-*."""
+    assert hr.resolve_machine_id(registry, "ACMA-ANSYS05") == "ace-win-1"
+    assert hr.resolve_machine_id(registry, "acma-ws014") == "ace-win-2"
+    assert hr.resolve_machine_id(registry, "licensed-win-1") == "ace-win-1"   # WF0 back-compat alias
+    assert hr.resolve_machine_id(registry, "ace-win-1") == "ace-win-1"        # new hostname
+    assert hr.resolve_machine_id(registry, "ace-linux-1") == "dev-primary"    # linux hostname
+    assert hr.resolve_machine_id(registry, "nope-host") is None
+
+
+def test_detect_live_daemons_is_windows_safe():
+    """A host without pgrep (Windows) must report no daemons, not crash."""
+    def _no_pgrep(_pat):
+        raise FileNotFoundError("pgrep")  # simulate pgrep absent
+    assert hr.detect_live_daemons(pgrep_fn=_no_pgrep) == []


### PR DESCRIPTION
## WF1 (#2999) — role-overlay reconciler on Windows (ace-win-1/2), OS-aware `_base`

Extends F1 (#2968) to the Windows hosts (epic #2998; WF0 #3001 renamed them, merged in #3008).
ace-win-1/2 now converge the role-invariant **safety deny-list** — the same gap-closure ace-linux-2
got. Per the locked decision, this uses **one shared `_base` with an OS decision tree** keyed on the
machine's registry `os`, not per-OS duplicate roles.

### Design
- **`harness-roles.yaml`** — `_base.deny_required` split into a **universal** list (28 entries:
  `rm -rf`, `curl|bash`, force-push, `eval`, `python -c`, … — these apply even in Git Bash) plus a
  new **`deny_required_os`** map: `linux` (the 9 *nix-only: crontab/systemctl/sudo/pkexec/doas/dd/
  mkfs/shred), `macos` (subset), `windows` (format/del/rd/reg delete/diskpart).
  **Invariant:** `universal ∪ deny_required_os.linux` == the pre-WF1 37-entry set → the already-
  converged Linux hosts (a1/a2) see **zero new drift** (regression-locked by test).
- **`harness_reconcile.py`** — `compose_overlay(…, machine_os)` resolves the OS subset into
  `deny_required` and pops the map; `resolve_machine_id()` resolves the real Windows computer name
  (e.g. `ace-win-1`) to `ace-win-1` via `hostname_aliases` (case-insensitive) — without it the
  reconciler couldn't identify a Windows host; `detect_live_daemons` guards a missing `pgrep`
  (Windows); the pyyaml-missing message gains the `python -m pip install pyyaml` path.
  `Path.home()` already resolves `%USERPROFILE%` for free.
- **`registry.yaml`** — ace-win-1/2 `managed: false → true` (the Windows deny subset arrives via
  `os: windows`).
- **Runbook** note for running it on the host via Git Bash.

### Adversarial finding (verified)
`apply_overlay`/`compute_drift` read only `deny_required`/`hooks_required`/`scalar_required`, so an
un-popped `deny_required_os` cannot leak into `settings.json`. The load-bearing action is the
OS-subset *merge*; the pop is cleanliness (tested).

### Verification (origin/main snapshot, edited vs baseline)
- 24/24 reconciler tests (7 new WF1 + 17 existing) — incl. the Linux `== frozen 37` regression lock.
- **0 new failures** vs baseline across readiness / workstations / cron / operations / monitoring
  (the 6 fails + 3 errors present are pre-existing on `origin/main`).
- End-to-end dry-run for `ace-win-1` resolves the machine, composes the Windows overlay, reports
  drift, writes nothing.

### Operator step (not in PR)
Live `--apply` runs **on the host** (no SSH): Git Bash → `python -m pip install --user pyyaml` →
`python scripts/readiness/harness_reconcile.py --machine ace-win-1 --apply` (additive, backed up,
idempotent). Or via the WF3 (#3000) pull agent once it lands.

Closes #2999.
