### PR TITLE
fix(cron): PII-filter auto-memory snapshots into the public repo (#3073)

### DIFF
--- a/scripts/cron/commit-learning-artifacts.sh
+++ b/scripts/cron/commit-learning-artifacts.sh
@@ -42,11 +42,15 @@ if [[ -f "${HOME}/.hermes/memories/MEMORY.md" ]]; then
   cp "${HOME}/.hermes/memories/USER.md" config/agents/hermes/memories/USER.md.snapshot 2>/dev/null || true
 fi
 
-# Claude Code project memory (#1779)
+# Claude Code project memory (#1779) — PII-filtered snapshot (#3073).
+# project_*.md (engagement-specific) is NEVER copied to the public repo; the
+# helper also self-heals any already-present project_*.md. See the helper header.
 CLAUDE_MEM="${HOME}/.claude/projects/-mnt-local-analysis-workspace-hub/memory"
 if [[ -d "$CLAUDE_MEM" ]]; then
-  mkdir -p config/agents/claude/memory-snapshots
-  cp "$CLAUDE_MEM"/*.md config/agents/claude/memory-snapshots/ 2>/dev/null || true
+  _wh_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  # shellcheck source=scripts/cron/lib/pii-safe-memory-snapshot.sh
+  source "$_wh_root/scripts/cron/lib/pii-safe-memory-snapshot.sh"
+  pii_safe_snapshot "$CLAUDE_MEM" config/agents/claude/memory-snapshots "$_wh_root/.legal-deny-list.yaml"
 fi
 CLAUDE_MEM_WED="${HOME}/.claude/projects/-mnt-local-analysis-workspace-hub-worldenergydata/memory"
 if [[ -d "$CLAUDE_MEM_WED" ]]; then

--- a/scripts/cron/lib/pii-safe-memory-snapshot.sh
+++ b/scripts/cron/lib/pii-safe-memory-snapshot.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# pii-safe-memory-snapshot.sh — sourced helper for commit-learning-artifacts.sh.
+#
+# Snapshots Claude auto-memory into the PUBLIC workspace-hub repo WITHOUT leaking
+# client-specific content (#3073). The prior blanket `cp *.md` copied engagement-
+# specific project_*.md (e.g. a client campaign) straight into the public repo.
+#
+# Rules:
+#   1. NEVER copy project_*.md — engagement-specific by convention; the leak vector.
+#      Generalizable classes (feedback_/reference_/user_/MEMORY) still snapshot.
+#   2. Defense-in-depth: skip any file matching a .legal-deny-list.yaml client pattern.
+#   3. Self-heal: remove any project_*.md already present in the public snapshot dir.
+# Prints a one-line summary. Always returns 0 (a snapshot must never break the cron).
+
+pii_safe_snapshot() {
+  local src="$1" dest="$2" denylist="${3:-}"
+  [ -d "$src" ] || return 0
+  mkdir -p "$dest"
+
+  # 3. self-heal — project_*.md must never live in the public snapshot
+  local healed=0 old
+  for old in "$dest"/project_*.md; do
+    [ -e "$old" ] && { rm -f "$old"; healed=$((healed + 1)); }
+  done
+
+  # 2. build deny patterns (optional)
+  local denyfile=""
+  if [ -n "$denylist" ] && [ -f "$denylist" ]; then
+    denyfile="$(mktemp)"
+    grep -E '^[[:space:]]*-[[:space:]]*pattern:' "$denylist" 2>/dev/null \
+      | sed -E 's/.*pattern:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/' \
+      | grep -v '^$' > "$denyfile" || true
+  fi
+
+  local copied=0 skipped=0 f base
+  for f in "$src"/*.md; do
+    [ -e "$f" ] || continue
+    base="$(basename "$f")"
+    # 1. structural exclusion
+    if [[ "$base" == project_* ]]; then skipped=$((skipped + 1)); continue; fi
+    # 2. deny-list defense-in-depth
+    if [ -n "$denyfile" ] && [ -s "$denyfile" ] && grep -qiFf "$denyfile" "$f"; then
+      skipped=$((skipped + 1)); continue
+    fi
+    cp "$f" "$dest/" && copied=$((copied + 1))
+  done
+  [ -n "$denyfile" ] && rm -f "$denyfile"
+
+  echo "[pii-snapshot] copied=$copied skipped=$skipped healed=$healed (project_* + deny-list excluded from public)"
+  return 0
+}

--- a/tests/cron/test_pii_safe_memory_snapshot.sh
+++ b/tests/cron/test_pii_safe_memory_snapshot.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tests for pii_safe_snapshot (#3073, epic #3058). Run: bash tests/cron/test_pii_safe_memory_snapshot.sh
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+source "$ROOT/scripts/cron/lib/pii-safe-memory-snapshot.sh"
+
+fail=0
+check() { if [ "$1" = "$2" ]; then echo "ok: $3"; else echo "FAIL: $3 (got '$1' want '$2')"; fail=1; fi; }
+
+work="$(mktemp -d)"; src="$work/src"; dest="$work/dest"; mkdir -p "$src" "$dest"
+deny="$work/deny.yaml"
+printf 'client_references:\n  - pattern: "Acme Field"\n    case_sensitive: false\n' > "$deny"
+
+# generalizable (should copy)
+echo "lesson: always verify" > "$src/feedback_verify.md"
+echo "see https://x" > "$src/reference_link.md"
+echo "# memory" > "$src/MEMORY.md"
+# engagement-specific (must NOT copy)
+echo "client campaign details" > "$src/project_fdas_corpus.md"
+# deny-list match in a non-project file (must NOT copy)
+echo "work on the Acme Field project" > "$src/feedback_acme.md"
+# pre-existing leak already in dest (must be self-healed away)
+echo "stale client" > "$dest/project_old_client.md"
+
+out="$(pii_safe_snapshot "$src" "$dest" "$deny")"
+echo "$out"
+
+[ -f "$dest/feedback_verify.md" ]; check "$?" 0 "generalizable feedback_ copied"
+[ -f "$dest/reference_link.md" ];  check "$?" 0 "reference_ copied"
+[ -f "$dest/MEMORY.md" ];          check "$?" 0 "MEMORY.md copied"
+[ ! -f "$dest/project_fdas_corpus.md" ]; check "$?" 0 "project_* NOT copied (structural)"
+[ ! -f "$dest/feedback_acme.md" ];       check "$?" 0 "deny-list match NOT copied (defense-in-depth)"
+[ ! -f "$dest/project_old_client.md" ];  check "$?" 0 "pre-existing project_* self-healed (removed)"
+
+# missing source dir is safe (returns 0, no error)
+pii_safe_snapshot "$work/nonexistent" "$dest" "$deny" >/dev/null; check "$?" 0 "missing src dir is safe"
+
+rm -rf "$work"
+if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
Implements the **systemic** part of #3073 (epic #3058) — stops the public-repo client-PII leak at its source.

## Root cause
`commit-learning-artifacts.sh` did a blanket `cp ~/.claude/.../memory/*.md` → public `config/agents/claude/memory-snapshots/`. That copied engagement-specific `project_*.md` (a client campaign) into the public repo, and would recur for **any** client-named auto-memory.

## Fix
- **`scripts/cron/lib/pii-safe-memory-snapshot.sh`** (new helper):
  1. Never copy `project_*.md` (engagement-specific = the leak vector); generalizable `feedback_/reference_/user_/MEMORY` still snapshot.
  2. Defense-in-depth: skip any file matching a `.legal-deny-list.yaml` client pattern.
  3. **Self-heal**: remove any `project_*.md` already in the public snapshot dir → the existing `project_fdas_*` leak **auto-clears on the next cron run**.
  - No client names listed anywhere — a structural rule, not a denylist-of-names (avoids the paradox of spelling clients out in a public file).
- Wired into `commit-learning-artifacts.sh`; **7 tests pass**.

## Still follow-up (#3073 Phase 2, tracked)
The 2 regenerating snapshots self-heal via this PR. Remaining: remove the non-regenerated public files (the `2026-06-08` handoff + `.planning/archive/data-sources/frontierdeepwater.yaml`), clean the machine-local auto-memory source, preserve campaign content to private `aceengineer-strategy`. Git-history scrub out of scope (accepted).

Advances #3073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)