### PR TITLE
fix(#3139): shared _skill_identity — reconcile scanner/report universe + _archived collision (TDD)

### DIFF
--- a/scripts/skills/_skill_identity.py
+++ b/scripts/skills/_skill_identity.py
@@ -1,0 +1,71 @@
+"""_skill_identity.py — single source of truth for the skill universe + the
+canonical short_name key (#3139).
+
+Both skill-invocation-scanner.py and skill-usage-report.py import this so they
+iterate the IDENTICAL skill set and derive the short_name join key from ONE
+implementation (closing the #3112 BUG-2 join's latent divergence).
+
+Pure stdlib (no yaml) so the scanner stays dependency-free; the report keeps its
+own yaml parse for OTHER frontmatter fields (related_skills/see_also) but routes
+the universe walk + short_name KEY through here.
+
+Underscore-named lib with no PEP-723 header (never executed directly) — mirrors
+the established scripts/skills/audit_skill_lib.py / skill_tier_lib.py precedent.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# The canonical exclusion set. NOTE `_archived` (trailing "d") is included —
+# the report previously excluded only `_archive`, leaking 6 archived email
+# skills and producing the gmail-data-extraction short_name collision (#3139).
+DEFAULT_EXCLUSIONS = frozenset({"_archive", "_archived", "_core", "_internal"})
+
+
+def discover_skills(skills_root, exclusions=DEFAULT_EXCLUSIONS):
+    """Return sorted rel-path skill ids under skills_root, minus excluded dirs.
+
+    A skill is a directory containing SKILL.md; its id is the POSIX rel-path of
+    that directory relative to skills_root (e.g. 'email/gmail-triage').
+    """
+    root = Path(skills_root)
+    out = []
+    for skill_md in root.rglob("SKILL.md"):
+        if any(part in exclusions for part in skill_md.parts):
+            continue
+        out.append(skill_md.parent.relative_to(root).as_posix())
+    return sorted(out)
+
+
+def _read_frontmatter_name(skill_md_path: Path):
+    """Minimal, dependency-free single-line `name:` frontmatter read.
+
+    Matches the value skill-usage-report.py derives via yaml for the common
+    single-line case (verified 0 divergences over the 833 report-visible skills,
+    #3139). Tolerant of surrounding quotes. Returns None if absent/unreadable.
+    """
+    try:
+        text = skill_md_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else ""
+    for line in block.splitlines():
+        s = line.strip()
+        if s.startswith("name:"):
+            return s[len("name:"):].strip().strip('"').strip("'")
+    return None
+
+
+def derive_short_name(skill_md_path) -> str:
+    """Canonical short_name = frontmatter `name` lowercased, else dir basename.
+
+    Mirrors skill-usage-report.py:150-153 so scanner output keys join report
+    tier keys. This is THE single derivation both scripts must use.
+    """
+    p = Path(skill_md_path)
+    basename = p.parent.name
+    name = _read_frontmatter_name(p)
+    return ((name or basename).strip() or basename).lower()

--- a/scripts/skills/skill-invocation-scanner.py
+++ b/scripts/skills/skill-invocation-scanner.py
@@ -35,6 +35,12 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+# #3139: shared skill universe + short_name key (single source of truth).
+# Self-heal sys.path so `import _skill_identity` resolves both when run directly
+# (uv run python scripts/skills/...) and when loaded via importlib in tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _skill_identity import discover_skills, derive_short_name  # noqa: E402
+
 DEFAULT_MIN_COVERAGE = 14  # days — shared with skill-usage-report.py demotion rule
 
 
@@ -90,42 +96,6 @@ def scan_sessions(sessions_dir: Path):
 
     coverage_days = (newest - oldest).days if oldest and newest else 0
     return event_ts, session_ts, coverage_days
-
-
-def discover_skills(skills_root: Path):
-    """Walk .claude/skills for SKILL.md, yield the relative skill name."""
-    skills = []
-    root = Path(skills_root)
-    for skill_md in root.rglob("SKILL.md"):
-        rel = skill_md.parent.relative_to(root).as_posix()
-        skills.append(rel)
-    return sorted(skills)
-
-
-def derive_short_name(skill_md_path) -> str:
-    """Canonical skill key = frontmatter `name` lowercased, else dir basename.
-
-    Mirrors skill-usage-report.py:150-153 (`canonical_name = fm.get("name",
-    parent.name); short_name = canonical_name.lower()`) so the scanner's OUTPUT
-    keys join the report's tier keys (#3112 BUG-2). Minimal frontmatter parse —
-    the scanner has no yaml dep; only the single-line `name:` field is needed.
-    """
-    p = Path(skill_md_path)
-    basename = p.parent.name
-    name = None
-    try:
-        text = p.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return basename.lower()
-    if text.startswith("---"):
-        end = text.find("\n---", 3)
-        block = text[3:end] if end != -1 else ""
-        for line in block.splitlines():
-            s = line.strip()
-            if s.startswith("name:"):
-                name = s[len("name:"):].strip().strip('"').strip("'")
-                break
-    return ((name or basename).strip() or basename).lower()
 
 
 def classify(event_ts, session_ts, coverage_days: int, skills_root: Path):

--- a/scripts/skills/skill-usage-report.py
+++ b/scripts/skills/skill-usage-report.py
@@ -44,6 +44,12 @@ from pathlib import Path
 
 import yaml
 
+# #3139: shared skill universe + short_name key (single source of truth).
+# Self-heal sys.path so `import _skill_identity` resolves both when run directly
+# and when loaded via importlib in tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _skill_identity import discover_skills, derive_short_name  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,16 +88,11 @@ def scan_skills(skills_dir: Path) -> dict[str, dict]:
     """
     skills: dict[str, dict] = {}
 
-    for skill_md in sorted(skills_dir.rglob("SKILL.md")):
-        parts = skill_md.parts
-        if any(excluded in parts for excluded in {"_archive", "_core", "_internal"}):
-            continue
-
+    for full_rel in discover_skills(skills_dir):  # #3139: shared universe (excludes _archive/_archived/_core/_internal)
+        skill_md = skills_dir / full_rel / "SKILL.md"
         rel_path = str(skill_md.relative_to(skills_dir))
         # Skill name is the parent directory name
         skill_name = skill_md.parent.name
-        # Full path for uniqueness
-        full_rel = str(skill_md.parent.relative_to(skills_dir)).replace(os.sep, "/")
 
         try:
             text = skill_md.read_text(encoding="utf-8")
@@ -150,7 +151,7 @@ def scan_skills(skills_dir: Path) -> dict[str, dict]:
         canonical_name = str(fm.get("name", skill_name)).strip() or skill_name
         skills[full_rel] = {
             "name": canonical_name,
-            "short_name": canonical_name.lower(),
+            "short_name": derive_short_name(skill_md),  # #3139: single canonical derivation
             "path": rel_path,
             "full_rel": full_rel,
             "related_skills": related,

--- a/tests/skills/test_skill_identity.py
+++ b/tests/skills/test_skill_identity.py
@@ -1,0 +1,84 @@
+"""TDD for #3139: shared scripts/skills/_skill_identity.py — one canonical
+discover_skills() + derive_short_name() for both scanner and report, with the
+_archived exclusion fix.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(subprocess.check_output(
+    ["git", "rev-parse", "--show-toplevel"], cwd=Path(__file__).parent, text=True).strip())
+SKILLS_DIR = REPO / "scripts" / "skills"
+LIB = SKILLS_DIR / "_skill_identity.py"
+
+
+@pytest.fixture
+def ident():
+    assert LIB.exists(), f"shared lib not yet written: {LIB}"
+    if str(SKILLS_DIR) not in sys.path:
+        sys.path.insert(0, str(SKILLS_DIR))
+    spec = importlib.util.spec_from_file_location("_skill_identity", LIB)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def tree(tmp_path):
+    root = tmp_path / "skills"
+    cases = {
+        "dev/y": "---\nname: Y Skill\n---\n",
+        "_archive/x": "---\nname: X\n---\n",
+        "_core/c": "---\nname: C\n---\n",
+        "_internal/i": "---\nname: I\n---\n",
+        "email/_archived/gmail-data-extraction": "---\nname: gmail-data-extraction\n---\n",
+        "email/gmail-data-extraction": "---\nname: gmail-data-extraction\n---\n",
+        "tools/quoted": '---\nname: "Baz"\n---\n',
+        "tools/no-fm": "just a body, no frontmatter\n",
+    }
+    for rel, body in cases.items():
+        p = root / rel
+        p.mkdir(parents=True)
+        (p / "SKILL.md").write_text(body)
+    return root
+
+
+def test_discover_excludes_archive_core_internal(ident, tree):
+    got = set(ident.discover_skills(tree))
+    assert not any(s.startswith(("_archive/", "_core/", "_internal/")) for s in got)
+
+
+def test_discover_excludes_archived_trailing_d(ident, tree):
+    # The bug fix: _archived (trailing d) must be excluded too.
+    got = set(ident.discover_skills(tree))
+    assert "email/_archived/gmail-data-extraction" not in got
+    assert "email/gmail-data-extraction" in got
+
+
+def test_discover_opt_out_returns_everything(ident, tree):
+    got = set(ident.discover_skills(tree, exclusions=frozenset()))
+    assert "_archive/x" in got and "email/_archived/gmail-data-extraction" in got
+
+
+def test_derive_short_name_from_frontmatter(ident, tree):
+    assert ident.derive_short_name(tree / "dev/y/SKILL.md") == "y skill"
+
+
+def test_derive_short_name_quoted(ident, tree):
+    assert ident.derive_short_name(tree / "tools/quoted/SKILL.md") == "baz"
+
+
+def test_derive_short_name_fallback_basename(ident, tree):
+    assert ident.derive_short_name(tree / "tools/no-fm/SKILL.md") == "no-fm"
+
+
+def test_no_archived_collision(ident, tree):
+    # After excluding _archived, gmail-data-extraction maps to exactly one rel-path.
+    rels = [s for s in ident.discover_skills(tree)
+            if ident.derive_short_name(tree / s / "SKILL.md") == "gmail-data-extraction"]
+    assert rels == ["email/gmail-data-extraction"]

--- a/tests/skills/test_skill_universe_parity.py
+++ b/tests/skills/test_skill_universe_parity.py
@@ -1,0 +1,63 @@
+"""#3139 core AC: after routing both scripts through _skill_identity, the
+scanner universe == the report universe, and the _archived-induced
+gmail-data-extraction collision is gone. Runs against the live .claude/skills.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(subprocess.check_output(
+    ["git", "rev-parse", "--show-toplevel"], cwd=Path(__file__).parent, text=True).strip())
+SKILLS_DIR = REPO / "scripts" / "skills"
+LIVE_SKILLS = REPO / ".claude" / "skills"
+
+
+def _load(name, path):
+    if str(SKILLS_DIR) not in sys.path:
+        sys.path.insert(0, str(SKILLS_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def libs():
+    ident = _load("_skill_identity", SKILLS_DIR / "_skill_identity.py")
+    scanner = _load("siscan_p", SKILLS_DIR / "skill-invocation-scanner.py")
+    report = _load("surep_p", SKILLS_DIR / "skill-usage-report.py")
+    return ident, scanner, report
+
+
+@pytest.mark.skipif(not LIVE_SKILLS.exists(), reason="no live skills tree")
+def test_scanner_and_report_share_one_universe(libs):
+    ident, scanner, report = libs
+    canonical = set(ident.discover_skills(LIVE_SKILLS))
+    # scanner uses the shared discover_skills now
+    assert set(scanner.discover_skills(LIVE_SKILLS)) == canonical
+    # report's scan_skills keys must equal the canonical universe
+    report_keys = set(report.scan_skills(LIVE_SKILLS).keys())
+    assert report_keys == canonical, (
+        f"universe mismatch: only-canonical={sorted(canonical - report_keys)[:5]}, "
+        f"only-report={sorted(report_keys - canonical)[:5]}")
+
+
+@pytest.mark.skipif(not LIVE_SKILLS.exists(), reason="no live skills tree")
+def test_no_archived_leak(libs):
+    ident, _, _ = libs
+    universe = ident.discover_skills(LIVE_SKILLS)
+    assert not any("/_archived/" in s or s.startswith("_archived/") for s in universe)
+
+
+@pytest.mark.skipif(not LIVE_SKILLS.exists(), reason="no live skills tree")
+def test_gmail_data_extraction_collision_gone(libs):
+    ident, _, _ = libs
+    rels = [s for s in ident.discover_skills(LIVE_SKILLS)
+            if ident.derive_short_name(LIVE_SKILLS / s / "SKILL.md") == "gmail-data-extraction"]
+    assert rels == ["email/gmail-data-extraction"], f"collision not resolved: {rels}"


### PR DESCRIPTION
Implements #3139 (approved). Reconciles the scanner-vs-report skill universe + short_name key into one shared module, fixing the `_archived` leak. TDD-first.

## Change
- **New `scripts/skills/_skill_identity.py`** (stdlib-only, no PEP-723 — mirrors `audit_skill_lib.py`): one `discover_skills(root, exclusions=DEFAULT_EXCLUSIONS)` + one `derive_short_name(path)`. `DEFAULT_EXCLUSIONS = {_archive, _archived, _core, _internal}` — the `_archived` (trailing-d) entry is the bug fix (it was leaking 6 archived email skills past the report's `_archive`-only exclusion → the `gmail-data-extraction` collision).
- **Scanner + report both import it**; their local `discover_skills`/`derive_short_name` / inline rglob+exclusion are deleted (no duplicate derivation). Each script self-heals `sys.path` so the existing importlib test-loaders still resolve.

## Verification (TDD)
- `tests/skills/test_skill_identity.py` (7) — exclusions incl. `_archived`, short_name derivation, collision-gone.
- `tests/skills/test_skill_universe_parity.py` (3, live `.claude/skills`) — **scanner universe == report universe**; no `_archived` leak; `gmail-data-extraction` resolves to one rel-path.
- Full suite: **240 pass**, same **19 pre-existing failures** (verified unrelated — none import these modules; `test_doc_extraction_skill` errors on collection on origin/main too).

## Notes
- `session-corpus-audit` is a *genuine* two-skill basename clash (not an archive artifact) — still aggregated conservatively + warned; disambiguation (rename) is out of scope, flagged on the issue.
- Pushed with audited `GIT_PRE_PUSH_SKIP` — blocker was pre-existing ruff/test debt in the unrelated `assetutilities` sibling repo; this change is workspace-hub-only.
- **Prerequisite for #3137 + #3138** — they now build on this shared helper.

Epic #3058. Plan: `docs/plans/2026-06-15-issue-3139-skill-universe-reconciliation.md`.
