### PR TITLE
docs(parity): model-swap playbook + parity decision ADR (#3055)

### DIFF
--- a/docs/governance/2026-06-14-model-parity-decision.md
+++ b/docs/governance/2026-06-14-model-parity-decision.md
@@ -1,0 +1,37 @@
+# Decision record — Model parity after Fable 5 loss (Opus-equivalent ecosystem)
+
+- **Date:** 2026-06-14
+- **Status:** Accepted (decisions ratified 2026-06-13; flip implemented in #3051 / PR #3088)
+- **Epic:** [#3043](https://github.com/vamseeachanta/workspace-hub/issues/3043) · **Harden epic:** [#3058](https://github.com/vamseeachanta/workspace-hub/issues/3058)
+
+## Context
+
+Access to the **Fable 5** model (`claude-fable-5`) — the prior premium, 1M-context primary — was lost. The ecosystem routed its hardest reasoning (Route C planning, cross-review) and large-context work through Fable. The objective: make the ecosystem **Opus-equivalent** so work continues at the same pace and quality, with model selection flowing through the single-source registry (`config/agents/model-registry.yaml`), not scattered hardcodes.
+
+A 193-session analysis of the Fable corpus ([`analysis/2026-06-13-fable5-opus-parity-learning.md`](../../analysis/2026-06-13-fable5-opus-parity-learning.md)) showed the residual risk is **behavioral, not capacity** once the 1M-context gap is closed.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | `latest_models.claude_primary` → **`claude-opus-4-8[1m]`** (1M-context Opus) | Closest Fable equivalent for pace + quality + large-context; closes the capacity gap directly. |
+| 2 | Route C `plan` + Route B/C cross-review → **1M-Opus** (via `claude_primary`) | Preserves the "reviewer out-reasons the Sonnet author" gate; complex plans keep full-codebase context. |
+| 3 | `claude-fable-5` → **`deprecated: true`**, retained | Keep for audit/history + one-line re-enable; nothing routes to it (`default_priority: 0`). |
+| 4 | Routine work stays **`sonnet-4-6`** | Cost discipline; only the heavy lanes ride 1M-Opus. |
+| 5 | Compound Engineering review fan-out **12 → 4–6** on Opus | Avoid draining the weekly quota per `/compound` run. |
+| 6 | `/fast` mode **manual-only** | Direct "same pace" lever; not auto-routed. |
+
+## Consequences
+
+- **Cost/quality trade (accepted):** cross-review and Route C planning now ride 1M-Opus by default — premium per run, deliberately chosen to hold pace. Routine work is unaffected (Sonnet).
+- **Behavioral deltas to watch** (from the corpus analysis, instrumented by #3061): D1 output verbosity (Opus ~3–5× Fable in loop work) and D2/D3 autonomy-confidence + adversarial-stance. The parity sentinel (`scripts/ai/parity-sentinel.sh`) alerts on regression vs the Fable baseline; first live run already flagged a D2 clarification-break increase.
+- **Equivalence is enforced, not assumed:** the drift sentinel (#3059) hashes the registry + each provider's `SOUL.runtime.md` (#3074) across machines; the #3060 ratchet guard blocks new hardcoded model IDs.
+
+## Implementation deviations (with cause)
+
+1. **No `claude-fable-5 → claude-opus-4-8[1m]` migration in `update-model-ids.sh`.** Its blanket `sed` (no `config/agents`/`analysis/` exclusion) would corrupt the *intentional* fable references — the deprecated registry entry, `analysis/parity-baseline.json`, and `scripts/ai/transcript-digest.py` model-tagging. The #3060 ratchet guard catches new fable hardcodes non-destructively.
+2. **Stale doc-IDs deferred** (`agent-usage-optimizer` `claude-opus-4-6`, `agent-library` `claude-sonnet-4.5`, mlops guidance, and the `provider-capabilities.yaml` horizon narrative) — out of the flip's critical path and outside the #3060 scope; focused follow-up.
+
+## How to swap the primary model next time
+
+See the **Primary Model Swap — Checklist** in [`docs/standards/MODEL_RELEASE_UPGRADE_PLAYBOOK.md`](../standards/MODEL_RELEASE_UPGRADE_PLAYBOOK.md). The intent of this whole effort: the next swap is a registry edit + a short reader checklist, not archaeology.

--- a/docs/standards/MODEL_RELEASE_UPGRADE_PLAYBOOK.md
+++ b/docs/standards/MODEL_RELEASE_UPGRADE_PLAYBOOK.md
@@ -84,6 +84,32 @@ If a release triggers regressions:
 
 ---
 
+## Primary Model Swap — Checklist (worked example: #3051, Fable 5 → Opus 4.8 1M)
+
+When the **default Claude model changes** (a provider deprecates one, or a better tier ships), the swap is a single-source registry edit + its readers. Follow in order; everything keys off `config/agents/model-registry.yaml`. Decision record: [`docs/governance/2026-06-14-model-parity-decision.md`](../governance/2026-06-14-model-parity-decision.md).
+
+1. **Registry — `config/agents/model-registry.yaml`** (the single source):
+   - Add the new tier block under `providers.claude.models` (`model_id`, `capability_tier`, context, `recommended_use`). For a context variant, the id carries a suffix, e.g. `claude-opus-4-8[1m]`.
+   - Set `latest_models.claude_primary` to the new id.
+   - Add the new id to `context_windows_k`.
+   - Mark the outgoing model `deprecated: true` + `default_priority: 0` — **keep the entry** for audit; do not delete.
+   - Point `work_queue_routing.route_c.plan` at the new tier; refresh `cross_review` comments (it tracks `claude_primary`, no logic change).
+   - Leave `default_model: sonnet-4-6` (routine work) unless that too is changing.
+2. **Propagate to the readers** (verified set):
+   - `scripts/ai/session-params.py` — `FALLBACK_CTX_MAP` + `ALIAS_MAP` (add the new alias; forward deprecated aliases to the new primary). The `[Nm]` suffix parser already yields the window.
+   - `scripts/ai/overnight-batch-planner.py` — the `_registry_model(..., "<fallback>")` literal.
+   - `config/agents/behavior-contract.yaml` — the `# Today: <id>` comment.
+   - `config/agents/provider-capabilities.yaml` — `model_ids.primary` + `context_window.primary`.
+3. **Verify (gate 2):**
+   - `python -c "import yaml; yaml.safe_load(open('config/agents/model-registry.yaml'))"` parses (bracketed ids are fine as quoted strings).
+   - `source scripts/lib/model-registry.sh && registry_model claude_primary` returns the new id (the `sed` extracts `[^"]+`, so `[1m]` is safe).
+   - `session-params.py` `ctx_k(<new id>)` returns the right window.
+   - The #3060 model-id-sourcing guard is green — annotate any new literal with `# model-id-ok` (it's a deliberate registry fallback/alias).
+4. **DO NOT add the old→new pair to `scripts/maintenance/update-model-ids.sh`.** That script does a blanket `sed` across the whole tree (no `config/agents` or `analysis/` exclusion), so it would corrupt the *intentional* references to the deprecated id: the deprecated registry block, `analysis/parity-baseline.json`, and `scripts/ai/transcript-digest.py` model-tagging. Reintroduction of a stale hardcode is already caught **non-destructively** by the #3060 ratchet guard.
+5. **Sentinel inheritance:** the equivalence sentinel (#3059) hashes `model-registry.yaml` + each provider's `SOUL.runtime.md` (#3074) across machines — no change needed; it will flag if a box doesn't pick up the swap. The behavioral baseline (#3061, `analysis/parity-baseline.json`) is the *old* model's profile — leave it as the comparison reference; regenerate only when establishing a new baseline.
+
+---
+
 ## Reference
 
 - Contract dimensions — [MODEL_RELEASE_READINESS_CONTRACT.md](MODEL_RELEASE_READINESS_CONTRACT.md)


### PR DESCRIPTION
Implements #3055 (model-parity epic #3043) — the durable capture so the **next** model swap is a one-file flip, not archaeology.

## What
- **`MODEL_RELEASE_UPGRADE_PLAYBOOK.md`** — new "Primary Model Swap — Checklist" (worked example: #3051). Ordered registry edits → readers to propagate → verify steps → the `update-model-ids.sh` gotcha → sentinel/baseline inheritance.
- **`docs/governance/2026-06-14-model-parity-decision.md`** — ADR recording the 6 ratified decisions (primary=`claude-opus-4-8[1m]`, Route C + cross-review on 1M-Opus, fable deprecated-not-removed, Compound 4–6, `/fast` manual, routine=Sonnet) + rationale + consequences + the two #3051 deviations.

Docs-only, PII-free. Closes #3055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)