### PR TITLE
feat(workflows): gated workflow templates + schema + tests (#3191)

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -107,8 +107,32 @@ Workflows integrate with %ctx tracking:
 | 60-80% | Create checkpoint, archive older exchanges |
 | 80-100% | Trim to essentials |
 
+## Gate-chain templates (#3191)
+
+Three **provider-neutral** templates encode the mandatory gate chain as data (so Claude/Codex/Gemini/Hermes follow the same gates). They carry `kind: gated-workflow` and are validated against `schema/workflow.schema.json` by `tests/workflow/test_gated_workflow_templates.py` (run: `uv run --group dev pytest tests/workflow/`). They are **Level-0/1 data, NOT enforcement** — enforcement lives in `scripts/workflow/plan_approval_gate_check.py` and `.github/workflows/completeness-gate.yml`.
+
+- `issue-gate-chain.yaml` — full lifecycle (issue → plan → USER approves → implement(TDD) → cross-review → close); per-tier review depth (T1=1/T2=2/T3=3 providers); `user_approval` is `USER_ONLY` + `self_approve: forbidden`.
+- `tdd-implementation.yaml` — test-first → implement → refactor → review → close; opt-in completeness gate.
+- `cross-provider-review-workflow.yaml` — encodes `scripts/review/plan-review-fanout.sh` (default Claude+Codex+Gemini, `on_provider_unavailable: continue_and_record`).
+
+## Choosing a workflow template
+
+| Use case | Template | Schema |
+|---|---|---|
+| Issue lifecycle / approval gate chain | **`issue-gate-chain.yaml`** | gated-workflow |
+| TDD implementation (new work) | **`tdd-implementation.yaml`** | gated-workflow |
+| Cross-provider adversarial review | **`cross-provider-review-workflow.yaml`** | gated-workflow |
+| Multi-repo pytest validation | `pytest-validation.yaml` | legacy `metadata/config/steps` |
+| Hierarchical result aggregation | `aggregation.yaml` | legacy `metadata/config/steps` |
+| Context-overflow checkpointing | `checkpoint.yaml` | legacy `metadata/config/steps` |
+| Standard TDD phases (**deprecated** — Claude-only, no gates) | `standard-development.yaml` → use `tdd-implementation.yaml` | legacy `name/phases` |
+| Data analysis (**deprecated** — Claude-only, no gates) | `data-analysis.yaml` | legacy `name/phases` |
+
+Only `kind: gated-workflow` files are validated by `schema/workflow.schema.json`; the two legacy dialects are out of its scope by construction.
+
 ## Related Documentation
 
 - Context Management Skill: `~/.claude/skills/context-management/SKILL.md`
 - CLAUDE.md Directives: `.claude/CLAUDE.md`
 - Batch Runner: `scripts/batchtools/batch_runner.sh`
+- Gate chain source: `AGENTS.md` / `config/agents/SHARED_SOUL.md` (Hard Gates); review fan-out: `scripts/review/plan-review-fanout.sh`

--- a/.claude/workflows/cross-provider-review-workflow.yaml
+++ b/.claude/workflows/cross-provider-review-workflow.yaml
@@ -1,0 +1,30 @@
+# Cross-provider review workflow (#3191) — provider-neutral. Encodes the existing
+# scripts/review/plan-review-fanout.sh fan-out (Claude + Codex + Gemini); does NOT
+# re-encode provider assignments (those live in config/ai-tools/provider-routing-policy.yaml).
+# DATA not enforcement.
+kind: gated-workflow
+metadata:
+  name: cross-provider-review
+  version: 1.0.0
+  description: Adversarial cross-review fan-out across providers with per-provider unavailability degradation + consensus handling.
+source: config/agents/SHARED_SOUL.md#cross-review-routing   # default 3-agent: Claude + Codex + Gemini
+
+tiers:
+  T1: { review_providers: [claude] }
+  T2: { review_providers: [claude, codex] }
+  T3: { review_providers: [claude, codex, gemini] }
+
+gates:
+  - id: dispatch_review
+    runner: scripts/review/plan-review-fanout.sh
+    default_providers: [claude, codex, gemini]
+    on_provider_unavailable: continue_and_record
+    description: Fan out the review to the tier's providers in parallel; record UNAVAILABLE rather than blocking.
+  - id: collect_verdicts
+    runner: scripts/review/validate-review-output.sh
+    description: Classify each artifact VALID | NO_OUTPUT | SKIPPED_NETWORK | INVALID_OUTPUT.
+  - id: consensus
+    description: Single-provider verdict != consensus. On r1/r2 disagreement apply r3 as inline patches (do NOT re-dispatch); default non-APPROVE.
+  - id: close
+    close_reason: completed
+    description: Record verdicts under scripts/review/results/ before proceeding.

--- a/.claude/workflows/issue-gate-chain.yaml
+++ b/.claude/workflows/issue-gate-chain.yaml
@@ -1,0 +1,51 @@
+# Issue gate-chain workflow (#3191) — provider-neutral, DATA not enforcement.
+# Encodes the mandatory lifecycle from AGENTS.md / SHARED_SOUL.md as data so any
+# provider (Claude / Codex / Gemini / Hermes) follows the same gates. Enforcement
+# stays in scripts/workflow/plan_approval_gate_check.py + completeness-gate.yml.
+kind: gated-workflow
+metadata:
+  name: issue-gate-chain
+  version: 1.0.0
+  description: Canonical issue lifecycle (issue -> plan -> USER approves -> implement(TDD) -> cross-review -> close).
+source: AGENTS.md#hard-gates   # "Issue -> Resource Intel -> Plan -> Adversarial Review -> status:plan-review -> USER APPROVES -> status:plan-approved -> Implement (TDD) -> Close"
+
+# Reference data only: the human assigns the tier at plan-review; the review depth
+# is looked up here (T1=1 / T2=2 / T3=3 providers per SHARED_SOUL Hard Gate 4).
+tiers:
+  T1: { review_providers: [claude] }
+  T2: { review_providers: [claude, codex] }
+  T3: { review_providers: [claude, codex, gemini] }
+
+gates:
+  - id: issue
+    description: Issue opened and scoped.
+  - id: resource_intel
+    description: Resource-intelligence gathering (>=3 cited sources) per the plan template.
+  - id: plan
+    status_label: status:plan-review
+    artifact: docs/plans/<date>-issue-<N>-<slug>.md
+    description: Author the plan from docs/plans/_template-issue-plan.md.
+  - id: adversarial_review_plan
+    review_depth_from: tiers
+    runner: scripts/review/plan-review-fanout.sh
+    description: Adversarial review at plan stage; default non-APPROVE.
+  - id: user_approval
+    status_label: status:plan-approved
+    actor: USER_ONLY
+    self_approve: forbidden
+    description: User-in-loop approval gate — never self-applied by an agent.
+  - id: implement
+    precondition: status:plan-approved
+    tests_before_code: true
+    description: TDD implementation; tests before code.
+  - id: adversarial_review_code
+    review_depth_from: tiers
+    runner: scripts/review/plan-review-fanout.sh
+    description: Adversarial review at code stage.
+  - id: completeness_gate
+    applies_when_label: gate:completeness
+    verifier: COMPLETENESS_OWNERS
+    description: Owner-verified completeness score before close (opt-in via the label).
+  - id: close
+    close_reason: completed
+    description: Close with a summary comment on the issue.

--- a/.claude/workflows/schema/workflow.schema.json
+++ b/.claude/workflows/schema/workflow.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://vamseeachanta.workspace-hub/schema/gated-workflow.json",
+  "title": "Gated workflow template (#3191)",
+  "description": "Schema for provider-neutral gate-chain workflow templates. Scoped by the `kind: gated-workflow` discriminator — legacy workflow dialects (metadata/config/steps, name/phases) are NOT validated by this schema. These templates are Level-0/1 DATA, not enforcement; enforcement lives in scripts/workflow/plan_approval_gate_check.py and .github/workflows/completeness-gate.yml.",
+  "type": "object",
+  "required": ["kind", "metadata", "source", "gates"],
+  "additionalProperties": true,
+  "properties": {
+    "kind": { "const": "gated-workflow" },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "version", "description"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "source": {
+      "type": "string",
+      "description": "Inline citation to the rule/gate-chain source (e.g. AGENTS.md#hard-gates)."
+    },
+    "tiers": {
+      "type": "object",
+      "description": "Reference data only — tier is assigned by the human at plan-review; providers are looked up here, not enforced by the template.",
+      "patternProperties": {
+        "^T[123]$": {
+          "type": "object",
+          "required": ["review_providers"],
+          "properties": {
+            "review_providers": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "status_label": { "type": ["string", "null"] },
+          "actor": { "type": "string" },
+          "self_approve": { "enum": ["forbidden", "allowed"] },
+          "precondition": { "type": ["string", "null"] },
+          "tests_before_code": { "type": "boolean" },
+          "review_depth_from": { "type": "string" },
+          "runner": { "type": "string" },
+          "applies_when_label": { "type": "string" },
+          "verifier": { "type": "string" },
+          "close_reason": { "type": "string" },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/.claude/workflows/tdd-implementation.yaml
+++ b/.claude/workflows/tdd-implementation.yaml
@@ -1,0 +1,36 @@
+# TDD implementation workflow (#3191) — provider-neutral rewrite of the shape in
+# standard-development.yaml (which hardcodes Claude Code subagent tooling).
+# DATA not enforcement.
+kind: gated-workflow
+metadata:
+  name: tdd-implementation
+  version: 1.0.0
+  description: Provider-neutral test-first implementation (test_first -> implement -> refactor -> review -> close).
+source: config/agents/SHARED_SOUL.md#hard-gates   # Gate 2: "TDD mandatory — tests before implementation; no exceptions."
+
+tiers:
+  T1: { review_providers: [claude] }
+  T2: { review_providers: [claude, codex] }
+  T3: { review_providers: [claude, codex, gemini] }
+
+gates:
+  - id: test_first
+    description: Write failing tests that encode the spec (red) before any implementation.
+  - id: implement
+    precondition: status:plan-approved
+    tests_before_code: true
+    description: Implement to green; smallest change that passes the tests.
+  - id: refactor
+    description: Refactor with tests green; no behavior change.
+  - id: review
+    review_depth_from: tiers
+    runner: scripts/review/plan-review-fanout.sh
+    description: Adversarial code-stage review at the tier's depth.
+  - id: completeness_gate
+    applies_when_label: gate:completeness
+    verifier: COMPLETENESS_OWNERS
+    thresholds: { code: 90, evidence: 80 }
+    description: Opt-in owner-verified completeness score before close.
+  - id: close
+    close_reason: completed
+    description: Close with a summary + evidence (tests, artifacts).

--- a/tests/workflow/test_gated_workflow_templates.py
+++ b/tests/workflow/test_gated_workflow_templates.py
@@ -1,0 +1,118 @@
+"""Validation for #3191 gated workflow templates.
+
+Run: uv run --group dev pytest tests/workflow/test_gated_workflow_templates.py -v
+(jsonschema is a dev-group dependency.)
+
+These templates are Level-0/1 DATA, not enforcement — this suite checks they parse,
+conform to schema/workflow.schema.json (scoped by `kind: gated-workflow`, so legacy
+dialects are untouched), and satisfy the gate-chain invariants.
+"""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WF_DIR = REPO_ROOT / ".claude" / "workflows"
+SCHEMA_PATH = WF_DIR / "schema" / "workflow.schema.json"
+
+CANONICAL_STATUS_LABELS = {"status:plan-review", "status:plan-approved", "status:completeness-verified"}
+CLAUDE_ONLY_TOKENS = ("tool: Task", "subagent_type", "@.claude/agent-library")
+
+
+def _load_yaml(p):
+    with open(p) as fh:
+        return yaml.safe_load(fh)
+
+
+def _gated_files():
+    out = []
+    for p in sorted(WF_DIR.glob("*.yaml")):
+        try:
+            doc = _load_yaml(p)
+        except yaml.YAMLError:
+            continue
+        if isinstance(doc, dict) and doc.get("kind") == "gated-workflow":
+            out.append(p)
+    return out
+
+
+GATED = _gated_files()
+
+
+def test_gated_files_present():
+    names = {p.name for p in GATED}
+    assert {"issue-gate-chain.yaml", "tdd-implementation.yaml",
+            "cross-provider-review-workflow.yaml"} <= names
+
+
+@pytest.mark.parametrize("path", GATED, ids=lambda p: p.name)
+def test_matches_schema(path):
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.Draft7Validator(schema).validate(_load_yaml(path))
+
+
+@pytest.mark.parametrize("path", GATED, ids=lambda p: p.name)
+def test_has_source_citation(path):
+    assert _load_yaml(path).get("source"), f"{path.name} missing inline `source:` citation"
+
+
+@pytest.mark.parametrize("path", GATED, ids=lambda p: p.name)
+def test_provider_neutral(path):
+    text = path.read_text()
+    for tok in CLAUDE_ONLY_TOKENS:
+        assert tok not in text, f"{path.name} contains Claude-only token {tok!r}"
+
+
+@pytest.mark.parametrize("path", GATED, ids=lambda p: p.name)
+def test_status_labels_canonical(path):
+    for g in _load_yaml(path)["gates"]:
+        lbl = g.get("status_label")
+        if lbl:
+            assert lbl in CANONICAL_STATUS_LABELS, f"{path.name}: non-canonical status_label {lbl!r}"
+
+
+@pytest.mark.parametrize("path", GATED, ids=lambda p: p.name)
+def test_tier_review_depths(path):
+    tiers = _load_yaml(path).get("tiers")
+    if tiers:
+        assert len(tiers["T1"]["review_providers"]) == 1
+        assert len(tiers["T2"]["review_providers"]) == 2
+        assert len(tiers["T3"]["review_providers"]) == 3
+
+
+def _gates(name):
+    return _load_yaml(WF_DIR / name)["gates"]
+
+
+def test_issue_gate_chain_ordered():
+    ids = [g["id"] for g in _gates("issue-gate-chain.yaml")]
+    assert ids == ["issue", "resource_intel", "plan", "adversarial_review_plan",
+                   "user_approval", "implement", "adversarial_review_code",
+                   "completeness_gate", "close"]
+
+
+def test_user_approval_is_user_only():
+    ua = next(g for g in _gates("issue-gate-chain.yaml") if g["id"] == "user_approval")
+    assert ua["actor"] == "USER_ONLY"
+    assert ua["self_approve"] == "forbidden"
+
+
+def test_tdd_tests_before_implement():
+    ids = [g["id"] for g in _gates("tdd-implementation.yaml")]
+    assert ids.index("test_first") < ids.index("implement")
+
+
+def test_review_workflow_references_real_fanout():
+    runners = [g.get("runner") for g in _gates("cross-provider-review-workflow.yaml") if g.get("runner")]
+    fanout = "scripts/review/plan-review-fanout.sh"
+    assert fanout in runners, "review workflow must reference the real fanout runner"
+    assert (REPO_ROOT / fanout).exists(), f"{fanout} not found on disk"
+
+
+def test_review_workflow_degradation_and_default_three():
+    dispatch = next(g for g in _gates("cross-provider-review-workflow.yaml") if g["id"] == "dispatch_review")
+    assert dispatch["on_provider_unavailable"] == "continue_and_record"
+    assert dispatch["default_providers"] == ["claude", "codex", "gemini"]


### PR DESCRIPTION
Closes #3191 · Part of epic #3058 · Plan: `docs/plans/2026-06-17-issue-3191-gated-workflow-templates.md`

## What
Three **provider-neutral** gate-chain workflow templates (`kind: gated-workflow`) that encode the mandatory lifecycle as data so any provider follows the same gates — plus a JSON schema, a pytest validation suite, and a README decision table.

- `.claude/workflows/issue-gate-chain.yaml` — issue → plan → **USER approves** → implement(TDD) → cross-review → close; per-tier review depth (T1=1/T2=2/T3=3); `user_approval` is `USER_ONLY` + `self_approve: forbidden`.
- `.claude/workflows/tdd-implementation.yaml` — test-first → implement → refactor → review → close (provider-neutral successor to the deprecated Claude-only `standard-development.yaml`).
- `.claude/workflows/cross-provider-review-workflow.yaml` — encodes `scripts/review/plan-review-fanout.sh` (default Claude+Codex+Gemini, `on_provider_unavailable: continue_and_record`).
- `.claude/workflows/schema/workflow.schema.json` — draft-07, scoped by the `kind` discriminator (legacy dialects untouched).
- `tests/workflow/test_gated_workflow_templates.py` — **21 tests**.
- `.claude/workflows/README.md` — which-template decision table + schema note.

## DATA, not enforcement
These templates are Level-0/1 data; enforcement stays in `scripts/workflow/plan_approval_gate_check.py` + `.github/workflows/completeness-gate.yml`. The README states this explicitly.

## Review findings applied (plan-stage)
Real validation entry point (the pytest fixture, not just a discriminator); per-template provider-neutrality (the test caught my own comment naming a banned token); README migration/decision table; dev-group test invocation; fanout-reference test verifies the YAML names the real script *and* it exists on disk.

## Tests
`uv run --group dev pytest tests/workflow/` → **21 passed**. abs-path clean. Code-stage cross-provider review via `plan-review-fanout.sh` recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)