### PR TITLE
feat(legal): scan commit messages + PR metadata for client identifiers (#3169)

### DIFF
--- a/.claude/docs/client-pii-prevention.md
+++ b/.claude/docs/client-pii-prevention.md
@@ -55,11 +55,13 @@ Client identifiers are kept out of **every public surface**, not just file conte
 (`--message-file` / `--stdin --source <label>`) feeds messages/metadata through the
 same engine and **never prints the matched value** — only the source label.
 
-**Squash-merge transient-token branches.** A merge-commit promotes a feature
-branch's individual commit messages into `main`'s history; a squash-merge does not
-(it uses the PR title/body). If a branch's commit messages might carry a transient
-token (e.g. mid-remediation), **squash-merge** it so nothing reaches `main` history —
-and remember git-history rewrites of `main` are out of scope (HEAD-only).
+**Merge method.** The CI gate blocks a PR whose commit messages carry an identifier
+**regardless of merge method**, so the gate — not the merge method — is what prevents
+the leak. Squash-merge remains useful as *hygiene* (a merge-commit copies every
+feature-branch commit message into `main`'s history; a squash uses only the PR
+title/body) and as defense-in-depth if a contributor locally bypasses the hook
+(`LEGAL_PII_ALLOW=1`). Pre-gate history that already contains a token is **out of
+scope** (HEAD-only — rewriting `main` history is not done).
 
 ### Provisioning the CI secret (one-time)
 ```bash

--- a/.claude/docs/client-pii-prevention.md
+++ b/.claude/docs/client-pii-prevention.md
@@ -44,8 +44,22 @@ public, so listing the names there *is* the leak (the deny-list paradox).
 | Layer | Mechanism | Blocking? | Notes |
 |---|---|---|---|
 | Emit | `.gitignore` stop-commit of dump clusters + redaction step in `scripts/cron/commit-learning-artifacts.sh` | n/a | dumps can't re-enter; cron redacts curated state at source (#3097) |
-| Local | pre-commit hook `legal-client-pii` (`.pre-commit-config.yaml`) | yes (bypassable) | fast feedback; reads local map, degrades-open |
-| CI | `.github/workflows/legal-client-pii-gate.yml` | yes (strict) | **the real backstop**; reads the private map from the `LEGAL_CLIENT_MAP` repo secret |
+| Local (files) | pre-commit hook `legal-client-pii` (`--staged`) | yes (bypassable) | fast feedback; reads local map, degrades-open |
+| Local (commit msg) | pre-commit hook `legal-client-pii-commit-msg` on the `commit-msg` stage (`--message-file "$1"`) | yes (bypassable) | scans the **commit message** (#3169); auto-wired via `default_install_hook_types`; degrades-open |
+| CI | `.github/workflows/legal-client-pii-gate.yml` | yes (strict) | **the real backstop**; scans the file diff **and** the PR title/body + each commit message in range (#3169); re-runs on PR `edited`; reads the private map from the `LEGAL_CLIENT_MAP` repo secret |
+
+### Surfaces covered (#3169)
+
+Client identifiers are kept out of **every public surface**, not just file content:
+**tracked files**, **commit messages**, and **PR title/body**. The guard's text mode
+(`--message-file` / `--stdin --source <label>`) feeds messages/metadata through the
+same engine and **never prints the matched value** — only the source label.
+
+**Squash-merge transient-token branches.** A merge-commit promotes a feature
+branch's individual commit messages into `main`'s history; a squash-merge does not
+(it uses the PR title/body). If a branch's commit messages might carry a transient
+token (e.g. mid-remediation), **squash-merge** it so nothing reaches `main` history —
+and remember git-history rewrites of `main` are out of scope (HEAD-only).
 
 ### Provisioning the CI secret (one-time)
 ```bash

--- a/.github/workflows/legal-client-pii-gate.yml
+++ b/.github/workflows/legal-client-pii-gate.yml
@@ -76,11 +76,19 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.base_ref }}   # via env, not interpolated into the script
         run: |
           rc=0
           printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | uv run python scripts/legal/check-client-pii.py --stdin --source "PR title/body" $STRICT || rc=$?
-          for sha in $(git rev-list "origin/${{ github.base_ref }}..HEAD"); do
+          # Fail CLOSED if the commit range can't be computed (e.g. base not fetched);
+          # an empty-but-valid range (rev-list succeeds, no commits) is a legitimate pass.
+          if ! shas="$(git rev-list --no-merges "origin/$BASE_REF..HEAD" 2>/dev/null)"; then
+            echo "::error::cannot compute commit range origin/$BASE_REF..HEAD — failing closed (need fetch-depth: 0)." >&2
+            echo "**Metadata/commits:** FAIL — commit range unavailable; scan could not run." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          for sha in $shas; do
             git log -1 --format=%B "$sha" \
               | uv run python scripts/legal/check-client-pii.py --stdin --source "commit $sha" $STRICT || rc=$?
           done

