### PR TITLE
feat(#3137): capture Skill-tool invocations (id→short_name)

### DIFF
--- a/.claude/hooks/session-logger.sh
+++ b/.claude/hooks/session-logger.sh
@@ -39,6 +39,41 @@ case "$FILE" in
     ;;
 esac
 
+# #3137 emit: capture Skill-TOOL invocations (distinct from the Read-of-SKILL.md
+# path above). The id lives at .tool_input.skill (empirically confirmed
+# 1080/1080 transcript records; .tool_input.skill_name kept only as a defensive
+# fallback in case a future harness renames it). Resolve <plugin>:<name> or a
+# bare id against the .claude/skills tree by DIRECTORY BASENAME (fast, no Python
+# spawn on the hot path; the batch scanner does the authoritative frontmatter-
+# name canonicalization via _skill_identity.normalize_skill_id). Plugin-only /
+# unresolved ids are recorded-and-flagged (skill_source set, raw skill_id
+# preserved) — NEVER silently dropped, NEVER fabricated.
+SKILL_ID=""
+SKILL_SOURCE=""
+if [ "$TOOL" = "Skill" ]; then
+    SKILL_ID=$(echo "$INPUT" | jq -r '.tool_input.skill // .tool_input.skill_name // ""' 2>/dev/null) || SKILL_ID=""
+    if [ -n "$SKILL_ID" ]; then
+        NAME="${SKILL_ID#*:}"                 # strip "<plugin>:" prefix if present
+        NAMESPACE=""
+        case "$SKILL_ID" in *:*) NAMESPACE="${SKILL_ID%%:*}";; esac
+        # basename resolve against the skills tree (exclude _archive*/_core/_internal)
+        HIT=$(find "$WS/.claude/skills" \
+                \( -path '*/_archive/*' -o -path '*/_archived/*' \
+                   -o -path '*/_core/*' -o -path '*/_internal/*' \) -prune -o \
+                -type d -name "$NAME" -print 2>/dev/null | head -1)
+        if [ -n "$HIT" ]; then
+            SKILL_NAME="$NAME"                 # report joins on short_name; basename==short_name common case
+            SKILL_SOURCE="workspace-hub"
+        elif [ -n "$NAMESPACE" ] && [ "$NAMESPACE" != "workspace-hub" ]; then
+            SKILL_NAME=""                      # external plugin skill (off-repo)
+            SKILL_SOURCE="plugin"
+        else
+            SKILL_NAME=""                      # bare/workspace-hub miss (likely a command)
+            SKILL_SOURCE="unresolved"
+        fi
+    fi
+fi
+
 # Get context
 TS=$(date -Iseconds)
 EPOCH=$(date +%s)
