### PR TITLE
feat(statusline): Claude weekly-reset countdown from session rate_limits JSON

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -190,8 +190,10 @@ g_pct=$(extract_pct "gemini")
 # Claude prefers the session JSON's rate_limits.seven_day.resets_at — the same
 # live source already trusted for the percentage — since the quota file's
 # claude entry is source:unavailable. Gemini is a daily limit, no reset suffix.
+# Both fields must come from the same session snapshot: a resets_at without a
+# used_percentage would pair a countdown with an unknown (or file-sourced) %.
 c_days=""
-[[ -n "$week_resets_at" ]] && c_days=$(days_until_iso "$week_resets_at")
+[[ -n "$week_used" && -n "$week_resets_at" ]] && c_days=$(days_until_iso "$week_resets_at")
 [[ -z "$c_days" ]] && c_days=$(reset_days claude)
 o_days=$(reset_days codex)
 [[ -n "$c_days" ]] && c_suffix="${c_suffix}·${c_days}d"

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -78,6 +78,37 @@ extract_pct() {
     fi
 }
 
+# Convert an ISO-8601 timestamp into days-from-now, 1 decimal, floored at 0.
+# Emits nothing on a parse failure so a malformed timestamp can't blank the
+# whole statusline under `set -euo pipefail`.
+days_until_iso() {
+    local resets_at="$1" reset_epoch
+    reset_epoch=$(
+        python3 - "$resets_at" 2>/dev/null <<'PY'
+import datetime
+import sys
+
+raw = sys.argv[1].strip()
+if raw.endswith("Z"):
+    raw = raw[:-1] + "+00:00"
+try:
+    dt = datetime.datetime.fromisoformat(raw)
+except ValueError:
+    if len(raw) > 5 and raw[-5] in "+-" and raw[-3] != ":":
+        raw = f"{raw[:-2]}:{raw[-2:]}"
+        dt = datetime.datetime.fromisoformat(raw)
+    else:
+        raise
+if dt.tzinfo is None:
+    dt = dt.replace(tzinfo=datetime.timezone.utc)
+print(int(dt.timestamp()))
+PY
+    ) || reset_epoch=""
+    [[ -n "$reset_epoch" ]] || return 0
+    awk -v r="$reset_epoch" -v n="$(date +%s)" \
+        'BEGIN { d=(r-n)/86400; if (d<0) d=0; printf "%.1f", d }'
+}
+
 # Days until a provider's weekly quota resets, to 1 decimal (e.g. "2.5") so
 # work can be planned around the refill (#2992). Prefers the absolute
 # `resets_at` timestamp — `hours_to_reset` is pre-rounded to whole hours and so
@@ -102,31 +133,10 @@ reset_days() {
         unavailable|estimated) return ;;
     esac
     if [[ -n "$resets_at" ]]; then
-        local reset_epoch
-        reset_epoch=$(
-            python3 - "$resets_at" 2>/dev/null <<'PY'
-import datetime
-import sys
-
-raw = sys.argv[1].strip()
-if raw.endswith("Z"):
-    raw = raw[:-1] + "+00:00"
-try:
-    dt = datetime.datetime.fromisoformat(raw)
-except ValueError:
-    if len(raw) > 5 and raw[-5] in "+-" and raw[-3] != ":":
-        raw = f"{raw[:-2]}:{raw[-2:]}"
-        dt = datetime.datetime.fromisoformat(raw)
-    else:
-        raise
-if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=datetime.timezone.utc)
-print(int(dt.timestamp()))
-PY
-        ) || reset_epoch=""
-        if [[ -n "$reset_epoch" ]]; then
-            awk -v r="$reset_epoch" -v n="$(date +%s)" \
-                'BEGIN { d=(r-n)/86400; if (d<0) d=0; printf "%.1f", d }'
+        local days
+        days=$(days_until_iso "$resets_at") || days=""
+        if [[ -n "$days" ]]; then
+            printf '%s' "$days"
             return
         fi
     fi
@@ -152,6 +162,7 @@ color_pct() {
 
 # Claude: prefer 7-day subscription remaining from API (most accurate)
 week_used=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+week_resets_at=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 c_suffix=""
 if [[ -n "$week_used" ]]; then
     c_rem=$(awk -v u="$week_used" 'BEGIN { printf "%d", 100 - u }')
@@ -176,8 +187,12 @@ g_pct=$(extract_pct "gemini")
 
 # Append a "·N.Nd" weekly-reset countdown (days, 1 decimal) to the weekly-quota
 # providers so delegation can see how long until headroom refills (#2992).
-# Gemini is a daily limit, not weekly — no reset suffix.
-c_days=$(reset_days claude)
+# Claude prefers the session JSON's rate_limits.seven_day.resets_at — the same
+# live source already trusted for the percentage — since the quota file's
+# claude entry is source:unavailable. Gemini is a daily limit, no reset suffix.
+c_days=""
+[[ -n "$week_resets_at" ]] && c_days=$(days_until_iso "$week_resets_at")
+[[ -z "$c_days" ]] && c_days=$(reset_days claude)
 o_days=$(reset_days codex)
 [[ -n "$c_days" ]] && c_suffix="${c_suffix}·${c_days}d"
 o_suffix=""

--- a/tests/statusline/test_weekly_reset.bats
+++ b/tests/statusline/test_weekly_reset.bats
@@ -97,6 +97,34 @@ EOF
   [[ "$output" == *"O:64%·"*"d"* ]]
 }
 