--- a/.github/workflows/legal-client-pii-gate.yml
+++ b/.github/workflows/legal-client-pii-gate.yml
@@ -18,7 +18,8 @@ name: Legal Client-PII Gate
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    # `edited` so a title/body changed AFTER opening is re-scanned (#3169).
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   client-pii-gate:
@@ -63,5 +64,29 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo "uv run python scripts/legal/redact-client-pii.py --map <private-map> <file>" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit $rc
+          fi
+
+      - name: Scan PR title/body + commit messages for client identifiers
+        # #3169: commit messages and PR metadata are public surfaces too. Uses the
+        # same LEGAL_CLIENT_MAP env sourcing + $STRICT as the diff step above.
+        # PR title/body arrive via env (never interpolated into the script) so an
+        # odd/hostile title can't break or echo. Commits are scanned individually
+        # so a hit names the offending SHA. Matched values are never printed.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          rc=0
+          printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
+            | uv run python scripts/legal/check-client-pii.py --stdin --source "PR title/body" $STRICT || rc=$?
+          for sha in $(git rev-list "origin/${{ github.base_ref }}..HEAD"); do
+            git log -1 --format=%B "$sha" \
+              | uv run python scripts/legal/check-client-pii.py --stdin --source "commit $sha" $STRICT || rc=$?
+          done
+          if [[ "$rc" -eq 0 ]]; then
+            echo "**Metadata/commits:** PASS — no client identifiers in PR title/body or commit messages." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Metadata/commits:** FAIL (exit $rc) — a PR title/body or commit message contains a client identifier (value withheld; amend or squash-merge to remove it)." >> "$GITHUB_STEP_SUMMARY"
             exit $rc
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 # Pre-commit hooks for workspace-hub
-# Install: pre-commit install --hook-type commit-msg
+# Install: pre-commit install   (default_install_hook_types below wires both
+#          the pre-commit and commit-msg stages automatically)
 # Test: echo "bad message" | pre-commit run commitizen --hook-stage commit-msg
