### PR TITLE
fix(legal): scrub closeout-sweep client-PII residuals (#3098)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -578,3 +578,11 @@ config/.client-wikis.local.yml
 
 # PII #3098: sibling-repo list (carries client repo names) — per-host, never track
 config/.sibling-repos.local
+
+# PII #3095/#3098: per-host private provision files for dev-ops scripts that would
+# otherwise hardcode client repo names / maps / routing tables / VIP domains.
+# These carry client identifiers, so they are gitignored and provisioned per host
+# from the private aceengineer-strategy archive. The committed *.local.example
+# templates (PII-free) document each format. Covers .vip-domains.local,
+# .branch-cleanup.local, .windows-repos.local, .repo-types.local, .ace-routes.local, …
+config/.*.local

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -267,7 +267,7 @@ Domain-specific security issues beyond general web security.
 
 | Mistake | Risk | Prevention |
 |---------|------|------------|
-| Hardcoded license server credentials in scripts | Credential exposure in git history | Environment variables for all credentials. The WRK-121 audit found plaintext passwords in `acma_vpn.md` -- do not repeat this pattern. |
+| Hardcoded license server credentials in scripts | Credential exposure in git history | Environment variables for all credentials. The WRK-121 audit found plaintext passwords in `mkt-a_vpn.md` -- do not repeat this pattern. |
 | HTML reports with unescaped user strings | XSS in shared reports (vessel names, analyst names, project IDs can contain malicious content) | The WRK-129 spec mandates `_escape()` helper wrapping `html.escape()` for ALL user-supplied strings. 6+ field-specific escaping tests required. Already specified -- enforce it. |
 | OrcaWave .owd files containing proprietary client data | Client data leakage if example files are committed to public repo | Keep client data in private repos only. Example/benchmark files use synthetic or published geometries (unit box, standard barge, WAMIT validation cases). |
 | Batch results left on shared licensed machine | Other users accessing confidential analysis results | Automated cleanup: copy results to secure storage, delete from shared machine after batch completion. |

--- a/config/.vip-domains.local.example
+++ b/config/.vip-domains.local.example
@@ -1,0 +1,9 @@
+# Template for config/.vip-domains.local (gitignored). Copy to .vip-domains.local
+# and add the real per-host VIP email domains. A client's corporate email domain
+# is PII (it reveals the engagement), so it lives only here, never in the repo.
+# Format: one entry per line — "domain" or "account:domain".
+#   default account = ace ; known accounts: ace, skestates
+#   '#' starts a comment.
+# Example:
+# exampleclient.com
+# skestates:exampletenant.com

--- a/config/quality/no-abs-paths-baseline.txt
+++ b/config/quality/no-abs-paths-baseline.txt
@@ -138,9 +138,9 @@ scripts/data/doc_intelligence/tests/test_benchmark_pdf_tools.py:127
 scripts/data/doc_intelligence/tests/test_benchmark_pdf_tools.py:21
 scripts/data/doc_intelligence/tests/test_benchmark_pdf_tools.py:22
 scripts/data/document-index/_summary_lookup.py:3
-scripts/data/document-index/acma_wiki_unblock.py:28
-scripts/data/document-index/acma_wiki_unblock.py:34
-scripts/data/document-index/acma_wiki_unblock.py:40
+scripts/data/document-index/mkt_a_wiki_unblock.py:28
+scripts/data/document-index/mkt_a_wiki_unblock.py:34
+scripts/data/document-index/mkt_a_wiki_unblock.py:40
 scripts/data/document-index/build-capability-map.py:38
 scripts/data/document-index/build-index-other-bucket-packs.py:27
 scripts/data/document-index/build-index-other-bucket-packs.py:283
@@ -174,10 +174,10 @@ scripts/data/document-index/remap_og_standards_paths.py:8
 scripts/data/document-index/remap_og_standards_paths.py:9
 scripts/data/document-index/summarise-worker.py:23
 scripts/data/document-index/summarise-worker.py:24
-scripts/data/document-index/tests/test_acma_wiki_unblock.py:35
-scripts/data/document-index/tests/test_acma_wiki_unblock.py:39
-scripts/data/document-index/tests/test_acma_wiki_unblock.py:43
-scripts/data/document-index/tests/test_acma_wiki_unblock.py:69
+scripts/data/document-index/tests/test_mkt_a_wiki_unblock.py:35
+scripts/data/document-index/tests/test_mkt_a_wiki_unblock.py:39
+scripts/data/document-index/tests/test_mkt_a_wiki_unblock.py:43
+scripts/data/document-index/tests/test_mkt_a_wiki_unblock.py:69
 scripts/data/document-index/tests/test_provenance.py:69
 scripts/data/document-index/tests/test_provenance.py:70
 scripts/data/document-index/tests/test_provenance.py:78

--- a/data/document-index/shards/shard-00.json
+++ b/data/document-index/shards/shard-00.json
@@ -79,7 +79,7 @@
     },
     {
       "sha": "sha256:21e680848f9a0f0bd0021c2fa3348b0af34d226b73eef4d58dd4e074d8573125",
-      "path": "/mnt/local-analysis/workspace-hub/specs/repos/mkt-a/B1522/specs/fatigue_analysis/acma_fatigue_assessment_emails.md",
+      "path": "/mnt/local-analysis/workspace-hub/specs/repos/mkt-a/B1522/specs/fatigue_analysis/mkt-a_fatigue_assessment_emails.md",
       "source": "workspace_spec"
     },
     {

--- a/scripts/email/gmail-digest.py
+++ b/scripts/email/gmail-digest.py
@@ -67,14 +67,38 @@ CONTACT_FILES = {
     "skestates": BASE / "sabithaandkrishnaestates/admin/contacts/skestates_contacts.csv",
 }
 
-# VIP domains per account
+# VIP domains per account. Industry-major defaults only; a CLIENT's corporate
+# email domain is PII (it reveals the engagement) so client VIP domains are NOT
+# hardcoded in this public repo (#3095/#3098). Provision them per host in the
+# gitignored config/.vip-domains.local (one "domain" or "account:domain" per
+# line; default account is "ace"; '#' comments allowed). Absent file → only the
+# defaults below are treated as VIP.
 ACE_VIP_DOMAINS = {
-    "ril.com", "dorisgroup.com", "mcdermott.com", "shell.com",
+    "ril.com", "mcdermott.com", "shell.com",
     "kbr.com", "bp.com", "subsea7.com", "technipfmc.com",
 }
 SKESTATES_VIP_DOMAINS = {
     "familydollar.com", "dollartree.com", "marsh.com",
 }
+
+
+def _load_local_vip_domains() -> None:
+    """Merge per-host private VIP domains from the gitignored local file."""
+    sets = {"ace": ACE_VIP_DOMAINS, "skestates": SKESTATES_VIP_DOMAINS}
+    try:
+        lines = (BASE / "config" / ".vip-domains.local").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    for line in lines:
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        account, _, domain = line.rpartition(":")
+        target = sets.get(account or "ace", ACE_VIP_DOMAINS)
+        target.add(domain.strip().lower())
+
+
+_load_local_vip_domains()
 
 # ============================================================
 # CONTACT LOADING

--- a/scripts/readiness/compare-harness-state.sh
+++ b/scripts/readiness/compare-harness-state.sh
@@ -67,7 +67,7 @@ check_ace2() {
 check_ace2
 
 # ── ace-win-1: stale-report detection (>25h) ───────────────────────────
-check_acma() {
+check_ace_win_1() {
   local report="${STATE_DIR}/harness-readiness-ace-win-1.yaml"
   if [[ ! -f "$report" ]]; then
     log_warn "ace-win-1: no report found — Windows Task Scheduler may not have run yet"
@@ -100,7 +100,7 @@ check_acma() {
     fi
   fi
 }
-check_acma
+check_ace_win_1
 
 echo ""
 if [[ "$DEGRADED" -eq 0 ]]; then


### PR DESCRIPTION
Part of epic [#3095](https://github.com/vamseeachanta/workspace-hub/issues/3095) / sub-issue [#3098](https://github.com/vamseeachanta/workspace-hub/issues/3098) closeout. **PII-free by construction** (codenames/generic descriptions only).

> **Please squash-merge** (keeps the final tree; individual commit messages are not promoted to `main`).

## What
Five residual client identifiers surfaced by the repo-wide guard sweep (`scripts/legal/check-client-pii.py --all`) during epic closeout — all **outside** the 14 dev-ops scripts, so not caught by earlier passes:

| File | Residual | Fix |
|---|---|---|
| `.planning/research/PITFALLS.md` | bare client token in a referenced filename | codename-redacted (redactor engine) |
| `data/document-index/shards/shard-00.json` | bare client token in a path leaf | codename-redacted (redactor engine) |
| `scripts/readiness/compare-harness-state.sh` | a client-token function name | renamed `check_ace_win_1()` — the fn checks the **ace-win-1** host report (sibling of `check_ace2`); host-accurate, no ambiguous token |
| `scripts/email/gmail-digest.py` | a client corporate email domain in the VIP set (reveals engagement) | externalized client VIP domains → gitignored `config/.vip-domains.local` (+ loader + PII-free `.example`); industry-major defaults stay inline |
| `config/quality/no-abs-paths-baseline.txt` | 7 stale entries naming a pre-rename filename | refreshed to the current filename (renamed in #3145) |

Also adds a `config/.*.local` **gitignore glob** so all per-host private provision files (this one + the upcoming dev-ops externalizations) are never tracked.

## Verification
- `check-client-pii.py` clean on all 7 changed files.
- `bash -n` (shell), `py_compile` (python), `json.load` (shard) all green.
- The client email domain removed from source, present only in the gitignored local file.
- Baseline diff is exactly 7 lines (surgical rename — not a full regen, which would have pulled in ~400 unrelated abs-path drift lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)