+@test "claude shows days-to-reset from session rate_limits resets_at" {
+  write_quota
+  in='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"'"$PWD"'"},"cost":{"total_cost_usd":0},"context_window":{"used_percentage":10},"rate_limits":{"seven_day":{"used_percentage":37,"resets_at":"2099-01-10T00:00:00Z"}}}'
+  run bash -c "printf '%s' '$in' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  # 100-37=63% remaining, with a day-countdown sourced from the session JSON
+  # (the quota file's claude entry is source:unavailable and must not matter).
+  [[ "$output" == *"C:63%·"*"d"* ]]
+}
+
+@test "claude session weekly pct without resets_at gets no fabricated countdown" {
+  write_quota
+  in='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"'"$PWD"'"},"cost":{"total_cost_usd":0},"context_window":{"used_percentage":10},"rate_limits":{"seven_day":{"used_percentage":37}}}'
+  run bash -c "printf '%s' '$in' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C:63%"* ]]
+  [[ "$output" != *"C:63%·"* ]]
+}
+
+@test "malformed session resets_at never blanks the statusline" {
+  write_quota
+  in='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"'"$PWD"'"},"cost":{"total_cost_usd":0},"context_window":{"used_percentage":10},"rate_limits":{"seven_day":{"used_percentage":37,"resets_at":"not-a-timestamp"}}}'
+  run bash -c "printf '%s' '$in' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C:63%"* ]]
+  [[ "$output" != *"C:63%·"* ]]
+}
+
 @test "missing reset fields never blank the statusline" {
   cat > "$STATUSLINE_QUOTA_PRIMARY" <<'EOF'
 {"agents":[{"provider":"codex","pct_remaining":64}]}

--- a/tests/statusline/test_weekly_reset.bats
+++ b/tests/statusline/test_weekly_reset.bats
@@ -47,9 +47,9 @@ EOF
   write_quota
   run bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
   [ "$status" -eq 0 ]
-  # Claude renders dim with no value and no day-suffix appended.
+  # Claude renders dim with no value and no day-suffix appended (any day
+  # suffix would start with "·" immediately after the "%").
   [[ "$output" != *"C:-%·"* ]]
-  [[ "$output" != *"C:-%"*"d "* ]] || true
 }
 
 @test "estimated reset telemetry gets NO fabricated countdown even with stale hours" {
@@ -114,6 +114,17 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"C:63%"* ]]
   [[ "$output" != *"C:63%·"* ]]
+}
+
+@test "session resets_at without weekly pct gets no countdown on unknown C" {
+  write_quota
+  # resets_at present but used_percentage absent: pairing a countdown with an
+  # unknown (or quota-file-sourced) percentage would mix telemetry sources, so
+  # the C segment must stay bare (codex r2 finding on PR #3021).
+  in='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"'"$PWD"'"},"cost":{"total_cost_usd":0},"context_window":{"used_percentage":10},"rate_limits":{"seven_day":{"resets_at":"2099-01-10T00:00:00Z"}}}'
+  run bash -c "printf '%s' '$in' | bash '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"C:-%·"* ]]
 }
 
 @test "malformed session resets_at never blanks the statusline" {


### PR DESCRIPTION
## Problem

The `C:` statusline segment shows weekly remaining-% from the session JSON's `rate_limits.seven_day.used_percentage`, but never a `·N.Nd` reset countdown — `reset_days()` only consults the agent-quota files, where the claude entry is permanently `source: unavailable`. Codex got a countdown (#2992 / #3004); Claude never did.

## Fix

Prefer the session JSON's `rate_limits.seven_day.resets_at` — the same live source already trusted for the percentage — and fall back to the quota files as before.

- Extracted the ISO-8601→days conversion into `days_until_iso()`, shared by the session-JSON path and `reset_days()` (no logic change for codex).
- Malformed timestamps emit nothing rather than blanking the line under `set -euo pipefail` (same defect class as #2954).

## Result

`C:63%·2.9d|O:61%·1.5d|G:100%` — both weekly providers now show days-to-reset.

## Testing

- 3 new bats tests in `tests/statusline/test_weekly_reset.bats` (TDD: red→green): countdown renders from session `resets_at`; absent `resets_at` adds no fabricated suffix; malformed `resets_at` never blanks the statusline.
- Full suite 13/13 green (`test_weekly_reset.bats` + `test_combined_wrapper.bats`); shellcheck clean.
- Smoke-tested from a non-git cwd per the #2957 diagnostic invariant.

Related: #2992, #2954, #2893