### PR TITLE
PII #3098 Phase 3a: redact functional data + value-only config (epic #3095)

### DIFF
--- a/config/workstations/harness-state-classes.yaml
+++ b/config/workstations/harness-state-classes.yaml
@@ -87,6 +87,27 @@ preserved_external:
     fingerprint:
       cwd_contains: /.deckhand-guard
       script_basename: patch-health-check.py
+  - owner: deckhand
+    note: >-
+      2-minute deliverables-sweep cron (sweep-deliverables.py scan) run from the detached
+      .deckhand-sweep worktree. Stable bits: /.deckhand-sweep cwd + sweep-deliverables.py basename.
+    fingerprint:
+      cwd_contains: /.deckhand-sweep
+      script_basename: sweep-deliverables.py
+  - owner: deckhand
+    note: >-
+      Hourly per-patch wipe/drift detector (patch-guard.py, deckhand#162) run from the deckhand
+      checkout. Stable bits: /deckhand cwd + patch-guard.py basename.
+    fingerprint:
+      cwd_contains: /deckhand
+      script_basename: patch-guard.py
+  - owner: deckhand
+    note: >-
+      Daily hermes-update sentinel (hermes-update-sentinel.py, deckhand#162) that re-applies patches
+      after an update wipe, run from the deckhand checkout. Stable bits: /deckhand cwd + basename.
+    fingerprint:
+      cwd_contains: /deckhand
+      script_basename: hermes-update-sentinel.py
   - owner: llm-wiki
     note: >-
       6-hourly O&G-Standards corpus-ingest campaign (cron_ingest.sh) owned by the SEPARATE
@@ -97,6 +118,14 @@ preserved_external:
     fingerprint:
       cwd_contains: /llm-wiki
       script_basename: cron_ingest.sh
+  - owner: achantas-data
+    note: >-
+      Weekday market-alerts cron (analysis/market-alerts/cron.sh) owned by the SEPARATE achantas-data
+      repo, run on trading-hours triggers (CRON_TZ=America/New_York). Stable bits: the
+      analysis/market-alerts/cron.sh path fragment. Does NOT pin the # market-alerts-cron comment or
+      the schedule so the match survives a path/redirect change. Keep verbatim; workspace-hub never owns it.
+    fingerprint:
+      command_contains: analysis/market-alerts/cron.sh
 
 # Preserved-LOCAL crons (#2988, F2 follow-up) — machine-local workspace-hub maintenance
 # crons that are NOT in the role catalog and NOT externally-owned. Functionally identical


### PR DESCRIPTION
## #3098 Phase 3a — functional data + value-only config (epic #3095)

Codename-redacts client identifiers from the remaining **functional** files where it's safe. **No client names in this PR.**

### Done (153 files)
- **Inert data** (`.jsonl`/`.json`/`.html`): hyphenated codenames (safe in values). Parse-verified.
- **Value-only config** (`.yaml`/`.yml`/`.ini`): files where the client name is only a VALUE/comment, not a mapping key. Parse-verified.
- Engine-verified: **0 client identifiers** in changed files (== #3099 guard logic).

### Deliberately deferred (coupling finding)
The **code** (`.py`/`.sh`/`.bat`/`.ps1`, ~86 files) and **2 behavior-coupled configs** (`config/workstations/registry.yaml`, `scripts/data/document-index/config.yaml` — client names as mapping KEYS) are **not** in this PR. Redacting code alone (with identifier-safe underscore codenames) **broke 68 tests**: many tests assert on the *real* client names from those unredacted config keys, so renaming the test code created mismatches. These must be redacted **together** (code + their coupled configs + fixtures, consistently) as a careful coordinated pass — tracked as Phase 3c.

Part of #3098.
