### PR TITLE
feat(monitoring): machine-equivalence drift sentinel (#3059)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -47,6 +47,26 @@ tasks:
       commit-on-change (no churn). Hot dims referenced from nightly readiness. Single
       source for both Linux cron and Windows Task Scheduler per this file's HARD RULE (#2801 DC5).
 
+  - id: equivalence-sentinel
+    label: Machine-equivalence drift sentinel (#3059)
+    schedule: "17 */6 * * *"
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2]
+    roles: [control-plane, comms-dispatch]
+    requires: [bash, python3, uv, git, claude]
+    command: >-
+      PATH=$HOME/.local/bin:$HOME/.npm-global/bin:$PATH;
+      cd $WORKSPACE_HUB &&
+      bash scripts/monitoring/equivalence-sentinel.sh
+      >> $WORKSPACE_HUB/logs/monitoring/equivalence-sentinel-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/monitoring/equivalence-sentinel-*.log
+    is_claude_task: false
+    description: >-
+      Per-box (every 6h) equivalence fingerprint -> publish to the equivalence-state
+      git ref -> compare all boxes -> alert on WARNING/CRITICAL drift (clone-vs-origin,
+      harness version/install, model-registry hash, hub learning-cron freshness).
+      Complements the weekly equality-report (#2801) with focused alerting on the
+      model-parity-critical dimensions. Set EQUIV_ALERT_ISSUE=<n> to post drift to an issue.
+
   - id: gsd-researcher
     label: Nightly GSD domain researcher
     schedule: "35 1 * * *"

--- a/scripts/monitoring/equivalence-fingerprint.sh
+++ b/scripts/monitoring/equivalence-fingerprint.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# equivalence-fingerprint.sh — emit THIS box's machine-equivalence fingerprint as JSON.
+#
+# Part of the machine-equivalence drift sentinel (#3059, harden-ecosystem epic #3058).
+# Captures the four dimensions audited manually on 2026-06-13: clone vs origin,
+# harness, model-registry hash, and hub learning-cron freshness.
+#
+# Usage: equivalence-fingerprint.sh [--out <file>]
+#   EQUIV_ROLE env overrides role detection (full | contribute | contribute-minimal).
+# Degrades gracefully: any field it cannot read is emitted as null, never an error.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+cd "$REPO_ROOT" || exit 1
+
+OUT=""
+[ "${1:-}" = "--out" ] && OUT="${2:-}"
+
+host="$(hostname 2>/dev/null || echo unknown)"
+
+# Role: env override, else map known hosts to setup-cron.sh roles, else unknown.
+role="${EQUIV_ROLE:-}"
+if [ -z "$role" ]; then
+  case "$host" in
+    ace-linux-1) role="full" ;;        # dev-primary / orchestration hub
+    ace-linux-2) role="contribute" ;;  # dev-secondary
+    *) role="unknown" ;;
+  esac
+fi
+
+# Clone position vs origin/main (best-effort fetch; soft on network failure).
+git fetch -q origin main 2>/dev/null
+clone_head="$(git rev-parse --short HEAD 2>/dev/null || echo null)"
+behind=null; ahead=null
+if counts="$(git rev-list --left-right --count origin/main...HEAD 2>/dev/null)"; then
+  behind="$(echo "$counts" | awk '{print $1}')"
+  ahead="$(echo "$counts" | awk '{print $2}')"
+fi
+
+# Harness version + install method.
+hv="$(claude --version 2>/dev/null | awk '{print $1}')"; [ -z "$hv" ] && hv=null
+cpath="$(command -v claude 2>/dev/null || true)"
+case "$cpath" in
+  *.npm-global*) hinstall="npm-global" ;;
+  *.local/share*|*claude/local*) hinstall="native" ;;
+  "") hinstall=null ;;
+  *) hinstall="other" ;;
+esac
+
+# Model-registry hash (the equivalence-critical config).
+reg="config/agents/model-registry.yaml"
+reg_sha="$( [ -f "$reg" ] && sha256sum "$reg" 2>/dev/null | awk '{print $1}' || echo null )"
+
+# Hub learning-cron ages (hours since newest matching log/artifact); null if unknown.
+# Only meaningful on role=full; the comparator ignores these for other roles.
+cron_age() {
+  local pat="$1" newest
+  newest="$(find logs .claude/state/learning-reports -type f -name "*${pat}*" -printf '%T@\n' 2>/dev/null | sort -rn | head -1)"
+  [ -z "$newest" ] && { echo null; return; }
+  python3 -c "import time,sys; print(round((time.time()-float(sys.argv[1]))/3600,1))" "$newest" 2>/dev/null || echo null
+}
+age_learning="$(cron_age comprehensive-learning)"
+age_session="$(cron_age session-analysis)"
+
+# Emit JSON via python for safe quoting.
+python3 - "$role" "$host" "$clone_head" "$behind" "$ahead" "$hv" "$hinstall" "$reg_sha" "$age_learning" "$age_session" <<'PY' > "${OUT:-/dev/stdout}"
+import json, sys
+from datetime import datetime, timezone
+role, host, head, behind, ahead, hv, hinstall, reg, al, as_ = sys.argv[1:11]
+def num(x):
+    if x in ("null", ""): return None
+    try: return int(x)
+    except ValueError:
+        try: return float(x)
+        except ValueError: return None
+def s(x): return None if x in ("null", "") else x
+fp = {
+    "fingerprint_version": 1,
+    "role": role, "hostname": host,
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "clone_head": s(head),
+    "behind_origin": num(behind), "ahead_origin": num(ahead),
+    "harness_version": s(hv), "harness_install": s(hinstall),
+    "registry_sha256": s(reg),
+    "learning_cron_ages_h": {
+        "comprehensive-learning-nightly": num(al),
+        "session-analysis": num(as_),
+    },
+}
+print(json.dumps(fp, indent=1))
+PY
+[ -n "$OUT" ] && echo "wrote fingerprint -> $OUT" >&2

