### PR TITLE
fix(legal): externalize client repo list in Windows batch scripts (#3098)

### DIFF
--- a/config/.windows-repos.local.example
+++ b/config/.windows-repos.local.example
@@ -1,0 +1,9 @@
+# Template for config\.windows-repos.local (gitignored). Copy to
+# .windows-repos.local and list the real per-host repos (one per line). The
+# scripts\windows\*.bat tools read it via `for /f`. Real repo names are kept out
+# of this public repo (#3095/#3098); provision from the private aceengineer-strategy.
+#
+# One repo name per line; '#' starts a comment line. Example:
+# aceengineer-admin
+# digitalmodel
+# worldenergydata

--- a/scripts/windows/claude_repo_switcher.bat
+++ b/scripts/windows/claude_repo_switcher.bat
@@ -1,39 +1,32 @@
 @echo off
+setlocal enabledelayedexpansion
 echo Claude Code Repository Switcher
 echo ================================
 echo.
-echo Available repositories:
-echo 1. aceengineer-admin
-echo 2. achantas-data
-echo 3. client_projects
-echo 4. doris
-echo 5. ecs
-echo 6. energy
-echo 7. hobbies
-echo 8. investments
-echo 9. OGManufacturing
-echo 10. predyct
-echo 11. rock-oil-field
-echo 12. saipem
-echo 13. seanation
-echo 14. spire_projects
-echo.
-set /p choice="Select repository (1-14): "
 
-if "%choice%"=="1" set "repo=aceengineer-admin"
-if "%choice%"=="2" set "repo=achantas-data"
-if "%choice%"=="3" set "repo=client_projects"
-if "%choice%"=="4" set "repo=doris"
-if "%choice%"=="5" set "repo=ecs"
-if "%choice%"=="6" set "repo=energy"
-if "%choice%"=="7" set "repo=hobbies"
-if "%choice%"=="8" set "repo=investments"
-if "%choice%"=="9" set "repo=OGManufacturing"
-if "%choice%"=="10" set "repo=predyct"
-if "%choice%"=="11" set "repo=rock-oil-field"
-if "%choice%"=="12" set "repo=saipem"
-if "%choice%"=="13" set "repo=seanation"
-if "%choice%"=="14" set "repo=spire_projects"
+REM Repo list is per-host (carried client repo names, #3098); read from a
+REM gitignored file. Provision config\.windows-repos.local (one repo per line);
+REM see config\.windows-repos.local.example. The numbered menu and the
+REM choice->repo mapping are generated from that list.
+set "REPO_LIST_FILE=%~dp0..\..\config\.windows-repos.local"
+if not exist "%REPO_LIST_FILE%" (
+    echo Error: repo list not found: %REPO_LIST_FILE%
+    echo Provision it from config\.windows-repos.local.example
+    pause
+    exit /b 1
+)
+
+echo Available repositories:
+set /a count=0
+for /f "usebackq eol=# delims=" %%r in ("%REPO_LIST_FILE%") do (
+    set /a count+=1
+    set "repo[!count!]=%%r"
+    echo !count!. %%r
+)
+echo.
+set /p choice="Select repository (1-!count!): "
+
+set "repo=!repo[%choice%]!"
 
 if "%repo%"=="" (
     echo Invalid selection!

--- a/scripts/windows/daily_routine_repos.bat
+++ b/scripts/windows/daily_routine_repos.bat
@@ -1,25 +1,11 @@
 REM #TODO get current directory and then refer back to the daily_routine batch file relative to this directory.
-cd C:\Users\vamseea\github\acma-projects
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
+REM Repo list is per-host (carried client repo names, #3098); read from a
+REM gitignored file. Provision config\.windows-repos.local (one repo per line);
+REM see config\.windows-repos.local.example.
+set "REPO_LIST_FILE=%~dp0..\..\config\.windows-repos.local"
+set "DAILY_ROUTINE=C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
 
-cd C:\Users\vamseea\github\assetutilities
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\client_projects
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\digitalmodel
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\energy
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\energydata
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\rock-oil-field
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
-cd C:\Users\vamseea\github\spire_projects
-cmd /c "C:\Users\vamseea\github\assetutilities\src\assetutilities\tools\git\daily_routine.bat"
-
+for /f "usebackq eol=# delims=" %%r in ("%REPO_LIST_FILE%") do (
+    cd /d "C:\Users\vamseea\github\%%r"
+    cmd /c "%DAILY_ROUTINE%"
+)

--- a/scripts/windows/setup_claude_repos.bat
+++ b/scripts/windows/setup_claude_repos.bat
@@ -1,8 +1,14 @@
 @echo off
 echo Setting up Claude Code for all repositories...
 
-REM List of repositories to configure
-set "repos=achantas-data client_projects doris ecs energy hobbies investments OGManufacturing predyct rock-oil-field saipem seanation spire_projects"
+REM Repo list is per-host (carried client repo names, #3098); read from a
+REM gitignored file. Provision config\.windows-repos.local (one repo per line);
+REM see config\.windows-repos.local.example.
+set "REPO_LIST_FILE=%~dp0..\..\config\.windows-repos.local"
+set "repos="
+if exist "%REPO_LIST_FILE%" (
+    for /f "usebackq eol=# delims=" %%r in ("%REPO_LIST_FILE%") do call set "repos=%%repos%% %%r"
+)
 
 for %%r in (%repos%) do (
     echo.

--- a/scripts/windows/verify_claude_setup.bat
+++ b/scripts/windows/verify_claude_setup.bat
@@ -48,7 +48,14 @@ if exist "C:\Program Files\Git\bin\bash.exe" (
 REM Check repositories and CLAUDE.md files
 echo.
 echo Checking repositories and CLAUDE.md files...
-set "repos=aceengineer-admin achantas-data client_projects doris ecs energy hobbies investments OGManufacturing predyct rock-oil-field saipem seanation spire_projects"
+REM Repo list is per-host (carried client repo names, #3098); read from a
+REM gitignored file. Provision config\.windows-repos.local (one repo per line);
+REM see config\.windows-repos.local.example.
+set "REPO_LIST_FILE=%~dp0..\..\config\.windows-repos.local"
+set "repos="
+if exist "%REPO_LIST_FILE%" (
+    for /f "usebackq eol=# delims=" %%r in ("%REPO_LIST_FILE%") do call set "repos=%%repos%% %%r"
+)
 
 for %%r in (%repos%) do (
     if exist "C:\Users\vamseea\github\%%r\.git" (


### PR DESCRIPTION
Part of epic [#3095](https://github.com/vamseeachanta/workspace-hub/issues/3095) / [#3098](https://github.com/vamseeachanta/workspace-hub/issues/3098) — CTA-B (Windows half), the **last** of the 14 functional dev-ops scripts. **PII-free by construction.**

The four `scripts/windows/*.bat` repo tools hardcoded **client repo names** in their lists. The fix reads the list from a gitignored per-host file via `for /f` and leaves all per-repo actions byte-identical.

| Script | Was | Now |
|---|---|---|
| `setup_claude_repos.bat`, `verify_claude_setup.bat` | inline `set "repos=..."` | `for /f "eol=# delims="` read of `config\.windows-repos.local` into `%repos%` (existing `for %%r in (%repos%)` loop unchanged) |
| `daily_routine_repos.bat` | per-repo sequential `cd`+`cmd` blocks | one `for /f` loop over the same file; per-repo action (cd + run `assetutilities\...\daily_routine.bat`) identical |
| `claude_repo_switcher.bat` | static numbered menu + `if "%choice%"=="N"` mapping | menu + mapping generated from the file (delayed-expansion numbered array); VS Code / Git Bash open logic + invalid-selection guard unchanged |

Adds a PII-free `config\.windows-repos.local.example`. Real list gitignored (`config/.*.local` glob from #3164), provisioned per host.

## Verification
- `check-client-pii.py` clean on all 4 `.bat` + the example.
- `for /f` list-parse simulation → 18 repos; `%~dp0..\..\config` path resolves to `config/.windows-repos.local`.
- ⚠️ **`.bat` cannot be executed on this Linux host (no cmd.exe).** Verification is the guard + standard well-formed batch idioms + parse/path simulation. A Windows operator (ace-win-1) should smoke-test before relying on them.

> Depends on #3164 only for the `config/.*.local` gitignore glob; no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)