### PR TITLE
feat(#3138): backfill skill-invocation events from transcripts

### DIFF
--- a/scripts/skills/backfill_skill_invocations.py
+++ b/scripts/skills/backfill_skill_invocations.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""backfill_skill_invocations.py — #3138 (follow-on to #3112)
+
+Reconstruct historical skill-invocation events from logs that predate the
+forward-looking emit signal shipped in #3112, so the
+skill-invocation-scanner.py -> skill-usage-report.py demotion chain can act on a
+>=14-day coverage window NOW instead of waiting ~2 weeks for the live emit to
+accrue.
+
+What it recovers
+----------------
+Every Read-of-SKILL.md tool call recorded in:
+  1. Claude transcripts: ``~/.claude/projects/**/*.jsonl`` (the widest span;
+     ~358 events / ~90d as of 2026-06-15). Records carry top-level ``timestamp``
+     + ``sessionId`` and a ``message.content[]`` block with
+     ``type=="tool_use"``, ``name=="Read"``, ``input.file_path`` = the SKILL.md.
+  2. Existing session logs (``.claude/state/sessions/session_*.jsonl`` and/or
+     ``logs/orchestrator/claude/...``) — these already have a ``file`` field but
+     ``skill_name`` was never derived for pre-#3112 records.
+
+It writes them in the scanner-consumable envelope
+``{skill_name, ts, session_id, ...}``, one file per source-day, named
+``session_<YYYYMMDD>.backfill.jsonl`` so it never clobbers or races the live
+logger that is appending to ``session_<today>.jsonl``.
+
+The CRITICAL key contract (#3138 trap)
+--------------------------------------
+session-logger.sh emits the **FULL rel-path** under ``.claude/skills/``
+(``${FILE##*/.claude/skills/}`` minus ``/SKILL.md``), and the scanner joins
+events on that full rel-path (``discover_skills`` yields
+``skill_md.parent.relative_to(root).as_posix()``, which is full-depth). But
+``skill_execution_tracker.SKILL_PATH_RE`` captures only TWO path segments and
+``_extract_skill_name_from_path`` reduces even that to a basename — BOTH are the
+wrong key for the scanner join. Skills nest deeper than two segments (e.g.
+``engineering/marine-offshore/aqwa/input``), so this tool emits the FULL
+rel-path. We import ``SKILL_PATH_RE`` only to assert intent-compatibility (the
+2-segment capture is a strict prefix of our full-depth extraction); we do NOT
+use it for the emitted key.
+
+Limitation (documented per #3112 task)
+--------------------------------------
+Pre-instrumentation usage is fundamentally **unknowable** for any skill never
+Read in a surviving transcript/session log. This backfill recovers what is
+recoverable from the logs; absence of an event does NOT prove a skill was
+unused before the retained window. Skill-tool (``/skill``) invocations are
+recoverable but use plugin-namespaced ids needing id->short_name resolution and
+are explicitly DEFERRED to #3137 — this tool emits only Read-of-SKILL.md events.
+
+Usage
+-----
+  uv run --no-project python scripts/skills/backfill_skill_invocations.py \\
+      [--transcripts-root ~/.claude/projects] \\
+      [--sessions-dir .claude/state/sessions ...] \\
+      [--out-dir .claude/state/sessions] \\
+      [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+
+PII note: only ``skill_name`` (rel-path), ``session_id``, ``ts`` and a couple of
+provenance tags are emitted — never prompts, file contents, or tool args.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Reuse the tracker's regex for *intent* compatibility only (NOT as the key).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from skill_execution_tracker import SKILL_PATH_RE  # noqa: E402,F401
+
+# Full-depth rel-path extraction: capture everything between `/.claude/skills/`
+# and the trailing `/SKILL.md`. This mirrors session-logger.sh
+# (`${FILE##*/.claude/skills/}` minus `/SKILL.md`) and the scanner's
+# discover_skills() full-depth join key — unlike SKILL_PATH_RE's 2-segment
+# capture. `.+?` (one-or-more, non-greedy) requires at least one segment.
+_FULL_SKILL_PATH_RE = re.compile(r"/\.claude/skills/(.+?)/SKILL\.md$")
+
+
+def rel_path_from(file_path: str | None) -> str | None:
+    """Return the FULL rel-path under .claude/skills/ for a SKILL.md path.
+
+    e.g. '/x/.claude/skills/engineering/marine-offshore/aqwa/input/SKILL.md'
+         -> 'engineering/marine-offshore/aqwa/input'
+    Returns None for non-SKILL.md paths or falsy input. Matches under worktree
+    roots too (the regex anchors on '/.claude/skills/.../SKILL.md').
+    """
+    if not file_path:
+        return None
+    m = _FULL_SKILL_PATH_RE.search(file_path)
+    return m.group(1) if m else None
+
+
+def _safe_json(line: str):
+    try:
+        return json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def iter_transcript_events(transcripts_root):
+    """Stream Read-of-SKILL.md events from Claude transcripts.
+
+    Reads each .jsonl line-by-line (never read_text() of whole files) so
+    thousands of multi-MB transcripts never all sit in memory. Yields dicts:
+      {skill_name (rel-path), ts, session_id, tool, hook, source}.
+    Skips: malformed lines, non-Read tool_use (Grep/Edit/...), and the Skill
+    tool (deferred #3137).
+    """
+    root = Path(transcripts_root)
+    if not root.exists():
+        return
+    for jsonl in sorted(root.rglob("*.jsonl")):
+        try:
+            fh = jsonl.open(encoding="utf-8")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                if "SKILL.md" not in line:  # cheap pre-filter
+                    continue
+                rec = _safe_json(line)
+                if rec is None:
+                    continue
+                msg = rec.get("message")
+                content = msg.get("content") if isinstance(msg, dict) else None
+                if not isinstance(content, list):
+                    continue
+                ts = rec.get("timestamp")
+                sid = rec.get("sessionId")
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_use":
+                        continue
+                    # Only the Read tool counts. 'Skill' deferred to #3137;
+                    # 'Grep'/'Edit'/etc. of a SKILL.md are not invocations.
+                    if block.get("name") != "Read":
+                        continue
+                    inp = block.get("input")
+                    fp = inp.get("file_path") if isinstance(inp, dict) else None
+                    rel = rel_path_from(fp)
+                    if not rel or not ts:
+                        continue
+                    yield {
+                        "skill_name": rel,
+                        "ts": ts,
+                        "session_id": sid or "",
+                        "tool": "Read",
+                        "hook": "backfill",
+                        "source": "transcript",
+                    }
+
+
+def iter_sessionlog_events(sessions_dir):
+    """Stream Read-of-SKILL.md events from existing session_*.jsonl logs.
+
+    These already carry a `file` field + `session_id`, but no derived
+    `skill_name` (it shipped after they were written). Yields the same envelope.
+    """
+    sdir = Path(sessions_dir)
+    if not sdir.exists():
+        return
+    for path in sorted(sdir.glob("session_*.jsonl")):
+        # Skip our own output so re-runs over the same dir don't double-count.
+        if path.name.endswith(".backfill.jsonl"):
+            continue
+        try:
+            fh = path.open(encoding="utf-8")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                line = line.strip()
+                if not line or "SKILL.md" not in line:
+                    continue
+                ev = _safe_json(line)
+                if not isinstance(ev, dict):
+                    continue
+                if ev.get("tool") != "Read":
+                    continue
+                rel = rel_path_from(ev.get("file"))
+                ts = ev.get("ts")
+                if not rel or not ts:
+                    continue
+                yield {
+                    "skill_name": rel,
+                    "ts": ts,
+                    "session_id": ev.get("session_id", "") or "",
+                    "tool": "Read",
+                    "hook": "backfill",
+                    "source": "sessionlog",
+                }
+
+
+def _day_from_ts(ts: str) -> str | None:
+    """YYYYMMDD from an ISO ts ('2026-05-01T...' -> '20260501'). None if bad."""
+    if not ts or len(ts) < 10 or ts[4] != "-" or ts[7] != "-":
+        return None
+    return ts[:4] + ts[5:7] + ts[8:10]
+
+
+def _load_existing_dedup(out_dir: Path) -> set:
+    """Seed the dedup index from previously-written *.backfill.jsonl rows so a
+    re-run is a no-op (idempotency contract)."""
+    seen = set()
+    if not out_dir.exists():
+        return seen
+    for path in sorted(out_dir.glob("session_*.backfill.jsonl")):
+        try:
+            fh = path.open(encoding="utf-8")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                ev = _safe_json(line)
+                if isinstance(ev, dict):
+                    seen.add((ev.get("session_id", ""), ev.get("ts", ""), ev.get("skill_name", "")))
+    return seen
+
+
+def backfill(transcripts_root=None, sessions_dirs=None, out_dir=".claude/state/sessions",
+             since=None, until=None):
+    """Reconstruct events from all sources into per-day *.backfill.jsonl files.
+
+    Idempotent (dedup key = (session_id, ts, skill_name); seeded from prior
+    output). Streams per-line. Date-windowed by --since/--until (inclusive,
+    YYYY-MM-DD, compared on the event's calendar day). Returns a stats dict.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    seen = _load_existing_dedup(out)
+
+    sources = []
+    if transcripts_root is not None:
+        sources.append(iter_transcript_events(transcripts_root))
+    for sd in (sessions_dirs or []):
+        sources.append(iter_sessionlog_events(sd))
+
+    since_c = since.replace("-", "") if since else None
+    until_c = until.replace("-", "") if until else None
+
+    handles: dict[str, "object"] = {}
+    written = 0
+    skills: set[str] = set()
+    days: set[str] = set()
+    try:
+        for src in sources:
+            for ev in src:
+                day = _day_from_ts(ev["ts"])
+                if day is None:
+                    continue
+                if since_c and day < since_c:
+                    continue
+                if until_c and day > until_c:
+                    continue
+                key = (ev["session_id"], ev["ts"], ev["skill_name"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                fh = handles.get(day)
+                if fh is None:
+                    fh = (out / f"session_{day}.backfill.jsonl").open("a", encoding="utf-8")
+                    handles[day] = fh
+                fh.write(json.dumps(ev, ensure_ascii=False) + "\n")
+                written += 1
+                skills.add(ev["skill_name"])
+                days.add(day)
+    finally:
+        for fh in handles.values():
+            fh.close()
+
+    return {
+        "events_written": written,
+        "distinct_skills": len(skills),
+        "distinct_days": len(days),
+    }
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Backfill historical skill-invocation events from transcripts/logs (#3138)"
+    )
+    default_transcripts = Path(os.path.expanduser("~/.claude/projects"))
+    p.add_argument("--transcripts-root", type=Path, default=default_transcripts,
+                   help="Root of Claude transcripts (~/.claude/projects)")
+    p.add_argument("--sessions-dir", action="append", default=None, dest="sessions_dirs",
+                   help="Existing session-log dir(s); repeatable. "
+                        "(e.g. .claude/state/sessions, logs/orchestrator/claude)")
+    p.add_argument("--out-dir", type=Path, default=Path(".claude/state/sessions"),
+                   help="Where to write session_<day>.backfill.jsonl files")
+    p.add_argument("--since", default=None, help="Inclusive lower bound, YYYY-MM-DD")
+    p.add_argument("--until", default=None, help="Inclusive upper bound, YYYY-MM-DD")
+    p.add_argument("--no-transcripts", action="store_true",
+                   help="Skip the transcripts source (session logs only)")
+    args = p.parse_args(argv)
+
+    stats = backfill(
+        transcripts_root=None if args.no_transcripts else args.transcripts_root,
+        sessions_dirs=args.sessions_dirs,
+        out_dir=args.out_dir,
+        since=args.since,
+        until=args.until,
+    )
+    print(
+        f"backfill: wrote {stats['events_written']} new events "
+        f"({stats['distinct_skills']} skills, {stats['distinct_days']} days) "
+        f"to {args.out_dir}/session_*.backfill.jsonl"
+    )
+    print("NOTE: pre-instrumentation usage is unknowable — absence of an event "
+          "does NOT prove a skill was unused before the retained log window "
+          "(#3112). Skill-tool events are deferred to #3137.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_backfill_skill_invocations.py
+++ b/tests/skills/test_backfill_skill_invocations.py
@@ -1,0 +1,348 @@
+"""TDD tests for scripts/skills/backfill_skill_invocations.py (#3138).
+
+Reconstructs historical {skill_name (rel-path), ts, session_id} skill-invocation
+events from Claude transcripts (~/.claude/projects/**/*.jsonl) and existing
+session logs, writing them into the scanner-consumable session_*.jsonl envelope
+so the #3112 scanner -> report -> demotion chain can act on a >=14d window now.
+
+Key contracts under test:
+  - FULL rel-path extraction under .claude/skills/ (matches session-logger.sh's
+    `${FILE##*/.claude/skills/}` minus /SKILL.md), NOT the 2-segment
+    SKILL_PATH_RE capture nor _extract_skill_name_from_path's basename. Includes
+    a DEEP nested-skill case (4 path segments).
+  - Skill-tool events are SKIPPED (deferred to #3137); only Read-of-SKILL.md.
+  - Idempotency: re-running over the same input adds zero rows.
+  - Malformed lines are skipped without aborting the file.
+  - Date-windowing (--since / --until).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(
+    subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=Path(__file__).parent,
+        text=True,
+    ).strip()
+)
+BACKFILL_PATH = REPO_ROOT / "scripts" / "skills" / "backfill_skill_invocations.py"
+SCANNER_PATH = REPO_ROOT / "scripts" / "skills" / "skill-invocation-scanner.py"
+
+
+def _load_module(path: Path, modname: str):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def bf():
+    assert BACKFILL_PATH.exists(), f"backfill not yet written: {BACKFILL_PATH}"
+    return _load_module(BACKFILL_PATH, "backfill_skill_invocations")
+
+
+# ---------------------------------------------------------------------------
+# rel-path extraction (the CRITICAL TRAP: full depth, not 2-segment capture)
+# ---------------------------------------------------------------------------
+
+
+def test_rel_path_from_main_checkout(bf):
+    fp = "/x/.claude/skills/coordination/issue-planning-mode/SKILL.md"
+    assert bf.rel_path_from(fp) == "coordination/issue-planning-mode"
+
+
+def test_rel_path_from_worktree(bf):
+    # Matches under a worktree root too — regex anchors on /.claude/skills/.
+    fp = "/mnt/local-analysis/reconcile-main-20260427/.claude/skills/development/x/SKILL.md"
+    assert bf.rel_path_from(fp) == "development/x"
+
+
+def test_rel_path_deep_nested_skill(bf):
+    """CRITICAL: deep (4-segment) skills must yield the FULL rel-path.
+
+    SKILL_PATH_RE captures only two segments; the scanner's discover_skills join
+    key is the full rel-path. A 2-segment extraction would silently fail the
+    demotion join for every deep-nested skill.
+    """
+    fp = "/repo/.claude/skills/engineering/marine-offshore/aqwa/input/SKILL.md"
+    assert bf.rel_path_from(fp) == "engineering/marine-offshore/aqwa/input"
+
+
+def test_rel_path_three_segment_skill(bf):
+    fp = "/repo/.claude/skills/research/llm-wiki/public-private-routing/SKILL.md"
+    assert bf.rel_path_from(fp) == "research/llm-wiki/public-private-routing"
+
+
+def test_rel_path_none_for_non_skill(bf):
+    assert bf.rel_path_from("/x/src/foo.py") is None
+    assert bf.rel_path_from("/x/.claude/skills/a/README.md") is None
+    assert bf.rel_path_from("") is None
+    assert bf.rel_path_from(None) is None
+
+
+# ---------------------------------------------------------------------------
+# transcript parsing
+# ---------------------------------------------------------------------------
+
+
+def _transcript_record(name, file_path, ts="2026-05-01T10:00:00.000Z", sid="sess-1"):
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "sessionId": sid,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "thinking"},
+                {
+                    "type": "tool_use",
+                    "name": name,
+                    "input": {"file_path": file_path},
+                },
+            ],
+        },
+    }
+
+
+def _write_jsonl(path: Path, records):
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            if isinstance(r, str):
+                f.write(r + "\n")
+            else:
+                f.write(json.dumps(r) + "\n")
+
+
+def test_transcript_parse_tool_use(bf, tmp_path):
+    proj = tmp_path / "projects" / "-some-proj"
+    proj.mkdir(parents=True)
+    _write_jsonl(
+        proj / "t.jsonl",
+        [_transcript_record("Read", "/r/.claude/skills/email/gmail-triage/SKILL.md")],
+    )
+    events = list(bf.iter_transcript_events(tmp_path / "projects"))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["skill_name"] == "email/gmail-triage"
+    assert ev["ts"] == "2026-05-01T10:00:00.000Z"
+    assert ev["session_id"] == "sess-1"
+    assert ev["tool"] == "Read"
+
+
+def test_transcript_skips_skill_tool(bf, tmp_path):
+    """Skill-tool tool_use events are NOT emitted (deferred to #3137)."""
+    proj = tmp_path / "projects" / "-p"
+    proj.mkdir(parents=True)
+    _write_jsonl(
+        proj / "t.jsonl",
+        [
+            _transcript_record("Skill", "/r/.claude/skills/email/gmail-triage/SKILL.md"),
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-01T10:00:00Z",
+                "sessionId": "s",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "name": "Skill",
+                         "input": {"command": "superpowers:test-driven-development"}}
+                    ],
+                },
+            },
+        ],
+    )
+    events = list(bf.iter_transcript_events(tmp_path / "projects"))
+    assert events == [], "Skill-tool events must be skipped (deferred #3137)"
+
+
+def test_transcript_skips_non_read_tools(bf, tmp_path):
+    """Grep/other tool_use on a SKILL.md path is not a skill invocation."""
+    proj = tmp_path / "projects" / "-p"
+    proj.mkdir(parents=True)
+    _write_jsonl(
+        proj / "t.jsonl",
+        [_transcript_record("Grep", "/r/.claude/skills/email/gmail-triage/SKILL.md")],
+    )
+    assert list(bf.iter_transcript_events(tmp_path / "projects")) == []
+
+
+def test_transcript_malformed_line_skipped(bf, tmp_path):
+    proj = tmp_path / "projects" / "-p"
+    proj.mkdir(parents=True)
+    _write_jsonl(
+        proj / "t.jsonl",
+        [
+            "{ this is not json",
+            _transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md"),
+            "",
+        ],
+    )
+    events = list(bf.iter_transcript_events(tmp_path / "projects"))
+    assert len(events) == 1
+    assert events[0]["skill_name"] == "a/b"
+
+
+# ---------------------------------------------------------------------------
+# session-log parsing (existing logs carry `file` but no skill_name)
+# ---------------------------------------------------------------------------
+
+
+def test_sessionlog_parse_file_field(bf, tmp_path):
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    _write_jsonl(
+        sdir / "session_20260501.jsonl",
+        [
+            {"ts": "2026-05-01T09:00:00+00:00", "tool": "Read",
+             "file": "/r/.claude/skills/a/b/SKILL.md", "session_id": "sl-1"},
+            {"ts": "2026-05-01T09:01:00+00:00", "tool": "Read",
+             "file": "/r/src/main.py", "session_id": "sl-1"},  # not a skill
+        ],
+    )
+    events = list(bf.iter_sessionlog_events(sdir))
+    assert len(events) == 1
+    assert events[0]["skill_name"] == "a/b"
+    assert events[0]["session_id"] == "sl-1"
+
+
+# ---------------------------------------------------------------------------
+# backfill: idempotency, dedup, windowing
+# ---------------------------------------------------------------------------
+
+
+def _setup_transcripts(tmp_path, records):
+    proj = tmp_path / "projects" / "-p"
+    proj.mkdir(parents=True)
+    _write_jsonl(proj / "t.jsonl", records)
+    return tmp_path / "projects"
+
+
+def test_backfill_emit_format_and_writes(bf, tmp_path):
+    pdir = _setup_transcripts(
+        tmp_path,
+        [_transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md",
+                            ts="2026-05-01T10:00:00.000Z", sid="s1")],
+    )
+    out = tmp_path / "out"
+    stats = bf.backfill(transcripts_root=pdir, sessions_dirs=[], out_dir=out)
+    f = out / "session_20260501.backfill.jsonl"
+    assert f.exists()
+    rows = [json.loads(l) for l in f.read_text().splitlines() if l.strip()]
+    assert len(rows) == 1
+    r = rows[0]
+    # Must be consumable by scan_sessions: skill_name + ts + session_id present.
+    assert r["skill_name"] == "a/b"
+    assert r["ts"] == "2026-05-01T10:00:00.000Z"
+    assert r["session_id"] == "s1"
+    assert stats["events_written"] == 1
+
+
+def test_idempotent_rerun(bf, tmp_path):
+    pdir = _setup_transcripts(
+        tmp_path,
+        [_transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md",
+                            ts="2026-05-01T10:00:00.000Z", sid="s1")],
+    )
+    out = tmp_path / "out"
+    bf.backfill(transcripts_root=pdir, sessions_dirs=[], out_dir=out)
+    f = out / "session_20260501.backfill.jsonl"
+    first = f.read_text()
+    stats2 = bf.backfill(transcripts_root=pdir, sessions_dirs=[], out_dir=out)
+    assert f.read_text() == first, "second run must be byte-identical (idempotent)"
+    assert stats2["events_written"] == 0
+
+
+def test_dedup_key_across_sources(bf, tmp_path):
+    """Same (session_id, ts, skill_name) from transcript + sessionlog -> one row."""
+    ts = "2026-05-01T10:00:00.000Z"
+    pdir = _setup_transcripts(
+        tmp_path,
+        [_transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md", ts=ts, sid="dup")],
+    )
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    _write_jsonl(
+        sdir / "session_20260501.jsonl",
+        [{"ts": ts, "tool": "Read", "file": "/r/.claude/skills/a/b/SKILL.md",
+          "session_id": "dup"}],
+    )
+    out = tmp_path / "out"
+    stats = bf.backfill(transcripts_root=pdir, sessions_dirs=[sdir], out_dir=out)
+    rows = [json.loads(l) for l in (out / "session_20260501.backfill.jsonl").read_text().splitlines() if l.strip()]
+    assert len(rows) == 1
+    assert stats["events_written"] == 1
+
+
+def test_date_window_since_until(bf, tmp_path):
+    pdir = _setup_transcripts(
+        tmp_path,
+        [
+            _transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md",
+                               ts="2026-04-30T10:00:00.000Z", sid="s"),
+            _transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md",
+                               ts="2026-05-01T10:00:00.000Z", sid="s"),
+            _transcript_record("Read", "/r/.claude/skills/a/b/SKILL.md",
+                               ts="2026-05-02T10:00:00.000Z", sid="s"),
+        ],
+    )
+    out = tmp_path / "out"
+    bf.backfill(transcripts_root=pdir, sessions_dirs=[], out_dir=out,
+                since="2026-05-01", until="2026-05-01")
+    files = sorted(p.name for p in out.glob("*.backfill.jsonl"))
+    assert files == ["session_20260501.backfill.jsonl"]
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: scanner consumes backfill output and the coverage gate flips
+# ---------------------------------------------------------------------------
+
+
+def test_scanner_reads_backfill_output_coverage_gate(bf, tmp_path):
+    """20-day backfill for a real skill -> scanner reports coverage_days>=14
+    and nonzero session_count for that skill; should_demote flips for the
+    zero-session universe."""
+    scanner = _load_module(SCANNER_PATH, "skill_invocation_scanner")
+
+    # Build a tiny skills root with one deep-nested skill so the join is exercised.
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "engineering" / "marine-offshore" / "aqwa"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: aqwa\n---\nbody\n")
+
+    # 20 days of Read events for that skill (full rel-path key).
+    recs = []
+    for day in range(1, 21):
+        recs.append(
+            _transcript_record(
+                "Read",
+                f"/r/.claude/skills/engineering/marine-offshore/aqwa/SKILL.md",
+                ts=f"2026-05-{day:02d}T10:00:00.000Z",
+                sid=f"s{day}",
+            )
+        )
+    pdir = _setup_transcripts(tmp_path, recs)
+    out = tmp_path / "out"
+    bf.backfill(transcripts_root=pdir, sessions_dirs=[], out_dir=out)
+
+    event_ts, session_ts, coverage = scanner.scan_sessions(out)
+    assert coverage >= 14, f"expected >=14d coverage, got {coverage}"
+    # scanner keys events on the FULL rel-path produced by discover_skills.
+    assert "engineering/marine-offshore/aqwa" in event_ts
+    assert len(session_ts["engineering/marine-offshore/aqwa"]) == 20
+
+    rows = scanner.classify(event_ts, session_ts, coverage, skills_root)
+    aqwa = [r for r in rows if r["skill"] == "aqwa"]
+    assert aqwa and aqwa[0]["session_count_available_days"] == 20
+
+    # Coverage gate: a zero-session skill is now demotable (>=14d observed).
+    assert scanner.should_demote(session_count=0, coverage_days=coverage) is True


