### PR TITLE
fix(legal): externalize client repo lists in bash dev-ops scripts (#3098)

### DIFF
--- a/config/.branch-cleanup.local.example
+++ b/config/.branch-cleanup.local.example
@@ -1,0 +1,10 @@
+# Template for config/.branch-cleanup.local (gitignored). Copy to
+# .branch-cleanup.local and fill in the real per-host repo->branch map.
+# merge_and_cleanup_branches.sh reads it. Real repo names are kept out of this
+# public repo (#3095/#3098); provision from the private aceengineer-strategy.
+#
+# Format: one entry per line — <repo>:<space-separated branch list>
+#   '#' starts a comment; blank lines ignored.
+# Example:
+# digitalmodel:feature-x for-merge
+# worldenergydata:copilot/fix-1234

--- a/config/.repo-types.local.example
+++ b/config/.repo-types.local.example
@@ -1,0 +1,11 @@
+# Template for config/.repo-types.local (gitignored). Copy to .repo-types.local
+# and fill in the real per-host repo type map. install_factory_enhanced.sh reads
+# it. Real repo names + descriptions are kept out of this public repo
+# (#3095/#3098); provision from the private aceengineer-strategy.
+#
+# Format: one entry per line — <repo>|<type>|<focus label>|<key tech>
+#   type is one of: python_analysis | engineering | web_app
+#   '#' starts a comment; blank lines ignored.
+# Example:
+# digitalmodel|python_analysis|Digital Model & FDAS|Python, NumPy, Pandas, Plotly
+# worldenergydata|python_analysis|World Energy Data Analysis|Python, Pandas, Plotly, UV

--- a/scripts/automation/install_factory_enhanced.sh
+++ b/scripts/automation/install_factory_enhanced.sh
@@ -46,34 +46,24 @@ echo -e "${GREEN}✓ Workspace droids.yml found${NC}"
 echo -e "${GREEN}✓ Repository template found${NC}"
 echo ""
 
-# Repository type mappings
+# Repository type mappings. The values carried client repo names + descriptions
+# (#3098), so the map is no longer hardcoded. It is loaded from a gitignored
+# per-host file ($REPO_TYPES_FILE or workspace-hub/config/.repo-types.local),
+# one entry per line, pipe-delimited:
+#     <repo>|<type>|<focus label>|<key tech>
+# ('#' comments and blank lines ignored). See config/.repo-types.local.example.
+# The value is reassembled to the original "type:focus:tech" colon form so the
+# downstream `IFS=':' read` parsing is unchanged. Absent file -> empty map ->
+# the per-repo loop processes nothing (safe no-op).
 declare -A REPO_TYPES
-REPO_TYPES=(
-    ["worldenergydata"]="python_analysis:World Energy Data Analysis:Python, Pandas, Plotly, UV"
-    ["digitalmodel"]="python_analysis:Digital Model & FDAS:Python, NumPy, Pandas, Plotly"
-    ["pyproject-starter"]="python_analysis:Python Project Starter:Python, UV, pytest"
-    ["aceengineercode"]="engineering:Engineering Calculations:Python, NumPy, SciPy"
-    ["energy"]="python_analysis:Energy Analysis:Python, Pandas, Plotly"
-    ["rock-oil-field"]="engineering:Rock & Oil Field Analysis:Python, NumPy, SciPy"
-    ["frontierdeepwater"]="engineering:Frontier Deepwater:Python, Engineering"
-    ["saipem"]="engineering:Saipem Engineering:Python, Calculations"
-    ["aceengineer-admin"]="web_app:Ace Engineer Admin:React, TypeScript, Node.js"
-    ["aceengineer-website"]="web_app:Ace Engineer Website:React, JavaScript, CSS"
-    ["assethold"]="web_app:Asset Management:React, TypeScript"
-    ["assetutilities"]="python_analysis:Asset Utilities:Python, Pandas"
-    ["achantas-data"]="python_analysis:Achantas Data:Python, Pandas"
-    ["achantas-media"]="web_app:Achantas Media:JavaScript, Media Processing"
-    ["acma-projects"]="engineering:ACMA Projects:Python, Engineering"
-    ["ai-native-traditional-eng"]="python_analysis:AI Native Traditional Engineering:Python, AI/ML"
-    ["client_projects"]="web_app:Client Projects:Multi-language"
-    ["doris"]="python_analysis:Doris Analysis:Python, Pandas"
-    ["hobbies"]="web_app:Hobbies & Projects:Multi-language"
-    ["investments"]="python_analysis:Investment Analysis:Python, Pandas, Finance"
-    ["sabithaandkrishnaestates"]="python_analysis:Real Estate Management:Python, Data Analysis"
-    ["sd-work"]="engineering:SD Work:Python, Engineering"
-    ["seanation"]="python_analysis:Sea Nation:Python, Marine Analysis"
-    ["teamresumes"]="web_app:Team Resumes:HTML, CSS, JavaScript"
-)
+_rt_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+_types_file="${REPO_TYPES_FILE:-$_rt_root/config/.repo-types.local}"
+if [[ -f "$_types_file" ]]; then
+    while IFS='|' read -r _repo _type _focus _tech; do
+        [[ -z "$_repo" || "$_repo" == \#* ]] && continue
+        REPO_TYPES["$_repo"]="${_type}:${_focus}:${_tech}"
+    done < "$_types_file"
+fi
 
 # Counters
 SUCCESS_COUNT=0

--- a/scripts/automation/setup_agent_links.sh
+++ b/scripts/automation/setup_agent_links.sh
@@ -32,7 +32,7 @@ usage() {
     echo "Examples:"
     echo "  $0 /mnt/github/aceengineer-admin"
     echo "  $0 ../aceengineercode --dry-run"
-    echo "  $0 /mnt/github/client_projects --universal-only"
+    echo "  $0 /mnt/github/digitalmodel --universal-only"
     exit 1
 }
 

--- a/scripts/coordination/git/merge_and_cleanup_branches.sh
+++ b/scripts/coordination/git/merge_and_cleanup_branches.sh
@@ -12,23 +12,23 @@ echo -e "${BLUE}🔀 Branch Merge and Cleanup Tool${NC}"
 echo "=================================="
 echo ""
 
-# Repositories with non-main branches that need attention
-declare -A repos_with_branches=(
-    ["ai-native-traditional-eng"]="custom_changes"
-    ["assetutilities"]="docs/openai-prompting-guide"
-    ["energy"]="apr_may for-merge"
-    ["pyproject-starter"]="custom_changes"
-    ["rock-oil-field"]="jun-jul"
-    ["aceengineer-admin"]="apr-may-jun"
-    ["client_projects"]="apr_may aug-sep-oct"
-    ["doris"]="2024 202501 202505"
-    ["frontierdeepwater"]="incremental-push"
-    ["hobbies"]="aug-sep-oct"
-    ["investments"]="urban-development-dashboard"
-    ["sabithaandkrishnaestates"]="family-dollar-deal-documentation"
-    ["teamresumes"]="sub-agents-enhancement"
-    ["worldenergydata"]="copilot/fix-2ed5a295-77af-4bd6-bd83-d19d89599404"
-)
+# Repositories with non-main branches that need attention. This repo->branch map
+# carried client repo names (#3098), so it is no longer hardcoded. It is loaded
+# from a gitignored per-host file ($BRANCH_CLEANUP_FILE or
+# workspace-hub/config/.branch-cleanup.local), one entry per line:
+#     <repo>:<space-separated branch list>
+# ('#' comments and blank lines ignored). See config/.branch-cleanup.local.example.
+# Absent file -> empty map -> the script processes nothing (safe no-op). The
+# merge/delete/push logic below is unchanged.
+declare -A repos_with_branches=()
+_wh_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+_map_file="${BRANCH_CLEANUP_FILE:-$_wh_root/config/.branch-cleanup.local}"
+if [[ -f "$_map_file" ]]; then
+    while IFS=: read -r _repo _branches; do
+        [[ -z "$_repo" || "$_repo" == \#* ]] && continue
+        repos_with_branches["$_repo"]="${_branches# }"
+    done < "$_map_file"
+fi
 
 # Track results
 merged_branches=()
@@ -178,8 +178,8 @@ fi
 
 echo ""
 echo -e "${BLUE}📝 Special Note:${NC}"
-echo -e "${YELLOW}  • saipem repository:${NC} Has workflow permission issues"
-echo "    Need to update GitHub OAuth permissions or use a Personal Access Token"
-echo "    with 'workflow' scope to push workflow files."
+echo -e "${YELLOW}  • Some repositories may have workflow permission issues${NC}"
+echo "    when pushing workflow files. Update GitHub OAuth permissions or use a"
+echo "    Personal Access Token with 'workflow' scope."
 echo ""
 echo -e "${GREEN}✅ Branch cleanup process completed!${NC}"

--- a/scripts/coordination/git/remove_assetutilities_submodule.sh
+++ b/scripts/coordination/git/remove_assetutilities_submodule.sh
@@ -5,19 +5,21 @@
 echo "=== Removing assetutilities submodule from repositories ==="
 echo
 
-# List of repos with the submodule
-repos_with_submodule=(
-    "aceengineer-website"
-    "acma-projects"
-    "ai-native-traditional-eng"
-    "assethold"
-    "assetutilities"
-    "energy"
-    "digitalmodel"
-    "rock-oil-field"
-    "saipem"
-    "pyproject-starter"
-)
+# List of repos to check for the submodule. This list carried client repo names
+# (#3098), so it is no longer hardcoded. Resolution order (same pattern as
+# scripts/coordination/git/batch_commit_all.sh, #3160):
+#   1) $SIBLING_REPOS_FILE or workspace-hub/config/.sibling-repos.local
+#      (gitignored, provisioned per host — one repo per line; '#' comments OK)
+#   2) dynamic discovery of sibling git repos under the current parent dir
+# The removal logic below is unchanged and idempotent (it no-ops on a repo that
+# has no .gitmodules entry for the submodule).
+_wh_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+_repos_file="${SIBLING_REPOS_FILE:-$_wh_root/config/.sibling-repos.local}"
+if [[ -f "$_repos_file" ]]; then
+    mapfile -t repos_with_submodule < <(grep -vE '^[[:space:]]*(#|$)' "$_repos_file")
+else
+    mapfile -t repos_with_submodule < <(find . -maxdepth 2 -type d -name .git 2>/dev/null | sed 's|/.git$||; s|^\./||' | sort)
+fi
 
 for repo in "${repos_with_submodule[@]}"; do
     repo_path="/mnt/github/github/$repo"

--- a/scripts/coordination/git/resolve_repos.sh
+++ b/scripts/coordination/git/resolve_repos.sh
@@ -11,17 +11,21 @@ echo -e "${BLUE}🔧 Repository Resolution Tool${NC}"
 echo "=================================="
 echo ""
 
-# List of diverged repositories
-diverged_repos=(
-    "aceengineer-website"
-    "ai-native-traditional-eng"
-    "assethold"
-    "assetutilities"
-    "energy"
-    "pyproject-starter"
-    "rock-oil-field"
-    "saipem"
-)
+# List of repositories to resolve. This list carried client repo names (#3098),
+# so it is no longer hardcoded. Resolution order (same pattern as
+# scripts/coordination/git/batch_commit_all.sh, #3160):
+#   1) $SIBLING_REPOS_FILE or workspace-hub/config/.sibling-repos.local
+#      (gitignored, provisioned per host — one repo per line; '#' comments OK)
+#   2) dynamic discovery of sibling git repos under the current parent dir
+# The push/branch-cleanup logic below is unchanged. Processing a non-diverged
+# repo is a safe no-op (push of an up-to-date branch does nothing).
+_wh_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+_repos_file="${SIBLING_REPOS_FILE:-$_wh_root/config/.sibling-repos.local}"
+if [[ -f "$_repos_file" ]]; then
+    mapfile -t diverged_repos < <(grep -vE '^[[:space:]]*(#|$)' "$_repos_file")
+else
+    mapfile -t diverged_repos < <(find . -maxdepth 2 -type d -name .git 2>/dev/null | sed 's|/.git$||; s|^\./||' | sort)
+fi
 
 # Arrays to track results
 branches_needing_attention=()


### PR DESCRIPTION
Part of epic [#3095](https://github.com/vamseeachanta/workspace-hub/issues/3095) / [#3098](https://github.com/vamseeachanta/workspace-hub/issues/3098) — CTA-B (bash half). **PII-free by construction.**

## Pattern (verified, safe)
Each script hardcoded **client repo names** in a list/map it then commits/pushes/`cd`s into. The fix changes **only how the list is acquired** — sourced from a gitignored per-host file (copying the landed [#3160](https://github.com/vamseeachanta/workspace-hub/pull/3160) `batch_commit_all.sh` pattern) — and leaves all commit/push/merge/removal logic **byte-identical**, so it is verifiable without running the destructive code.

## Files
| Script | Hardcoded thing | Now sourced from |
|---|---|---|
| `scripts/coordination/git/resolve_repos.sh` | `diverged_repos=()` array | `$SIBLING_REPOS_FILE` / `config/.sibling-repos.local` (+ dynamic discovery fallback) |
| `scripts/coordination/git/remove_assetutilities_submodule.sh` | `repos_with_submodule=()` array | same |
| `scripts/coordination/git/merge_and_cleanup_branches.sh` | `declare -A` repo→branch map + a client-named "Special Note" echo | `config/.branch-cleanup.local` (note genericized) |
| `scripts/automation/install_factory_enhanced.sh` | `declare -A REPO_TYPES` (repo→`type:focus:tech`) | `config/.repo-types.local` (pipe-delimited; reassembled to colon form so the downstream `IFS=':' read` is unchanged) |
| `scripts/automation/setup_agent_links.sh` | client repo name in a **usage example** line | replaced with a non-client repo |

Adds PII-free `.example` templates for the two new provision files. The real lists are gitignored (`config/.*.local` glob from #3164) and provisioned per host from the private `aceengineer-strategy` archive.

## Verification
- `bash -n` green on all 4 functional scripts.
- Loaders exercised in isolation against the provisioned files: sibling list = 23, branch map = 14 (branch strings parse correctly), repo-types = 24 with **byte-identical** `type:focus:tech` colon-split.
- `check-client-pii.py` clean on all changed files.
- ⚠️ `setup_agent_links.sh` carries a **pre-existing** `for ... 2>/dev/null` syntax error at line 218 (present on base HEAD, unrelated to the one-line example change) — left untouched.

> Depends on #3164 only for the `config/.*.local` gitignore glob (already covers these provision files); no file overlap, so merge order is flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)