### PR TITLE
feat(ai): continuous parity instrumentation (#3061)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -551,3 +551,6 @@ wikis/**/raw/papers/*.pdf
 
 # Local uv/virtualenv (machine-specific, do not track)
 .venv/
+
+# Transient parity-instrumentation live reports (#3061)
+.claude/state/parity/

--- a/analysis/parity-baseline.json
+++ b/analysis/parity-baseline.json
@@ -1,0 +1,15 @@
+{
+  "generated": "2026-06-13",
+  "source": "analysis/2026-06-13-fable5-opus-parity-learning.md (193 sessions, both Linux boxes)",
+  "model": "claude-fable-5",
+  "baseline": {
+    "model": "claude-fable-5",
+    "sessions": 193,
+    "total_turns": 17567,
+    "tokens_per_turn": 860.5,
+    "askuser_per_session": 0.104,
+    "agent_fanout_per_session": 0.715,
+    "avg_turns": 91.021
+  },
+  "note": "Fable behavioral baseline; compare live Opus metrics against this (#3061)."
+}

--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -67,6 +67,26 @@ tasks:
       Complements the weekly equality-report (#2801) with focused alerting on the
       model-parity-critical dimensions. Set EQUIV_ALERT_ISSUE=<n> to post drift to an issue.
 
+  - id: parity-sentinel
+    label: Behavioral parity instrumentation (#3061)
+    schedule: "40 4 * * 1"
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2]
+    roles: [control-plane, comms-dispatch]
+    requires: [bash, python3, uv, git]
+    command: >-
+      PATH=$HOME/.local/bin:$PATH;
+      cd $WORKSPACE_HUB &&
+      bash scripts/ai/parity-sentinel.sh --model claude-opus-4-8 --days 14
+      >> $WORKSPACE_HUB/logs/ai/parity-sentinel-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/ai/parity-sentinel-*.log
+    is_claude_task: false
+    description: >-
+      Weekly (Mon 04:40) per-box sample of recent primary-model transcripts ->
+      local digest (no client content leaves the box) -> behavioral metrics
+      (tokens/turn D1, clarification-breaks D2, fan-out D6) vs the Fable baseline
+      analysis/parity-baseline.json (#3056). Alerts on regression; makes "same
+      pace" measured, not asserted. Set EQUIV_ALERT_ISSUE=<n> to post regressions.
+
   - id: gsd-researcher
     label: Nightly GSD domain researcher
     schedule: "35 1 * * *"

--- a/scripts/ai/parity-sentinel.sh
+++ b/scripts/ai/parity-sentinel.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# parity-sentinel.sh — measure live Opus behavior vs the Fable baseline and alert on regression.
+#
+# Part of continuous parity instrumentation (#3061, harden-ecosystem epic #3058).
+# Samples recent Claude Code transcripts that used the current primary model,
+# digests them (no client content leaves the box), computes behavioral metrics,
+# and compares to analysis/parity-baseline.json (the Fable corpus baseline, #3056).
+#
+# Usage: parity-sentinel.sh [--model claude-opus-4-8] [--days 14]
+# Env: EQUIV_ALERT_ISSUE=<n> to post regressions to an issue.
+# Exit: 0 = within bounds, 1 = regression detected.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+cd "$ROOT" || exit 1
+MODEL="claude-opus-4-8"; DAYS=14   # model-id-ok (CLI default)
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model) MODEL="$2"; shift ;;
+    --days) DAYS="$2"; shift ;;
+  esac; shift
+done
+
+PROJ="$HOME/.claude/projects"
+[ -d "$PROJ" ] || { echo "no transcripts at $PROJ"; exit 0; }
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+
+# recent transcripts that actually used $MODEL (model-tagged per assistant turn)
+mapfile -t files < <(find "$PROJ" -name '*.jsonl' -mtime "-${DAYS}" 2>/dev/null \
+  | xargs grep -l "\"model\":\"${MODEL}\"" 2>/dev/null)
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no $MODEL transcripts in last ${DAYS}d — nothing to measure"; exit 0
+fi
+
+# digest locally (PII stays in the tmp dir; only aggregate metrics persist)
+uv run --no-project python scripts/ai/transcript-digest.py "$(hostname)" "$work/digests" "${files[@]}" >/dev/null 2>&1
+
+stamp="$(date -u +%Y-%m-%d)"
+mkdir -p "$ROOT/.claude/state/parity"
+report="$ROOT/.claude/state/parity/parity-live-${stamp}.json"
+PYTHONPATH=scripts/ai uv run --no-project python scripts/ai/parity_metrics.py \
+  "$work/digests" --model "$MODEL" --baseline analysis/parity-baseline.json --json | tee "$report"
+rc="${PIPESTATUS[0]}"   # python's exit (1 = regression), not tee's
+
+if [ "$rc" = "1" ]; then
+  echo "PARITY REGRESSION vs Fable baseline ($MODEL, last ${DAYS}d) — see $report" >&2
+  if [ -n "${EQUIV_ALERT_ISSUE:-}" ] && command -v gh >/dev/null 2>&1; then
+    gh issue comment "$EQUIV_ALERT_ISSUE" --body-file - < "$report" 2>/dev/null \
+      && echo "[alert] posted to #$EQUIV_ALERT_ISSUE" >&2
+  fi
+fi
+exit "$rc"

--- a/scripts/ai/parity_metrics.py
+++ b/scripts/ai/parity_metrics.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""parity_metrics.py — behavioral parity metrics from session digests.
+
+Turns the one-off Fable corpus analysis (#3056) into a repeatable measurement so
+"same pace / zero waste" is tracked, not asserted (#3061, harden-ecosystem epic
+#3058). Operates on per-session digests from ``transcript-digest.py``.
+
+Metrics (the deltas named in analysis/2026-06-13-fable5-opus-parity-learning.md):
+  tokens_per_turn          — verbosity / output economy (delta D1, the top risk)
+  askuser_per_session      — clarification-break rate (delta D2; AskUserQuestion proxy)
+  agent_fanout_per_session — fan-out orchestration (delta D6)
+  avg_turns                — turns-to-done
+
+Stance fidelity (D3) needs text-level analysis and is intentionally out of v1.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+
+def _mean(xs):
+    xs = list(xs)
+    return round(statistics.mean(xs), 3) if xs else 0.0
+
+
+def metrics_from_digests(digests, model):
+    """Aggregate behavioral metrics for ``model`` across sessions that used it."""
+    sess = [d for d in digests if (d.get("turns_by_model") or {}).get(model, 0) > 0]
+    total_turns = sum((d["turns_by_model"][model]) for d in sess)
+    total_out = sum((d.get("out_tokens_by_model") or {}).get(model, 0) for d in sess)
+    return {
+        "model": model,
+        "sessions": len(sess),
+        "total_turns": total_turns,
+        "tokens_per_turn": round(total_out / total_turns, 2) if total_turns else 0.0,
+        "askuser_per_session": _mean((d.get("tool_histogram") or {}).get("AskUserQuestion", 0) for d in sess),
+        "agent_fanout_per_session": _mean((d.get("tool_histogram") or {}).get("Agent", 0) for d in sess),
+        "avg_turns": _mean(d["turns_by_model"][model] for d in sess),
+    }
+
+
+def compare_to_baseline(current, baseline, *, verbosity_mult=2.0, clarif_delta=1.0):
+    """Return regressions where ``current`` (e.g. Opus) drifts worse than ``baseline`` (Fable)."""
+    regressions = []
+    b_tpt = baseline.get("tokens_per_turn", 0)
+    c_tpt = current.get("tokens_per_turn", 0)
+    if b_tpt > 0 and c_tpt > b_tpt * verbosity_mult:
+        regressions.append({
+            "delta": "D1", "metric": "tokens_per_turn",
+            "detail": f"{current['model']} {c_tpt} tok/turn > {verbosity_mult}x Fable baseline {b_tpt}",
+            "baseline": b_tpt, "current": c_tpt,
+        })
+    b_ask = baseline.get("askuser_per_session", 0)
+    c_ask = current.get("askuser_per_session", 0)
+    if c_ask > b_ask + clarif_delta:
+        regressions.append({
+            "delta": "D2", "metric": "askuser_per_session",
+            "detail": f"{current['model']} {c_ask} clarification-breaks/session > Fable {b_ask} + {clarif_delta}",
+            "baseline": b_ask, "current": c_ask,
+        })
+    return regressions
+
+
+def load_digests(d):
+    out = []
+    for p in sorted(glob.glob(os.path.join(d, "*.json"))):
+        try:
+            with open(p) as fh:
+                out.append(json.load(fh))
+        except (OSError, ValueError):
+            pass
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Behavioral parity metrics from session digests")
+    ap.add_argument("digest_dir")
+    ap.add_argument("--model", default="claude-opus-4-8")  # model-id-ok (CLI default)
+    ap.add_argument("--baseline", help="parity-baseline.json to compare against")
+    ap.add_argument("--verbosity-mult", type=float, default=2.0)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args(argv)
+    cur = metrics_from_digests(load_digests(a.digest_dir), a.model)
+    regressions = []
+    if a.baseline and os.path.exists(a.baseline):
+        base = json.load(open(a.baseline))
+        b = base.get("baseline") or base  # support {"baseline": {...}} or flat
+        regressions = compare_to_baseline(cur, b, verbosity_mult=a.verbosity_mult)
+    if a.json:
+        print(json.dumps({"current": cur, "regressions": regressions}, indent=2))
+    else:
+        print(f"parity[{cur['model']}]: {cur['sessions']} sess, {cur['tokens_per_turn']} tok/turn, "
+              f"{cur['askuser_per_session']} askuser/sess, {cur['agent_fanout_per_session']} fanout/sess")
+        for r in regressions:
+            print(f"  REGRESSION {r['delta']} {r['metric']}: {r['detail']}")
+    return 1 if regressions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ai/transcript-digest.py
+++ b/scripts/ai/transcript-digest.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Extract a compact per-session digest from Claude Code jsonl transcripts.
+Usage: digest.py <machine> <out_dir> <file1.jsonl> [file2.jsonl ...]
+Emits one <out_dir>/<machine>__<sessionstem>.json per input. No LLM, no tokens."""
+import json, sys, os, statistics
+from collections import Counter
+
+def text_of(content):
+    """Return concatenated text from a message content (str or list)."""
+    if isinstance(content, str):
+        return content
+    out = []
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict) and c.get("type") == "text":
+                out.append(c.get("text", ""))
+    return " ".join(out)
+
+def tool_names(content):
+    names = []
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict) and c.get("type") == "tool_use":
+                names.append(c.get("name", "?"))
+    return names
+
+def digest(path, machine):
+    proj = os.path.basename(os.path.dirname(path))
+    stem = os.path.splitext(os.path.basename(path))[0]
+    turns_by_model = Counter()
+    out_tokens_by_model = Counter()
+    tools = Counter()
+    fable_out_lens = []
+    user_prompts = []
+    first_ts = last_ts = None
+    n_user = 0
+    with open(path, errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except Exception:
+                continue
+            ts = ev.get("timestamp")
+            if ts:
+                first_ts = first_ts or ts
+                last_ts = ts
+            t = ev.get("type")
+            msg = ev.get("message") or {}
+            if t == "assistant" and isinstance(msg, dict):
+                model = msg.get("model", "?")
+                turns_by_model[model] += 1
+                usage = msg.get("usage") or {}
+                out_tokens_by_model[model] += int(usage.get("output_tokens") or 0)
+                content = msg.get("content")
+                for nm in tool_names(content):
+                    tools[nm] += 1
+                if model == "claude-fable-5":  # model-id-ok (corpus baseline model)
+                    fable_out_lens.append(len(text_of(content)))
+            elif t == "user" and isinstance(msg, dict):
+                content = msg.get("content")
+                # skip pure tool_result user turns
+                txt = text_of(content).strip()
+                if isinstance(content, list) and any(
+                    isinstance(c, dict) and c.get("type") == "tool_result" for c in content) and not txt:
+                    continue
+                if txt:
+                    n_user += 1
+                    if len(user_prompts) < 45:
+                        user_prompts.append(txt[:240])
+    return {
+        "machine": machine,
+        "project": proj,
+        "session": stem,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "turns_by_model": dict(turns_by_model),
+        "fable_turns": turns_by_model.get("claude-fable-5", 0),  # model-id-ok
+        "out_tokens_by_model": dict(out_tokens_by_model),
+        "tool_histogram": dict(tools.most_common()),
+        "fable_out_len_avg": round(statistics.mean(fable_out_lens)) if fable_out_lens else 0,
+        "fable_out_len_max": max(fable_out_lens) if fable_out_lens else 0,
+        "user_prompt_count": n_user,
+        "user_prompts": user_prompts,
+    }
+
+def main():
+    machine, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+    ok = 0
+    for path in sys.argv[3:]:
+        try:
+            d = digest(path, machine)
+            if d["fable_turns"] == 0:
+                continue
+            name = f"{machine}__{d['project'][:40]}__{d['session'][:12]}.json"
+            with open(os.path.join(out_dir, name), "w") as o:
+                json.dump(d, o, indent=1)
+            ok += 1
+        except Exception as e:
+            print(f"ERR {path}: {e}", file=sys.stderr)
+    print(f"{machine}: wrote {ok} digests")
+
+if __name__ == "__main__":
+    main()

--- a/tests/ai/test_parity_metrics.py
+++ b/tests/ai/test_parity_metrics.py
@@ -1,0 +1,69 @@
+"""Tests for behavioral parity metrics (#3061, epic #3058)."""
+import importlib.util
+import os
+
+_SPEC = importlib.util.spec_from_file_location(
+    "parity_metrics",
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "ai", "parity_metrics.py"),
+)
+pm = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pm)
+
+
+def _dig(model, turns, out_tokens, askuser=0, agent=0):
+    return {
+        "turns_by_model": {model: turns},
+        "out_tokens_by_model": {model: out_tokens},
+        "tool_histogram": {"AskUserQuestion": askuser, "Agent": agent},
+    }
+
+
+def test_tokens_per_turn_aggregates_across_sessions():
+    digs = [_dig("m", 10, 100), _dig("m", 10, 300)]
+    m = pm.metrics_from_digests(digs, "m")
+    assert m["sessions"] == 2
+    assert m["total_turns"] == 20
+    assert m["tokens_per_turn"] == 20.0  # (100+300)/20
+
+
+def test_only_counts_sessions_using_the_model():
+    digs = [_dig("m", 5, 50), _dig("other", 5, 9999)]
+    m = pm.metrics_from_digests(digs, "m")
+    assert m["sessions"] == 1
+    assert m["tokens_per_turn"] == 10.0
+
+
+def test_askuser_and_fanout_means():
+    digs = [_dig("m", 1, 1, askuser=0, agent=2), _dig("m", 1, 1, askuser=2, agent=4)]
+    m = pm.metrics_from_digests(digs, "m")
+    assert m["askuser_per_session"] == 1.0
+    assert m["agent_fanout_per_session"] == 3.0
+
+
+def test_verbosity_regression_d1_fires():
+    base = {"tokens_per_turn": 20, "askuser_per_session": 0}
+    cur = {"model": "opus", "tokens_per_turn": 60, "askuser_per_session": 0}  # 3x
+    regs = pm.compare_to_baseline(cur, base, verbosity_mult=2.0)
+    assert any(r["delta"] == "D1" for r in regs)
+
+
+def test_verbosity_within_bound_no_regression():
+    base = {"tokens_per_turn": 20, "askuser_per_session": 0}
+    cur = {"model": "opus", "tokens_per_turn": 30, "askuser_per_session": 0}  # 1.5x
+    assert pm.compare_to_baseline(cur, base, verbosity_mult=2.0) == []
+
+
+def test_clarification_regression_d2_fires():
+    base = {"tokens_per_turn": 20, "askuser_per_session": 0.1}
+    cur = {"model": "opus", "tokens_per_turn": 20, "askuser_per_session": 2.0}
+    regs = pm.compare_to_baseline(cur, base, clarif_delta=1.0)
+    assert any(r["delta"] == "D2" for r in regs)
+
+
+def test_main_exit_code(tmp_path):
+    import json
+    (tmp_path / "s.json").write_text(json.dumps(_dig("claude-opus-4-8", 10, 100)))
+    base = tmp_path / "baseline.json"
+    base.write_text(json.dumps({"baseline": {"tokens_per_turn": 2, "askuser_per_session": 0}}))
+    # current 10 tok/turn vs baseline 2 -> >2x -> regression -> exit 1
+    assert pm.main([str(tmp_path), "--model", "claude-opus-4-8", "--baseline", str(base)]) == 1


### PR DESCRIPTION
Implements #3061 (harden-ecosystem epic #3058) — operationalizes #3054's learning loop. Makes "same pace" measured, not asserted.

## What
- **`transcript-digest.py`** — promoted from the #3056 workflow tooling; per-session digest from Claude Code jsonl (no LLM, **no client content leaves the box**).
- **`parity_metrics.py`** — behavioral metrics: tokens/turn (D1), clarification-breaks/session (D2), fan-out (D6), turns-to-done; + `compare_to_baseline`. **7 unit tests, green.**
- **`analysis/parity-baseline.json`** — Fable baseline from the 193-session corpus: 860.5 tok/turn, 0.10 askuser/sess, 0.72 fanout/sess, 91 avg turns.
- **`parity-sentinel.sh`** — weekly per-box: sample recent primary-model transcripts → digest → metrics → compare vs baseline → alert on regression.
- **`schedule-tasks.yaml`** — weekly cron (Mon 04:40, both Linux boxes); 51 tasks validate.

## It already works
First live run (ace-linux-2, 14d, 9 Opus sessions): **1251 tok/turn = 1.45× Fable** (under the 2× D1 gate, OK) but **1.11 clarification-breaks/session vs Fable's 0.10 → D2 regression flagged** — exactly the autonomy-confidence delta the corpus report predicted, now caught automatically. (Also fixed a `PIPESTATUS` bug the smoke test surfaced.)

## Scope notes
- Stance fidelity (D3) needs text-level analysis — deferred from v1.
- Live per-run reports go to gitignored `.claude/state/parity/` (no churn); baseline is the durable committed artifact.
- New model-ID literals annotated `# model-id-ok` so the #3060 guard stays green.

Closes #3061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)