### PR TITLE
docs(skills): incident-to-issue evidence-research for github-issues

### DIFF
--- a/.claude/skills/github/github-issues/SKILL.md
+++ b/.claude/skills/github/github-issues/SKILL.md
@@ -19,6 +19,10 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 - Authenticated with GitHub (see `github-auth` skill)
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
 
+### Private repos behind Deckhand shims
+
+When operating on a private repo whose `git`/`gh` binaries are wrapped by Deckhand scope shims, do not assume ordinary `gh issue list --repo ...` will work from every chat/session. First verify the session has the identity fields the shim needs (`HERMES_SESSION_USER_ID`, `HERMES_SESSION_PLATFORM`, `HERMES_SESSION_CHAT_ID`) and that the current chat is bound to a scope that authorizes the target repo. If `gh` fails closed with `unknown operator` or no active scope, report that as an authorization/context gap, not as “no issues.” For read-only status requests, fall back to durable repo-local handoff/issue-map documents only as clearly labeled secondary evidence, and keep direct GitHub issue state marked unverified until an authorized Deckhand/`gh` path succeeds. Avoid browser or unauthenticated REST as the primary path for private repos; 404 commonly means private/auth-blocked, not absent.
+
 ### Setup
 
 ```bash
@@ -138,7 +142,8 @@ Before creating a new feature issue, do a quick grounding pass to avoid duplicat
 10. If ending a session with a linked issue tree, produce a restart-safe closeout: issue states/gate labels, artifact paths, validation results, pushed commits, remote-ref sync evidence, and preserved unrelated worktrees. See `references/issue-tree-exit-closeout.md`.
 11. If you accidentally create an issue with unresolved placeholders, fix it immediately with `gh issue edit --body-file ...` and then re-verify the rendered body.
 12. For layered architecture/governance issue trees, see `references/layered-architecture-review-issue-tree.md`; it includes parent/child issue structure, data/execution/report layer scope, and the rule that output/report residency must mirror input/data residency unless an explicit promotion gate says otherwise.
-13. Before closing layered architecture contract implementation issues, run the closeout checks in `references/layered-architecture-contract-closeout.md`; in particular, schema readiness gates must reject placeholder checksums and any unresolved adversarial `MAJOR` blocks commit/close.
+13. When researching a user-referenced incident from another chat/channel, distinguish the observed runtime/chat failure from adjacent GitHub asset/workflow issues. Use `references/incident-to-issue-evidence-research.md` to search session history, inspect candidate issue bodies/comments, extract evidence, and explicitly report any gap where no direct issue exists.
+14. Before closing layered architecture contract implementation issues, run the closeout checks in `references/layered-architecture-contract-closeout.md`; in particular, schema readiness gates must reject placeholder checksums and any unresolved adversarial `MAJOR` blocks commit/close.
 14. For per-machine repository placement decisions, create one decision issue per machine in the user's requested order and do not perform repo moves/deletes/sync changes inside issue creation. Use `references/machine-repo-placement-decision-issues.md` for the reusable issue body shape and verification checklist. Keep delegation/dispatch strategy independent from repo placement unless a separate approved delegation plan explicitly requires otherwise; repo placement should be justified by locality, canonical source of truth, storage footprint, sync/backup risk, licensed tooling, and machine role. When the first machine issue establishes the baseline, include a completion note/acceptance criterion that the story leaves a reusable pattern for consistent tier-1 repo folder structure, methodical primary/reference placement decisions, and repo harness/file ecosystem handling through a single repo-tracked authority.
 15. For revisions to completed/closed work, prefer a new open revision issue with a parent link-back comment when the closed issue should remain the baseline trace. Use `references/closed-issue-revision-thread.md` for the body shape and verification checklist.
 

--- a/.claude/skills/github/github-issues/references/incident-to-issue-evidence-research.md
+++ b/.claude/skills/github/github-issues/references/incident-to-issue-evidence-research.md
@@ -1,0 +1,28 @@
+# Incident-to-issue evidence research
+
+Use this when the user references a problem from a chat/channel and asks what GitHub issue captured it, what happened, and what evidence/research is already on the issue.
+
+## Workflow
+
+1. **Separate observed incident from nearby GitHub work.** A chat incident may be about delivery/runtime behavior while the closest GitHub issue may be about a related asset or workflow. Do not collapse them unless evidence links them.
+2. **Search session history first when the incident happened in chat.** Use exact phrases from the user's recollection and likely variants: channel name, bot handle, artifact type, failure symptom, and generated artifact filenames if visible.
+3. **Search GitHub issues second.** Start with exact phrases from the incident (`"PDF attachment"`, `"HTML attachment"`, `"nothing came thru"`, artifact basename), then broaden to workflow/asset terms. Include open and closed issues.
+4. **Read the candidate issue body and comments.** The useful evidence is often in comments: review rounds, plan decisions, verification outputs, live URLs, hashes, commits, and closeout notes.
+5. **Report with a hard distinction:**
+   - `Observed channel incident`: what happened in chat, with session evidence.
+   - `GitHub issue evidence`: issue URL/title/state, body evidence, comments/research, artifacts, commits, validation.
+   - `Gap`: whether a direct incident-tracking issue exists or whether only adjacent work exists.
+6. **Do not claim a GitHub issue documents the incident unless the issue body or comments explicitly connect to the incident.** If only adjacent issues exist, say so and recommend filing a follow-up.
+
+## Useful evidence fields to extract
+
+- Issue URL, number, title, state, labels.
+- Body `Evidence` or `Acceptance` sections.
+- Comments containing adversarial review summaries, implementation closeout, deployed URLs, content types, file sizes, SHA256 hashes, commits, and test results.
+- Session-search quotes showing user-visible failure symptoms.
+
+## Pitfalls
+
+- **Asset workflow ≠ messaging delivery bug.** A PDF/HTML generation issue can be complete while Telegram media delivery still fails for that file type.
+- **Search result proximity is not proof.** The top GitHub result may be an umbrella issue or a related GTM asset issue, not the incident ticket.
+- **Avoid over-generalizing transient API limits or auth state.** If public GitHub API search is rate-limited, continue with available browser/session evidence or authenticated tooling when available; do not encode the rate limit as a durable tool limitation.


### PR DESCRIPTION
Adds incident-to-issue tracing to the `github-issues` skill: a reference doc plus the SKILL.md wiring and a Deckhand-shim prerequisite note.

## Commits
1. **New reference** — `references/incident-to-issue-evidence-research.md` (28 lines): separate observed channel incident from adjacent GitHub work, search session history before issues, report incident vs. issue-evidence vs. gap.
2. **SKILL.md wiring** — item 13 links the reference; new Prerequisites note: private repos behind Deckhand scope shims need session identity + scope binding, and a fail-closed `gh` is an auth/context gap, not "no issues".

Generic methodology — no client/PII content (public-repo safe). The recovered SKILL.md edit had been orphaned in a sync autostash; folded in here so the doc and its link land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)