+
+# Auto-wire both stages so `pre-commit install` enables the commit-msg hooks
+# (the #3169 client-PII commit-message guard depends on this).
+default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   # Commit message linting (conventional commits)
@@ -46,6 +51,17 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: legal-client-pii-commit-msg
+        name: no client identifiers in the commit message (#3095/#3169)
+        # Blocks a commit whose MESSAGE contains a client identifier (the
+        # file-content guard above does not see commit messages). Reads the same
+        # PRIVATE local map; degrades-open if absent (parity with --staged). The
+        # value is never printed. Bypass: LEGAL_PII_ALLOW=1.
+        # pre-commit appends the commit-message file path → it becomes the value
+        # of the trailing --message-file argument.
+        entry: uv run python scripts/legal/check-client-pii.py --source "commit message" --message-file
+        language: system
+        stages: [commit-msg]
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -481,3 +481,4 @@ Add one row per plan:
 | [#3029](https://github.com/vamseeachanta/workspace-hub/issues/3029) | Wire lane: labels into dispatch routing + planning template + planning skill | [Plan](2026-06-10-issue-3029-lane-label-workflow-wiring.md) | done | T2 | 2026-06-10 |
 | [#3030](https://github.com/vamseeachanta/workspace-hub/issues/3030) | Dispatch-time codex weekly-quota gate (suspend lane:codex when available <10%) | [Plan](2026-06-10-issue-3030-codex-quota-dispatch-gate.md) | done | T2 | 2026-06-10 |
 | [#3034](https://github.com/vamseeachanta/workspace-hub/issues/3034) | Quota cache staleness — statusline freshness-aware sourcing + slim local refresh | [Plan](2026-06-10-issue-3034-quota-cache-staleness.md) | plan-review | T2 | 2026-06-10 |
+| [#3169](https://github.com/vamseeachanta/workspace-hub/issues/3169) | PII guard — extend coverage to commit messages + PR bodies | [Plan](2026-06-16-issue-3169-pii-guard-commit-msg-pr-body.md) | plan-approved | T2 | 2026-06-16 |

--- a/scripts/legal/check-client-pii.py
+++ b/scripts/legal/check-client-pii.py
@@ -91,12 +91,36 @@ def violations_in(path: Path, rules) -> list[int]:
     return hits
 
 
+def scan_text(text: str, rules, label: str) -> int:
+    """Scan arbitrary text (a commit message, PR title/body) for client identifiers.
+
+    Reuses the redactor engine so the guard never disagrees with the redactor.
+    NEVER prints the matched text — only the caller-supplied `label` (e.g.
+    "commit <sha>", "PR metadata"), so public CI logs can't leak the value.
+    Returns 1 if an identifier is present, else 0.
+    """
+    _, n = _engine.redact_text(text, rules)
+    if n:
+        print(f"✖ Client identifier found in {label} — blocked (#3095/#3099).", file=sys.stderr)
+        print("  (value withheld — public logs would leak it; remove the client name "
+              "from the message/metadata, or squash-merge to drop it from history.)", file=sys.stderr)
+        print("Bypass (discouraged): LEGAL_PII_ALLOW=1", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--map", type=Path, default=Path(os.environ.get("LEGAL_CLIENT_MAP", DEFAULT_MAP)))
     ap.add_argument("--base-ref", help="scan files changed vs this ref (CI/PR mode)")
     ap.add_argument("--staged", action="store_true", help="scan staged files (pre-commit mode)")
     ap.add_argument("--all", action="store_true", help="scan all tracked files")
+    ap.add_argument("--message-file", type=Path,
+                    help="scan the text in this file (e.g. a commit message — the commit-msg hook's $1) instead of tracked files")
+    ap.add_argument("--stdin", action="store_true",
+                    help="scan text read from stdin (e.g. PR title/body, commit-range messages) instead of tracked files")
+    ap.add_argument("--source", default=None,
+                    help="label for the scanned text in messages (e.g. 'commit <sha>', 'PR metadata'); the matched value is never printed")
     ap.add_argument("--strict", action="store_true", help="fail (exit 2) if the private map is missing")
     ap.add_argument("paths", nargs="*", help="explicit files to scan")
     args = ap.parse_args()
@@ -114,6 +138,22 @@ def main() -> int:
         return 0
 
     rules = _engine.load_rules(args.map)
+
+    # Text mode (#3169): scan a commit message / PR metadata instead of files.
+    if args.message_file is not None or args.stdin:
+        if args.message_file is not None:
+            try:
+                text = args.message_file.read_text(encoding="utf-8")
+            except OSError as e:
+                msg = f"legal-client-pii: cannot read --message-file {args.message_file}: {e}"
+                print(msg, file=sys.stderr)
+                return 2 if args.strict else 0
+            label = args.source or str(args.message_file)
+        else:
+            text = sys.stdin.read()
+            label = args.source or "stdin"
+        return scan_text(text, rules, label)
+
     targets = collect_targets(args)
 
     bad: list[tuple[str, list[int]]] = []

--- a/scripts/legal/tests/test_check_client_pii.py
+++ b/scripts/legal/tests/test_check_client_pii.py
@@ -3,6 +3,8 @@
 Synthetic names only — the test file carries no real client identifiers.
 """
 import importlib.util
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -67,9 +69,6 @@ def test_binary_unreadable_skipped(tmp_path):
 
 
 # ── #3169: text mode (commit messages / PR metadata) ──────────────────────────
-import os
-import subprocess
-
 _SCRIPT = _LEGAL / "check-client-pii.py"
 
 

--- a/scripts/legal/tests/test_check_client_pii.py
+++ b/scripts/legal/tests/test_check_client_pii.py
@@ -64,3 +64,102 @@ def test_binary_unreadable_skipped(tmp_path):
     f.write_bytes(b"\xff\xfe alphacorp \x00")
     # non-utf8 → skipped, no crash
     assert guard.violations_in(f, rules) == []
+
+
+# ── #3169: text mode (commit messages / PR metadata) ──────────────────────────
+import os
+import subprocess
+
+_SCRIPT = _LEGAL / "check-client-pii.py"
+
+
+def _write_map(tmp_path):
+    p = tmp_path / "map.yaml"
+    p.write_text(SYNTH_MAP, encoding="utf-8")
+    return p
+
+
+def _run_cli(args, stdin=None, env_extra=None):
+    env = dict(os.environ)
+    env.pop("LEGAL_PII_ALLOW", None)
+    if env_extra:
+        env.update(env_extra)
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        input=stdin, capture_output=True, text=True, env=env,
+    )
+    return r.returncode, r.stdout, r.stderr
+
+
+def test_scan_text_clean_returns_zero(tmp_path):
+    rules = _rules(tmp_path)
+    assert guard.scan_text("fix(loader): refactor parsing", rules, "commit abc123") == 0
+
+
+def test_scan_text_detects_identifier(tmp_path):
+    rules = _rules(tmp_path)
+    assert guard.scan_text("rename alphacorp dir", rules, "commit abc123") == 1
+
+
+def test_scan_text_withholds_value(tmp_path, capsys):
+    """The matched token (and its codename) must never appear in output."""
+    rules = _rules(tmp_path)
+    rc = guard.scan_text("touch alphacorp config", rules, "commit deadbee")
+    out = capsys.readouterr()
+    blob = out.out + out.err
+    assert rc == 1
+    assert "alphacorp" not in blob
+    assert "client-a" not in blob
+    assert "commit deadbee" in blob  # source label IS shown
+
+
+def test_message_file_dirty_blocks(tmp_path):
+    m = _write_map(tmp_path)
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("wip: move alphacorp things\n", encoding="utf-8")
+    rc, _out, _err = _run_cli(["--message-file", str(msg), "--map", str(m), "--source", "commit X"])
+    assert rc == 1
+
+
+def test_message_file_clean_passes(tmp_path):
+    m = _write_map(tmp_path)
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("wip: tidy the loader\n", encoding="utf-8")
+    rc, _out, _err = _run_cli(["--message-file", str(msg), "--map", str(m)])
+    assert rc == 0
+
+
+def test_stdin_dirty_blocks(tmp_path):
+    m = _write_map(tmp_path)
+    rc, _out, _err = _run_cli(["--stdin", "--map", str(m)], stdin="see alphacorp\n")
+    assert rc == 1
+
+
+def test_stdin_clean_passes(tmp_path):
+    m = _write_map(tmp_path)
+    rc, _out, _err = _run_cli(["--stdin", "--map", str(m)], stdin="nothing to see\n")
+    assert rc == 0
+
+
+def test_text_mode_degrade_open_no_map(tmp_path):
+    missing = tmp_path / "nope.yaml"
+    rc, _out, _err = _run_cli(["--stdin", "--map", str(missing)], stdin="alphacorp\n")
+    assert rc == 0  # non-strict + missing map → degrade-open
+
+
+def test_text_mode_strict_no_map(tmp_path):
+    missing = tmp_path / "nope.yaml"
+    rc, _out, _err = _run_cli(["--stdin", "--strict", "--map", str(missing)], stdin="alphacorp\n")
+    assert rc == 2  # strict + missing map → exit 2
+
+
+def test_commit_msg_hook_path(tmp_path):
+    """Exercise exactly what the commit-msg hook runs: --message-file "$1"."""
+    m = _write_map(tmp_path)
+    dirty = tmp_path / "msg_dirty"
+    dirty.write_text("squash: alphacorp cleanup\n", encoding="utf-8")
+    clean = tmp_path / "msg_clean"
+    clean.write_text("squash: cleanup\n", encoding="utf-8")
+    rc_dirty, _o, _e = _run_cli(["--message-file", str(dirty), "--map", str(m)])
+    rc_clean, _o, _e = _run_cli(["--message-file", str(clean), "--map", str(m)])
+    assert rc_dirty == 1 and rc_clean == 0


### PR DESCRIPTION
Implements the approved plan for [#3169](https://github.com/vamseeachanta/workspace-hub/issues/3169) (`docs/plans/2026-06-16-issue-3169-pii-guard-commit-msg-pr-body.md`). Closes the leak vector found in the #3098 closeout: the guard scanned **tracked file content only**, so client tokens could reach `main` via commit messages / PR bodies.

TDD; reuses the redactor engine (guard ≡ redactor; matched value never printed).

## Changes
- **`scripts/legal/check-client-pii.py`** — new text mode: `--message-file PATH` / `--stdin` / `--source LABEL`. Same map sourcing + degrade-open as file modes; emits only the source label.
- **`.pre-commit-config.yaml`** — `legal-client-pii-commit-msg` hook on the `commit-msg` stage (scans `$1`, degrades-open); `default_install_hook_types: [pre-commit, commit-msg]` auto-wires it.
- **`.github/workflows/legal-client-pii-gate.yml`** — `edited` trigger; new step scans PR title/body (via **env**, never interpolated) + **each commit message in range individually** (a hit names the SHA — Gemini r2 #2), reusing the existing `LEGAL_CLIENT_MAP` env + strict flag.
- **`.claude/docs/client-pii-prevention.md`** — documents the new surfaces + the **squash-merge** rule.

## Verification (acceptance criteria)
- ✅ `uv run pytest scripts/legal/tests/` — **21 passed** (incl. `test_commit_msg_hook_path` exercising the real `--message-file`/`$1` path; `test_text_mode_withholds_value` asserting the match is never printed).
- ✅ YAML parses (pre-commit + workflow).
- ✅ `bash scripts/legal/legal-sanity-scan.sh --diff-only` → PASS (hard-gate #6).
- ✅ guard clean on all changed files; hook entry exercised (clean→0).
- ✅ Plan-stage adversarial review folded (Claude/Codex/Gemini); artifacts in `scripts/review/results/` (gitignored by #3097 — verdicts captured in the plan).

Note: `pre-commit` is not installed on the dev host, so the framework-level hook run is by-inspection; the hook *command* and the blocking path are both test-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)