### PR TITLE
fix(legal): codename-redact cron schedule comment

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -712,7 +712,7 @@ tasks:
   # + README). U5 dry-run cycle verified both legs on 2026-04-21:
   # (a) linkedin + indeed via --skip-career-pages: 19 jobs, no policy violations;
   # (b) full 30-site career_page run: 48 jobs, robots fail-closed working on
-  # real disallowed sites (Aker Solutions, Saipem, Orsted, Talos, Bollinger,
+  # real disallowed sites (Aker Solutions, client-d, Orsted, Talos, Bollinger,
   # Huntington Ingalls), unreachable → DENY fired on VT Halter. Owner override
   # active for LinkedIn per TOS_REVIEW.md. Cron resumes its Monday 5AM UTC cadence.
   # Governance gate: removing the `Owner override:` block in TOS_REVIEW.md


### PR DESCRIPTION
## Summary
- Codename-redacts the single client identifier flagged by the Client-PII Gate in the cron schedule comments from merged PR #3122.
- Keeps the cron task behavior unchanged; this is a comment-only legal cleanup.

## Verification
- `uv run python scripts/legal/check-client-pii.py --map <local-private-map> --base-ref origin/main --strict`
- `bash scripts/legal/legal-sanity-scan.sh --diff-only`
- YAML parse of `config/scheduled-tasks/schedule-tasks.yaml`

## Notes
- Normal push hit the known temp-worktree sibling-layout coverage hook issue; pushed with `SKIP_COVERAGE_REASON` after the legal/YAML checks above passed.