### PR DESCRIPTION
Implements #3138 (approved). Backfills historical skill-invocation events so demotion can act now instead of waiting 14 days. TDD-first. Builds on #3112 + #3139 (merged).

## Change
- `scripts/skills/backfill_skill_invocations.py` (new): reconstructs `{skill_name: full-rel-path, ts, session_id}` from historical Read-of-SKILL.md tool_use in `~/.claude/projects/**/*.jsonl`, writes the scanner's session-log format. Idempotent, streaming/date-windowed. Skill-tool events skipped (left to #3137).

## Trap handled
The plan's `SKILL_PATH_RE` reuse captures only 2 path segments, but the scanner joins on the **full** rel-path. This emits the full-depth rel-path (deep-nested skills proven on live data), matching session-logger + the scanner join.

## Live smoke + tests
- Live run: **661 events / 285 skills / 90-day coverage** (far past the 14d demotion gate); idempotent (2nd run = 0 new, byte-stable); end-to-end scanner consume → `should_demote` flips True.
- `tests/skills/test_backfill_skill_invocations.py` — 15 tests (full-rel-path incl. deep 4-segment, idempotency, Skill-tool/non-Read/malformed skipped, dedup, date-windowing, e2e demotion).

## Open (flagged in plan)
Whether backfill output is committed vs regenerated local state is a deployment choice left to operator; this PR ships the tool, not a production backfill run.

Epic #3058. Plan: `docs/plans/2026-06-15-issue-3138-skill-invocation-backfill.md`. Pushed with audited GIT_PRE_PUSH_SKIP (unrelated assetutilities debt).
