### PR TITLE
chore(maintenance): add agy to update-harness-tools

### DIFF
--- a/scripts/maintenance/update-harness-tools.sh
+++ b/scripts/maintenance/update-harness-tools.sh
@@ -6,6 +6,7 @@
 #   claude  -> claude update
 #   codex   -> codex update
 #   gemini  -> npm install -g @google/gemini-cli@latest
+#   agy     -> agy update   (Antigravity CLI; ~/.local/bin/agy, OAuth/Code Assist)
 #
 # Each step is independent: a failure is reported but does not abort the rest.
 # Run with --dry-run to print the commands without executing them.
@@ -161,6 +162,7 @@ fi
 run_step claude claude update
 run_step codex  codex  update
 run_step gemini npm install -g @google/gemini-cli@latest
+run_step agy    agy    update
 
 echo
 echo "================ Summary ================"


### PR DESCRIPTION
Adds `agy` (Antigravity CLI, `~/.local/bin/agy`, OAuth/Code Assist) as a step in the nightly harness-tools updater, mirroring the existing codex/gemini steps.

**Why now:** `agy` / `google-gemini-cli` is being wired as the hermes Codex-fallback lane, so its CLI must be kept current alongside the other provider CLIs.

**Safety:** `run_step` already `command -v`-guards each tool and SKIPs cleanly on hosts where `agy` isn't installed, so this is a no-op on non-agy machines. `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)