### PR TITLE
feat(monitoring): provider-behavior parity across machines (#3074)

### DIFF
--- a/scripts/monitoring/equivalence-fingerprint.sh
+++ b/scripts/monitoring/equivalence-fingerprint.sh
@@ -64,9 +64,25 @@ age_session="$(cron_age session-analysis)"
 
 # Emit JSON via python for safe quoting.
 python3 - "$role" "$host" "$clone_head" "$behind" "$ahead" "$hv" "$hinstall" "$reg_sha" "$age_learning" "$age_session" <<'PY' > "${OUT:-/dev/stdout}"
-import json, sys
+import json, sys, hashlib, os
 from datetime import datetime, timezone
 role, host, head, behind, ahead, hv, hinstall, reg, al, as_ = sys.argv[1:11]
+def fhash(path):
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return None
+# Per-provider built-runtime behavior hashes (#3074): equivalent provider
+# behavior across machines means these match box-to-box. Behavior files only —
+# never secrets/auth.
+provider_soul = {
+    "hermes": fhash("config/agents/hermes/SOUL.runtime.md"),
+    "claude": fhash("config/agents/claude/SOUL.runtime.md"),
+    "codex": fhash("config/agents/codex/SOUL.runtime.md"),
+    "codex_agents": fhash("config/agents/codex/AGENTS.runtime.md"),
+    "gemini": fhash("config/agents/gemini/SOUL.runtime.md"),
+}
 def num(x):
     if x in ("null", ""): return None
     try: return int(x)
@@ -86,6 +102,7 @@ fp = {
         "comprehensive-learning-nightly": num(al),
         "session-analysis": num(as_),
     },
+    "provider_soul_hashes": provider_soul,
 }
 print(json.dumps(fp, indent=1))
 PY

--- a/scripts/monitoring/equivalence_compare.py
+++ b/scripts/monitoring/equivalence_compare.py
@@ -95,6 +95,21 @@ def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0):
                                 f"{r}: learning cron '{cron}' last ran {age:.0f}h ago (> {learning_max_h:.0f}h)",
                                 {r: round(age, 1)}))
 
+    # 5b. per-provider SOUL.runtime divergence across machines -> WARNING (#3074).
+    # Equivalent provider behavior across all machines means each provider's
+    # built runtime hash matches box-to-box. Only providers reported by >1 box
+    # are checked (a provider absent on a box is handled by hub/role config, not here).
+    prov_seen = {}  # provider -> {box: hash}
+    for r, f in zip(roles, fps):
+        for prov, h in (f.get("provider_soul_hashes") or {}).items():
+            if h:
+                prov_seen.setdefault(prov, {})[r] = h
+    for prov, by_box in sorted(prov_seen.items()):
+        if len(by_box) > 1 and len(set(by_box.values())) > 1:
+            out.append(_div(WARNING, "provider-soul-divergence",
+                            f"provider '{prov}' SOUL.runtime differs across boxes — behavior not equivalent",
+                            {b: h[:8] for b, h in by_box.items()}))
+
     # 6. stale fingerprint (a box stopped reporting) -> WARNING, vs newest ts
     valid = [(r, _parse_ts(f.get("ts"))) for r, f in zip(roles, fps)]
     valid = [(r, t) for r, t in valid if t]

--- a/tests/monitoring/test_equivalence_compare.py
+++ b/tests/monitoring/test_equivalence_compare.py
@@ -24,6 +24,7 @@ def _fp(role="full", **kw):
         "harness_install": "npm-global",
         "registry_sha256": "deadbeef" * 8,
         "learning_cron_ages_h": {"comprehensive-learning-nightly": 12.0, "session-analysis": 8.0},
+        "provider_soul_hashes": {"hermes": "h1", "claude": "c1", "codex": "x1", "gemini": "g1"},
     }
     base.update(kw)
     return base
@@ -95,6 +96,36 @@ def test_stale_fingerprint_detected():
     d = next(d for d in divs if d["code"] == "stale-fingerprint")
     assert d["severity"] == ec.WARNING
     assert "contribute" in d["boxes"]
+
+
+def test_provider_soul_identical_no_divergence():
+    divs = ec.compare([_fp("full"), _fp("contribute")])
+    assert "provider-soul-divergence" not in _codes(divs)
+
+
+def test_provider_soul_divergence_flagged():
+    b = _fp("contribute")
+    b["provider_soul_hashes"] = {"hermes": "h1", "claude": "c1", "codex": "x1", "gemini": "DIFFERENT"}
+    divs = ec.compare([_fp("full"), b])
+    d = next(d for d in divs if d["code"] == "provider-soul-divergence")
+    assert d["severity"] == ec.WARNING
+    assert "gemini" in d["detail"]
+
+
+def test_provider_on_single_box_not_flagged():
+    # a provider reported by only one box is not a cross-machine divergence
+    a = _fp("full")
+    b = _fp("contribute")
+    b["provider_soul_hashes"] = {"hermes": "h1", "claude": "c1", "codex": "x1"}  # gemini absent here
+    divs = ec.compare([a, b])
+    assert "provider-soul-divergence" not in _codes(divs)
+
+
+def test_provider_null_hash_ignored():
+    b = _fp("contribute")
+    b["provider_soul_hashes"] = {"hermes": "h1", "claude": "c1", "codex": "x1", "gemini": None}
+    divs = ec.compare([_fp("full"), b])
+    assert "provider-soul-divergence" not in _codes(divs)
 
 
 def test_empty_input_safe():


### PR DESCRIPTION
Implements #3074 (harden-ecosystem epic #3058) — your directive: hermes/claude/codex/gemini must have **equivalent behavior across all machines**, governed by repo files.

## What
- **`equivalence-fingerprint.sh`** — adds `provider_soul_hashes`: sha256 of each provider's built runtime (`hermes/claude/codex(+AGENTS)/gemini SOUL.runtime.md`). Missing → null. Behavior files only; never auth/secrets.
- **`equivalence_compare.py`** — new **WARNING `provider-soul-divergence`** when a provider reported by >1 box has >1 distinct hash. +4 tests; **suite 15/15 green**.

## How it satisfies the directive
The mechanism already existed (`SHARED_SOUL.md` + per-provider `SOUL.delta` → `build`/`install-soul-runtime.sh` → `check-soul-runtime-drift.sh`). The missing piece was a **cross-machine** assertion. The sentinel now flags, per-provider, if any box's `SOUL.runtime.md` diverges. Since runtimes are git-tracked, this catches clones-at-different-commits **and uncommitted local runtime edits** that clone-HEAD comparison alone misses; the per-machine `check-soul-runtime-drift.sh` covers source↔runtime. Together = a checked cross-machine guarantee, sourced from repo files.

## Scope
Per your decision: `SOUL.runtime.md` only (registry/capabilities/auth deferred). Validated locally (all 5 provider hashes emit on ace-linux-2 + unit tests); the live cross-machine compare runs on the sentinel's existing 6-hourly cron.

Closes #3074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)