### PR TITLE
PII #3099: client-PII prevention guard (CI + pre-commit, private-sourced)

### DIFF
--- a/.claude/docs/client-pii-prevention.md
+++ b/.claude/docs/client-pii-prevention.md
@@ -1,0 +1,74 @@
+# Client-PII prevention (epic #3095)
+
+How the public `workspace-hub` repo is kept free of client identifiers, and why
+the previous gate failed. This document is intentionally **PII-free** (it names
+no clients) so it can live in the public repo without tripping its own guard.
+
+## Why the old gate failed
+
+`scripts/legal/legal-sanity-scan.sh --diff-only` ran at commit time but matched
+only the patterns in the public `.legal-deny-list.yaml`. That list **lacked the
+active clients**, so real client references passed straight through (see #3096).
+Worse, the fix can't be "add the client names to the deny-list" — that file is
+public, so listing the names there *is* the leak (the deny-list paradox).
+
+## The model: private source, public-safe tooling
+
+1. **Single private source of truth.** Client identifiers live only in
+   `client-codename-map.yaml` in the **private** `aceengineer-strategy` repo
+   (`pii-remediation/3097-2026-06-14/`). It maps each real identifier to a
+   neutral codename and lists its `/mnt/ace/<bucket>/` path. The canonical client
+   roster is `config/client-wikis.yml` (the registry); the map is built from it.
+
+2. **Name-agnostic tooling.** Two scripts in `scripts/legal/` contain **no client
+   names** — they read the private map by path:
+   - `redact-client-pii.py` — replaces real identifiers with codenames (and
+     renames bucket paths). Used for bulk remediation and by the learning cron.
+   - `check-client-pii.py` — the guard: *"if running the redactor would change a
+     file, that file still contains an un-redacted client identifier."* Guard and
+     redactor share one engine, so they can never disagree. The guard **never
+     prints a matched value** — only file + line — because public CI logs would
+     otherwise leak it.
+
+3. **Local provisioning.** Each host (and the learning cron) reads a gitignored
+   local copy `config/agents/.client-codename-map.local.yaml`. Provision it once:
+   ```bash
+   cp <aceengineer-strategy>/pii-remediation/3097-2026-06-14/client-codename-map.yaml \
+      config/agents/.client-codename-map.local.yaml
+   ```
+   If absent, tools degrade-open (warn, don't block) — the CI gate is the strict
+   backstop.
+
+## Enforcement layers (gradient per `.claude/rules/patterns.md`)
+
+| Layer | Mechanism | Blocking? | Notes |
+|---|---|---|---|
+| Emit | `.gitignore` stop-commit of dump clusters + redaction step in `scripts/cron/commit-learning-artifacts.sh` | n/a | dumps can't re-enter; cron redacts curated state at source (#3097) |
+| Local | pre-commit hook `legal-client-pii` (`.pre-commit-config.yaml`) | yes (bypassable) | fast feedback; reads local map, degrades-open |
+| CI | `.github/workflows/legal-client-pii-gate.yml` | yes (strict) | **the real backstop**; reads the private map from the `LEGAL_CLIENT_MAP` repo secret |
+
+### Provisioning the CI secret (one-time)
+```bash
+gh secret set LEGAL_CLIENT_MAP \
+  < <aceengineer-strategy>/pii-remediation/3097-2026-06-14/client-codename-map.yaml
+```
+Without the secret the CI job runs degrade-open (warns, non-blocking). On the
+main repo the secret should always be set so the gate is strict.
+
+## Keeping the client list current
+
+When a client is added/renamed in `config/client-wikis.yml`, update the private
+`client-codename-map.yaml`, re-`gh secret set LEGAL_CLIENT_MAP`, and refresh the
+local copies. The guard then covers the new identifier automatically — no edit to
+any public file is required (and none should name the client).
+
+## Bypass
+
+`LEGAL_PII_ALLOW=1` skips the guard (logged). Use only for a deliberate,
+reviewed exception.
+
+## Related
+- Counts-only remediation record: `analysis/3097-generated-pii-remediation.md`
+- Epic #3095; sub-issues #3096 (assessment), #3097 (generated remediation),
+  #3098 (hand-authored scrub — incl. relocating `config/client-wikis.yml`),
+  #3099 (this prevention layer).

--- a/.github/workflows/legal-client-pii-gate.yml
+++ b/.github/workflows/legal-client-pii-gate.yml
@@ -1,0 +1,67 @@
+name: Legal Client-PII Gate
+
+# Recurrence backstop for the public-repo client-PII epic (#3095, sub-issue #3099).
+# Fails a PR that introduces a client identifier into a tracked file.
+#
+# The client list is PRIVATE. It is supplied via the encrypted repo/org secret
+# LEGAL_CLIENT_MAP (the contents of client-codename-map.yaml). No client names
+# live in this workflow or the repo, and the guard never echoes a matched value
+# (these CI logs are public).
+#
+# Provision once:  gh secret set LEGAL_CLIENT_MAP \
+#                    < /path/to/aceengineer-strategy/pii-remediation/3097-2026-06-14/client-codename-map.yaml
+#
+# If the secret is unset, the job runs in DEGRADE-OPEN mode (warns, does not
+# block) so forks / unconfigured environments don't break — but on the main
+# repo the secret should always be set so the gate is strict.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  client-pii-gate:
+    name: Client-PII Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Materialize private client map from secret
+        env:
+          LEGAL_CLIENT_MAP_SECRET: ${{ secrets.LEGAL_CLIENT_MAP }}
+        run: |
+          if [[ -n "$LEGAL_CLIENT_MAP_SECRET" ]]; then
+            printf '%s' "$LEGAL_CLIENT_MAP_SECRET" > "$RUNNER_TEMP/client-map.yaml"
+            echo "LEGAL_CLIENT_MAP=$RUNNER_TEMP/client-map.yaml" >> "$GITHUB_ENV"
+            echo "STRICT=--strict" >> "$GITHUB_ENV"
+            echo "secret present → strict mode" >&2
+          else
+            echo "::warning::LEGAL_CLIENT_MAP secret not set — gate runs degrade-open (non-blocking)."
+            echo "STRICT=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Scan PR diff for client identifiers
+        run: |
+          echo "## Legal Client-PII Gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if uv run python scripts/legal/check-client-pii.py \
+               --base-ref "origin/${{ github.base_ref }}" $STRICT; then
+            echo "**Result:** PASS — no client identifiers in changed files." >> "$GITHUB_STEP_SUMMARY"
+          else
+            rc=$?
+            echo "**Result:** FAIL (exit $rc) — a changed file contains a client identifier." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Values are withheld from logs (public). Codename-redact before re-pushing:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "uv run python scripts/legal/redact-client-pii.py --map <private-map> <file>" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit $rc
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,15 @@ repos:
         entry: python scripts/email/fixture-redaction-check.py
         language: system
         files: '^tests/fixtures/email/.*\.(ya?ml|txt|md)$'
+      - id: legal-client-pii
+        name: no client identifiers in tracked files (#3095/#3099)
+        # Blocks staged files that contain a client identifier. Reads a PRIVATE
+        # local map (config/agents/.client-codename-map.local.yaml); degrades-open
+        # if absent. The #3099 CI gate is the strict backstop. Bypass: LEGAL_PII_ALLOW=1.
+        entry: uv run python scripts/legal/check-client-pii.py --staged
+        language: system
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/scripts/legal/check-client-pii.py
+++ b/scripts/legal/check-client-pii.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Fail when staged/changed tracked files contain client identifiers.
+
+Prevention guard for the public-repo client-PII epic (#3095, sub-issue #3099).
+This is the recurrence backstop the incomplete `.legal-deny-list.yaml` failed to
+provide (it lacked the active clients, so the leak passed the old gate).
+
+DESIGN
+- **Name-agnostic + leak-safe.** Client identifiers live ONLY in a PRIVATE map
+  (the same `client-codename-map.yaml` the redactor uses). This script contains
+  no client names, and it NEVER prints a matched client string — only the file
+  and line number — because CI logs on a public repo would themselves leak.
+- **Engine parity with the redactor.** It reuses `redact-client-pii.py`'s exact
+  matching: "if running the redactor would change this file, the file still
+  contains an un-redacted client identifier → violation." Guard and redactor can
+  never disagree about what counts as a client identifier.
+
+SOURCING the private map
+- `--map <path>` or `$LEGAL_CLIENT_MAP`, else default
+  `config/agents/.client-codename-map.local.yaml` (gitignored; provisioned per
+  host and, in CI, written from a GitHub Actions secret).
+- If the map is absent: warn and exit 0 by default (degrade-open like the other
+  enforcement scripts), or exit 2 under `--strict` (CI should run strict so a
+  mis-provisioned secret fails loudly rather than silently passing).
+
+USAGE
+  # pre-commit (staged files):
+  uv run python scripts/legal/check-client-pii.py --staged
+  # CI (PR diff):
+  uv run python scripts/legal/check-client-pii.py --base-ref origin/main --strict
+  # explicit files / all tracked:
+  uv run python scripts/legal/check-client-pii.py path1 path2
+  uv run python scripts/legal/check-client-pii.py --all
+
+Bypass (logged): LEGAL_PII_ALLOW=1
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_ENGINE_PATH = Path(__file__).resolve().parent / "redact-client-pii.py"
+_spec = importlib.util.spec_from_file_location("redact_client_pii", _ENGINE_PATH)
+_engine = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _engine
+_spec.loader.exec_module(_engine)
+
+DEFAULT_MAP = Path("config/agents/.client-codename-map.local.yaml")
+
+# Files that legitimately reference the private map path / tooling and must not
+# self-trip the guard. (They contain no client names themselves.)
+SELF_EXCLUDE = {
+    "scripts/legal/check-client-pii.py",
+    "scripts/legal/redact-client-pii.py",
+    "scripts/legal/tests/test_check_client_pii.py",
+    "scripts/legal/tests/test_redact_client_pii.py",
+}
+
+
+def _git(args: list[str]) -> list[str]:
+    out = subprocess.run(["git", *args], capture_output=True, text=True)
+    return [ln for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def collect_targets(args) -> list[str]:
+    if args.paths:
+        return args.paths
+    if args.all:
+        return _git(["ls-files"])
+    if args.base_ref:
+        return _git(["diff", "--name-only", "--diff-filter=ACM", f"{args.base_ref}...HEAD"])
+    # default: staged (pre-commit)
+    return _git(["diff", "--cached", "--name-only", "--diff-filter=ACM"])
+
+
+def violations_in(path: Path, rules) -> list[int]:
+    """Return 1-based line numbers that contain a client identifier (no values)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    hits: list[int] = []
+    for i, line in enumerate(text.splitlines(), 1):
+        _, n = _engine.redact_text(line, rules)
+        if n:
+            hits.append(i)
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--map", type=Path, default=Path(os.environ.get("LEGAL_CLIENT_MAP", DEFAULT_MAP)))
+    ap.add_argument("--base-ref", help="scan files changed vs this ref (CI/PR mode)")
+    ap.add_argument("--staged", action="store_true", help="scan staged files (pre-commit mode)")
+    ap.add_argument("--all", action="store_true", help="scan all tracked files")
+    ap.add_argument("--strict", action="store_true", help="fail (exit 2) if the private map is missing")
+    ap.add_argument("paths", nargs="*", help="explicit files to scan")
+    args = ap.parse_args()
+
+    if os.environ.get("LEGAL_PII_ALLOW") == "1":
+        print("legal-client-pii: bypassed via LEGAL_PII_ALLOW=1", file=sys.stderr)
+        return 0
+
+    if not args.map.is_file():
+        msg = f"legal-client-pii: private client map not found at {args.map}"
+        if args.strict:
+            print(f"{msg} — FAILING (strict). Provision it from the private archive / CI secret.", file=sys.stderr)
+            return 2
+        print(f"{msg} — skipping (degrade-open). #3099 CI gate is the strict backstop.", file=sys.stderr)
+        return 0
+
+    rules = _engine.load_rules(args.map)
+    targets = collect_targets(args)
+
+    bad: list[tuple[str, list[int]]] = []
+    for rel in targets:
+        if rel in SELF_EXCLUDE:
+            continue
+        fp = Path(rel)
+        if not fp.is_file():
+            continue
+        lines = violations_in(fp, rules)
+        if lines:
+            bad.append((rel, lines))
+
+    if bad:
+        print("✖ Client identifier(s) found in tracked file(s) — blocked (#3095/#3099).", file=sys.stderr)
+        print("  (values withheld — public CI logs would leak them; codename-redact before committing.)", file=sys.stderr)
+        for rel, lines in bad:
+            shown = ",".join(map(str, lines[:10])) + (" …" if len(lines) > 10 else "")
+            print(f"  {rel}: line(s) {shown}", file=sys.stderr)
+        print("\nFix: uv run python scripts/legal/redact-client-pii.py --map <private-map> <file>", file=sys.stderr)
+        print("Bypass (discouraged): LEGAL_PII_ALLOW=1", file=sys.stderr)
+        return 1
+
+    print(f"✓ legal-client-pii: {len(targets)} changed file(s) clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legal/tests/test_check_client_pii.py
+++ b/scripts/legal/tests/test_check_client_pii.py
@@ -1,0 +1,66 @@
+"""Tests for the client-PII prevention guard (scripts/legal/check-client-pii.py).
+
+Synthetic names only — the test file carries no real client identifiers.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_LEGAL = Path(__file__).resolve().parents[1]
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, _LEGAL / filename)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load("check_client_pii", "check-client-pii.py")
+engine = _load("redact_client_pii", "redact-client-pii.py")
+
+SYNTH_MAP = """
+version: 1
+rules:
+  - {pattern: '/mnt/ace/alphacorp', replacement: '/mnt/ace/client-a', word_bound: false}
+  - {pattern: 'alpha ?corp',        replacement: 'client-a', word_bound: false}
+  - {pattern: 'beta',               replacement: 'client-b', word_bound: true}
+"""
+
+
+def _rules(tmp_path):
+    p = tmp_path / "map.yaml"
+    p.write_text(SYNTH_MAP, encoding="utf-8")
+    return engine.load_rules(p)
+
+
+def test_detects_violation_lines(tmp_path):
+    rules = _rules(tmp_path)
+    f = tmp_path / "doc.md"
+    f.write_text("clean line\nthis mentions alphacorp here\nanother clean\nbeta too\n", encoding="utf-8")
+    hits = guard.violations_in(f, rules)
+    assert hits == [2, 4]
+
+
+def test_clean_file_no_hits(tmp_path):
+    rules = _rules(tmp_path)
+    f = tmp_path / "ok.md"
+    f.write_text("client-a and client-b are codenames, betatron is unrelated\n", encoding="utf-8")
+    assert guard.violations_in(f, rules) == []
+
+
+def test_word_bound_no_false_positive(tmp_path):
+    """'beta' is word-bound → must not flag 'betatron'/'alphabeta'."""
+    rules = _rules(tmp_path)
+    f = tmp_path / "w.md"
+    f.write_text("betatron alphabeta\n", encoding="utf-8")
+    assert guard.violations_in(f, rules) == []
+
+
+def test_binary_unreadable_skipped(tmp_path):
+    rules = _rules(tmp_path)
+    f = tmp_path / "b.bin"
+    f.write_bytes(b"\xff\xfe alphacorp \x00")
+    # non-utf8 → skipped, no crash
+    assert guard.violations_in(f, rules) == []


### PR DESCRIPTION
## Client-PII prevention guard — epic #3095, sub-issue #3099

The recurrence backstop. The old `legal-sanity-scan --diff-only` passed client leaks because `.legal-deny-list.yaml` lacked the active clients — and fixing it publicly is the deny-list paradox. This PR sources the client list **privately** and adds layered enforcement. **No client names appear in this PR.**

### What's added
- **`scripts/legal/check-client-pii.py`** — name-agnostic guard that **reuses the redactor's engine**: *"if running the redactor would change a file, that file still contains an un-redacted client identifier."* Guard and redactor can never disagree. It **never prints a matched value** (public CI logs would leak it) — only file + line.
- **`.github/workflows/legal-client-pii-gate.yml`** — PR gate. Sources the private map from the **`LEGAL_CLIENT_MAP` repo secret**; **strict** when set, **degrade-open** (non-blocking warn) when unset so forks/unconfigured envs don't break.
- **`.pre-commit-config.yaml`** — local `legal-client-pii` hook (fast feedback, bypassable via `LEGAL_PII_ALLOW=1`).
- **`.claude/docs/client-pii-prevention.md`** — PII-free prevention doc.
- **Tests** — `scripts/legal/tests/` 11 passing (4 guard + 7 engine), incl. word-boundary and binary-skip cases. Smoke-verified: blocks a real-name file, passes a codenamed one.

### Operator action required (one-time, to make the CI gate strict)
```bash
gh secret set LEGAL_CLIENT_MAP \
  < <aceengineer-strategy>/pii-remediation/3097-2026-06-14/client-codename-map.yaml
```
Until set, the gate runs degrade-open.

### Emitter audit (task in #3099)
Dumps are gitignore-excluded and the learning cron redacts at source (both landed in #3097). Remaining residual = hand-authored files incl. `config/client-wikis.yml` → **#3098**.

Closes #3099.
