### PR TITLE
chore(quality): un-exempt digitalmodel mypy baseline (error_count 11003)

### DIFF
--- a/config/quality/mypy-baseline.yaml
+++ b/config/quality/mypy-baseline.yaml
@@ -10,11 +10,9 @@ repos:
     updated_at: "2026-06-16"
     note: "1148 errors; web-contextualization + agent-os hyphen-dirs excluded (workspace-hub#3148)."
   digitalmodel:
-    exempt: true
-    error_count: 0
+    error_count: 11003
     updated_at: "2026-06-16"
-    exempt_reason: "12 non-Python .py files crash mypy (exit 2) — tracked in digitalmodel#788; un-exempt after fix."
-    note: "EXEMPT — mypy cannot run until digitalmodel#788 (corrupted .py files) is fixed."
+    note: "11003 errors in 1112 files (un-exempted after digitalmodel#788 repaired the 12 non-Python .py files that crashed mypy exit 2; gate-exact: uv run mypy src/ --config-file pyproject.toml)."
   worldenergydata:
     error_count: 3589
     updated_at: "2026-06-16"


### PR DESCRIPTION
## Summary

Un-exempts **digitalmodel** in the mypy ratchet now that [digitalmodel#788](https://github.com/vamseeachanta/digitalmodel/pull/790) (merged) repaired the 12 non-Python `.py` files that crashed mypy (`exit 2`). Closes the final backlog item of the check-all ratchet arc (#3146 ruff, #3148 mypy).

## Change

`config/quality/mypy-baseline.yaml` — digitalmodel entry:

```diff
   digitalmodel:
-    exempt: true
-    error_count: 0
-    updated_at: "2026-06-16"
-    exempt_reason: "12 non-Python .py files crash mypy (exit 2) — tracked in digitalmodel#788; un-exempt after fix."
-    note: "EXEMPT — mypy cannot run until digitalmodel#788 (corrupted .py files) is fixed."
+    error_count: 11003
+    updated_at: "2026-06-16"
+    note: "11003 errors in 1112 files (un-exempted after digitalmodel#788 repaired the 12 non-Python .py files that crashed mypy exit 2; gate-exact: uv run mypy src/ --config-file pyproject.toml)."
```

## Why 11003

Measured with the **exact** command the ratchet wraps, against digitalmodel `origin/main` post-#788-merge:

```
$ uv run mypy src/ --config-file pyproject.toml
Found 11003 errors in 1112 files (checked 1756 source files)
```

The ratchet rule is `actual <= baseline → PASS`, so digitalmodel now passes at `11003 <= 11003` and any future type-debt regression FAILs.

## Verification

- digitalmodel#788 merged; post-merge: 0 ast.parse failures, mypy completes (`exit 1`, no crash).
- The mypy ratchet wiring is confirmed working — the pre-push hook printed `[worldenergydata] mypy: PASS (3589<=3589)` and `[assethold] mypy: PASS (355<=355)`.
- Baseline YAML schema-validated (parses, no `exempt` key, `error_count: 11003`).

## Test plan
- [x] `uv run mypy src/ --config-file pyproject.toml` on digitalmodel main → 11003
- [x] Baseline schema validates
- [x] Ratchet emits PASS for sibling repos under the same wiring