@@ -57,11 +92,15 @@ ENTRY=$(jq -cn \
   --arg cmd "${CMD:-}" \
   --arg session_id "${SESSION_ID:-}" \
   --arg skill_name "${SKILL_NAME:-}" \
+  --arg skill_id "${SKILL_ID:-}" \
+  --arg skill_source "${SKILL_SOURCE:-}" \
   '{ts:$ts, epoch:$epoch, hook:$hook, tool:$tool, project:$project, repo:$repo}
    + if ($file != "") then {file:$file} else {} end
    + if ($cmd != "") then {cmd:$cmd} else {} end
    + if ($session_id != "") then {session_id:$session_id} else {} end
-   + if ($skill_name != "") then {skill_name:$skill_name} else {} end' \
+   + if ($skill_name != "") then {skill_name:$skill_name} else {} end
+   + if ($skill_id != "") then {skill_id:$skill_id} else {} end
+   + if ($skill_source != "") then {skill_source:$skill_source} else {} end' \
   2>/dev/null) \
   || ENTRY="{\"ts\":\"${TS}\",\"hook\":\"${HOOK_TYPE}\",\"tool\":\"${TOOL}\"}"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,7 +171,7 @@
         ]
       },
       {
-        "matcher": "Bash|Read|Write|Edit|MultiEdit|Glob|Grep|Agent|Task",
+        "matcher": "Bash|Read|Write|Edit|MultiEdit|Glob|Grep|Agent|Task|Skill",
         "hooks": [
           {
             "type": "command",

--- a/scripts/skills/_skill_identity.py
+++ b/scripts/skills/_skill_identity.py
@@ -69,3 +69,78 @@ def derive_short_name(skill_md_path) -> str:
     basename = p.parent.name
     name = _read_frontmatter_name(p)
     return ((name or basename).strip() or basename).lower()
+
+
+# --------------------------------------------------------------------------- #
+# #3137: resolve a Skill-tool id to the canonical short_name + a source flag.
+# --------------------------------------------------------------------------- #
+
+# Namespaces that exist as external plugins under ~/.claude/plugins/cache/ and
+# are NOT mirrored in the workspace-hub .claude/skills tree (verified #3137:
+# codex 815, superpowers 97, gsd 32, data 1 invocations). A namespaced id that
+# fails to resolve is flagged `plugin` (still a real skill, just off-repo) vs a
+# bare/workspace-hub-namespaced miss which is flagged `unresolved` (likely a
+# slash-command, not a SKILL.md). Both preserve the raw id — never dropped.
+KNOWN_PLUGIN_NAMESPACES = frozenset({"codex", "superpowers", "gsd", "data"})
+# The namespace under which the repo exposes its OWN skills/commands.
+WORKSPACE_NAMESPACE = "workspace-hub"
+
+
+def _build_shortname_index(skills_root, exclusions=DEFAULT_EXCLUSIONS):
+    """Map every resolvable lookup key -> canonical short_name.
+
+    Two keys point at each skill so a Skill-tool id resolves whether it carries
+    the dir basename or the frontmatter name: the lowercased dir basename AND
+    the canonical short_name itself (frontmatter `name` lowercased). Uses the
+    SAME discover_skills + derive_short_name the scanner keys rows by, so a
+    resolved short_name JOINS the scanner/report tier rows.
+    """
+    root = Path(skills_root)
+    index = {}
+    for skill_rel in discover_skills(root, exclusions=exclusions):
+        skill_md = root / skill_rel / "SKILL.md"
+        short = derive_short_name(skill_md)
+        basename = Path(skill_rel).name.lower()
+        # short_name wins as the canonical join key; basename is a secondary
+        # alias. Insert basename first so short_name (set last) is authoritative
+        # if they ever collide on the same string.
+        index.setdefault(basename, short)
+        index[short] = short
+    return index
+
+
+def normalize_skill_id(raw_id, skills_root, exclusions=DEFAULT_EXCLUSIONS):
+    """Resolve a Skill-tool id to {skill_name, skill_source, skill_id}.
+
+    `raw_id` is the value of `.tool_input.skill` (e.g. 'superpowers:test-driven-
+    development', 'codex:rescue', 'corporate-tax-form-fill', 'workspace-hub:repo-sync').
+
+    Resolution (pure, no side effects):
+      1. split `<namespace>:<name>` on the first ':' (bare id -> empty namespace)
+      2. look the lowercased `<name>` up against the workspace-hub skill universe
+         (dir basename OR frontmatter-name, _archive/_core/_internal excluded)
+      3. classify:
+         - resolved                  -> skill_source='workspace-hub', skill_name=<short_name>
+         - unresolved + plugin ns    -> skill_source='plugin',        skill_name=''
+         - unresolved + bare/wshub ns -> skill_source='unresolved',    skill_name=''
+      `skill_id` always preserves the raw id verbatim (never dropped, the
+      canonical short_name is NEVER fabricated for an id absent from the tree).
+    """
+    raw = raw_id or ""
+    if ":" in raw:
+        namespace, name = raw.split(":", 1)
+    else:
+        namespace, name = "", raw
+    namespace = namespace.strip().lower()
+    name_l = name.strip().lower()
+
+    index = _build_shortname_index(skills_root, exclusions=exclusions)
+    short = index.get(name_l, "")
+
+    if short:
+        return {"skill_name": short, "skill_source": "workspace-hub", "skill_id": raw}
+    if namespace and namespace != WORKSPACE_NAMESPACE:
+        # A namespaced id that didn't resolve: an external plugin skill (logged + flagged).
+        return {"skill_name": "", "skill_source": "plugin", "skill_id": raw}
+    # Bare or workspace-hub-namespaced miss (likely a slash-command, not a SKILL.md).
+    return {"skill_name": "", "skill_source": "unresolved", "skill_id": raw}

--- a/tests/skills/test_skill_tool_capture.py
+++ b/tests/skills/test_skill_tool_capture.py
@@ -1,0 +1,263 @@
+"""TDD for #3137: capture Skill-tool calls (id -> short_name resolution).
+
+Two surfaces under test:
+
+1. ``scripts/skills/_skill_identity.normalize_skill_id`` — a pure resolver from a
+   raw Skill-tool id (``<plugin>:<name>`` or bare) to the canonical workspace-hub
+   short_name plus a source flag. Plugin-only / unresolved ids are recorded-and-
+   flagged (raw id preserved), never silently dropped, never fabricated.
+
+2. ``.claude/hooks/session-logger.sh`` — on a ``Skill`` PostToolUse payload it
+   emits ``skill_name`` (resolved short_name when the id maps into the synthetic
+   skills tree) + ``skill_id`` (raw) + ``skill_source`` flag, reading the id from
+   ``.tool_input.skill`` (the empirically-confirmed field; 1080/1080 transcript
+   records) with ``.tool_input.skill_name`` as a defensive fallback. Non-Skill,
+   non-Read calls emit no skill_name.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+REPO = Path(
+    subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"], cwd=Path(__file__).parent, text=True
+    ).strip()
+)
+SKILLS_DIR = REPO / "scripts" / "skills"
+LIB = SKILLS_DIR / "_skill_identity.py"
+SCRIPT = REPO / ".claude" / "hooks" / "session-logger.sh"
+
+
+# --------------------------------------------------------------------------- #
+# normalize_skill_id (pure resolver)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def ident():
+    assert LIB.exists(), f"shared lib not yet written: {LIB}"
+    if str(SKILLS_DIR) not in sys.path:
+        sys.path.insert(0, str(SKILLS_DIR))
+    spec = importlib.util.spec_from_file_location("_skill_identity", LIB)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A small skills tree mirroring the real layout.
+
+    - corporate-tax-form-fill: bare, dir basename == short_name
+    - workspace-hub/repo-sync: namespaced workspace-hub:repo-sync should resolve
+    - dev/fancy: frontmatter name differs from dir basename (name-based resolve)
+    - _archive/ghost: excluded universe member must NOT resolve
+    """
+    root = tmp_path / "skills"
+    cases = {
+        "corporate-tax-form-fill": "---\nname: corporate-tax-form-fill\n---\n",
+        "workspace-hub/repo-sync": "---\nname: repo-sync\n---\n",
+        "dev/fancy": "---\nname: Fancy Skill\n---\n",
+        "_archive/ghost": "---\nname: ghost\n---\n",
+    }
+    for rel, body in cases.items():
+        p = root / rel
+        p.mkdir(parents=True)
+        (p / "SKILL.md").write_text(body)
+    return root
+
+
+def test_normalize_bare_resolved(ident, tree):
+    r = ident.normalize_skill_id("corporate-tax-form-fill", tree)
+    assert r["skill_name"] == "corporate-tax-form-fill"
+    assert r["skill_source"] == "workspace-hub"
+    assert r["skill_id"] == "corporate-tax-form-fill"
+
+
+def test_normalize_namespaced_workspace_hub(ident, tree):
+    r = ident.normalize_skill_id("workspace-hub:repo-sync", tree)
+    assert r["skill_name"] == "repo-sync"
+    assert r["skill_source"] == "workspace-hub"
+    assert r["skill_id"] == "workspace-hub:repo-sync"
+
+
+def test_normalize_plugin_unresolved(ident, tree):
+    # codex:rescue has no counterpart in the wshub tree -> flagged, not dropped.
+    r = ident.normalize_skill_id("codex:rescue", tree)
+    assert r["skill_name"] == ""
+    assert r["skill_source"] == "plugin"
+    assert r["skill_id"] == "codex:rescue"
+
+
+def test_normalize_superpowers_unmirrored(ident, tree):
+    r = ident.normalize_skill_id("superpowers:writing-plans", tree)
+    assert r["skill_name"] == ""
+    assert r["skill_source"] == "plugin"
+    assert r["skill_id"] == "superpowers:writing-plans"
+
+
+def test_normalize_bare_unresolved(ident, tree):
+    # A bare id that maps to nothing (e.g. a slash-command, not a SKILL.md):
+    # recorded-and-flagged as unresolved, raw id preserved, no fabrication.
+    r = ident.normalize_skill_id("whats-next", tree)
+    assert r["skill_name"] == ""
+    assert r["skill_source"] == "unresolved"
+    assert r["skill_id"] == "whats-next"
+
+
+def test_normalize_frontmatter_name(ident, tree):
+    # dir basename is 'fancy' but frontmatter name is 'Fancy Skill'.
+    # The canonical short_name is the lowercased frontmatter name.
+    r = ident.normalize_skill_id("fancy", tree)
+    assert r["skill_name"] == "fancy skill"
+    assert r["skill_source"] == "workspace-hub"
+
+
+def test_normalize_archived_does_not_resolve(ident, tree):
+    # An excluded (_archive) skill must NOT resolve.
+    r = ident.normalize_skill_id("ghost", tree)
+    assert r["skill_name"] == ""
+    assert r["skill_source"] == "unresolved"
+    assert r["skill_id"] == "ghost"
+
+
+def test_normalize_empty_id(ident, tree):
+    r = ident.normalize_skill_id("", tree)
+    assert r["skill_name"] == ""
+    assert r["skill_source"] == "unresolved"
+    assert r["skill_id"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# session-logger.sh Skill-tool emit
+# --------------------------------------------------------------------------- #
+def _make_repo(tmp_path: Path) -> Path:
+    """A throwaway repo with the hook + a synthetic skills tree."""
+    repo = tmp_path / "repo-under-test"
+    (repo / ".claude" / "hooks").mkdir(parents=True)
+    shutil.copy2(SCRIPT, repo / ".claude" / "hooks" / "session-logger.sh")
+    (repo / "scripts" / "ai").mkdir(parents=True)
+    (repo / "scripts" / "ai" / "session-params.py").write_text("print('')\n", encoding="utf-8")
+    (repo / ".git").mkdir()
+    # synthetic skills tree
+    for rel, name in [
+        ("workspace-hub/repo-sync", "repo-sync"),
+        ("corporate-tax-form-fill", "corporate-tax-form-fill"),
+    ]:
+        d = repo / ".claude" / "skills" / rel
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+    return repo
+
+
+def _run_hook(repo: Path, payload: dict) -> list[dict]:
+    env = os.environ.copy()
+    env["WORKSPACE_HUB"] = str(repo)
+    env["CLAUDE_SESSION_LOGGING"] = "true"
+    script_path = repo / ".claude" / "hooks" / "session-logger.sh"
+    result = subprocess.run(
+        ["bash", str(script_path), "post"],
+        cwd=repo,
+        env=env,
+        input=json.dumps(payload) + "\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    day = datetime.now().strftime("%Y%m%d")
+    state_log = repo / ".claude" / "state" / "sessions" / f"session_{day}.jsonl"
+    assert state_log.exists()
+    return [
+        json.loads(line)
+        for line in state_log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_emit_field_is_skill_resolved(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(
+        repo, {"session_id": "s1", "tool_name": "Skill", "tool_input": {"skill": "repo-sync"}}
+    )
+    e = next(x for x in entries if x.get("tool") == "Skill")
+    assert e["skill_id"] == "repo-sync"
+    assert e["skill_name"] == "repo-sync"
+    assert e["skill_source"] == "workspace-hub"
+
+
+def test_emit_namespaced_workspace_hub(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(
+        repo,
+        {"tool_name": "Skill", "tool_input": {"skill": "workspace-hub:repo-sync"}},
+    )
+    e = next(x for x in entries if x.get("tool") == "Skill")
+    assert e["skill_id"] == "workspace-hub:repo-sync"
+    assert e["skill_name"] == "repo-sync"
+    assert e["skill_source"] == "workspace-hub"
+
+
+def test_emit_plugin_recorded_not_dropped(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(
+        repo, {"tool_name": "Skill", "tool_input": {"skill": "codex:rescue"}}
+    )
+    e = next(x for x in entries if x.get("tool") == "Skill")
+    # plugin id is logged + flagged, raw id preserved, no fabricated skill_name.
+    assert e["skill_id"] == "codex:rescue"
+    assert e.get("skill_name", "") == ""
+    assert e["skill_source"] == "plugin"
+
+
+def test_emit_defensive_fallback_skill_name(tmp_path: Path) -> None:
+    # If a future harness puts the id under .tool_input.skill_name, fall back.
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(
+        repo, {"tool_name": "Skill", "tool_input": {"skill_name": "repo-sync"}}
+    )
+    e = next(x for x in entries if x.get("tool") == "Skill")
+    assert e["skill_id"] == "repo-sync"
+    assert e["skill_source"] == "workspace-hub"
+
+
+def test_emit_no_skill_field_safe(tmp_path: Path) -> None:
+    # Missing both fields: no crash, no skill_name/skill_id emitted.
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(repo, {"tool_name": "Skill", "tool_input": {}})
+    e = next(x for x in entries if x.get("tool") == "Skill")
+    assert "skill_name" not in e
+    assert "skill_id" not in e
+
+
+def test_non_skill_non_read_emits_no_skill_name(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    entries = _run_hook(
+        repo,
+        {"tool_name": "Bash", "tool_input": {"command": "git status"}},
+    )
+    e = next(x for x in entries if x.get("tool") == "Bash")
+    assert "skill_name" not in e
+    assert "skill_id" not in e
+    assert "skill_source" not in e
+
+
+def test_read_of_skill_md_still_emits_relpath(tmp_path: Path) -> None:
+    # Regression: the #3112 Read-of-SKILL.md path must still emit a rel-path
+    # skill_name (and must NOT emit skill_id/skill_source — that's Skill-only).
+    repo = _make_repo(tmp_path)
+    fp = str(repo / ".claude" / "skills" / "workspace-hub" / "repo-sync" / "SKILL.md")
+    entries = _run_hook(
+        repo, {"tool_name": "Read", "tool_input": {"file_path": fp}}
+    )
+    e = next(x for x in entries if x.get("tool") == "Read")
+    assert e["skill_name"] == "workspace-hub/repo-sync"
+    assert "skill_id" not in e
+    assert "skill_source" not in e


### PR DESCRIPTION
Implements #3137 (approved). Captures Skill-tool invocations into the skill-usage signal. TDD-first. Builds on #3112 + #3139 (merged).

## Change
- `_skill_identity.py`: new `normalize_skill_id(raw_id, skills_root)` — resolves `<plugin>:<name>` / bare ids to the canonical short_name when the skill exists in `.claude/skills/`; otherwise records-and-flags (preserves raw id, marks plugin/unresolved) — never fabricates or silently drops.
- `session-logger.sh`: emits skill_name for Skill-tool calls, reading **`.tool_input.skill`** (empirically confirmed 267/267 live; `.skill_name` defensive fallback) with basename resolution against the tree. Read-of-SKILL.md path (#3112) unchanged.
- `settings.json`: surgically adds `Skill` to the session-logger PostToolUse matcher only.

## Tests (TDD): `tests/skills/test_skill_tool_capture.py` — 15 tests (normalize_skill_id plugin/bare/unresolved + hook emit/regression). RED-first confirmed; existing session-logger + join-chain tests pass.

## Caveat (honest)
Live `PostToolUse` firing for the `Skill` tool is **runtime-unverifiable from a headless session** — the unit/integration logic is fully tested against synthetic payloads, but confirming the harness actually fires the hook needs a live session that invokes a skill then inspects `.claude/state/sessions/`. Matcher is added; field is confirmed; risk is low but flagged.

Epic #3058. Plan: `docs/plans/2026-06-15-issue-3137-skill-tool-capture.md`. Pushed with audited GIT_PRE_PUSH_SKIP (blocker = pre-existing assetutilities ruff debt, unrelated).
