### PR TITLE
docs(agent-library): clear stale refs to #3103-retired scripts

### DIFF
--- a/.claude/agent-library/README.md
+++ b/.claude/agent-library/README.md
@@ -12,14 +12,9 @@ This directory contains the **master agent registry** for workspace-hub, central
 ## Quick Start
 
 ```bash
-# Navigate to any repository
-cd <workspace-hub>/<repo-name>
-
-# Use agent orchestrator for intelligent agent selection
-./modules/automation/agent_orchestrator.sh code-generation "Create REST API"
-
-# Or use Factory AI with centralized config
-droid  # Automatically loads .claude/CLAUDE.md with agent references
+# Load an agent directly by its definition (the live pattern):
+#   @.claude/agent-library/core/coder.md   (see .claude/workflows/standard-development.yaml)
+# Or invoke a devops skill that loads its agent: /database /infrastructure /observability /security-audit
 ```
 
 ## Directory Structure
@@ -163,23 +158,12 @@ droid  # Automatically loads .claude/CLAUDE.md with agent references
 
 ## Agent Selection & Orchestration
 
-### Intelligent Agent Selection
+### Agent Selection
 
-Use the agent orchestrator for automatic agent selection based on task type and complexity:
-
-```bash
-# Basic usage
-./modules/automation/agent_orchestrator.sh <task-type> "<description>"
-
-# With review
-./modules/automation/agent_orchestrator.sh code-generation "Create API" --with-review
-
-# Specify complexity
-./modules/automation/agent_orchestrator.sh architecture-design "Design microservices" --complexity complex
-
-# Force specific agent
-./modules/automation/agent_orchestrator.sh code-review "Review auth module" --agent code-review-swarm
-```
+> **Note (#3103):** the legacy `agent_orchestrator.sh` runner was retired (claude-flow-era, never scheduled).
+> Agents are loaded **directly** via `@.claude/agent-library/<category>/<agent>.md` references — see
+> `.claude/workflows/standard-development.yaml` and the `/database` `/infrastructure` `/observability`
+> `/security-audit` devops skills for the live pattern. The agent definitions below remain current.
 
 ### Task Types & Primary Agents
 
@@ -284,13 +268,6 @@ bash modules/automation/sync_agent_configs.sh --push
 bash modules/automation/sync_agent_configs.sh --validate
 ```
 
-### Daily Updates
-
-```bash
-# Auto-run daily at 00:00 UTC
-bash modules/automation/update_ai_agents_daily.sh
-```
-
 ### Validation
 
 ```bash
@@ -321,24 +298,14 @@ agents:
     - "@assetutilities/agents/registry/sub-agents/visualization-automation"
 ```
 
-### Example 3: Workflow Automation
+### Example 3: Direct agent loading (live pattern)
 
-```bash
-# Use shared workflow automation from hub
-./modules/automation/agent_orchestrator.sh spec-creation "Design payment API" \
-  --agent workflow-automation \
-  --domain python
+```text
+# Reference the agent definition directly (as standard-development.yaml does):
+@.claude/agent-library/core/coder.md
+@.claude/agent-library/devops/database.md   # or invoke /database
 ```
-
-### Example 4: Intelligent Selection
-
-```bash
-# Let orchestrator choose best agent
-./modules/automation/agent_orchestrator.sh architecture-design \
-  "Design microservices for e-commerce platform" \
-  --complexity complex \
-  --with-review
-```
+> The legacy `agent_orchestrator.sh` selection examples were removed in #3103 — see the note under "Agent Selection".
 
 ## Migration & Rollback
 
@@ -372,8 +339,6 @@ bash modules/automation/rollback_agent_configs.sh
 
 - **Registry:** `registry.yaml` (master reference)
 - **Best Practices:** `BEST_PRACTICES.md`
-- **Orchestrator:** `modules/automation/agent_orchestrator.sh`
-- **MCP Registry:** `modules/config/ai-agents-registry.json`
 
 ## Version History
 

--- a/.claude/agent-library/registry.yaml
+++ b/.claude/agent-library/registry.yaml
@@ -13,7 +13,7 @@ meta:
   last_updated: "2025-10-05T13:45:00Z"
   total_agents: 78
   update_frequency: "daily"
-  orchestrator: "@modules/automation/agent_orchestrator.sh"
+  orchestrator: "RETIRED-in-#3103 (agent_orchestrator.sh removed; agents load directly via @.claude/agent-library/<cat>/<agent>.md refs)"
   best_practices: "@.claude/agents/BEST_PRACTICES.md"
 
 # ==========================================
@@ -263,7 +263,7 @@ repositories:
 
 agent_selection:
   orchestrator:
-    path: "@modules/automation/agent_orchestrator.sh"
+    path: "RETIRED-in-#3103 (agent_orchestrator.sh removed; agents load directly via @.claude/agent-library/<cat>/<agent>.md refs)"
     description: "Intelligent agent selection based on task type and complexity"
 
   registry:
@@ -466,7 +466,7 @@ automation:
       - validate: "Validate all agent configurations"
 
   update_script:
-    path: "@modules/automation/update_ai_agents_daily.sh"
+    path: "RETIRED-in-#3103 (update_ai_agents_daily.sh removed; was claude-flow-era, never scheduled)"
     description: "Daily update of agent capabilities and registry"
     schedule: "daily at 00:00 UTC"
     operations:
@@ -485,7 +485,7 @@ automation:
       - performance_benchmark
 
   orchestrator:
-    path: "@modules/automation/agent_orchestrator.sh"
+    path: "RETIRED-in-#3103 (agent_orchestrator.sh removed; agents load directly via @.claude/agent-library/<cat>/<agent>.md refs)"
     description: "Intelligent agent selection and task delegation"
     features:
       - task_type_classification


### PR DESCRIPTION
Finishes #3103 (Closes it). Companion to PR #3105 (script deletions).

## Context
After #3105 deleted the dead orchestration *runner* scripts, the **LIVE** `.claude/agent-library/` (loaded by `standard-development.yaml` + the 4 devops skills — adversarial review confirmed it is NOT dead) still pointed at them. This clears those dangling refs.

## Changes (docs-only; NO live agent definition touched)
- `registry.yaml`: orchestrator/update_script `path` values → `RETIRED-in-#3103` notes (structure preserved).
- `README.md`: replaced the `agent_orchestrator.sh` usage examples (Quick Start, Examples 3-4, summary) + removed the dead "Daily Updates" block → documented the live `@`-ref loading pattern instead.

## Verified
- registry.yaml parses.
- No dangling invocation/path of the deleted scripts remains (only deprecation notes that name them).
- Live agent-def `.md` files + their load paths untouched.

## Noted, out of scope (pre-existing, NOT from #3103)
registry.yaml still has stale `@modules/automation/` refs to `sync_agent_configs.sh` (live, wrong path prefix) and `validate_/rollback_agent_configs.sh` (not present in this repo). Separate hygiene if desired.