### PR TITLE
feat(routing): cost-ceiling execution_contexts + governance SSoT (#3192)

### DIFF
--- a/config/agents/routing-config.yaml
+++ b/config/agents/routing-config.yaml
@@ -109,3 +109,28 @@ agents:
       Hermes is the documentation, data-analysis, skill, and delegation specialist.
       Preferred for overnight batch work due to its delegation toolchain and
       self-contained prompt generation capabilities.
+
+# ── Execution contexts + cost ceiling (#3192) ────────────────────────────────
+# SSoT for the cost policy: docs/governance/2026-06-17-cost-ceiling-policy.md
+# policy_summary: Claude is the interactive-dev lane only; Hermes backing stays
+#   gpt-5.5/openai-codex; agy (Antigravity, Gemini-backed -> the `gemini` token)
+#   is the cheap fallback/delegation lane; NO Claude for Hermes-context work.
+#
+# routing_resolution_note: ADVISORY ONLY. The executed routers
+#   (scripts/coordination/routing/lib/tier_router.sh, scripts/ai/task-dispatcher.py)
+#   hold hardcoded chains and do NOT parse this file. Do NOT rely on the cost
+#   ceiling to block Claude on Hermes tasks at runtime until the executed-router
+#   consolidation lands (#3058 follow-up). The guard test asserts DECLARED intent.
+cost_ceiling_policy: docs/governance/2026-06-17-cost-ceiling-policy.md
+execution_contexts:
+  hermes_batch:               # docs / data-analysis / delegation / overnight-batch
+    primary: openai-codex     # Hermes backing = gpt-5.5 via openai-codex (unchanged)
+    fallbacks: [gemini]       # agy = the Antigravity Gemini CLI surface -> gemini token
+    forbid: [claude]          # cost ceiling
+    cost_ceiling: true
+  interactive_dev:            # human-driven Claude Code / codex sessions
+    primary: claude
+    fallbacks: [codex, gemini]
+  cross_review:               # quality gate — unchanged (rides claude_primary)
+    primary: claude
+    fallbacks: [codex, gemini]

--- a/config/agents/routing-config.yaml
+++ b/config/agents/routing-config.yaml
@@ -113,8 +113,9 @@ agents:
 # ── Execution contexts + cost ceiling (#3192) ────────────────────────────────
 # SSoT for the cost policy: docs/governance/2026-06-17-cost-ceiling-policy.md
 # policy_summary: Claude is the interactive-dev lane only; Hermes backing stays
-#   gpt-5.5/openai-codex; agy (Antigravity, Gemini-backed -> the `gemini` token)
-#   is the cheap fallback/delegation lane; NO Claude for Hermes-context work.
+#   openai-codex (model pinned in model-registry.yaml); agy (Antigravity,
+#   Gemini-backed -> the `gemini` token) is the cheap fallback/delegation lane;
+#   NO Claude for Hermes-context work.
 #
 # routing_resolution_note: ADVISORY ONLY. The executed routers
 #   (scripts/coordination/routing/lib/tier_router.sh, scripts/ai/task-dispatcher.py)
@@ -124,7 +125,7 @@ agents:
 cost_ceiling_policy: docs/governance/2026-06-17-cost-ceiling-policy.md
 execution_contexts:
   hermes_batch:               # docs / data-analysis / delegation / overnight-batch
-    primary: openai-codex     # Hermes backing = gpt-5.5 via openai-codex (unchanged)
+    primary: openai-codex     # Hermes backing via openai-codex; model pinned in model-registry (unchanged)
     fallbacks: [gemini]       # agy = the Antigravity Gemini CLI surface -> gemini token
     forbid: [claude]          # cost ceiling
     cost_ceiling: true

--- a/docs/governance/2026-06-17-cost-ceiling-policy.md
+++ b/docs/governance/2026-06-17-cost-ceiling-policy.md
@@ -1,0 +1,32 @@
+# Decision record — AI provider cost-ceiling policy
+
+- **Date:** 2026-06-17
+- **Status:** Accepted (operator decision 2026-06-17)
+- **Issue:** [#3192](https://github.com/vamseeachanta/workspace-hub/issues/3192) · **Epic:** [#3058](https://github.com/vamseeachanta/workspace-hub/issues/3058)
+- **SSoT for:** provider cost routing intent. Referenced from `config/agents/routing-config.yaml` (`execution_contexts`).
+
+## Context
+
+The operator runs fixed multi-provider budgets (Anthropic Max base + overage, OpenAI, Google AI Pro). Claude API is the most expensive surface and is reserved for interactive development. The prior `routing-config.yaml` named `claude` primary for every tier with no notion of a cost ceiling, and there was an apparent conflict between the policy phrase "agy powers Hermes" and the configs (which all say Hermes runs `gpt-5.5` via the `openai-codex` provider).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Claude is the interactive-dev lane only.** | API cost; reserve the premium surface for human-driven work. |
+| 2 | **Hermes's backing lane STAYS `gpt-5.5` / `openai-codex`.** The phrase "agy powers Hermes" is **overridden** — agy is a *fallback/delegation* lane, not Hermes's backing model. | All configs + the provider-capabilities strategy note already run Hermes on `gpt-5.5`; no reason to switch its backing model. Resolves the #3192 conflict. |
+| 3 | **agy (Antigravity, Gemini-backed) is the cheap fallback / delegation lane.** In routing it resolves to the `gemini` provider token (the capability that exists in `provider-capabilities.yaml`); `agy` is the CLI surface for it. | Keeps the token set consistent with `provider-capabilities.yaml`; a first-class `agy` token is scoped to [#3190](https://github.com/vamseeachanta/workspace-hub/issues/3190). |
+| 4 | **Cost ceiling: no Claude for Hermes-context work.** Encoded as `execution_contexts.hermes_batch.forbid: [claude]`. | Hermes batch/docs/delegation must not consume the Claude API budget. |
+
+## Enforcement status — ADVISORY ONLY (important)
+
+This policy is currently **declarative**. The executed routers (`scripts/coordination/routing/lib/tier_router.sh`, `scripts/ai/task-dispatcher.py`) hold their own **hardcoded** routing chains and do **not** parse `routing-config.yaml`. Therefore:
+
+> **Do NOT rely on `execution_contexts` / the cost ceiling to block Claude on Hermes tasks at runtime until the executed-router consolidation lands.**
+
+Consolidating the three drifted routing copies into one executed source is a follow-up under epic [#3058](https://github.com/vamseeachanta/workspace-hub/issues/3058). The guard test (`tests/config/test_cost_ceiling_policy.py`) asserts the config's **declared intent**, not runtime enforcement.
+
+## Related
+- `config/agents/routing-config.yaml` — `execution_contexts` + `routing_resolution_note` reference this doc.
+- `config/agents/model-registry.yaml` / `provider-capabilities.yaml` — model IDs; Hermes = `gpt-5.5` (unchanged).
+- `docs/governance/2026-06-14-model-parity-decision.md` — sibling decision record (single-registry principle).

--- a/tests/config/test_cost_ceiling_policy.py
+++ b/tests/config/test_cost_ceiling_policy.py
@@ -1,0 +1,62 @@
+"""Cost-ceiling policy guard (#3192).
+
+Asserts the DECLARED intent of routing-config.yaml's execution_contexts — NOT
+runtime enforcement (the executed routers don't parse this file; see
+docs/governance/2026-06-17-cost-ceiling-policy.md "Enforcement status").
+"""
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTING = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
+CAPS = REPO_ROOT / "config" / "agents" / "provider-capabilities.yaml"
+
+
+def _routing():
+    with open(ROUTING) as fh:
+        return yaml.safe_load(fh)
+
+
+def test_cost_ceiling_context_declares_forbid_claude():
+    ctx = _routing()["execution_contexts"]
+    for name, c in ctx.items():
+        if c.get("cost_ceiling"):
+            forbidden = c.get("forbid", [])
+            assert "claude" in forbidden, f"{name} is cost_ceiling but does not forbid claude"
+            assert "claude" != c.get("primary"), f"{name} cost-ceiling primary must not be claude"
+            assert "claude" not in (c.get("fallbacks") or []), f"{name} cost-ceiling fallbacks must not include claude"
+
+
+def test_hermes_context_primary_is_openai_codex():
+    # Operator decision 2026-06-17: Hermes backing stays gpt-5.5/openai-codex.
+    assert _routing()["execution_contexts"]["hermes_batch"]["primary"] == "openai-codex"
+
+
+def test_hermes_context_fallback_is_gemini():
+    # agy = the Antigravity Gemini CLI surface -> resolves to the `gemini` token.
+    assert "gemini" in _routing()["execution_contexts"]["hermes_batch"]["fallbacks"]
+
+
+def test_interactive_dev_primary_is_claude():
+    assert _routing()["execution_contexts"]["interactive_dev"]["primary"] == "claude"
+
+
+def test_cost_policy_reference_resolves():
+    ref = _routing().get("cost_ceiling_policy")
+    assert ref, "routing-config missing cost_ceiling_policy reference"
+    doc = REPO_ROOT / ref
+    assert doc.exists(), f"cost-ceiling policy doc missing: {ref}"
+    text = doc.read_text().lower()
+    assert "advisory only" in text, "policy doc must state the ceiling is advisory only"
+
+
+def test_provider_caps_hermes_aligned():
+    # provider-capabilities + routing-config must agree Hermes runs gpt-5.5.
+    routing = _routing()
+    with open(CAPS) as fh:
+        caps = yaml.safe_load(fh)
+    rc_primary = routing["agents"]["hermes"]["models"]["primary"]
+    assert rc_primary == "gpt-5.5", f"routing-config hermes primary drifted: {rc_primary}"
+    cap_primary = caps["providers"]["hermes"]["model_ids"]["primary"]
+    assert cap_primary == "gpt-5.5", f"provider-capabilities hermes primary drifted: {cap_primary}"


### PR DESCRIPTION
Closes #3192 · Part of epic #3058 · Plan: `docs/plans/2026-06-17-issue-3192-routing-config-cost-policy.md` (in #3200)

## What
Encodes the operator cost policy as **declarative** routing intent + a governance SSoT.
- `config/agents/routing-config.yaml` — appended `execution_contexts` (hermes_batch: primary `openai-codex`, fallback `gemini`, **forbid `claude`**, `cost_ceiling: true`; interactive_dev: claude; cross_review: claude) + `cost_ceiling_policy` ref + an **ADVISORY-ONLY** `routing_resolution_note`.
- `docs/governance/2026-06-17-cost-ceiling-policy.md` — decision record: **Hermes backing stays openai-codex** (the "agy powers Hermes" phrase overridden; agy = fallback/delegation lane); Claude = interactive-dev only.
- `tests/config/test_cost_ceiling_policy.py` — 6 guard tests.

## Key design choices (from plan-stage review)
- **Cost ceiling lives in `execution_contexts`, not tier primaries** → the `tiers` block is unchanged, so the existing `test_simple_and_standard_route_to_claude` passes (no inversion).
- **Appended at EOF** → `gpt-5.5`@L93 (model-id baseline) is untouched; literal model-id kept out of new comments (Model-ID Sourcing Guard clean).
- **ADVISORY ONLY, stated unmistakably**: the executed routers (`tier_router.sh`, `task-dispatcher.py`) hold hardcoded chains and do NOT parse this file; the guard test asserts *declared intent*, not runtime enforcement. Executed-router consolidation is a deferred #3058 follow-up.

## Tests
`tests/config/`: **9 passed** (6 new + 3 existing). abs-path + model-id-sourcing guards clean.

Code-stage cross-provider review via `plan-review-fanout.sh` recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)