### PR TITLE
fix(legal): externalize client repo lists/routes in python dev-ops (#3098)

### DIFF
--- a/config/.ace-routes.local.example
+++ b/config/.ace-routes.local.example
@@ -1,0 +1,4 @@
+{
+  "_README": "Template for config/.ace-routes.local (gitignored). Copy to .ace-routes.local and add one entry per CLIENT repo prefix. Client repo names are kept out of this public repo (#3095/#3098); provision from the private aceengineer-strategy. Keys starting with '_' are ignored by the loader (they lack repo/command/description).",
+  "ex": {"repo": "example-client-repo", "command": "example-tool", "description": "Example client route"}
+}

--- a/scripts/automation/_sibling_repos.py
+++ b/scripts/automation/_sibling_repos.py
@@ -1,0 +1,53 @@
+"""Per-host sibling-repo list loader.
+
+The full ecosystem repo list carried client repo names, so it is no longer
+hardcoded in this public repo (epic #3095, sub-issue #3098). Scripts that need
+the list call ``load_sibling_repos()``, which reads the gitignored, per-host
+``config/.sibling-repos.local`` (one repo name per line; ``#`` comments allowed)
+and falls back to a non-client public default when that file is absent.
+
+Provision ``config/.sibling-repos.local`` per host from the private
+``aceengineer-strategy`` archive.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# Non-client public repos — the safe fallback when config/.sibling-repos.local
+# is not provisioned. Contains NO client identifiers.
+PUBLIC_DEFAULT_REPOS = [
+    "aceengineer-admin",
+    "aceengineercode",
+    "aceengineer-website",
+    "achantas-data",
+    "achantas-media",
+    "ai-native-traditional-eng",
+    "assethold",
+    "assetutilities",
+    "digitalmodel",
+    "energy",
+    "hobbies",
+    "investments",
+    "pyproject-starter",
+    "sabithaandkrishnaestates",
+    "sd-work",
+    "teamresumes",
+    "worldenergydata",
+]
+
+
+def load_sibling_repos() -> list[str]:
+    """Return the per-host sibling-repo list, or the public default if unprovisioned."""
+    # scripts/automation/_sibling_repos.py -> workspace-hub root is two parents up.
+    repos_file = Path(__file__).resolve().parents[2] / "config" / ".sibling-repos.local"
+    try:
+        names = [
+            line.split("#", 1)[0].strip()
+            for line in repos_file.read_text(encoding="utf-8").splitlines()
+        ]
+        names = [n for n in names if n]
+        if names:
+            return names
+    except OSError:
+        pass
+    return list(PUBLIC_DEFAULT_REPOS)

--- a/scripts/automation/setup_all_commands.py
+++ b/scripts/automation/setup_all_commands.py
@@ -5,7 +5,11 @@ Setup all slash commands in the root github folder by copying from existing repo
 import os
 import shutil
 import json
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _sibling_repos import load_sibling_repos  # noqa: E402
 
 def setup_all_commands():
     """Copy all command files from repositories to root .agent-os/commands/"""
@@ -68,17 +72,10 @@ def setup_all_commands():
         "/sync-all-commands": "sync_all_commands.py",
     }
     
-    # Source repositories to check for commands
-    source_repos = [
-        "aceengineer-admin",
-        "aceengineercode", 
-        "aceengineer-website",
-        "assetutilities",
-        "digitalmodel",
-        "achantas-data",
-        "frontierdeepwater",
-        "saipem"
-    ]
+    # Source repositories to check for commands — per-host (carried client repo
+    # names, #3098); loaded from the gitignored config/.sibling-repos.local (or
+    # the public default when unprovisioned). Repos without commands are skipped.
+    source_repos = load_sibling_repos()
     
     copied_commands = []
     missing_commands = []

--- a/scripts/automation/sync_engineering_data_context.py
+++ b/scripts/automation/sync_engineering_data_context.py
@@ -5,22 +5,19 @@ Sync the engineering-data-context command across all repositories.
 
 import os
 import shutil
+import sys
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _sibling_repos import load_sibling_repos  # noqa: E402
 
 # Source file
 SOURCE_FILE = Path("/mnt/github/github/.agent-os/commands/engineering_data_context.py")
 
-# List of repositories
-REPOS = [
-    "aceengineer-admin", "aceengineercode", "aceengineer-website", 
-    "achantas-data", "achantas-media", "acma-projects",
-    "ai-native-traditional-eng", "assethold", "assetutilities",
-    "client_projects", "digitalmodel", "doris", "energy",
-    "frontierdeepwater", "hobbies", "investments",
-    "pyproject-starter", "rock-oil-field", "sabithaandkrishnaestates",
-    "saipem", "sd-work", "seanation", "teamresumes", "worldenergydata"
-]
+# Repository list — per-host (carried client repo names, #3098); loaded from the
+# gitignored config/.sibling-repos.local (or the public default when unprovisioned).
+REPOS = load_sibling_repos()
 
 def sync_to_repo(repo_name: str) -> tuple:
     """Sync the command to a single repository."""

--- a/scripts/automation/sync_enhanced_specs.py
+++ b/scripts/automation/sync_enhanced_specs.py
@@ -12,38 +12,21 @@ This script ensures:
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from datetime import datetime
 import json
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _sibling_repos import load_sibling_repos  # noqa: E402
 
 # Configuration
 BASE_PATH = Path("/mnt/github/github")
 SOURCE_REPO = "aceengineer-admin"  # Repository with the correct enhanced specs
 
-# List of all repositories to sync
-REPOSITORIES = [
-    "aceengineer-admin",
-    "aceengineercode", 
-    "aceengineer-website",
-    "achantas-data",
-    "achantas-media",
-    "acma-projects",
-    "ai-native-traditional-eng",
-    "assethold",
-    "assetutilities",
-    "digitalmodel",
-    "energy",
-    "frontierdeepwater",
-    "hobbies",
-    "investments",
-    "rock-oil-field",
-    "sabithaandkrishnaestates",
-    "saipem",
-    "sd-work",
-    "seanation",
-    "teamresumes",
-    "worldenergydata"
-]
+# Repository list — per-host (carried client repo names, #3098); loaded from the
+# gitignored config/.sibling-repos.local (or the public default when unprovisioned).
+REPOSITORIES = load_sibling_repos()
 
 # Files to sync
 ENHANCED_SPEC_FILES = {

--- a/scripts/automation/sync_slash_command_ecosystem.py
+++ b/scripts/automation/sync_slash_command_ecosystem.py
@@ -9,9 +9,13 @@ import json
 import yaml
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, List, Set
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _sibling_repos import load_sibling_repos  # noqa: E402
 
 class SlashCommandEcosystemSync:
     def __init__(self):
@@ -36,17 +40,10 @@ class SlashCommandEcosystemSync:
     def scan_all_repositories(self) -> Dict[str, List[str]]:
         """Scan all repositories for slash commands"""
         repo_commands = {}
-        
-        repos = [
-            "aceengineer-admin", "aceengineercode", "aceengineer-website",
-            "achantas-data", "achantas-media", "acma-projects",
-            "ai-native-traditional-eng", "assethold", "assetutilities",
-            "digitalmodel", "energy", "frontierdeepwater",
-            "hobbies", "investments",
-            "rock-oil-field", "sabithaandkrishnaestates", "saipem",
-            "sd-work", "seanation", "teamresumes", "worldenergydata",
-            "pyproject-starter", "doris", "client_projects"
-        ]
+
+        # Repository list — per-host (carried client repo names, #3098); loaded from
+        # the gitignored config/.sibling-repos.local (or public default if unprovisioned).
+        repos = load_sibling_repos()
         
         for repo in repos:
             repo_path = self.base_path / repo

--- a/src/ace/router.py
+++ b/src/ace/router.py
@@ -5,6 +5,7 @@ ABOUTME: Maps prefix aliases to repo tools and invokes them via subprocess
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +20,10 @@ from typing import Dict, List, Optional, Tuple
 #                OR a dotted "module:function" string used with `python -m`
 #     description: one-line description for `ace --list`
 # ---------------------------------------------------------------------------
+# Public (non-client) routes. Client-repo routes carried client identifiers, so
+# they are NOT hardcoded here (#3095/#3098); they are merged in at import time
+# from the gitignored config/.ace-routes.local (provisioned per host — see
+# config/.ace-routes.local.example). Absent file => only these routes exist.
 ROUTES: Dict[str, Dict[str, str]] = {
     "dm": {
         "repo": "digitalmodel",
@@ -40,21 +45,6 @@ ROUTES: Dict[str, Dict[str, str]] = {
         "command": "assetutils-devtools",
         "description": "Asset utilities development tools",
     },
-    "fdw": {
-        "repo": "frontierdeepwater",
-        "command": "frontierdeepwater",
-        "description": "Frontier deepwater project tools",
-    },
-    "spm": {
-        "repo": "saipem",
-        "command": "saipem",
-        "description": "Saipem offshore engineering analysis",
-    },
-    "doris": {
-        "repo": "doris",
-        "command": "doris",
-        "description": "Doris subsea pipeline analysis tools",
-    },
     "ogm": {
         "repo": "OGManufacturing",
         "command": "ogmanufacturing",
@@ -65,17 +55,34 @@ ROUTES: Dict[str, Dict[str, str]] = {
         "command": "achantas-data",
         "description": "Achantas data processing tools",
     },
-    "sea": {
-        "repo": "seanation",
-        "command": "seanation",
-        "description": "SeaNation offshore drilling analysis",
-    },
     "sdw": {
         "repo": "sd-work",
         "command": "sd-work",
         "description": "SD-work engineering tools",
     },
 }
+
+
+def _load_local_routes() -> None:
+    """Merge per-host private routes (client repos) from the gitignored file.
+
+    Format: a JSON object mapping prefix -> {repo, command, description}. Each
+    entry is validated before merging so a malformed file can't corrupt ROUTES.
+    """
+    routes_file = Path(__file__).resolve().parents[2] / "config" / ".ace-routes.local"
+    try:
+        extra = json.loads(routes_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(extra, dict):
+        return
+    required = {"repo", "command", "description"}
+    for prefix, info in extra.items():
+        if isinstance(info, dict) and required <= info.keys():
+            ROUTES[str(prefix)] = {k: str(info[k]) for k in required}
+
+
+_load_local_routes()
 
 
 def workspace_root() -> Path:


### PR DESCRIPTION
Part of epic [#3095](https://github.com/vamseeachanta/workspace-hub/issues/3095) / [#3098](https://github.com/vamseeachanta/workspace-hub/issues/3098) — CTA-B (python half). **PII-free by construction.** Same verified pattern as the bash half ([#3165](https://github.com/vamseeachanta/workspace-hub/pull/3165)): change only **how the list is acquired**, leave sync/route logic byte-identical.

## Files
| File | Hardcoded thing | Now sourced from |
|---|---|---|
| **new** `scripts/automation/_sibling_repos.py` | — | `load_sibling_repos()` reads gitignored `config/.sibling-repos.local`; non-client `PUBLIC_DEFAULT_REPOS` fallback |
| `scripts/automation/setup_all_commands.py` | `source_repos` list | `load_sibling_repos()` |
| `scripts/automation/sync_engineering_data_context.py` | `REPOS` list | `load_sibling_repos()` |
| `scripts/automation/sync_enhanced_specs.py` | `REPOSITORIES` list | `load_sibling_repos()` |
| `scripts/automation/sync_slash_command_ecosystem.py` | in-method `repos` list | `load_sibling_repos()` |
| `src/ace/router.py` | 4 client routes in inline `ROUTES` | merged at import from gitignored `config/.ace-routes.local` (validated per entry); 7 non-client routes stay inline |

Adds PII-free `config/.ace-routes.local.example`. Real lists/routes gitignored (`config/.*.local` glob from #3164), provisioned per host.

## Verification
- `py_compile` green on all 6 files.
- `load_sibling_repos()` = 23 from the provisioned file; `PUBLIC_DEFAULT_REPOS` (17) has **no** client names.
- router `ROUTES` merges to 11 (7 public + 4 client) with the local file; every route carries the required keys; with no local file (CI) only the 7 public routes exist.
- `tests/unit/test_ace_{router,cli,completion}.py`: **67 passed**. The 11 failures are the **pre-existing** `TestKnownPrefixesInWorkspace` env failures (repos not checked out nested under workspace-hub on this host) — a clean-`main` baseline run shows the identical 11, so this PR adds **zero** new failures.

> Depends on #3164 only for the `config/.*.local` gitignore glob; no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)