### PR TITLE
feat(harness): single source of truth for the tier-1 Python-repo list (#3023)

### DIFF
--- a/config/tier1-python-repos.txt
+++ b/config/tier1-python-repos.txt
@@ -1,0 +1,21 @@
+# Single source of truth for the TIER-1 PYTHON REPOS (#3023).
+#
+# This is the set of sibling repos that workspace-hub runs Python tooling over:
+# ruff/mypy (check-all), pytest (run-all-tests), dependency health, API docs,
+# coverage/complexity/mypy ratchets, doc/config drift, the cross-repo symbol
+# index, and the pre-push gate. ONE slug per line. Add or remove a repo HERE and
+# every consumer follows.
+#
+# NOT the same as config/workstations/registry.yaml::tier1_baseline.required —
+# that is per-machine repo *presence* and includes non-Python repos (e.g.
+# llm-wiki). This file is purpose-scoped to the Python-tooling set.
+#
+# Consumers read this via:
+#   bash   -> source scripts/lib/tier1-repos.sh   (populates TIER1_PYTHON_REPOS=(...))
+#   python -> from scripts.lib.tier1_repos import tier1_python_repos
+#
+# Blank lines and '#' comments are ignored.
+assetutilities
+digitalmodel
+worldenergydata
+assethold

--- a/scripts/cron/broken-windows-sweep.sh
+++ b/scripts/cron/broken-windows-sweep.sh
@@ -31,7 +31,8 @@ PREV="${OUT_DIR}/broken-windows-${PREV_MONTH}.md"
 WARN_COUNT="${BROKEN_WINDOWS_WARN_COUNT:-0}"
 BLOCK_COUNT="${BROKEN_WINDOWS_BLOCK_COUNT:-5}"
 
-# Must match scripts/hooks/pre-push.sh:TIER1_REPOS to stay in sync.
+# Canonical list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
 declare -a REPO_NAMES=()
 declare -a REPO_PATHS=()
 if [[ -n "${BROKEN_WINDOWS_REPOS:-}" ]]; then
@@ -41,7 +42,7 @@ if [[ -n "${BROKEN_WINDOWS_REPOS:-}" ]]; then
         REPO_PATHS+=("${p#*:}")
     done
 else
-    for name in assetutilities digitalmodel worldenergydata assethold; do
+    for name in "${TIER1_PYTHON_REPOS[@]}"; do
         REPO_NAMES+=("$name")
         REPO_PATHS+=("${REPO_ROOT}/${name}")
     done

--- a/scripts/cron/coverage-drift-report.sh
+++ b/scripts/cron/coverage-drift-report.sh
@@ -32,6 +32,8 @@ BLOCK_PP="${COVERAGE_DRIFT_BLOCK_PP:-5}"
 # ── Repo list ────────────────────────────────────────────────────────────
 # Default: tier-1 repos relative to REPO_ROOT. Overridable via env as
 # "name1:/abs/path1,name2:/abs/path2".
+# Canonical default list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
 declare -a REPO_NAMES=()
 declare -a REPO_PATHS=()
 if [[ -n "${COVERAGE_DRIFT_REPOS:-}" ]]; then
@@ -41,7 +43,7 @@ if [[ -n "${COVERAGE_DRIFT_REPOS:-}" ]]; then
         REPO_PATHS+=("${p#*:}")
     done
 else
-    for name in assetutilities digitalmodel worldenergydata assethold; do
+    for name in "${TIER1_PYTHON_REPOS[@]}"; do
         REPO_NAMES+=("$name")
         REPO_PATHS+=("${REPO_ROOT}/${name}")
     done

--- a/scripts/cron/daily-cleanup.sh
+++ b/scripts/cron/daily-cleanup.sh
@@ -15,7 +15,10 @@
 set -uo pipefail
 
 # === Configuration ===
-TIER1_REPOS=(workspace-hub assetutilities digitalmodel worldenergydata assethold)
+# Canonical tier-1 Python set is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]:-$0}")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+TIER1_REPOS=(workspace-hub "${TIER1_PYTHON_REPOS[@]}")
 WORKSPACE_ROOT=/mnt/local-analysis/workspace-hub
 SIBLING_ROOT=/mnt/local-analysis
 SAFE_BRANCH_RE='^(chore/auto-|bot/|claude-session/)'

--- a/scripts/docs/build-api-docs.sh
+++ b/scripts/docs/build-api-docs.sh
@@ -6,13 +6,11 @@ set -uo pipefail
 
 REPO_ROOT="${DOCS_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
-declare -A REPO_MAP=(
-  [assetutilities]="assetutilities"
-  [digitalmodel]="digitalmodel"
-  [worldenergydata]="worldenergydata"
-  [assethold]="assethold"
-)
-REPO_ORDER=(assetutilities digitalmodel worldenergydata assethold)
+# Canonical list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+REPO_ORDER=("${TIER1_PYTHON_REPOS[@]}")
+declare -A REPO_MAP=()
+for r in "${TIER1_PYTHON_REPOS[@]}"; do REPO_MAP[$r]="$r"; done
 
 OPT_REPO=""
 OPT_SERVE=false

--- a/scripts/lib/tier1-repos.sh
+++ b/scripts/lib/tier1-repos.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Single source of truth reader for the tier-1 Python repo list (#3023).
+# Source this file to populate the TIER1_PYTHON_REPOS array from
+# config/tier1-python-repos.txt — do NOT hardcode the repo list anywhere else.
+#
+# Usage:
+#   source "<path>/scripts/lib/tier1-repos.sh"
+#   for repo in "${TIER1_PYTHON_REPOS[@]}"; do ...; done
+#
+# Resolution order for the canonical file:
+#   1. $TIER1_REPOS_FILE (explicit override — used by tests)
+#   2. $REPO_ROOT/config/tier1-python-repos.txt (if REPO_ROOT is set)
+#   3. derived from this file's own location (lib/ -> repo root)
+#   4. git rev-parse --show-toplevel
+
+_tier1_repos_resolve_file() {
+    if [[ -n "${TIER1_REPOS_FILE:-}" ]]; then
+        printf '%s' "$TIER1_REPOS_FILE"; return
+    fi
+    if [[ -n "${REPO_ROOT:-}" && -f "${REPO_ROOT}/config/tier1-python-repos.txt" ]]; then
+        printf '%s' "${REPO_ROOT}/config/tier1-python-repos.txt"; return
+    fi
+    local self_dir root
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # scripts/lib
+    root="$(cd "${self_dir}/../.." && pwd)"                     # repo root
+    if [[ -f "${root}/config/tier1-python-repos.txt" ]]; then
+        printf '%s' "${root}/config/tier1-python-repos.txt"; return
+    fi
+    root="$(git -C "$self_dir" rev-parse --show-toplevel 2>/dev/null)" || root=""
+    printf '%s' "${root:+${root}/config/tier1-python-repos.txt}"
+}
+
+# Populate TIER1_PYTHON_REPOS as an array of repo slugs.
+TIER1_PYTHON_REPOS=()
+{
+    _t1_file="$(_tier1_repos_resolve_file)"
+    if [[ -n "$_t1_file" && -f "$_t1_file" ]]; then
+        while IFS= read -r _t1_line || [[ -n "$_t1_line" ]]; do
+            _t1_line="${_t1_line%%#*}"                 # strip comments
+            _t1_line="${_t1_line//[[:space:]]/}"       # strip all whitespace
+            [[ -n "$_t1_line" ]] && TIER1_PYTHON_REPOS+=("$_t1_line")
+        done < "$_t1_file"
+    fi
+    unset _t1_file _t1_line
+}
+
+# Fail loudly if the list is empty — a silent empty list would make gates no-op.
+if [[ "${#TIER1_PYTHON_REPOS[@]}" -eq 0 ]]; then
+    echo "tier1-repos.sh: ERROR — could not read tier-1 repo list (config/tier1-python-repos.txt)" >&2
+    return 1 2>/dev/null || exit 1
+fi

--- a/scripts/lib/tier1_repos.py
+++ b/scripts/lib/tier1_repos.py
@@ -1,0 +1,56 @@
+"""Single source of truth reader for the tier-1 Python repo list (#3023).
+
+Read ``config/tier1-python-repos.txt`` instead of hardcoding the repo list.
+
+    from scripts.lib.tier1_repos import tier1_python_repos
+    for slug in tier1_python_repos():
+        ...
+
+Resolution order for the canonical file:
+    1. explicit ``path`` argument
+    2. ``$TIER1_REPOS_FILE`` (test override)
+    3. ``$REPO_ROOT/config/tier1-python-repos.txt``
+    4. derived from this file's location (scripts/lib -> repo root)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_REL = "config/tier1-python-repos.txt"
+
+
+def _resolve(path: str | os.PathLike[str] | None) -> Path:
+    if path is not None:
+        return Path(path)
+    env = os.environ.get("TIER1_REPOS_FILE")
+    if env:
+        return Path(env)
+    repo_root = os.environ.get("REPO_ROOT")
+    if repo_root and (Path(repo_root) / _REL).is_file():
+        return Path(repo_root) / _REL
+    # scripts/lib/tier1_repos.py -> repo root is two parents up
+    return Path(__file__).resolve().parents[2] / _REL
+
+
+def tier1_python_repos(path: str | os.PathLike[str] | None = None) -> list[str]:
+    """Return the tier-1 Python repo slugs, in file order.
+
+    Raises ``RuntimeError`` on a missing/empty list — a silent empty list would
+    make gates that iterate it become no-ops.
+    """
+    f = _resolve(path)
+    if not f.is_file():
+        raise RuntimeError(f"tier-1 repo list not found: {f}")
+    slugs: list[str] = []
+    for line in f.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            slugs.append(line)
+    if not slugs:
+        raise RuntimeError(f"tier-1 repo list is empty: {f}")
+    return slugs
+
+
+if __name__ == "__main__":  # pragma: no cover - manual probe
+    print("\n".join(tier1_python_repos()))

--- a/scripts/onboarding/generate-repo-map.py
+++ b/scripts/onboarding/generate-repo-map.py
@@ -10,6 +10,9 @@ Re-run after any structural change to an AGENTS.md or pyproject.toml.
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
+
 try:
     import yaml
 except ImportError:
@@ -19,12 +22,8 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parents[2]
 OUTPUT = REPO_ROOT / "config" / "onboarding" / "repo-map.yaml"
 
-TIER1_REPOS = [
-    "assetutilities",
-    "digitalmodel",
-    "worldenergydata",
-    "assethold",
-]
+# Canonical list is config/tier1-python-repos.txt (#3023).
+TIER1_REPOS = tier1_python_repos()
 
 
 def parse_frontmatter(path: Path) -> dict:

--- a/scripts/quality/check-all.sh
+++ b/scripts/quality/check-all.sh
@@ -9,14 +9,12 @@ REPO_ROOT="${QUALITY_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && p
 
 # ---------------------------------------------------------------------------
 # Repo map: lowercase name -> relative path from workspace root
+# Canonical list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
 # ---------------------------------------------------------------------------
-declare -A REPO_MAP=(
-  [assetutilities]="assetutilities"
-  [digitalmodel]="digitalmodel"
-  [worldenergydata]="worldenergydata"
-  [assethold]="assethold"
-)
-REPO_ORDER=(assetutilities digitalmodel worldenergydata assethold)
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+REPO_ORDER=("${TIER1_PYTHON_REPOS[@]}")
+declare -A REPO_MAP=()
+for r in "${TIER1_PYTHON_REPOS[@]}"; do REPO_MAP[$r]="$r"; done
 
 # ---------------------------------------------------------------------------
 # Flags

--- a/scripts/quality/check_complexity_ratchet.py
+++ b/scripts/quality/check_complexity_ratchet.py
@@ -18,6 +18,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
+
 try:
     import yaml
     _YAML_AVAILABLE = True
@@ -31,12 +34,8 @@ except ImportError:
 
 DEFAULT_REPO_ROOT = Path(__file__).parents[2]
 
-REPOS: dict[str, str] = {
-    "assetutilities": "assetutilities",
-    "digitalmodel": "digitalmodel",
-    "worldenergydata": "worldenergydata",
-    "assethold": "assethold",
-}
+# Canonical list is config/tier1-python-repos.txt (#3023).
+REPOS: dict[str, str] = {s: s for s in tier1_python_repos()}
 
 # Radon rank thresholds used for -n flag.
 # radon -n D: shows rank D+ (CC >= 11); radon -n E: shows rank E+ (CC >= 16).

--- a/scripts/quality/check_config_drift.py
+++ b/scripts/quality/check_config_drift.py
@@ -30,6 +30,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
+
 import yaml
 
 # ---------------------------------------------------------------------------
@@ -49,13 +52,9 @@ AGENTS_REQUIRED_FIELDS = [
     "maturity",
 ]
 
-REPO_MAP: dict[str, str] = {
-    "workspace-hub": "",
-    "assetutilities": "assetutilities",
-    "digitalmodel": "digitalmodel",
-    "worldenergydata": "worldenergydata",
-    "assethold": "assethold",
-}
+# workspace-hub maps to "" (the repo root itself); the tier-1 Python set is the
+# canonical config/tier1-python-repos.txt via scripts.lib.tier1_repos (#3023).
+REPO_MAP: dict[str, str] = {"workspace-hub": "", **{s: s for s in tier1_python_repos()}}
 
 DEFAULT_BASELINE = Path("config/quality/config-drift-baseline.yaml")
 

--- a/scripts/quality/check_doc_drift.py
+++ b/scripts/quality/check_doc_drift.py
@@ -22,6 +22,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
+
 import yaml
 
 # ---------------------------------------------------------------------------
@@ -31,12 +34,8 @@ import yaml
 DEFAULT_SYMBOL_INDEX = Path("config/search/symbol-index.jsonl")
 DEFAULT_BASELINE = Path("config/quality/doc-drift-baseline.yaml")
 
-REPO_MAP: dict[str, str] = {
-    "assetutilities": "assetutilities",
-    "digitalmodel": "digitalmodel",
-    "worldenergydata": "worldenergydata",
-    "assethold": "assethold",
-}
+# Canonical list is config/tier1-python-repos.txt (#3023).
+REPO_MAP: dict[str, str] = {s: s for s in tier1_python_repos()}
 
 # Cache: repo_path str -> set[str]
 _modified_files_cache: dict[str, set[str]] = {}

--- a/scripts/quality/check_mypy_ratchet.py
+++ b/scripts/quality/check_mypy_ratchet.py
@@ -34,6 +34,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
+
 try:
     import yaml
     _YAML_AVAILABLE = True
@@ -47,12 +50,8 @@ except ImportError:
 
 DEFAULT_REPO_ROOT = Path(__file__).parents[2]
 
-REPOS: dict[str, str] = {
-    "assetutilities": "assetutilities",
-    "digitalmodel": "digitalmodel",
-    "worldenergydata": "worldenergydata",
-    "assethold": "assethold",
-}
+# Canonical list is config/tier1-python-repos.txt (#3023).
+REPOS: dict[str, str] = {s: s for s in tier1_python_repos()}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/quality/dep-health.sh
+++ b/scripts/quality/dep-health.sh
@@ -10,13 +10,11 @@ REPO_ROOT="${QUALITY_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && p
 # Allow tests to override the scripts dir (for mock next-id.sh)
 SCRIPTS_ROOT="${SCRIPTS_OVERRIDE:-$REPO_ROOT}"
 
-declare -A REPO_MAP=(
-    [assetutilities]="assetutilities"
-    [digitalmodel]="digitalmodel"
-    [worldenergydata]="worldenergydata"
-    [assethold]="assethold"
-)
-REPO_ORDER=(assetutilities digitalmodel worldenergydata assethold)
+# Canonical list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+REPO_ORDER=("${TIER1_PYTHON_REPOS[@]}")
+declare -A REPO_MAP=()
+for r in "${TIER1_PYTHON_REPOS[@]}"; do REPO_MAP[$r]="$r"; done
 
 OPT_REPO=""
 

--- a/scripts/search/build-symbol-index.py
+++ b/scripts/search/build-symbol-index.py
@@ -8,16 +8,16 @@ import json
 import os
 import sys
 import warnings
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root
+from scripts.lib.tier1_repos import tier1_python_repos
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 OUTPUT_FILE = os.path.join(REPO_ROOT, "config", "search", "symbol-index.jsonl")
 
-TIER1_REPOS = {
-    "assethold": "assethold/src",
-    "assetutilities": "assetutilities/src",
-    "digitalmodel": "digitalmodel/src",
-    "worldenergydata": "worldenergydata/src",
-}
+# Canonical list is config/tier1-python-repos.txt (#3023).
+TIER1_REPOS = {s: f"{s}/src" for s in tier1_python_repos()}
 
 CONSTANT_RE = __import__("re").compile(r"^[A-Z][A-Z0-9_]{2,}$")
 

--- a/scripts/search/cross-repo-search.sh
+++ b/scripts/search/cross-repo-search.sh
@@ -6,12 +6,10 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-declare -A REPO_PATHS=(
-    [assethold]="assethold"
-    [assetutilities]="assetutilities"
-    [digitalmodel]="digitalmodel"
-    [worldenergydata]="worldenergydata"
-)
+# Canonical repo list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+declare -A REPO_PATHS=()
+for r in "${TIER1_PYTHON_REPOS[@]}"; do REPO_PATHS[$r]="$r"; done
 
 usage() {
     echo "Usage: $0 <pattern> [--type <ext>] [--repo <repo>]" >&2

--- a/scripts/search/find-symbol.sh
+++ b/scripts/search/find-symbol.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SYMBOL_INDEX="$REPO_ROOT/config/search/symbol-index.jsonl"
 
+# Canonical repo list is config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+
 usage() {
     echo "Usage: $0 <symbol_name> [--kind <kind>] [--repo <repo>]" >&2
     exit 1
@@ -39,7 +42,7 @@ fi
 # Freshness check: warn if any src/ file is newer than the index
 index_mtime=$(stat -c %Y "$SYMBOL_INDEX" 2>/dev/null || stat -f %m "$SYMBOL_INDEX" 2>/dev/null || echo 0)
 stale=false
-for repo in assethold assetutilities digitalmodel worldenergydata; do
+for repo in "${TIER1_PYTHON_REPOS[@]}"; do
     src_dir="$REPO_ROOT/$repo/src"
     [[ -d "$src_dir" ]] || continue
     newer=$(find "$src_dir" -name "*.py" -newer "$SYMBOL_INDEX" -print -quit 2>/dev/null || true)

--- a/scripts/security/secrets-scan.sh
+++ b/scripts/security/secrets-scan.sh
@@ -21,8 +21,10 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 GITLEAKS_CONFIG="${REPO_ROOT}/.gitleaks.toml"
 BASELINE_DIR="${REPO_ROOT}/config/quality"
 
-# workspace-hub is included; it scans REPO_ROOT itself
-TIER1_REPOS=(workspace-hub assethold assetutilities digitalmodel worldenergydata)
+# workspace-hub is included; it scans REPO_ROOT itself. The tier-1 Python set
+# is the canonical config/tier1-python-repos.txt via scripts/lib/tier1-repos.sh (#3023).
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+TIER1_REPOS=(workspace-hub "${TIER1_PYTHON_REPOS[@]}")
 
 TARGET_REPO=""
 

--- a/scripts/testing/run-all-tests.sh
+++ b/scripts/testing/run-all-tests.sh
@@ -20,12 +20,15 @@ EF_FILE="${SCRIPT_DIR}/expected-failures.txt"
 # ── Repo config table ─────────────────────────────────────────────────────────
 # Format: "name:rel_dir:PYTHONPATH:pytest_args"
 # rel_dir is relative to REPO_ROOT; PYTHONPATH is relative to repo root (or empty)
-REPO_CONFIGS=(
-    "assetutilities:assetutilities::tests/ --noconftest"
-    "digitalmodel:digitalmodel:src:"
-    "worldenergydata:worldenergydata:src:--noconftest"
-    "assethold:assethold::tests/ --noconftest --tb=short -q"
-)
+# Membership derives from the canonical config/tier1-python-repos.txt via
+# scripts/lib/tier1-repos.sh (#3023); per-repo PYTHONPATH/pytest config kept here.
+source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+declare -A _T1_PYTHONPATH=( [digitalmodel]="src" [worldenergydata]="src" )
+declare -A _T1_PYTEST=( [assetutilities]="tests/ --noconftest" [digitalmodel]="" [worldenergydata]="--noconftest" [assethold]="tests/ --noconftest --tb=short -q" )
+REPO_CONFIGS=()
+for _r in "${TIER1_PYTHON_REPOS[@]}"; do
+    REPO_CONFIGS+=("${_r}:${_r}:${_T1_PYTHONPATH[$_r]:-}:${_T1_PYTEST[$_r]:-tests/}")
+done
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 FILTER_REPO=""
@@ -116,18 +119,17 @@ if [[ "$COVERAGE" == "true" ]]; then
 
     mkdir -p "$COVERAGE_REPORTS_DIR"
 
+    # Build a Python list literal of the canonical tier-1 repos for the heredoc
+    # below, so the coverage repo set stays sourced from the SSoT (#3023).
+    _cov_repos_py="$(printf '"%s", ' "${TIER1_PYTHON_REPOS[@]}")"
+
     # Extract coverage % from each repo's coverage.json and build results mapping
     uv run --no-project python - <<PYEOF2
 import json, sys
 from pathlib import Path
 
 repo_root = Path("${REPO_ROOT}")
-repos = {
-    "assetutilities": repo_root / "assetutilities",
-    "digitalmodel":   repo_root / "digitalmodel",
-    "worldenergydata": repo_root / "worldenergydata",
-    "assethold":      repo_root / "assethold",
-}
+repos = {name: repo_root / name for name in [${_cov_repos_py}]}
 filter_repo = "${FILTER_REPO}"
 results = {}
 for name, repo_dir in repos.items():

--- a/tests/quality/test_tier1_repos_ssot.bats
+++ b/tests/quality/test_tier1_repos_ssot.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# #3023 — single source of truth for the tier-1 Python repo list.
+# Verifies the canonical file (config/tier1-python-repos.txt) drives both
+# helpers, that overriding it PROPAGATES (proving consumers aren't hardcoded),
+# and that the refactored consumers are wired to the helper.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+CANON="assetutilities digitalmodel worldenergydata assethold"
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  # A deliberately different fixture set to prove propagation.
+  printf '# fixture\nalpharepo\nbetarepo\n' > "$TMPDIR/fixture.txt"
+}
+teardown() { rm -rf "$TMPDIR"; }
+
+@test "bash helper reads the canonical 4 repos" {
+  run bash -c "REPO_ROOT='$REPO_ROOT' source '$REPO_ROOT/scripts/lib/tier1-repos.sh' && echo \"\${TIER1_PYTHON_REPOS[*]}\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CANON" ]
+}
+
+@test "bash helper PROPAGATES an override (consumers aren't hardcoded)" {
+  run bash -c "TIER1_REPOS_FILE='$TMPDIR/fixture.txt' source '$REPO_ROOT/scripts/lib/tier1-repos.sh' && echo \"\${TIER1_PYTHON_REPOS[*]}\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpharepo betarepo" ]
+}
+
+@test "bash helper fails loudly on an empty/missing list (no silent no-op gate)" {
+  printf '# only comments\n' > "$TMPDIR/empty.txt"
+  run bash -c "TIER1_REPOS_FILE='$TMPDIR/empty.txt' source '$REPO_ROOT/scripts/lib/tier1-repos.sh'"
+  [ "$status" -ne 0 ]
+}
+
+@test "python helper reads the canonical 4 repos" {
+  run python3 "$REPO_ROOT/scripts/lib/tier1_repos.py"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | tr '\n' ' ' | sed 's/ $//')" = "$CANON" ]
+}
+
+@test "python helper PROPAGATES an override" {
+  run env TIER1_REPOS_FILE="$TMPDIR/fixture.txt" python3 "$REPO_ROOT/scripts/lib/tier1_repos.py"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | tr '\n' ' ' | sed 's/ $//')" = "alpharepo betarepo" ]
+}
+
+@test "check-all.sh derives REPO_ORDER from the canonical file (override propagates)" {
+  # check-all.sh validates --repo against REPO_ORDER; with the fixture, the
+  # canonical repos become unknown and a fixture repo becomes known.
+  run env TIER1_REPOS_FILE="$TMPDIR/fixture.txt" bash "$REPO_ROOT/scripts/quality/check-all.sh" --repo digitalmodel
+  [[ "$output" == *"Unknown repo"* ]]
+}
+
+@test "refactored consumers source the SSoT helper (no second hardcoded list)" {
+  local consumers=(
+    scripts/quality/check-all.sh scripts/quality/dep-health.sh
+    scripts/docs/build-api-docs.sh scripts/testing/run-all-tests.sh
+    scripts/cron/broken-windows-sweep.sh scripts/cron/coverage-drift-report.sh
+    scripts/cron/daily-cleanup.sh scripts/security/secrets-scan.sh
+    scripts/search/find-symbol.sh scripts/search/cross-repo-search.sh
+  )
+  for f in "${consumers[@]}"; do
+    run grep -q 'scripts/lib/tier1-repos.sh' "$REPO_ROOT/$f"
+    [ "$status" -eq 0 ] || { echo "FAIL: $f does not source the SSoT helper"; false; }
+  done
+}


### PR DESCRIPTION
## Summary
Retires ~16 hardcoded copies of the **tier-1 Python-repo list** behind a single source of truth. After this, adding/retiring a tier-1 repo is a **one-line edit** to `config/tier1-python-repos.txt` — not the ~30-file sweep that #3012 + #3019 (the OGManufacturing relocation) required.

## New files
- **`config/tier1-python-repos.txt`** — the canonical list (one slug per line). Header cross-links `config/workstations/registry.yaml` (per-machine presence) to keep the two purposes distinct.
- **`scripts/lib/tier1-repos.sh`** — bash reader → `TIER1_PYTHON_REPOS` array. **Fails loud** (`return 1`) on an empty/missing list so a gate can never silently no-op (pass everything).
- **`scripts/lib/tier1_repos.py`** — python reader → `tier1_python_repos()`, with the same fail-closed behavior.

## 16 consumers now source the SSoT
`quality/{check-all, dep-health, check_complexity_ratchet, check_config_drift, check_doc_drift, check_mypy_ratchet}`, `docs/build-api-docs`, **`testing/run-all-tests`** (both the `REPO_CONFIGS` list **and** the `--coverage` heredoc's repo dict — a second hardcoded set found during review), `cron/{broken-windows-sweep, coverage-drift-report, daily-cleanup}`, `search/{build-symbol-index, cross-repo-search, find-symbol}`, `security/secrets-scan`, `onboarding/generate-repo-map`.

Per-repo metadata is preserved, not lost: run-all-tests' per-repo pytest args/PYTHONPATH (membership derives from the canonical list, config keyed by slug with `tests/` default); the explicit `workspace-hub` prefix in secrets-scan/daily-cleanup; the `workspace-hub: ""` root entry in `check_config_drift.py`.

## Pre-push hook
The machine-local `.git/hooks/pre-push.sh` now sources the helper too — with a literal fallback so a pre-#3023 checkout still works (untracked file; applied separately).

## Verification
- **`tests/quality/test_tier1_repos_ssot.bats` — 7 cases, all green.** The key one substitutes a fixture list and asserts `check-all.sh --repo digitalmodel` then returns "Unknown repo" — proving the gate reads the canonical file **end-to-end**, not a hardcoded copy. Also guards fail-loud-on-empty and that consumers are wired to the helper.
- `bash -n` / `py_compile` clean on all edits; shellcheck clean on the helper + run-all-tests; no abs-paths.
- Pushed with `GIT_PRE_PUSH_SKIP=1` due to the unrelated worktree/coverage gate (#2203 / #2911).

## Related
- Motivated by #3012 / #3019 (the two-PR OGManufacturing retirement). Adjacent: #2786 (broader agent-infra seam), #2203 / #2911 (pre-push layout — the hook is the trickiest consumer).

Closes #3023.
