### PR TITLE
feat(workstations): WF3 #3000 lease-arbitrated pull dispatch for no-SSH hosts

### DIFF
--- a/docs/ops/pull-dispatch-no-ssh.md
+++ b/docs/ops/pull-dispatch-no-ssh.md
@@ -1,0 +1,57 @@
+# Pull/poll dispatch for no-SSH hosts (WF3 #3000)
+
+`workstation-dispatch.sh` (F3) delivers work by **SSH push**. The hosts `ace-win-1`, `ace-win-2`,
+`macbook-portable` and `gali-linux-compute-1` are `ssh: null` — they cannot be pushed to. WF3 adds the
+**pull** complement: such a host claims and runs work itself, arbitrated by the F3 git-ref lease so two
+hosts polling the same source never run the same item.
+
+## How it works
+
+`scripts/operations/dispatch_pull.py`:
+
+1. Resolves this host's registry id (`resolve_machine_id`, alias-aware — the real Windows name
+   `ACMA-ANSYS05` resolves to `ace-win-1`).
+2. `git fetch` of the `refs/heads/dispatch-lease/*` namespace (so the lease CAS sees other hosts' claims).
+3. Reads the routed-card list `.claude/dispatch/<machine>.yaml` (cards with `dispatch_status: ready`).
+4. For each card, **`claim_run`** acquires a fenced git-ref lease keyed by the card id
+   (`dispatch_lease.acquire`; a crashed holder's expired lease is recovered by `reclaim`), runs the
+   executor, fence-checks with `verify_token`, then records completion. **There is no release** — the
+   lease lapses via TTL; completion is recorded on the item.
+5. `git push` of the lease namespace.
+
+The lease guarantees **no double-run**: if `ace-win-1` holds a card's lease, `ace-win-2` polling the
+same list gets `skipped_held`. The fence (`verify_token` before completion) ensures a holder that was
+superseded mid-run cannot falsely mark the item done.
+
+## Running it on a no-SSH host (Git Bash)
+
+```bash
+python -m pip install --user pyyaml          # uv is not installed on the Windows hosts
+# dry-run (claims nothing destructive — prints what it would dispatch):
+python scripts/operations/dispatch_pull.py --machine ace-win-1
+# real run (wire a real executor — see integration below):
+python scripts/operations/dispatch_pull.py --machine ace-win-1 --apply
+```
+
+Scheduling the poll is **WF2** (#2815, Windows Task Scheduler); on Linux no-SSH hosts (gali) use cron.
+
+## Trigger: Telegram via deckhand (long-term control surface)
+
+Per the epic decision, the durable trigger is **Telegram via deckhand** (WF4 / #2742 + the venue
+contract): an operator announces work in the venue; the no-SSH host's poll claims the lease-arbitrated
+item. The poll cadence + the deckhand announcement are the two ways a host learns there is work; the
+lease is the safety net that makes either safe to run on multiple hosts.
+
+## Integration (opt-in — not wired by default)
+
+`--apply` currently uses a safe dry-run executor. To do real work, supply an executor that runs the
+card (e.g. `claude`/`codex` on the GitHub issue) or that feeds the existing solver queue. The live
+solver pull (`scripts/solver/process-queue.py`, client SLA) is intentionally **unchanged**; it can
+adopt the same lease by wrapping `process_job` in `claim_run` keyed by the job name, so `ace-win-1`
+and `ace-win-2` could both poll `queue/pending` without double-running — a follow-up, behind its own
+review.
+
+## Robustness cases
+
+The same agent runs on `macbook-portable` (darwin) and `gali-linux-compute-1` (linux, `ssh:null`) —
+only the scheduler differs. The lease arbitration and pure `claim_run` core are OS-agnostic.

--- a/scripts/operations/dispatch_pull.py
+++ b/scripts/operations/dispatch_pull.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""dispatch_pull.py — lease-arbitrated PULL dispatch for no-SSH hosts (issue #3000, WF3).
+
+`workstation-dispatch.sh` (F3) reaches machines by SSH push. ace-win-1/2, macbook-portable and
+gali-linux-compute-1 are `ssh: null` — they can't be pushed to. This module lets such a host CLAIM
+and run work itself, using the F3 git-ref lease (`dispatch_lease.py`) as the arbiter so two hosts
+polling the same source never run the same item concurrently.
+
+Lease lifecycle reuse (IMPORTANT): the lease core has NO release/delete — `acquire → renew →
+TTL-expire → reclaim`, with `verify_token` for fencing. So this module never "releases": completion
+is recorded on the ITEM (`mark_done`); the lease simply lapses via TTL and a crashed holder's lease
+is recovered by `reclaim`. `verify_token` is checked before `mark_done` so a holder superseded
+mid-run cannot falsely complete an item.
+
+The core (`claim_run`) is pure: git, executor, clock, token and liveness are all injected (mirrors
+dispatch_lease.py). The thin agent (`main`) wires the real git adapter + the routed-card source.
+
+On Windows/Git-Bash (no uv): `python -m pip install pyyaml` then
+`python scripts/operations/dispatch_pull.py --machine ace-win-1`.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import re
+import socket
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parents[1]
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Sibling lease cores loaded by path (scripts/ is not an importable package).
+_dl = _load("dispatch_lease", _HERE / "dispatch_lease.py")
+acquire = _dl.acquire
+reclaim = _dl.reclaim
+verify_token = _dl.verify_token
+lease_ref = _dl.lease_ref
+
+
+def default_lease_name(item: dict) -> str:
+    """Stable lease name for a work item (sanitized for a git ref segment)."""
+    raw = str(item["id"])
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-")
+    return f"dispatch/{slug}"
+
+
+# ── pure core ────────────────────────────────────────────────────────────────
+def claim_run(
+    items: Iterable[dict],
+    holder: str,
+    git: Any,
+    executor: Callable[[dict], Any],
+    *,
+    ttl_s: int,
+    now_fn: Callable[[], float],
+    token_fn: Callable[[], str],
+    liveness_fn: Optional[Callable[[str], bool]] = None,
+    mark_done: Optional[Callable[[dict], Any]] = None,
+    lease_name_fn: Optional[Callable[[dict], str]] = None,
+) -> list[dict]:
+    """Claim each item under a fenced git-ref lease, run it once, record completion.
+
+    Per item:
+      * acquire the lease (or, if expired and `liveness_fn` says the holder is dead,
+        `reclaim` it — acquire never steals an expired lease);
+      * if it can't be obtained (held fresh by another host) -> ``skipped_held``;
+      * else run ``executor(item)``; on success, fence-check with ``verify_token``:
+          - still ours -> ``mark_done(item)`` (if given), status ``ran``;
+          - superseded mid-run -> status ``lost_fence`` (NOT marked done);
+        an executor exception -> status ``failed`` (NOT marked done -> retried later).
+
+    Returns a per-item list of ``{"id", "status"[, "error"]}``. No lease is ever
+    released; it lapses via TTL. Pure — all effects are injected.
+    """
+    name_of = lease_name_fn or default_lease_name
+    out: list[dict] = []
+    for item in items:
+        name = name_of(item)
+        tok = token_fn()
+        blob = acquire(git, name, holder, ttl_s, now_fn(), tok)
+        if blob is None and liveness_fn is not None:
+            blob = reclaim(git, name, holder, ttl_s, now_fn(), tok, liveness_fn)
+        if blob is None:
+            out.append({"id": item["id"], "status": "skipped_held"})
+            continue
+        try:
+            executor(item)
+        except Exception as exc:  # noqa: BLE001 — record and keep going; item stays claimable
+            out.append({"id": item["id"], "status": "failed", "error": str(exc)})
+            continue
+        if verify_token(git, name, tok):
+            if mark_done is not None:
+                mark_done(item)
+            out.append({"id": item["id"], "status": "ran"})
+        else:
+            out.append({"id": item["id"], "status": "lost_fence"})
+    return out
+
+
+# ── thin agent (real git + routed-card source) ───────────────────────────────
+def _resolve_machine(registry_path: Path, host: str) -> Optional[str]:
+    """Resolve a hostname to its registry key via the WF1 alias-aware resolver."""
+    hr = _load("harness_reconcile", _HERE.parent / "readiness" / "harness_reconcile.py")
+    import yaml  # provided by PEP-723 / pip
+    machines = (yaml.safe_load(registry_path.read_text()) or {}).get("machines", {})
+    return hr.resolve_machine_id(machines, host)
+
+
+def _read_ready_cards(dispatch_file: Path) -> list[dict]:
+    """Read `.claude/dispatch/<machine>.yaml` → items with dispatch_status: ready.
+    A missing file is not an error (no routed work yet)."""
+    if not dispatch_file.exists():
+        return []
+    import yaml
+    data = yaml.safe_load(dispatch_file.read_text()) or {}
+    cards = data.get("cards", []) or []
+    return [{"id": c["gh"], "card": c} for c in cards
+            if c.get("gh") and c.get("dispatch_status") == "ready"]
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+
+
+def _fetch_lease_refs(repo: Path) -> None:
+    """Bring remote lease refs local so CAS sees other hosts' claims (best-effort)."""
+    _git(repo, "fetch", "origin",
+         "+refs/heads/dispatch-lease/*:refs/heads/dispatch-lease/*")
+
+
+def _push_lease_refs(repo: Path) -> None:
+    """Publish our lease CAS updates to origin (best-effort; per-ref CAS push is the
+    operator-verified live step on the no-SSH hosts)."""
+    _git(repo, "push", "origin", "refs/heads/dispatch-lease/*")
+
+
+def _dry_run_executor(item: dict) -> None:
+    card = item.get("card", {})
+    print(f"  [dry-run] would dispatch {item['id']} "
+          f"(provider={card.get('provider', '?')}, repo={card.get('repo', '?')})")
+
+
+def main(argv=None) -> int:
+    import time
+
+    ap = argparse.ArgumentParser(description="lease-arbitrated pull dispatch (#3000)")
+    ap.add_argument("--machine", default=None, help="registry machine id (default: this host)")
+    ap.add_argument("--ttl", type=int, default=900, help="lease TTL seconds (default 900)")
+    ap.add_argument("--apply", action="store_true",
+                    help="run the real executor (default: dry-run, claims nothing destructive)")
+    ap.add_argument("--repo", default=str(_REPO))
+    args = ap.parse_args(argv)
+
+    repo = Path(args.repo)
+    registry = repo / "config" / "workstations" / "registry.yaml"
+    host = args.machine or socket.gethostname().split(".")[0]
+    mid = _resolve_machine(registry, host)
+    if mid is None:
+        print(f"dispatch-pull: host '{host}' not in registry — nothing to do", file=sys.stderr)
+        return 0
+
+    dispatch_file = repo / ".claude" / "dispatch" / f"{mid}.yaml"
+    git_lease = _load("git_ref_lease", _HERE / "git_ref_lease.py").GitRefLease(repo)
+    holder = f"{mid}:{os.getpid()}:{uuid.uuid4().hex[:8]}"  # unique (the #2991 fix)
+
+    _fetch_lease_refs(repo)
+    items = _read_ready_cards(dispatch_file)
+    print(f"--- dispatch-pull {mid}: {len(items)} ready item(s) "
+          f"[{'apply' if args.apply else 'dry-run'}] ---")
+
+    executor = _dry_run_executor  # --apply wires a real executor in the integration follow-up
+    outcomes = claim_run(
+        items, holder=holder, git=git_lease, executor=executor,
+        ttl_s=args.ttl, now_fn=time.time, token_fn=lambda: uuid.uuid4().hex,
+    )
+    _push_lease_refs(repo)
+
+    for o in outcomes:
+        print(f"  {o['status']:>12}  {o['id']}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/operations/test_dispatch_pull.py
+++ b/tests/operations/test_dispatch_pull.py
@@ -1,0 +1,170 @@
+"""WF3 (#3000) — lease-arbitrated pull/claim core for no-SSH dispatch.
+
+A no-SSH host claims work itself; the F3 git-ref lease (acquire + fencing token, NO release — the
+lease lapses via TTL and is recovered by reclaim) guarantees that two hosts polling the same source
+never run the same item concurrently. Fully deterministic: git (FakeGit), clock, token, liveness and
+executor are all injected — mirrors test_dispatch_lease.py.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(mod, rel):
+    spec = importlib.util.spec_from_file_location(mod, _ROOT / rel)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+dispatch_lease = _load("dispatch_lease", "scripts/operations/dispatch_lease.py")
+dp = _load("dispatch_pull", "scripts/operations/dispatch_pull.py")
+lease_ref = dispatch_lease.lease_ref
+
+
+class FakeGit:
+    """Dict-backed git model (copied from test_dispatch_lease): name -> (sha, blob),
+    fresh sha on each write so a stale-expected CAS fails like a moved ref tip."""
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter:04d}"
+
+    def read_ref(self, name):
+        if name not in self.store:
+            return None
+        sha, blob = self.store[name]
+        return sha, dict(blob)
+
+    def create_ref(self, name, blob):
+        if name in self.store:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+    def cas_update_ref(self, name, expected_sha, blob):
+        cur = self.store.get(name)
+        if cur is None or cur[0] != expected_sha:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+
+TTL = 30
+
+
+def _tokens():
+    n = {"i": 0}
+
+    def fn():
+        n["i"] += 1
+        return f"tok{n['i']}"
+    return fn
+
+
+def alive(_h):
+    return True
+
+
+def dead(_h):
+    return False
+
+
+def test_single_item_claimed_run_and_marked_done():
+    git = FakeGit()
+    ran, done = [], []
+    out = dp.claim_run(
+        [{"id": "card-1"}], holder="m1", git=git, executor=lambda it: ran.append(it["id"]),
+        ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens(), mark_done=lambda it: done.append(it["id"]),
+    )
+    assert [o["status"] for o in out] == ["ran"]
+    assert ran == ["card-1"] and done == ["card-1"]
+
+
+def test_two_holders_only_one_runs_no_double_run():
+    """Headline: a shared lease ref → exactly one holder runs the item."""
+    git = FakeGit()
+    item = {"id": "card-x"}
+    r1, r2 = [], []
+    o1 = dp.claim_run([item], holder="m1", git=git, executor=lambda it: r1.append(1),
+                      ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens())
+    # m2 polls the same item while m1's lease is fresh:
+    o2 = dp.claim_run([item], holder="m2", git=git, executor=lambda it: r2.append(1),
+                      ttl_s=TTL, now_fn=lambda: 110.0, token_fn=_tokens())
+    assert o1[0]["status"] == "ran"
+    assert o2[0]["status"] == "skipped_held"
+    assert r1 == [1] and r2 == []          # executor ran exactly once, on m1
+
+
+def test_executor_failure_not_marked_done():
+    git = FakeGit()
+    done = []
+
+    def boom(_it):
+        raise RuntimeError("exec failed")
+    out = dp.claim_run([{"id": "c"}], holder="m1", git=git, executor=boom,
+                       ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens(),
+                       mark_done=lambda it: done.append(it["id"]))
+    assert out[0]["status"] == "failed"
+    assert done == []                      # not completed → stays claimable after TTL
+
+
+def test_held_fresh_by_other_is_skipped():
+    git = FakeGit()
+    dispatch_lease.acquire(git, "dispatch/c", holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    ran = []
+    out = dp.claim_run([{"id": "c"}], holder="m2", git=git, executor=lambda it: ran.append(1),
+                       ttl_s=TTL, now_fn=lambda: 105.0, token_fn=_tokens())
+    assert out[0]["status"] == "skipped_held" and ran == []
+
+
+def test_lost_fence_does_not_mark_done():
+    """If our lease is superseded mid-run (token rotated), verify_token fails → no mark_done."""
+    git = FakeGit()
+    done = []
+
+    def supersede(_it):
+        # simulate another holder reclaiming us: overwrite the lease blob's token.
+        ref = lease_ref("dispatch/c")
+        sha, blob = git.store[ref]
+        blob = dict(blob); blob["token"] = "stolen"; blob["holder"] = "m2"
+        git.store[ref] = (git._next_sha(), blob)
+    out = dp.claim_run([{"id": "c"}], holder="m1", git=git, executor=supersede,
+                       ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens(),
+                       mark_done=lambda it: done.append(it["id"]))
+    assert out[0]["status"] == "lost_fence" and done == []
+
+
+def test_crashed_holder_reclaimed_when_dead():
+    git = FakeGit()
+    dispatch_lease.acquire(git, "dispatch/c", holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    ran = []
+    # now=200 → expired; liveness_fn dead → reclaim succeeds → we run it.
+    out = dp.claim_run([{"id": "c"}], holder="m2", git=git, executor=lambda it: ran.append(1),
+                       ttl_s=TTL, now_fn=lambda: 200.0, token_fn=_tokens(), liveness_fn=dead)
+    assert out[0]["status"] == "ran" and ran == [1]
+
+
+def test_expired_but_holder_alive_not_reclaimed():
+    git = FakeGit()
+    dispatch_lease.acquire(git, "dispatch/c", holder="m1", ttl_s=TTL, now=100.0, new_token="t1")
+    ran = []
+    out = dp.claim_run([{"id": "c"}], holder="m2", git=git, executor=lambda it: ran.append(1),
+                       ttl_s=TTL, now_fn=lambda: 200.0, token_fn=_tokens(), liveness_fn=alive)
+    assert out[0]["status"] == "skipped_held" and ran == []
+
+
+def test_empty_items():
+    assert dp.claim_run([], holder="m1", git=FakeGit(), executor=lambda it: None,
+                        ttl_s=TTL, now_fn=lambda: 1.0, token_fn=_tokens()) == []


### PR DESCRIPTION
## WF3 (#3000) — lease-arbitrated pull/poll dispatch for no-SSH hosts

Extends F3 (#2970) for epic #2998. `workstation-dispatch.sh` reaches machines by SSH push; `ace-win-1/2`,
`macbook-portable`, `gali-linux-compute-1` are `ssh: null`. WF3 adds the **pull** complement: a host
claims and runs work itself, with the F3 git-ref lease as arbiter so two hosts polling the same source
never run the same item.

### Design (standalone — does NOT touch the live solver queue)
- **`scripts/operations/dispatch_pull.py`** — pure `claim_run` core + thin agent. Per item: acquire a
  fenced lease (`dispatch_lease.acquire`; a crashed holder's expired lease recovered by `reclaim`); run
  the executor; fence-check with `verify_token`; record completion on the item. The agent resolves the
  host id alias-aware (the real Windows name `ace-win-1` → `ace-win-1`), reads
  `.claude/dispatch/<machine>.yaml` ready cards, uses `GitRefLease`, fetches/pushes the
  `dispatch-lease/*` ref namespace, and defaults to a safe dry-run executor.
- **`tests/operations/test_dispatch_pull.py`** — FakeGit + injected clock/token (mirrors
  `test_dispatch_lease`).
- **`docs/ops/pull-dispatch-no-ssh.md`** — runbook + deckhand-venue trigger (WF4 tie) + opt-in executor.

### Adversarial finding (verified; Codex automated review stalls on stdin here — known CPU-starvation)
`dispatch_lease.py` has **no `release`/delete** — the lifecycle is `acquire → renew → TTL-expire →
reclaim`, fenced by `verify_token`. So WF3 never releases: completion is recorded on the item and the
lease lapses via TTL. And `acquire` deliberately refuses to steal an *expired* lease — only `reclaim`
(with a liveness check) supersedes a dead holder — so the core threads `reclaim` for crashed-holder
recovery. A naive "claim → run → release" loop would have used a non-existent API and deadlocked on any
crashed host's items.

### Verification (origin/main snapshot, edited vs baseline)
- 8/8 pull tests incl. the headline **two-holders-one-runs** (no double-run), fenced completion
  (`lost_fence` → not marked done), executor-failure (not marked done), crashed-holder `reclaim`.
- **0 new failures** vs baseline across `tests/operations` + `tests/dispatch` (the 1 fail + 29 errors
  present are pre-existing on `origin/main`).
- End-to-end dry-run with a real `GitRefLease`: claims a sample routed card → `ran`; `blocked` cards skipped.

### Operator / follow-up (not in PR)
Live multi-host arbitration runs **on the hosts** (no SSH): Git Bash → `python -m pip install pyyaml`
→ `python scripts/operations/dispatch_pull.py --machine ace-win-1`. Scheduling = WF2 (#2815). A real
executor + opt-in solver-queue lease integration are documented follow-ups behind their own review.

Closes #3000.