--- a/scripts/monitoring/equivalence-sentinel.sh
+++ b/scripts/monitoring/equivalence-sentinel.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# equivalence-sentinel.sh — detect machine-equivalence drift across boxes and alert.
+#
+# Flow: fingerprint THIS box -> publish to the `equivalence-state` git ref ->
+# collect all boxes' fingerprints -> compare -> alert on WARNING/CRITICAL.
+# Part of the drift sentinel (#3059, harden-ecosystem epic #3058).
+#
+# Env:
+#   EQUIV_ROLE         override role detection
+#   EQUIV_ALERT_ISSUE  if set, post a comment to this issue # on WARNING/CRITICAL
+# Exit: 0 equivalent/INFO, 1 WARNING, 2 CRITICAL, 3 store unavailable.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+cd "$REPO_ROOT" || exit 1
+MON="$REPO_ROOT/scripts/monitoring"
+export PYTHONPATH="$MON:${PYTHONPATH:-}"
+PY="uv run --no-project python"
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+fp_local="$REPO_ROOT/.claude/state/equivalence/local-fingerprint.json"
+mkdir -p "$(dirname "$fp_local")"
+
+# 1. fingerprint this box
+bash "$MON/equivalence-fingerprint.sh" --out "$fp_local" 2>/dev/null || { echo "fingerprint failed"; exit 1; }
+role="$($PY -c "import json,sys;print(json.load(open(sys.argv[1]))['role'])" "$fp_local" 2>/dev/null || echo unknown)"
+
+# 2. publish to the shared git ref (soft — network/auth issues must not crash the cron)
+$PY "$MON/equivalence_state.py" publish --repo "$REPO_ROOT" --role "$role" --file "$fp_local" 2>&1 | sed 's/^/[publish] /'
+
+# 3. collect + 4. compare (in one python pass)
+report="$REPO_ROOT/.claude/state/equivalence/divergences-latest.json"
+$PY - "$report" <<'PY'
+import json, sys
+import equivalence_state as store
+import equivalence_compare as cmp
+try:
+    fps = store.collect(".")
+except store.StoreUnavailable as e:
+    print(f"[collect] store unavailable: {e}", file=sys.stderr)
+    sys.exit(3)
+divs = cmp.compare(fps)
+json.dump({"boxes": len(fps), "divergences": divs}, open(sys.argv[1], "w"), indent=1)
+print(f"[compare] {len(fps)} box(es), {len(divs)} divergence(s)")
+for d in divs:
+    print(f"  [{d['severity']}] {d['code']}: {d['detail']}")
+worst = cmp.worst_severity(divs)
+sys.exit(2 if worst == cmp.CRITICAL else (1 if worst == cmp.WARNING else 0))
+PY
+rc=$?
+
+# 5. alert on WARNING/CRITICAL
+if [ "$rc" = "1" ] || [ "$rc" = "2" ]; then
+  echo "EQUIVALENCE DRIFT (rc=$rc) at $ts — see $report" >&2
+  if [ -n "${EQUIV_ALERT_ISSUE:-}" ] && command -v gh >/dev/null 2>&1; then
+    body="$($PY -c "import json,sys;d=json.load(open(sys.argv[1]));print('\n'.join(f\"- **{x[\"severity\"]}** \`{x[\"code\"]}\`: {x[\"detail\"]}\" for x in d['divergences']))" "$report" 2>/dev/null)"
+    printf '## Machine-equivalence drift detected — %s\n\n%s\n' "$ts" "$body" \
+      | gh issue comment "$EQUIV_ALERT_ISSUE" --body-file - 2>/dev/null \
+      && echo "[alert] posted to #$EQUIV_ALERT_ISSUE" >&2
+  fi
+fi
+exit "$rc"

--- a/scripts/monitoring/equivalence_compare.py
+++ b/scripts/monitoring/equivalence_compare.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""equivalence_compare.py — compare per-machine equivalence fingerprints, emit divergences.
+
+Pure logic (no git, no network) so it is unit-testable; the CLI reads a directory
+of ``<role>.json`` fingerprints produced by ``equivalence-fingerprint.sh`` and
+collected via the ``equivalence-state`` git ref.
+
+Part of the machine-equivalence drift sentinel (#3059, harden-ecosystem epic #3058).
+Codifies the manual cross-machine audit performed 2026-06-13.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from datetime import datetime
+
+CRITICAL, WARNING, INFO = "CRITICAL", "WARNING", "INFO"
+_SEV_RANK = {CRITICAL: 0, WARNING: 1, INFO: 2}
+
+# Learning-loop crons expected to stay fresh on the orchestration hub (role "full").
+# Staleness here means ecosystem learning is silently degrading — the SPOF risk
+# surfaced on 2026-06-13 when ace-linux-1 was 14 commits behind unnoticed.
+HUB_LEARNING_CRONS = ("comprehensive-learning-nightly", "session-analysis")
+
+
+def _div(severity: str, code: str, detail: str, boxes: dict) -> dict:
+    return {"severity": severity, "code": code, "detail": detail, "boxes": boxes}
+
+
+def _parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0):
+    """Compare fingerprint dicts; return divergences sorted worst-first.
+
+    A divergence is ``{severity, code, detail, boxes}``. Empty list == equivalent.
+    Role-aware: cron *set* differences between roles are expected and NOT flagged;
+    only registry/harness equivalence, clone lag, hub-cron freshness, and
+    reporting staleness are checked.
+    """
+    out: list[dict] = []
+    if not fps:
+        return out
+    roles = [f.get("role") or f.get("hostname") or "?" for f in fps]
+
+    # 1. model-registry divergence across boxes -> CRITICAL (config not equivalent)
+    reg = {f.get("registry_sha256") for f in fps if f.get("registry_sha256")}
+    if len(reg) > 1:
+        out.append(_div(CRITICAL, "registry-divergence",
+                        "config/agents/model-registry.yaml differs across boxes — model config not equivalent",
+                        {r: (f.get("registry_sha256") or "?")[:12] for r, f in zip(roles, fps)}))
+
+    # 2. harness version mismatch -> WARNING
+    hv = {f.get("harness_version") for f in fps if f.get("harness_version")}
+    if len(hv) > 1:
+        out.append(_div(WARNING, "harness-version-mismatch",
+                        "claude harness version differs across boxes",
+                        {r: f.get("harness_version") for r, f in zip(roles, fps)}))
+
+    # 3. harness install method mismatch -> INFO
+    hi = {f.get("harness_install") for f in fps if f.get("harness_install")}
+    if len(hi) > 1:
+        out.append(_div(INFO, "harness-install-mismatch",
+                        "claude install method differs across boxes",
+                        {r: f.get("harness_install") for r, f in zip(roles, fps)}))
+
+    # 4. clone behind origin/main -> WARNING (>= behind_warn) or INFO (1..behind_warn-1)
+    for r, f in zip(roles, fps):
+        b = f.get("behind_origin")
+        if isinstance(b, int) and b > 0:
+            out.append(_div(WARNING if b >= behind_warn else INFO, "clone-behind-origin",
+                            f"{r} clone is {b} commit(s) behind origin/main", {r: b}))
+
+    # 5. hub learning-cron staleness (orchestration SPOF) -> WARNING
+    for r, f in zip(roles, fps):
+        if f.get("role") != "full":
+            continue
+        ages = f.get("learning_cron_ages_h") or {}
+        for cron in HUB_LEARNING_CRONS:
+            age = ages.get(cron)
+            if age is None:
+                out.append(_div(WARNING, "hub-cron-unknown",
+                                f"{r}: learning cron '{cron}' last-run age unknown", {r: cron}))
+            elif age > learning_max_h:
+                out.append(_div(WARNING, "hub-cron-stale",
+                                f"{r}: learning cron '{cron}' last ran {age:.0f}h ago (> {learning_max_h:.0f}h)",
+                                {r: round(age, 1)}))
+
+    # 6. stale fingerprint (a box stopped reporting) -> WARNING, vs newest ts
+    valid = [(r, _parse_ts(f.get("ts"))) for r, f in zip(roles, fps)]
+    valid = [(r, t) for r, t in valid if t]
+    if len(valid) > 1:
+        newest = max(t for _, t in valid)
+        for r, t in valid:
+            age_h = (newest - t).total_seconds() / 3600.0
+            if age_h > stale_h:
+                out.append(_div(WARNING, "stale-fingerprint",
+                                f"{r} fingerprint is {age_h:.1f}h older than the newest box — may not be reporting",
+                                {r: round(age_h, 1)}))
+
+    out.sort(key=lambda d: _SEV_RANK[d["severity"]])
+    return out
+
+
+def worst_severity(divs):
+    """Return the worst severity present, or None."""
+    if not divs:
+        return None
+    return min((d["severity"] for d in divs), key=lambda s: _SEV_RANK[s])
+
+
+def load_dir(d):
+    fps = []
+    for p in sorted(glob.glob(os.path.join(d, "*.json"))):
+        try:
+            with open(p) as fh:
+                fps.append(json.load(fh))
+        except (OSError, ValueError) as e:
+            print(f"WARN: skip {p}: {e}", file=sys.stderr)
+    return fps
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Compare machine-equivalence fingerprints")
+    ap.add_argument("dir", help="directory of <role>.json fingerprints")
+    ap.add_argument("--behind-warn", type=int, default=10)
+    ap.add_argument("--stale-h", type=float, default=6.0)
+    ap.add_argument("--learning-max-h", type=float, default=48.0)
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    a = ap.parse_args(argv)
+    fps = load_dir(a.dir)
+    divs = compare(fps, behind_warn=a.behind_warn, stale_h=a.stale_h,
+                   learning_max_h=a.learning_max_h)
+    if a.json:
+        print(json.dumps({"boxes": len(fps), "divergences": divs}, indent=2))
+    else:
+        print(f"equivalence: {len(fps)} box(es), {len(divs)} divergence(s)")
+        for d in divs:
+            print(f"  [{d['severity']}] {d['code']}: {d['detail']}")
+    worst = worst_severity(divs)
+    return 2 if worst == CRITICAL else (1 if worst == WARNING else 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitoring/equivalence_state.py
+++ b/scripts/monitoring/equivalence_state.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""equivalence_state.py — share per-machine fingerprints via a dedicated git ref.
+
+Mirrors the proven ``dispatch_leader.py`` GitLeaderStateStore idiom: state lives in
+a dedicated ref (``equivalence-state``) written with git plumbing (hash-object /
+mktree / commit-tree) and pushed with ``--force-with-lease`` — so it never churns
+``main``. The ref's tree holds one ``<role>.json`` blob per box.
+
+Part of the machine-equivalence drift sentinel (#3059, epic #3058).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+DEFAULT_REF = "equivalence-state"
+
+
+class StoreUnavailable(RuntimeError):
+    pass
+
+
+def _git(repo, *args, _input=None):
+    return subprocess.run(["git", "-C", repo, *args], input=_input,
+                          capture_output=True, text=True)
+
+
+def _fetch_tip(repo, remote, ref):
+    """Return the commit SHA of the remote ref, or None if it doesn't exist yet."""
+    ls = _git(repo, "ls-remote", "--exit-code", remote, ref)
+    if ls.returncode == 2:
+        return None
+    if ls.returncode != 0:
+        raise StoreUnavailable(f"git ls-remote failed: {ls.stderr.strip()[:200]}")
+    tracking = f"refs/equivalence-tracking/{ref}"
+    f = _git(repo, "fetch", "--quiet", remote, f"+{ref}:{tracking}")
+    if f.returncode != 0:
+        raise StoreUnavailable(f"git fetch failed: {f.stderr.strip()[:200]}")
+    rev = _git(repo, "rev-parse", "--verify", "--quiet", tracking)
+    return rev.stdout.strip() or None
+
+
+def _tree_entries(repo, parent):
+    """name -> blob sha for each top-level *.json in the ref tree."""
+    if parent is None:
+        return {}
+    ls = _git(repo, "ls-tree", parent)
+    out = {}
+    for line in ls.stdout.splitlines():
+        meta, _, name = line.partition("\t")
+        parts = meta.split()
+        if len(parts) == 3 and parts[1] == "blob" and name.endswith(".json"):
+            out[name] = parts[2]
+    return out
+
+
+def collect(repo, *, remote="origin", ref=DEFAULT_REF):
+    """Return list of fingerprint dicts currently published by all boxes."""
+    parent = _fetch_tip(repo, remote, ref)
+    fps = []
+    for name, sha in _tree_entries(repo, parent).items():
+        show = _git(repo, "cat-file", "-p", sha)
+        if show.returncode == 0:
+            try:
+                fps.append(json.loads(show.stdout))
+            except ValueError:
+                pass
+    return fps
+
+
+def publish(repo, role, content, *, remote="origin", ref=DEFAULT_REF, retries=3):
+    """Publish this box's fingerprint as <role>.json into the ref. CAS with retry."""
+    name = f"{role}.json"
+    for _ in range(retries):
+        parent = _fetch_tip(repo, remote, ref)
+        entries = _tree_entries(repo, parent)
+        h = _git(repo, "hash-object", "-w", "--stdin", _input=content)
+        if h.returncode != 0:
+            raise StoreUnavailable(f"hash-object failed: {h.stderr.strip()[:200]}")
+        entries[name] = h.stdout.strip()
+        mktree_in = "".join(f"100644 blob {sha}\t{n}\n" for n, sha in sorted(entries.items()))
+        mk = _git(repo, "mktree", _input=mktree_in)
+        if mk.returncode != 0:
+            raise StoreUnavailable(f"mktree failed: {mk.stderr.strip()[:200]}")
+        tree = mk.stdout.strip()
+        commit_args = ["commit-tree", tree, "-m", f"chore(equivalence): {role} fingerprint"]
+        if parent:
+            commit_args += ["-p", parent]
+        c = _git(repo, *commit_args)
+        if c.returncode != 0:
+            raise StoreUnavailable(f"commit-tree failed: {c.stderr.strip()[:200]}")
+        commit = c.stdout.strip()
+        if parent:
+            push = _git(repo, "push", remote, f"{commit}:refs/heads/{ref}",
+                        f"--force-with-lease=refs/heads/{ref}:{parent}")
+        else:
+            push = _git(repo, "push", remote, f"{commit}:refs/heads/{ref}")
+        if push.returncode == 0:
+            return True
+        blob = (push.stdout + push.stderr).lower()
+        if not any(s in blob for s in ("rejected", "non-fast-forward", "stale info",
+                                       "fetch first", "already exists")):
+            raise StoreUnavailable(f"push failed: {push.stderr.strip()[:200]}")
+        # else: lost the race, retry from a fresh tip
+    return False
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Publish/collect equivalence fingerprints via git ref")
+    ap.add_argument("cmd", choices=["publish", "collect"])
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--role", help="role for publish (e.g. full, contribute)")
+    ap.add_argument("--file", help="fingerprint JSON file to publish")
+    ap.add_argument("--remote", default="origin")
+    ap.add_argument("--ref", default=DEFAULT_REF)
+    a = ap.parse_args(argv)
+    try:
+        if a.cmd == "publish":
+            if not a.role or not a.file:
+                ap.error("publish requires --role and --file")
+            content = open(a.file).read()
+            ok = publish(a.repo, a.role, content, remote=a.remote, ref=a.ref)
+            print("published" if ok else "publish lost CAS race after retries", file=sys.stderr)
+            return 0 if ok else 1
+        fps = collect(a.repo, remote=a.remote, ref=a.ref)
+        print(json.dumps(fps, indent=1))
+        return 0
+    except StoreUnavailable as e:
+        print(f"equivalence-state unavailable: {e}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/monitoring/test_equivalence_compare.py
+++ b/tests/monitoring/test_equivalence_compare.py
@@ -1,0 +1,118 @@
+"""Tests for the machine-equivalence drift comparator (#3059, epic #3058)."""
+import importlib.util
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+_SPEC = importlib.util.spec_from_file_location(
+    "equivalence_compare",
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "monitoring", "equivalence_compare.py"),
+)
+ec = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ec)
+
+
+def _fp(role="full", **kw):
+    base = {
+        "role": role,
+        "hostname": kw.get("hostname", role),
+        "ts": kw.get("ts", "2026-06-13T12:00:00+00:00"),
+        "clone_head": "abc123",
+        "behind_origin": 0,
+        "ahead_origin": 0,
+        "harness_version": "2.1.177",
+        "harness_install": "npm-global",
+        "registry_sha256": "deadbeef" * 8,
+        "learning_cron_ages_h": {"comprehensive-learning-nightly": 12.0, "session-analysis": 8.0},
+    }
+    base.update(kw)
+    return base
+
+
+def _codes(divs):
+    return {d["code"] for d in divs}
+
+
+def test_identical_boxes_no_divergence():
+    divs = ec.compare([_fp("full"), _fp("contribute")])
+    assert divs == []
+    assert ec.worst_severity(divs) is None
+
+
+def test_registry_divergence_is_critical():
+    a = _fp("full")
+    b = _fp("contribute", registry_sha256="cafe" * 16)
+    divs = ec.compare([a, b])
+    assert "registry-divergence" in _codes(divs)
+    reg = next(d for d in divs if d["code"] == "registry-divergence")
+    assert reg["severity"] == ec.CRITICAL
+    assert ec.worst_severity(divs) == ec.CRITICAL
+
+
+def test_harness_version_mismatch_is_warning():
+    divs = ec.compare([_fp("full"), _fp("contribute", harness_version="2.1.99")])
+    d = next(d for d in divs if d["code"] == "harness-version-mismatch")
+    assert d["severity"] == ec.WARNING
+
+
+def test_harness_install_mismatch_is_info():
+    divs = ec.compare([_fp("full"), _fp("contribute", harness_install="native")])
+    d = next(d for d in divs if d["code"] == "harness-install-mismatch")
+    assert d["severity"] == ec.INFO
+
+
+def test_clone_far_behind_is_warning_and_threshold_respected():
+    # 14 behind -> WARNING (the real ace-linux-1 case on 2026-06-13)
+    divs = ec.compare([_fp("full", behind_origin=14), _fp("contribute")])
+    d = next(d for d in divs if d["code"] == "clone-behind-origin")
+    assert d["severity"] == ec.WARNING
+    # 3 behind -> INFO (default behind_warn=10)
+    divs2 = ec.compare([_fp("full"), _fp("contribute", behind_origin=3)])
+    d2 = next(d for d in divs2 if d["code"] == "clone-behind-origin")
+    assert d2["severity"] == ec.INFO
+
+
+def test_hub_learning_cron_stale_is_warning_only_on_full_role():
+    stale = {"comprehensive-learning-nightly": 100.0, "session-analysis": 8.0}
+    # stale cron on the hub (full) -> WARNING
+    divs = ec.compare([_fp("full", learning_cron_ages_h=stale), _fp("contribute")])
+    assert "hub-cron-stale" in _codes(divs)
+    # same staleness on a non-hub (contribute) box -> NOT flagged
+    divs2 = ec.compare([_fp("full"), _fp("contribute", learning_cron_ages_h=stale)])
+    assert "hub-cron-stale" not in _codes(divs2)
+
+
+def test_hub_learning_cron_unknown_age_is_warning():
+    divs = ec.compare([_fp("full", learning_cron_ages_h={"session-analysis": 8.0}), _fp("contribute")])
+    # comprehensive-learning-nightly age missing -> hub-cron-unknown
+    assert "hub-cron-unknown" in _codes(divs)
+
+
+def test_stale_fingerprint_detected():
+    fresh = "2026-06-13T12:00:00+00:00"
+    old = "2026-06-13T02:00:00+00:00"  # 10h older than fresh, default stale_h=6
+    divs = ec.compare([_fp("full", ts=fresh), _fp("contribute", ts=old)])
+    d = next(d for d in divs if d["code"] == "stale-fingerprint")
+    assert d["severity"] == ec.WARNING
+    assert "contribute" in d["boxes"]
+
+
+def test_empty_input_safe():
+    assert ec.compare([]) == []
+
+
+def test_main_exit_codes(tmp_path):
+    # one clean pair -> exit 0
+    (tmp_path / "full.json").write_text(json.dumps(_fp("full")))
+    (tmp_path / "contribute.json").write_text(json.dumps(_fp("contribute")))
+    assert ec.main([str(tmp_path), "--json"]) == 0
+    # introduce a registry divergence -> exit 2 (CRITICAL)
+    (tmp_path / "contribute.json").write_text(json.dumps(_fp("contribute", registry_sha256="f00d" * 16)))
+    assert ec.main([str(tmp_path)]) == 2
+
+
+def test_load_dir_skips_malformed(tmp_path):
+    (tmp_path / "full.json").write_text(json.dumps(_fp("full")))
+    (tmp_path / "bad.json").write_text("{not json")
+    fps = ec.load_dir(str(tmp_path))
+    assert len(fps) == 1


### PR DESCRIPTION
Implements #3059 (harden-ecosystem epic #3058) — codifies the manual cross-machine audit from 2026-06-13 into a standing sentinel.

## What
- **`equivalence_compare.py`** — pure, tested comparator (11 unit tests) over per-box fingerprints: model-registry hash divergence (CRITICAL), harness version mismatch (WARNING), install-method mismatch (INFO), clone-behind-origin (WARNING ≥10 / INFO), hub learning-cron staleness (WARNING, role=full only), stale fingerprint (WARNING).
- **`equivalence-fingerprint.sh`** — emit this box's fingerprint JSON; degrades each field to `null` rather than erroring.
- **`equivalence_state.py`** — share fingerprints via a dedicated `equivalence-state` git ref (plumbing + `--force-with-lease`), mirroring the shipped `dispatch_leader.py` pattern — **no churn on `main`**.
- **`equivalence-sentinel.sh`** — fingerprint → publish → collect → compare → alert on WARNING/CRITICAL (log + `EQUIV_ALERT_ISSUE` opt-in).
- **`schedule-tasks.yaml`** — registered on dev-primary + dev-secondary every 6h. Complements the weekly equality-report (#2801) with focused drift alerting on the model-parity-critical dimensions.

## Decisions honored
Rendezvous = **(A) git ref** (the approved/recommended option). Role-aware: cron-set differences between roles are expected and not flagged.

## Validation
- `pytest tests/monitoring/test_equivalence_compare.py` → **11/11 green**.
- Complete same-box fingerprint emitted on ace-linux-2; cross-machine compare runs.
- **Honest gap:** the git-ref publish/collect and the hub's full fingerprint are exercised by the cron's `cd $WORKSPACE_HUB &&` invocation; first scheduled run confirms them live (my interactive ssh validation hit a cwd error, not a script bug).
- Note: repo-wide legal-scan red baseline is pre-existing (logs/old docs); **zero hits in these files**.

Closes #3059 (gate:completeness — score on close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)