### PR TITLE
fix(monitoring): machine-scope cron-health checks (kills false MISSING)

### DIFF
--- a/scripts/monitoring/cron-health-check.sh
+++ b/scripts/monitoring/cron-health-check.sh
@@ -146,8 +146,29 @@ while IFS=$'\t' read -r tid label schedule machines_str log_pattern scheduler is
         continue
     fi
 
-    # Skip tasks not assigned to this machine (if we can resolve identity)
-    # For now, check all cron tasks since this is a repo-level health check
+    # Skip tasks not assigned to this machine (only when we can resolve our
+    # identity and the task declares an explicit machine list). A task pinned to
+    # other hosts writes its log on those hosts, never in this host's local tree,
+    # so checking it here is a guaranteed false MISSING (#3034 quota-snapshot-refresh
+    # is assigned to ace-linux-2 but was flagged red in dev-primary's report). If
+    # the task has no machine list, or we cannot resolve our own identity, fall
+    # back to the previous behaviour of checking every task.
+    if [[ -n "$MY_MACHINE_NAMES" && -n "$machines_str" ]]; then
+        task_for_this_machine=false
+        IFS=',' read -ra _task_machines <<< "$machines_str"
+        IFS=',' read -ra _my_names <<< "$MY_MACHINE_NAMES"
+        for _tm in "${_task_machines[@]}"; do
+            for _mn in "${_my_names[@]}"; do
+                if [[ "$_tm" == "$_mn" ]]; then
+                    task_for_this_machine=true
+                    break 2
+                fi
+            done
+        done
+        if [[ "$task_for_this_machine" == false ]]; then
+            continue
+        fi
+    fi
 
     TOTAL_TASKS=$((TOTAL_TASKS + 1))
 


### PR DESCRIPTION
## Problem
`cron-health-check.sh` runs on ace-linux-1 (dev-primary) but checks **every** task in the manifest regardless of which host the task is pinned to. A task assigned to ace-linux-2 writes its log only on ace-linux-2, so ace-linux-1's report flags it `[MISSING]` even though it's running fine — false alarms (`quota-snapshot-refresh`, `flywheel-review`, `email-queue-attention-notify`).

## Evidence it's a false positive, not a real gap
`quota-snapshot-refresh` produces `logs/quality/quota-snapshot-refresh-*.log` **daily on ace-linux-2** (verified 06-14/15/16). The job is healthy; only the cross-host health check was wrong.

## Fix
Skip a task only when we can resolve our own identity (`MY_MACHINE_NAMES`, already computed at line 126) **and** the task declares an explicit machine list that excludes this host. Tasks with no machine list, or when identity can't be resolved, fall back to the prior check-everything behaviour. `bash -n` passes.

## Note / follow-up
Tasks pinned to ace-linux-2 are now correctly *skipped* on ace-linux-1 — but ace-linux-1 is the only host running cron-health, so those tasks lose health coverage entirely. A proper multi-host health roll-up is a separate follow-up; this PR's goal is to stop the false-red that masks genuine problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)