### PR TITLE
PII #3098 (CTA-B): externalize sibling-repo list in git scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -575,3 +575,6 @@ config/.client-wikis.local.yml
 # Stray inspection/staging scratch dirs (#3098) — never track
 .tmp-inspect-*/
 .tmp-*/
+
+# PII #3098: sibling-repo list (carries client repo names) — per-host, never track
+config/.sibling-repos.local

--- a/scripts/coordination/git/batch_commit_all.sh
+++ b/scripts/coordination/git/batch_commit_all.sh
@@ -46,8 +46,18 @@ commit_repo() {
 export -f commit_repo
 export GREEN YELLOW RED BLUE NC
 
-# Get all repos with changes
-repos_with_changes="aceengineer-admin aceengineercode aceengineer-website achantas-data achantas-media acma-projects ai-native-traditional-eng assetutilities client_projects digitalmodel doris energy frontierdeepwater hobbies investments pyproject-starter rock-oil-field sabithaandkrishnaestates saipem sd-work seanation teamresumes worldenergydata"
+# Get all repos. The sibling-repo list carried client repo names (#3098), so it
+# is no longer hardcoded here. Resolution order:
+#   1) $SIBLING_REPOS_FILE or workspace-hub/config/.sibling-repos.local (gitignored,
+#      provisioned per host — one repo per line or space-separated)
+#   2) dynamic discovery of sibling git repos under the current parent dir
+_wh_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+_repos_file="${SIBLING_REPOS_FILE:-$_wh_root/config/.sibling-repos.local}"
+if [[ -f "$_repos_file" ]]; then
+    repos_with_changes="$(tr '\n' ' ' < "$_repos_file")"
+else
+    repos_with_changes="$(find . -maxdepth 2 -type d -name .git 2>/dev/null | sed 's|/.git$||; s|^\./||' | sort | tr '\n' ' ')"
+fi
 
 # Process in parallel (max 5 at a time to avoid overwhelming git)
 echo "$repos_with_changes" | tr ' ' '\n' | xargs -I {} -P 5 bash -c 'commit_repo "$@"' _ {}

--- a/scripts/coordination/git/commit_and_sync_all.sh
+++ b/scripts/coordination/git/commit_and_sync_all.sh
@@ -72,8 +72,10 @@ export RED GREEN YELLOW BLUE CYAN NC
 
 echo -e "${BLUE}Step 1: Handling repositories with uncommitted changes${NC}\n"
 
-# Process repos with uncommitted changes in parallel
-echo -e "assethold\nworldenergydata\nsaipem" | xargs -I {} -P 3 bash -c 'commit_and_push "$@"' _ {}
+# Process a couple of priority repos first (the rest are handled by the dynamic
+# Step-2 pass below, so any repo omitted here is still covered). Client repo names
+# removed from this public list (#3098); they remain covered by the Step-2 sweep.
+echo -e "assethold\nworldenergydata" | xargs -I {} -P 3 bash -c 'commit_and_push "$@"' _ {}
 
 echo -e "${BLUE}Step 2: Checking all repositories for any remaining changes${NC}\n"
 


### PR DESCRIPTION
Removes hardcoded client repo names from `batch_commit_all.sh` (→ sources gitignored `config/.sibling-repos.local` with dynamic-discovery fallback) and `commit_and_sync_all.sh` (dropped a client repo from the priority list; still covered by the dynamic sweep). **Commit/push logic unchanged — only list-acquisition** (verifiable in isolation; syntax + guard clean). Establishes the externalization pattern for the remaining CTA-B scripts. Part of #3098.