### PR TITLE
fix(git-safe): defer git_heal_index when a live git op holds index.lock (#3196)

### DIFF
--- a/scripts/cron/lib/git-safe.sh
+++ b/scripts/cron/lib/git-safe.sh
@@ -90,6 +90,16 @@ git_heal_index() {
     local git_dir="${GIT_SAFE_REPO:-.}"
     if ! git -C "$git_dir" status >/dev/null 2>&1; then
         _git_safe_log "WARNING: git index appears corrupt, attempting recovery"
+        # Don't yank index.lock out from under a LIVE git op (#3187 follow-up):
+        # only clear it when no git process is running. Uses the same pgrep-x-git
+        # liveness idiom as the #3187 reaper/fingerprint. A crashed op leaves no
+        # process (kernel closes its fds), so its orphan lock IS cleared; a live
+        # op's lock is left alone and recovery defers to the next cycle.
+        if [ -f "${git_dir}/.git/index.lock" ] && command -v pgrep >/dev/null 2>&1 \
+           && pgrep -x git >/dev/null 2>&1; then
+            _git_safe_log "index.lock held by a live git process — deferring index recovery"
+            return 1
+        fi
         # Remove stale lock if present
         rm -f "${git_dir}/.git/index.lock" 2>/dev/null || true
         # Rebuild index from HEAD


### PR DESCRIPTION
Closes #3196 · Follow-up to #3187 / #3194 · Epic #3058

## What
One-line-of-logic hardening to `scripts/cron/lib/git-safe.sh:git_heal_index()`. It cleared `.git/index.lock` **unconditionally** during corrupt-index recovery; now it **defers** (`return 1`) when a git process is live, so it never yanks the lock from an in-flight op. Uses `pgrep -x git` — the same liveness idiom #3194 already uses in the fingerprint/guard. A crashed op leaves no process (kernel closes its fds), so its orphan lock is still cleared.

## Why this, and only this
This is the sole residual improvement from the #3187 code-stage review that the merged #3194 implementation didn't include (#3194 deliberately scoped `git-safe.sh` out; the parallel #3195 was closed as a duplicate). Everything else in #3194 is equivalent-or-better, so this is a tiny, surgical port rather than a competing implementation.

## Tests
`scripts/cron/tests/test_git_safe.sh`: **27 passed, 0 failed, 3 skipped** (push tests). The new branch is a guarded early-return ahead of the existing `rm`; the stale-lock-removal and corrupt-index-recovery tests still pass (no live git process in the test env → `rm` proceeds as before). abs-path check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)