### PR TITLE
feat(routing): enforce execution-context cost ceiling at runtime (#3205)

### DIFF
--- a/config/agents/routing-config.yaml
+++ b/config/agents/routing-config.yaml
@@ -117,11 +117,13 @@ agents:
 #   Gemini-backed -> the `gemini` token) is the cheap fallback/delegation lane;
 #   NO Claude for Hermes-context work.
 #
-# routing_resolution_note: ADVISORY ONLY. The executed routers
-#   (scripts/coordination/routing/lib/tier_router.sh, scripts/ai/task-dispatcher.py)
-#   hold hardcoded chains and do NOT parse this file. Do NOT rely on the cost
-#   ceiling to block Claude on Hermes tasks at runtime until the executed-router
-#   consolidation lands (#3058 follow-up). The guard test asserts DECLARED intent.
+# routing_resolution_note: ENFORCED at runtime as of #3205 (cost ceiling only).
+#   scripts/ai/routing_resolver.py is the single forbid-policy interpreter; it
+#   reads execution_contexts below and is consulted by tier_router.sh
+#   (route.sh + orchestrate.sh), provider_filter.sh, task-dispatcher.py, and
+#   overnight-batch-planner.py. Pass --context / ROUTE_CONTEXT to activate; an
+#   unknown context fails closed (exit 3), never claude. NOTE: the per-tier
+#   `tiers.*` table is NOT yet single-sourced — that reconciliation is #3209.
 cost_ceiling_policy: docs/governance/2026-06-17-cost-ceiling-policy.md
 execution_contexts:
   hermes_batch:               # docs / data-analysis / delegation / overnight-batch

--- a/docs/governance/2026-06-17-cost-ceiling-policy.md
+++ b/docs/governance/2026-06-17-cost-ceiling-policy.md
@@ -18,13 +18,25 @@ The operator runs fixed multi-provider budgets (Anthropic Max base + overage, Op
 | 3 | **agy (Antigravity, Gemini-backed) is the cheap fallback / delegation lane.** In routing it resolves to the `gemini` provider token (the capability that exists in `provider-capabilities.yaml`); `agy` is the CLI surface for it. | Keeps the token set consistent with `provider-capabilities.yaml`; a first-class `agy` token is scoped to [#3190](https://github.com/vamseeachanta/workspace-hub/issues/3190). |
 | 4 | **Cost ceiling: no Claude for Hermes-context work.** Encoded as `execution_contexts.hermes_batch.forbid: [claude]`. | Hermes batch/docs/delegation must not consume the Claude API budget. |
 
-## Enforcement status — ADVISORY ONLY (important)
+## Enforcement status — ENFORCED at runtime (cost ceiling), as of #3205
 
-This policy is currently **declarative**. The executed routers (`scripts/coordination/routing/lib/tier_router.sh`, `scripts/ai/task-dispatcher.py`) hold their own **hardcoded** routing chains and do **not** parse `routing-config.yaml`. Therefore:
+The cost ceiling is **runtime-enforced** (no longer advisory). A single resolver,
+`scripts/ai/routing_resolver.py`, is the only place forbid policy is interpreted; it
+reads `execution_contexts` from `routing-config.yaml` and is consulted by **every**
+executed surface that can spend provider budget:
 
-> **Do NOT rely on `execution_contexts` / the cost ceiling to block Claude on Hermes tasks at runtime until the executed-router consolidation lands.**
+| Surface | How it consults the resolver |
+|---|---|
+| `scripts/coordination/routing/lib/tier_router.sh` (`route_by_tier`, reached by **both** `route.sh` and `orchestrate.sh`) | filters candidates + uses a context-aware emergency default (never claude) when `ROUTE_CONTEXT` is set |
+| `scripts/coordination/routing/lib/provider_filter.sh` (`filter_available_providers`) | drops forbidden providers from the available set (`--filter --no-fallback`) |
+| `scripts/ai/task-dispatcher.py` | `--context` drops forbidden agents from the scored list |
+| `scripts/ai/overnight-batch-planner.py` | overnight/overnight-batch issues run in `hermes_batch`; no claude default, and an explicit `agent:claude` is a hard error |
 
-Consolidating the three drifted routing copies into one executed source is a follow-up under epic [#3058](https://github.com/vamseeachanta/workspace-hub/issues/3058). The guard test (`tests/config/test_cost_ceiling_policy.py`) asserts the config's **declared intent**, not runtime enforcement.
+**Invocation:** routers pass `--context hermes_batch` (CLI flag) or set `ROUTE_CONTEXT=hermes_batch` (env). **Fail-closed:** an explicit but *unknown* context (e.g. a typo `hermes-batch`) errors with exit 3 — it never falls through to claude. Provider tokens are CLI-normalized in one place (`openai-codex` → `codex`).
+
+**Scope:** this enforces the **cost ceiling** (the `execution_contexts.*.forbid` lists). It does **not** yet single-source the per-tier routing table (`tiers.*`) — that reconciliation (cost-aligned, codex for cheap tiers) is the deferred follow-up [#3209](https://github.com/vamseeachanta/workspace-hub/issues/3209) under epic [#3058](https://github.com/vamseeachanta/workspace-hub/issues/3058).
+
+**Tests (drive the real surfaces):** `tests/ai/test_routing_resolver.py`, `tests/ai/test_task_dispatcher_cost_ceiling.py`, `tests/ai/test_overnight_planner_cost_ceiling.py`, `tests/coordination/test_tier_router_cost_ceiling.py`, `tests/coordination/test_orchestrate_and_provider_filter_cost_ceiling.py`. `tests/config/test_cost_ceiling_policy.py` continues to assert the config's declared intent.
 
 ## Related
 - `config/agents/routing-config.yaml` — `execution_contexts` + `routing_resolution_note` reference this doc.

--- a/docs/plans/2026-06-17-issue-3205-executed-router-consolidation.md
+++ b/docs/plans/2026-06-17-issue-3205-executed-router-consolidation.md
@@ -1,0 +1,302 @@
+# Plan for #3205: Executed-router consolidation — make the routing-config cost ceiling actually enforced
+
+> **Status:** adversarial-reviewed (r1 Claude MAJOR + r2 Codex MAJOR → both revised in)
+> **Complexity:** T2
+> **Date:** 2026-06-17
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3205
+> **Client:** N/A
+> **Project:** (none)
+> **Lane:** lane:claude
+> **Review artifacts:** scripts/review/results/2026-06-17-plan-3205-claude.md | ...-codex.md
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+- Found: `config/agents/routing-config.yaml` — declarative SSoT. `tiers.*` all `primary: claude`; `execution_contexts.hermes_batch` has `forbid: [claude]`, `cost_ceiling: true`, `primary: openai-codex`, `fallbacks: [gemini]` (added #3192).
+- Found: `scripts/coordination/routing/lib/tier_router.sh` — the **executed** tier router (`route_by_tier()`). Assigns `ROUTING_CONFIG=` (line 10) but **never reads it**; routing is hardcoded bash arrays `TIER_PRIMARY/FALLBACK1/FALLBACK2` (lines 13–32). No notion of execution_contexts/forbid. Emergency default is `claude` (lines 97–100) — would **violate** a cost ceiling.
+- Found: `scripts/coordination/routing/route.sh` — CLI entry; sources `tier_router.sh`, calls `route_by_tier "$tier" "$classifier_provider" "$confidence"` (line 278). No `--context` flag today.
+- Found (**r1-F1 — was missed in draft**): `scripts/coordination/routing/orchestrate.sh:61` — a **second executed caller** of `route_by_tier` (also sources `tier_router.sh` at line 27). Threading context only through `route.sh` would leave this path forbid-blind. **Fix:** put the filter *inside* `route_by_tier` so BOTH callers inherit it; thread `ROUTE_CONTEXT` through both entrypoints.
+- Found (**r1-F2 — was missed in draft**): `scripts/coordination/routing/lib/provider_filter.sh:43–47` (`filter_available_providers`) **unconditionally appends `claude`** when usage <80% — a separate forbid-blind availability layer sourced by both route.sh and orchestrate.sh. Must also honor the ceiling.
+- Found: `scripts/ai/task-dispatcher.py` — advisory CLI. Loads the YAML but reads only `tiers.*.description` (line 166); provider preference is the hardcoded `TIER_AGENT_PREFERENCE` dict (lines 63–68). No execution_contexts/forbid awareness.
+- Found (**r1-F9 — was missed in draft**): `scripts/ai/overnight-batch-planner.py` — routes `overnight`/`overnight-batch` issues; `AGENT_MODEL_MAP` maps to `claude` and it has a `claude` "safe default". `overnight-batch` IS a Hermes role (routing-config.yaml:99) → the hermes_batch ceiling context. This is the **highest-volume Claude leak** and must be brought in scope.
+- Found: `scripts/dispatch/route.py` (#3030) — lane-quota dispatcher, lane-label driven, does not reference routing-config. **Out of scope** (different axis: lane quota, not tier/context routing).
+
+### Standards
+Not applicable (harness/infrastructure issue).
+
+### LLM Wiki pages consulted
+No relevant wiki pages (Client: N/A).
+
+### Documents consulted
+- `docs/governance/2026-06-17-cost-ceiling-policy.md` — SSoT for the policy; §"Enforcement status — ADVISORY ONLY" explicitly says routers don't parse the YAML and the ceiling must not be relied on at runtime until this consolidation lands. This plan flips it to ENFORCED.
+- `docs/plans/2026-06-17-issue-3192-routing-config-cost-policy.md` — the predecessor plan that introduced `execution_contexts` as declarative-only.
+- Memory `routing-config-is-advisory.md` — confirms THREE drifted copies and the token-space details; flags that editing the YAML does not change runtime routing.
+- Issue #3205 (body) — acceptance criteria; follow-up to #3192, parent epic #3058.
+
+### Gaps identified
+- No single executed source that reads `execution_contexts` / `forbid` from the YAML. All forbid-blind surfaces must consult one resolver.
+- **Forbid-blind executed surfaces (full set, post-r1):** `route_by_tier` (tier_router.sh) reached via BOTH route.sh + orchestrate.sh (r1-F1); `filter_available_providers` (provider_filter.sh, r1-F2); `task-dispatcher.py`; `overnight-batch-planner.py` (r1-F9). All four must be wired.
+- No `--context`/`ROUTE_CONTEXT` input on any router → no way to signal "this is a Hermes-batch dispatch" so the ceiling can apply.
+- `tier_router.sh` emergency default (`claude`) is unsafe under a cost ceiling — must default to the context primary (CLI-normalized) instead.
+- The resolver must emit **CLI-normalized** provider tokens (`openai-codex`→`codex`) for its bash-facing modes so the bash routers can use the output directly — no invented `map_provider_to_cli` glue (r1-F3/F4).
+- **Latent (deferred, NOT this scope):** the YAML `tiers` block (claude-everywhere) conflicts with the executed bash arrays (SIMPLE/STANDARD=codex). Operator decision 2026-06-17: tier table should become cost-aligned (codex for cheap tiers). Filed as a separate follow-up issue (see Deliverable) — this plan does **not** touch tier chains.
+
+### Evidence (embedded verification)
+
+**Issue statuses** (verified 2026-06-17 via `gh issue view`):
+- `#3205` — OPEN — "Executed-router consolidation: make routing-config cost ceiling actually enforced" (labels: domain:harness, lane:claude, priority:high)
+- `#3192` — CLOSED/merged (#3201) — introduced execution_contexts (advisory)
+- `#3058` — OPEN — parent epic (self-enforcing invariants)
+
+**File existence** (`ls -la` 2026-06-17):
+- EXISTS: `scripts/coordination/routing/lib/tier_router.sh`, `scripts/ai/task-dispatcher.py`, `scripts/coordination/routing/route.sh`, `config/agents/routing-config.yaml`, `tests/config/test_cost_ceiling_policy.py`
+- MISSING (new — this plan creates): `scripts/ai/routing_resolver.py`, `tests/ai/test_routing_resolver.py`, `tests/ai/test_task_dispatcher_cost_ceiling.py`, `tests/coordination/test_tier_router_cost_ceiling.py`
+
+**Line excerpts** (`config/agents/routing-config.yaml` 126–131):
+```
+execution_contexts:
+  hermes_batch:               # docs / data-analysis / delegation / overnight-batch
+    primary: openai-codex
+    fallbacks: [gemini]
+    forbid: [claude]          # cost ceiling
+    cost_ceiling: true
+```
+
+**Gap proof** (`grep -n "execution_contexts\|forbid" scripts/coordination/routing/lib/tier_router.sh scripts/ai/task-dispatcher.py` → empty) → confirms neither executed router references the ceiling today.
+
+**Reproduction proof** (Step 1.5 — the issue alleges "advisory only / not enforced"):
+```
+$ grep -n "ROUTING_CONFIG" scripts/coordination/routing/lib/tier_router.sh
+10:ROUTING_CONFIG="${ROUTER_CONFIG_DIR}/agents/routing-config.yaml"
+# ...no other reference — the var is assigned and never read.
+```
+- Reproduced at: 2026-06-17. Failure mode (cost ceiling is declarative only; routers hold hardcoded chains) matches the issue claim: **YES**.
+
+<!-- distinct sources: issue #3205 + routing-config.yaml + tier_router.sh + task-dispatcher.py + cost-ceiling-policy doc + memory = 6 -->
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | docs/plans/2026-06-17-issue-3205-executed-router-consolidation.md |
+| Resolver (new) | `scripts/ai/routing_resolver.py` |
+| Resolver tests (new) | `tests/ai/test_routing_resolver.py` |
+| Dispatcher ceiling test (new) | `tests/ai/test_task_dispatcher_cost_ceiling.py` |
+| Overnight-planner ceiling test (new) | `tests/ai/test_overnight_planner_cost_ceiling.py` |
+| Tier-router ceiling test (new) | `tests/coordination/test_tier_router_cost_ceiling.py` |
+| Modify | `scripts/ai/task-dispatcher.py` |
+| Modify | `scripts/ai/overnight-batch-planner.py` (r1-F9: no claude default under overnight-batch) |
+| Modify | `scripts/coordination/routing/lib/tier_router.sh` (filter inside `route_by_tier`; safe emergency default) |
+| Modify | `scripts/coordination/routing/lib/provider_filter.sh` (r1-F2: honor forbid) |
+| Modify | `scripts/coordination/routing/route.sh` (thread `--context`) |
+| Modify | `scripts/coordination/routing/orchestrate.sh` (r1-F1: thread `ROUTE_CONTEXT`) |
+| Update | `config/agents/routing-config.yaml` (`routing_resolution_note` ADVISORY → ENFORCED) |
+| Update | `docs/governance/2026-06-17-cost-ceiling-policy.md` (§Enforcement ADVISORY → ENFORCED) |
+| Update | `tests/config/test_cost_ceiling_policy.py` (`test_cost_policy_reference_resolves` now asserts "enforced") |
+| Update | docs/plans/README.md (index this plan) |
+| Update (memory) | `~/.claude/.../routing-config-is-advisory.md` (ceiling now enforced; tier maps still advisory) |
+
+---
+
+## Deliverable
+
+A single executed resolver (`scripts/ai/routing_resolver.py`, the only place forbid policy is interpreted) that reads `execution_contexts` from `routing-config.yaml`; **every** forbid-blind executed surface (`route_by_tier` → route.sh + orchestrate.sh, `filter_available_providers`, `task-dispatcher.py`, `overnight-batch-planner.py`) consults it via a `--context`/`ROUTE_CONTEXT` input and **cannot select a forbidden provider** — so a Hermes-/overnight-batch dispatch can never select `claude` at runtime — with tests that drive the real surfaces (positive selection assertions, not just `≠ claude`), and the policy doc flipped ADVISORY → ENFORCED (scoped to the cost ceiling). A follow-up issue is filed for the deferred tier-table reconciliation.
+
+---
+
+## Pseudocode
+
+`scripts/ai/routing_resolver.py` (the ONE place forbid policy is interpreted; all bash-facing output is CLI-normalized):
+```
+TOKEN_TO_CLI = {"openai-codex": "codex"}     # provider-token -> CLI-token (single source)
+def cli(tok): return TOKEN_TO_CLI.get(tok, tok)
+
+load_routing_config(path=ROUTING_CONFIG) -> dict           # cached yaml.safe_load
+resolve_context(name, cfg) -> dict | None                  # execution_contexts[name] or None
+forbidden_providers(name, cfg) -> set[str]                 # {cli(t) for t in ctx.forbid}  (normalized)
+is_cost_ceiling(name, cfg) -> bool                         # ctx.cost_ceiling truthy
+context_chain(name, cfg) -> list[str]                      # [cli(primary)] + [cli(f) for f in fallbacks], minus forbid
+
+filter_candidates(candidates, context, cfg) -> list[str]:
+    if not context: return candidates                      # context=None (interactive) -> unchanged
+    ctx = resolve_context(context, cfg)
+    if ctx is None: raise UnknownContextError(context)     # r2-C2 FAIL CLOSED: explicit-but-unknown context is an error,
+                                                           #   NOT pass-through (a typo `hermes-batch` must not leak claude)
+    forbid = forbidden_providers(context, cfg)
+    kept = [c for c in candidates if cli(c) not in forbid] # preserve order, compare normalized
+    if not kept: kept = context_chain(context, cfg)        # all forbidden -> context chain (already cli+forbid-filtered)
+    return kept                                            # NEVER blank lines; [] prints nothing
+
+CLI (all emit CLI-normalized tokens, one per line, no trailing blank):
+  --context NAME --filter c1,c2,c3   -> kept list   (empty --filter "" -> [], not [""])
+  --context NAME --forbidden         -> forbidden tokens
+  --context NAME --chain             -> context_chain (used by the emergency default)
+  --context NAME --json              -> {primary_cli,fallbacks_cli,forbid_cli,cost_ceiling}
+  Unknown explicit context (any mode) -> stderr error + EXIT 3 (callers must abort, not fall to claude).
+
+# Dependency contract (r2-C3): resolver self-bootstraps pyyaml (same pattern as
+#   task-dispatcher.py:24-29 / overnight-batch-planner.py); bash callers invoke it
+#   via `uv run` when available, else `python3` (which self-bootstraps). A bash
+#   helper centralizes this:
+#     _resolver() { if command -v uv >/dev/null; then uv run --quiet "$RESOLVER" "$@";
+#                   else python3 "$RESOLVER" "$@"; fi; }
+```
+
+`tier_router.sh` — apply the filter **inside `route_by_tier`** (so route.sh AND orchestrate.sh both inherit it, r1-F1), after the candidate list is built (~line 82), guarding the empty case (r1-F7):
+```
+if [[ -n "${ROUTE_CONTEXT:-}" && ${#candidates[@]} -gt 0 ]]; then
+    local _csv; _csv="$(IFS=,; echo "${candidates[*]}")"
+    if ! mapfile -t candidates < <(_resolver --context "$ROUTE_CONTEXT" --filter "$_csv"); then
+        echo "route_by_tier: unknown/invalid context '$ROUTE_CONTEXT' — aborting (fail closed)" >&2
+        return 3        # r2-C2: do NOT fall through to claude on a bad context
+    fi
+fi
+# availability loop unchanged (operates on the now-forbid-free candidates)
+# emergency default — CLI-normalized context primary, NEVER claude under a ceiling context:
+if [[ -z "$chosen" ]]; then
+    if [[ -n "${ROUTE_CONTEXT:-}" ]]; then
+        chosen=$(_resolver --context "$ROUTE_CONTEXT" --chain | head -1)   # already cli-normalized
+        reason="Emergency under context $ROUTE_CONTEXT: context primary $chosen"
+    else
+        chosen="claude"; reason="Emergency: no CLI providers detected, defaulting to claude"
+    fi
+fi
+# emit context + forbidden in the JSON for auditability
+```
+
+`provider_filter.sh::filter_available_providers` (r1-F2, r2-C5): build `available_providers` as today, then — when `ROUTE_CONTEXT` is set — pass the **whole list** through the resolver's `--filter` mode (the single filtering implementation; NOT a re-implemented shell drop):
+```
+if [[ -n "${ROUTE_CONTEXT:-}" ]]; then
+    local _csv; _csv="$(IFS=,; echo "${available_providers[*]}")"
+    mapfile -t available_providers < <(_resolver --context "$ROUTE_CONTEXT" --filter "$_csv") \
+        || { echo "filter_available_providers: bad context '$ROUTE_CONTEXT'" >&2; return 3; }
+fi
+```
+This way the unconditional `claude` append (line 47) is filtered back out by the resolver if `claude` is forbidden — no second copy of the forbid rule.
+
+`route.sh` + `orchestrate.sh`: add `--context NAME` → `export ROUTE_CONTEXT="$NAME"` before the pipeline. (route_by_tier reads the env, so no signature change.)
+
+`task-dispatcher.py`: add `--context`; after `score_agents`, drop agents whose token ∈ `forbidden_providers(context)`; re-pick best; add `context`/`forbidden` to output JSON. (forbid=[claude] over {hermes,claude,codex,gemini} can't empty the list, but guard anyway → context_chain.)
+
+`overnight-batch-planner.py` (r1-F9): treat `overnight`/`overnight-batch` issues as the `hermes_batch` context. When mapping an issue to an agent, pass the resolved agent through `filter_candidates([agent, *fallbacks], "hermes_batch")` (importing the resolver directly — same process, no subshell); the `claude` "safe default" becomes the context primary (`codex`). An explicit `agent:claude` label on an overnight-batch issue is a **hard error** (surfaced, not silently downgraded).
+- **r2-C4 (dry-run fixture conflict):** `_synthetic_issues()` issue #1823 currently carries `agent:claude` + `overnight` (lines 157-160) and is returned by `--dry-run` (lines 106-110) → the new hard-error would break dry-run. Fix: relabel #1823's synthetic entry to `agent:codex` so `--dry-run` stays clean/usable, and exercise the error path with a **dedicated** unit test that feeds an `agent:claude`+`overnight` issue straight to the mapping function (not via the bundled dry-run set).
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Create | `scripts/ai/routing_resolver.py` | single source where forbid policy is interpreted; CLI-normalized output |
+| Create | `tests/ai/test_routing_resolver.py` | unit tests for the resolver (incl. cli-normalization, empty-filter) |
+| Create | `tests/ai/test_task_dispatcher_cost_ceiling.py` | drives real dispatcher; claude excluded under hermes_batch |
+| Create | `tests/ai/test_overnight_planner_cost_ceiling.py` | overnight-batch issue never routes to claude; `agent:claude` label errors |
+| Create | `tests/coordination/test_tier_router_cost_ceiling.py` | drives real `route_by_tier` (positive: selects codex; emergency ≠ claude; real `command -v` variant) |
+| Modify | `scripts/ai/task-dispatcher.py` | `--context`, consult resolver, drop forbidden |
+| Modify | `scripts/ai/overnight-batch-planner.py` | r1-F9: resolver-gate overnight-batch; no claude default |
+| Modify | `scripts/coordination/routing/lib/tier_router.sh` | filter inside `route_by_tier`; safe emergency default; emit context/forbidden |
+| Modify | `scripts/coordination/routing/lib/provider_filter.sh` | r1-F2: drop forbidden tokens when ROUTE_CONTEXT set |
+| Modify | `scripts/coordination/routing/route.sh` | `--context` flag → `ROUTE_CONTEXT` |
+| Modify | `scripts/coordination/routing/orchestrate.sh` | r1-F1: `--context` flag → `ROUTE_CONTEXT` |
+| Update | `config/agents/routing-config.yaml` | `routing_resolution_note`: ADVISORY → ENFORCED (cost ceiling only) |
+| Update | `docs/governance/2026-06-17-cost-ceiling-policy.md` | §Enforcement: ADVISORY → ENFORCED, scoped to the cost ceiling (not tier routing) |
+| Update | `tests/config/test_cost_ceiling_policy.py` | `test_cost_policy_reference_resolves` assert "enforced" not "advisory only" |
+| Update | docs/plans/README.md | index this plan |
+| Comment | issue #3205 | re-scope acceptance #1 to "context routing"; link the deferred tier-table issue (before plan-approved) |
+
+---
+
+## TDD Test List
+
+| Test name | What it verifies | Input | Expected |
+|---|---|---|---|
+| test_forbidden_providers_hermes_batch | parses forbid from YAML | context="hermes_batch" | {"claude"} |
+| test_forbidden_providers_interactive_none | non-ceiling context has no forbid | "interactive_dev" | empty set |
+| test_filter_drops_claude_preserves_order | order-preserving removal | ["claude","codex","gemini"], "hermes_batch" | ["codex","gemini"] |
+| test_filter_no_context_passthrough | None context unchanged | ["claude","codex"], None | ["claude","codex"] |
+| test_filter_unknown_context_fails_closed | r2-C2: explicit unknown context errors, no pass-through | ["claude"], "hermes-batch" (typo) | raises UnknownContextError / CLI exit 3 |
+| test_router_aborts_on_bad_context | r2-C2: route_by_tier returns 3 (not claude) when ROUTE_CONTEXT invalid | ROUTE_CONTEXT="bogus" | rc=3; no claude selection |
+| test_resolver_invoked_via_uv_or_python3 | r2-C3: `_resolver` helper works with uv present and absent (PATH-stubbed) | — | resolver runs; pyyaml available |
+| test_filter_all_forbidden_falls_to_context_chain | empty after filter → context chain | ["claude"], "hermes_batch" | ["codex","gemini"] (CLI-normalized) |
+| test_chain_is_cli_normalized | r1-F3/F4: openai-codex→codex in chain output | "hermes_batch" | ["codex","gemini"] (no "openai-codex") |
+| test_filter_empty_input_is_empty_list | r1-F7: `--filter ""` ≠ [""] | "", "hermes_batch" | [] (no blank-string candidate) |
+| test_is_cost_ceiling_true_false | reads cost_ceiling flag | hermes_batch / interactive_dev | True / False |
+| test_cli_filter_mode | CLI `--context hermes_batch --filter claude,codex` | — | stdout "codex" |
+| test_cli_chain_mode | CLI `--context hermes_batch --chain` | — | "codex\ngemini" |
+| test_dispatcher_hermes_context_excludes_claude | real dispatcher main() | --task "summarize report" --tier complex --context hermes_batch | recommended_agent ≠ claude; claude ∉ alternatives |
+| test_dispatcher_no_context_can_pick_claude | no regression to interactive path | same task, no --context | claude selectable (unchanged behavior) |
+| test_tier_router_context_selects_codex (positive) | real `route_by_tier`, all providers available (stub→0), ROUTE_CONTEXT=hermes_batch on COMPLEX | — | `.provider == "codex"`; reason indicates filter (not emergency); "claude" ∉ candidates |
+| test_tier_router_real_availability_only_codex | r1-F5: real `check_provider_available`, only `codex` on PATH | — | `.provider == "codex"` (proves CLI-normalization end-to-end) |
+| test_tier_router_emergency_default_not_claude | no providers available + ceiling context | stub check_provider_available→1 | `.provider` == context primary ("codex"), ≠ "claude" |
+| test_orchestrate_context_excludes_claude | r1-F1: drive orchestrate.sh path with --context | COMPLEX task | selected provider ≠ "claude" |
+| test_provider_filter_drops_claude_under_context | r1-F2: `filter_available_providers` w/ ROUTE_CONTEXT=hermes_batch, claude usage <80% | — | "claude" ∉ available_providers |
+| test_overnight_planner_no_claude_default | r1-F9: overnight-batch issue, no agent label | — | assigned agent ≠ "claude" (== codex) |
+| test_overnight_planner_agent_claude_label_errors | explicit agent:claude on overnight-batch | — | hard error / non-zero, surfaced |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uv run pytest tests/ai/test_routing_resolver.py tests/ai/test_task_dispatcher_cost_ceiling.py tests/ai/test_overnight_planner_cost_ceiling.py tests/coordination/test_tier_router_cost_ceiling.py -v` all pass
+- [ ] `uv run pytest tests/config/test_cost_ceiling_policy.py -v` passes (updated assertion)
+- [ ] Driving the **real** routers under `hermes_batch`/overnight-batch never selects `claude` — across ALL four surfaces: route_by_tier (route.sh + orchestrate.sh), filter_available_providers, task-dispatcher, overnight-batch-planner (acceptance #2; positive selection asserted, not just `≠ claude`)
+- [ ] One source (`routing_resolver.py`) is the only place forbid policy is interpreted; every surface delegates to it — no duplicated forbid logic (acceptance #1, scoped to **context** routing per the issue re-scope comment)
+- [ ] `docs/governance/2026-06-17-cost-ceiling-policy.md` §Enforcement reads ENFORCED (scoped to cost ceiling) with the resolver + `--context` mechanism described (acceptance #3)
+- [ ] `routing-config.yaml` `routing_resolution_note` updated to ENFORCED
+- [ ] Issue #3205 acceptance #1 re-scoped to "context routing" via comment; follow-up issue filed (tier-table reconciliation → cost-aligned codex-cheap) under epic #3058, linked from this issue
+- [ ] No regression: `uv run pytest tests/config/ tests/ai/ tests/coordination/` green; `bash -n` clean on all edited shell scripts
+- [ ] Review artifacts posted to scripts/review/results/
+
+---
+
+## Adversarial Review Summary
+
+**r1 — Claude (adversarial subagent), 2026-06-17:** verdict **MAJOR**. Findings, all verified against the live tree and incorporated:
+
+| # | Sev | Finding | Resolution in revised plan |
+|---|---|---|---|
+| F1 | MAJOR | `orchestrate.sh:61` is a second executed caller of `route_by_tier`, uncovered → claude leaks there | Filter moved **inside `route_by_tier`**; `ROUTE_CONTEXT` threaded through both route.sh + orchestrate.sh; `test_orchestrate_context_excludes_claude` added |
+| F2 | MAJOR | `provider_filter.sh:43-47` unconditionally re-adds `claude` (usage<80%) — forbid-blind | provider_filter honors `ROUTE_CONTEXT` forbid; `test_provider_filter_drops_claude_under_context` added |
+| F3/F4 | MAJOR | invented `map_provider_to_cli`; `openai-codex` token wouldn't match bash CLI token → emergency fallthrough | resolver owns `cli()` normalization; `--filter`/`--chain`/`--json` emit CLI tokens; `--chain` replaces the jq glue; normalization tests added |
+| F5 | MAJOR | tier-router test only asserted `≠ claude` (satisfiable by buggy emergency path); stubbing masks real path | added **positive** `test_tier_router_context_selects_codex` + real-`command -v` `test_tier_router_real_availability_only_codex` |
+| F6 | MAJOR | acceptance #1 says "tier/context"; plan silently re-scoped to context-only | explicit step: comment on #3205 re-scoping #1 to "context routing" + link deferred tier issue BEFORE plan-approved; surfaced to user at approval |
+| F7 | MINOR | empty-filter / mapfile blank-line edge cases | empty-input guard in bash + resolver `--filter ""`→[] test |
+| F8 | MINOR | "ENFORCED" doc language could imply tier routing enforced | doc + note scoped explicitly to the cost ceiling |
+| F9 | MAJOR | `overnight-batch-planner.py` routes overnight-batch and defaults to claude — biggest leak | brought in scope; resolver-gated; `agent:claude` on overnight-batch is a hard error; 2 tests added |
+
+**r2 — Codex (via `scripts/review/plan-review-fanout.sh`, `env -u CLAUDECODE` workaround for the stdin-hang #2684), 2026-06-17:** verdict **MAJOR**. Artifact: `scripts/review/results/2026-06-17-plan-3205-codex.md`. All 5 findings verified against the live tree and incorporated:
+
+| # | Sev | Finding | Resolution in revised plan |
+|---|---|---|---|
+| C1 | MAJOR | Acceptance #1 ("tier/context") re-scope to context-only is not yet *authorized* (issue has no comment) | Re-scope is an explicit **precondition of plan-approved**, surfaced to user; the #3205 comment + acceptance edit happen before any `status:plan-approved` (this is the user's gate, not self-applied) |
+| C2 | MAJOR | Resolver failed **open** on unknown context → a typo `hermes-batch` would pass claude through | Changed to **fail closed**: explicit unknown context = error + exit 3; bash routers `return 3` (never fall to claude). Tests updated (`..._fails_closed`, `..._aborts_on_bad_context`) |
+| C3 | MAJOR | Bare `python3` violates the repo `uv run` contract; missing system `yaml` under `set -euo pipefail` breaks routing | `_resolver` bash helper prefers `uv run` else `python3`; resolver self-bootstraps pyyaml (sibling precedent); test for both invocation modes |
+| C4 | MAJOR | Overnight hard-error conflicts with its own `--dry-run` fixture (#1823 = `agent:claude`+`overnight`) | Relabel synthetic #1823 → `agent:codex` (dry-run stays usable); error path covered by a dedicated unit test feeding the mapping function directly |
+| C5 | MAJOR | provider_filter re-implemented forbid drop in shell → second surface, contradicts single-source | provider_filter now passes its full list through the resolver `--filter` API (the only filtering impl) |
+
+**Overall result after r1+r2 revisions:** PASS. Both lenses independently converged on the same core risk (acceptance #1 scope + coverage completeness); no open MAJORs remain. Per `feedback_r3_inline_loop_break_pattern`, r1/r2 differing findings were folded inline — no r3 dispatch.
+
+---
+
+## Risks and Open Questions
+
+- **Risk — bash↔python boundary cost:** `route_by_tier` shelling to `python3` adds per-route latency. Mitigation: only invoked when `ROUTE_CONTEXT` is set (interactive path untouched); resolver is import-light (yaml only). Routing is not a hot loop.
+- **Risk — token-space mismatch (r1-F3/F4):** `execution_contexts` uses `openai-codex`; the bash routers know `codex`. Mitigation: the resolver `cli()` map is the single normalizer; ALL bash-facing modes (`--filter`/`--chain`/`--json`) emit CLI tokens; no bash-side glue. forbid=[claude] is token-consistent everywhere (verified).
+- **Risk — flipping the policy doc breaks `test_cost_policy_reference_resolves`** (asserts "advisory only"). Mitigation: update that test in the same PR (in Files to Change) — caught pre-implementation.
+- **Risk — emergency default regression:** existing `claude` emergency default would violate the ceiling. Mitigation: context-aware emergency default (`--chain | head -1`) + `test_tier_router_emergency_default_not_claude`.
+- **Risk — faithful real-router test (r1-F5):** the tier-router tests include BOTH a stubbed-availability positive case (`== codex`, reason=filter) AND a real-`check_provider_available` variant with only `codex` on PATH, so a green suite implies the happy path actually selects a working non-claude provider — not just the emergency path. `jq` is already a router dependency.
+- **Risk — coverage completeness (r1-F1/F2/F9):** the four forbid-blind surfaces are now all wired + each has a test driving the real surface. Remaining non-tier router callers audited: `scripts/dispatch/route.py` (lane-quota, different axis — out of scope). No other caller of `route_by_tier`/`filter_available_providers` found (`grep` clean beyond route.sh + orchestrate.sh).
+- **Risk — fail-open on bad context (r2-C2):** an enforcement filter that silently passes through on an *explicit* unknown context is a threat-model inversion (the skip condition is more dangerous than the guarded path). Mitigation: explicit unknown context fails closed (exit 3 / `return 3`); only `context=None` passes through. **Generalizable** — promote to a review heuristic: "enforcement skip-conditions must fail closed on malformed explicit input." (Candidate for `.claude/rules/` if it recurs; noted per the promote-generalizable-findings must-fire rule.)
+- **Risk — `uv run` contract + dependency fragility (r2-C3):** bare `python3` under `set -euo pipefail` breaks if system `yaml` is absent. Mitigation: `_resolver` helper prefers `uv run`, falls back to a self-bootstrapping `python3` (sibling precedent); tested both ways.
+- **Deferred (not a risk to this scope):** YAML tier table (claude-everywhere) vs bash (codex-cheap) reconciliation → separate issue, operator-confirmed direction = cost-aligned codex-cheap. The `test_simple_and_standard_route_to_claude` observed-behavior test is intentionally **left untouched** here.
+- **Open (flag at approval):** (a) acceptance #1 re-scope to "context routing" — needs the #3205 comment + user OK. (b) should the routers *auto-derive* `hermes_batch` from the classifier/labels rather than an explicit `--context`/label? Proposed out of scope (explicit is deterministic + testable); auto-derivation = follow-up.
+
+---
+
+## Complexity: T2
+
+**T2** — multi-file harness change across two languages (bash + python), TDD with tests driving the real routers, one new shared module, config + doc + test updates. Plan-stage adversarial review = 2 providers (Claude inline + 1 dispatched).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -488,3 +488,4 @@ Add one row per plan:
 | [#3190](https://github.com/vamseeachanta/workspace-hub/issues/3190) | Provider-neutral skill router + when_to_use (full-tree + agy via unsupported) | [Plan](2026-06-17-issue-3190-skill-router-when-to-use.md) | plan-review | T3 | 2026-06-17 |
 | [#3191](https://github.com/vamseeachanta/workspace-hub/issues/3191) | Gated workflow templates + cross-provider review workflow | [Plan](2026-06-17-issue-3191-gated-workflow-templates.md) | plan-review | T2 | 2026-06-17 |
 | [#3192](https://github.com/vamseeachanta/workspace-hub/issues/3192) | Reconcile routing-config.yaml with operator cost policy | [Plan](2026-06-17-issue-3192-routing-config-cost-policy.md) | plan-review | T2 | 2026-06-17 |
+| [#3205](https://github.com/vamseeachanta/workspace-hub/issues/3205) | Executed-router consolidation — enforce the routing cost ceiling at runtime | [Plan](2026-06-17-issue-3205-executed-router-consolidation.md) | plan-approved | T2 | 2026-06-17 |

--- a/scripts/ai/overnight-batch-planner.py
+++ b/scripts/ai/overnight-batch-planner.py
@@ -61,6 +61,13 @@ LABEL_AGENT_MAP: dict[str, str] = {
 
 OVERNIGHT_LABELS = {"overnight", "overnight-batch", "batch"}
 
+# Overnight/batch work runs in the hermes_batch execution context, where the
+# cost ceiling forbids claude (#3205). The single resolver is the only place
+# forbid policy is interpreted.
+OVERNIGHT_CONTEXT = "hermes_batch"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import routing_resolver  # noqa: E402
+
 MODEL_REGISTRY = REPO_ROOT / "config" / "agents" / "model-registry.yaml"
 
 
@@ -156,7 +163,10 @@ def _synthetic_issues() -> list[dict]:
         {
             "number": 1823,
             "title": "Refactor authentication module with full test coverage",
-            "labels": [{"name": "agent:claude"}, {"name": "overnight"}, {"name": "refactor"}],
+            # agent:codex (not claude): overnight issues run under the hermes_batch
+            # cost ceiling, which forbids claude (#3205); an agent:claude overnight
+            # issue is now a hard error, so the demo fixture uses codex.
+            "labels": [{"name": "agent:codex"}, {"name": "overnight"}, {"name": "refactor"}],
             "body": "Rewrite auth.py to use JWT; add pytest suite with >=90% coverage.",
             "assignees": [],
         },
@@ -195,24 +205,64 @@ def _synthetic_issues() -> list[dict]:
 # Issue → agent resolution
 # ---------------------------------------------------------------------------
 
-def resolve_agent(issue: dict) -> str:
-    """Pick the best agent for an issue based on its labels."""
-    label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+def _enforce_overnight_ceiling(agent: str, was_explicit: bool) -> str:
+    """Apply the hermes_batch cost ceiling to an overnight issue's agent (#3205).
 
-    # Explicit agent label wins
-    for lbl, agent in LABEL_AGENT_MAP.items():
-        if lbl in label_names:
-            return agent
+    - allowed agent: returned unchanged.
+    - forbidden via explicit `agent:<x>` label: HARD ERROR (surface the conflict,
+      don't silently downgrade).
+    - forbidden via heuristic/default: downgrade to the context primary.
+    """
+    forbid = routing_resolver.forbidden_providers(OVERNIGHT_CONTEXT)
+    if routing_resolver.cli(agent) not in forbid:
+        return agent
+    if was_explicit:
+        raise ValueError(
+            f"overnight issue explicitly requests agent '{agent}', forbidden by the "
+            f"'{OVERNIGHT_CONTEXT}' cost ceiling (forbidden: {sorted(forbid)}). "
+            f"Relabel the issue (e.g. agent:codex) or run it outside the overnight context."
+        )
+    chain = routing_resolver.context_chain(OVERNIGHT_CONTEXT)
+    if not chain:  # pathological: context forbids its entire chain
+        raise ValueError(
+            f"no allowed provider for context '{OVERNIGHT_CONTEXT}' — entire chain is forbidden")
+    return chain[0]
+
+
+def resolve_agent(issue: dict) -> str:
+    """Pick the best agent for an issue based on its labels (cost-ceiling aware)."""
+    label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+    is_overnight = bool(OVERNIGHT_LABELS & label_names)
+
+    # Explicit agent label(s) win. With multiple explicit labels under an
+    # overnight ceiling, prefer a non-forbidden one and only hard-error if EVERY
+    # explicit choice is forbidden (review r3-F4).
+    explicit_agents = [agent for lbl, agent in LABEL_AGENT_MAP.items() if lbl in label_names]
+    if explicit_agents:
+        if is_overnight:
+            forbid = routing_resolver.forbidden_providers(OVERNIGHT_CONTEXT)
+            allowed = [a for a in explicit_agents if routing_resolver.cli(a) not in forbid]
+            if allowed:
+                return allowed[0]
+            # all explicit choices forbidden -> hard error via the enforcer
+            return _enforce_overnight_ceiling(explicit_agents[0], was_explicit=True)
+        return explicit_agents[0]
 
     # Heuristic fallback from title/body keywords
     text = (issue.get("title", "") + " " + (issue.get("body") or "")).lower()
     if any(kw in text for kw in ["pdf", "csv", "data", "report", "skill", "doc", "readme"]):
-        return "hermes"
-    if any(kw in text for kw in ["test", "refactor", "cleanup", "implement", "fix"]):
-        return "codex"
-    if any(kw in text for kw in ["architecture", "design", "complex", "review"]):
-        return "claude"
-    return "claude"  # safe default
+        chosen = "hermes"
+    elif any(kw in text for kw in ["test", "refactor", "cleanup", "implement", "fix"]):
+        chosen = "codex"
+    elif any(kw in text for kw in ["architecture", "design", "complex", "review"]):
+        chosen = "claude"
+    else:
+        chosen = "claude"  # default
+
+    if is_overnight:
+        # Heuristic pick under the ceiling -> downgrade (never hard-error).
+        return _enforce_overnight_ceiling(chosen, was_explicit=False)
+    return chosen
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ai/routing_resolver.py
+++ b/scripts/ai/routing_resolver.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Single routing resolver — the ONE place execution-context forbid policy is interpreted (#3205).
+
+Reads `execution_contexts` from config/agents/routing-config.yaml and answers:
+  - which providers are forbidden for a context (the cost ceiling),
+  - a candidate list with forbidden providers removed (order-preserving),
+  - the context's fallback chain (primary + fallbacks), CLI-normalized.
+
+Every executed routing surface (tier_router.sh via route.sh/orchestrate.sh,
+provider_filter.sh, task-dispatcher.py, overnight-batch-planner.py) consults
+THIS module instead of carrying its own forbid logic.
+
+Provider token-space note: routing-config uses provider tokens (e.g.
+`openai-codex`); the bash routers and CLIs use CLI tokens (e.g. `codex`). All
+bash-facing output here is CLI-normalized via cli() so callers can use it
+directly — there is no second normalizer.
+
+Fail-closed contract (r2-C2): an explicit but UNKNOWN context is an error
+(UnknownContextError / CLI exit 3), never a silent pass-through — a typo such as
+`hermes-batch` must not let `claude` leak past a cost ceiling. `context=None`
+(the interactive path) passes through unchanged by design.
+
+Usage (bash-facing; emit CLI-normalized tokens, one per line, no trailing blank):
+  uv run scripts/ai/routing_resolver.py --context hermes_batch --filter claude,codex,gemini
+  uv run scripts/ai/routing_resolver.py --context hermes_batch --chain
+  uv run scripts/ai/routing_resolver.py --context hermes_batch --forbidden
+  uv run scripts/ai/routing_resolver.py --context hermes_batch --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Dependency bootstrap — mirrors task-dispatcher.py / overnight-batch-planner.py
+# so the module works under `uv run` (pyyaml is a project dep) AND under a bare
+# `python3` fallback when uv is unavailable.
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without uv/pyyaml
+    import subprocess
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pyyaml", "-q"])
+    import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTING_CONFIG = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
+
+# Provider-token -> CLI-token. The single source of normalization. Carries the
+# full provider token-space (not just openai-codex) so a forbid authored in
+# provider tokens (e.g. `anthropic`) can't silently fail open (review r3-F3).
+TOKEN_TO_CLI = {
+    "openai-codex": "codex",
+    "anthropic": "claude",
+    "copilot": "gemini",
+}
+
+EXIT_UNKNOWN_CONTEXT = 3
+
+
+class UnknownContextError(ValueError):
+    """Raised when an explicit context is not present in execution_contexts."""
+
+
+def cli(token: str) -> str:
+    """Normalize a provider token to its CLI token."""
+    return TOKEN_TO_CLI.get(token, token)
+
+
+_CACHE: dict[str, dict] = {}
+
+
+def load_routing_config(path: Path | str | None = None) -> dict:
+    p = Path(path) if path is not None else ROUTING_CONFIG
+    key = str(p)
+    if key not in _CACHE:
+        with open(p) as fh:
+            _CACHE[key] = yaml.safe_load(fh) or {}
+    return _CACHE[key]
+
+
+def _contexts(cfg: dict | None) -> dict:
+    cfg = cfg if cfg is not None else load_routing_config()
+    return cfg.get("execution_contexts", {}) or {}
+
+
+def resolve_context(name: str, cfg: dict | None = None) -> dict | None:
+    """Return the execution_contexts entry for `name`, or None if absent."""
+    return _contexts(cfg).get(name)
+
+
+def forbidden_providers(name: str, cfg: dict | None = None) -> set[str]:
+    """CLI-normalized set of providers forbidden for `name` (empty if none)."""
+    ctx = resolve_context(name, cfg)
+    if not ctx:
+        return set()
+    return {cli(t) for t in (ctx.get("forbid") or [])}
+
+
+def is_cost_ceiling(name: str, cfg: dict | None = None) -> bool:
+    ctx = resolve_context(name, cfg)
+    return bool(ctx and ctx.get("cost_ceiling"))
+
+
+def context_chain(name: str, cfg: dict | None = None) -> list[str]:
+    """CLI-normalized [primary, *fallbacks] for `name`, with forbidden removed."""
+    ctx = resolve_context(name, cfg)
+    if ctx is None:
+        raise UnknownContextError(name)
+    forbid = forbidden_providers(name, cfg)
+    chain: list[str] = []
+    for tok in [ctx.get("primary"), *(ctx.get("fallbacks") or [])]:
+        if not tok:
+            continue
+        c = cli(tok)
+        if c not in forbid and c not in chain:
+            chain.append(c)
+    return chain
+
+
+def filter_candidates(candidates: list[str], context: str | None, cfg: dict | None = None,
+                      fallback: bool = True) -> list[str]:
+    """Drop forbidden providers from `candidates` for `context` (order-preserving).
+
+    - context=None: pass through unchanged (interactive path).
+    - explicit unknown context: raise UnknownContextError (fail closed, r2-C2).
+    - everything forbidden + fallback=True: fall back to the context chain
+      (route_by_tier always wants *some* provider to route to).
+    - everything forbidden + fallback=False: return [] (provider_filter reports
+      genuine availability and must not re-add unavailable providers).
+    """
+    if not context:
+        return list(candidates)
+    if resolve_context(context, cfg) is None:
+        raise UnknownContextError(context)
+    forbid = forbidden_providers(context, cfg)
+    kept = [c for c in candidates if c and cli(c) not in forbid]
+    if not kept and fallback:
+        kept = context_chain(context, cfg)
+    return kept
+
+
+def _parse_csv(value: str) -> list[str]:
+    # `--filter ""` must yield [] (not [""]) — r1-F7.
+    return [tok for tok in value.split(",") if tok.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--context", required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--filter", dest="filter_csv", metavar="c1,c2,c3")
+    mode.add_argument("--chain", action="store_true")
+    mode.add_argument("--forbidden", action="store_true")
+    mode.add_argument("--json", dest="json_mode", action="store_true")
+    parser.add_argument("--no-fallback", dest="fallback", action="store_false", default=True,
+                        help="With --filter: return [] when all forbidden (no context-chain fallback).")
+    args = parser.parse_args(argv)
+
+    try:
+        # Uniform fail-closed: an explicit unknown context errors in EVERY mode
+        # (review r3-F1), not just --filter/--chain/--json.
+        if resolve_context(args.context) is None:
+            raise UnknownContextError(args.context)
+        if args.filter_csv is not None:
+            out = filter_candidates(_parse_csv(args.filter_csv), args.context, fallback=args.fallback)
+            print("\n".join(out))
+        elif args.chain:
+            print("\n".join(context_chain(args.context)))
+        elif args.forbidden:
+            print("\n".join(sorted(forbidden_providers(args.context))))
+        elif args.json_mode:
+            if resolve_context(args.context) is None:
+                raise UnknownContextError(args.context)
+            ctx = resolve_context(args.context)
+            print(json.dumps({
+                "context": args.context,
+                "primary_cli": cli(ctx.get("primary")) if ctx.get("primary") else None,
+                "fallbacks_cli": [cli(t) for t in (ctx.get("fallbacks") or [])],
+                "forbid_cli": sorted(forbidden_providers(args.context)),
+                "cost_ceiling": is_cost_ceiling(args.context),
+            }))
+    except UnknownContextError as exc:
+        print(f"routing_resolver: unknown context '{exc}' — failing closed (exit {EXIT_UNKNOWN_CONTEXT})", file=sys.stderr)
+        return EXIT_UNKNOWN_CONTEXT
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ai/task-dispatcher.py
+++ b/scripts/ai/task-dispatcher.py
@@ -35,6 +35,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ROUTING_CONFIG = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
 PROVIDER_CAPS   = REPO_ROOT / "config" / "agents" / "provider-capabilities.yaml"
 
+# Single forbid-policy interpreter (#3205) — never re-implement forbid logic here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import routing_resolver  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Keyword signals per agent/dimension
@@ -199,6 +203,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Complexity tier for the task.",
     )
     parser.add_argument(
+        "--context", default=None,
+        help="Execution context for the cost ceiling (e.g. hermes_batch). "
+             "When set, providers forbidden for that context are excluded. "
+             "An unknown context fails closed (#3205).",
+    )
+    parser.add_argument(
         "--top", type=int, default=3,
         help="Number of alternatives to include in output (default: 3).",
     )
@@ -220,12 +230,36 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     scored = score_agents(args.task, args.tier, routing_cfg, provider_caps)
+
+    # Cost-ceiling enforcement (#3205): drop forbidden agents for the context.
+    forbidden: list[str] = []
+    if args.context:
+        try:
+            forbid = routing_resolver.forbidden_providers(args.context)
+        except routing_resolver.UnknownContextError:
+            print(json.dumps({"error": f"unknown context '{args.context}' — failing closed"}))
+            return routing_resolver.EXIT_UNKNOWN_CONTEXT
+        if routing_resolver.resolve_context(args.context) is None:
+            print(json.dumps({"error": f"unknown context '{args.context}' — failing closed"}))
+            return routing_resolver.EXIT_UNKNOWN_CONTEXT
+        forbidden = sorted(forbid)
+        filtered = [s for s in scored if routing_resolver.cli(s["agent"]) not in forbid]
+        if filtered:
+            scored = filtered
+        else:
+            # Everything scored is forbidden — fall to the context chain.
+            chain = routing_resolver.context_chain(args.context)
+            scored = [s for s in score_agents(args.task, args.tier, routing_cfg, provider_caps)
+                      if routing_resolver.cli(s["agent"]) in chain] or scored
+
     best   = scored[0]
     alts   = scored[1:args.top]
 
     result = {
         "task": args.task,
         "tier": args.tier.upper(),
+        "context": args.context,
+        "forbidden": forbidden,
         "recommended_agent": best["agent"],
         "model": best["model"],
         "provider": best["provider"],

--- a/scripts/coordination/routing/lib/provider_filter.sh
+++ b/scripts/coordination/routing/lib/provider_filter.sh
@@ -16,6 +16,19 @@ fi
 # Assuming CONFIG_DIR is set by the calling script (orchestrate.sh)
 CONFIG_DIR="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)/config}"
 
+# Single routing resolver (#3205) — the only forbid-policy interpreter. Define
+# _resolver only if a sibling lib (tier_router.sh) hasn't already.
+if ! declare -F _resolver >/dev/null 2>&1; then
+    RESOLVER="${RESOLVER:-$(dirname "$CONFIG_DIR")/scripts/ai/routing_resolver.py}"
+    _resolver() {
+        if command -v uv >/dev/null 2>&1; then
+            uv run --quiet "$RESOLVER" "$@"
+        else
+            python3 "$RESOLVER" "$@"
+        fi
+    }
+fi
+
 # --- Function: filter_available_providers ---
 #
 # @return: JSON array of available provider names
@@ -60,6 +73,31 @@ filter_available_providers() {
         fi
     done
 
+    # --- Cost-ceiling enforcement (#3205) ---
+    # Drop providers forbidden for the active execution context via the single
+    # resolver (no re-implemented forbid logic). --no-fallback: report genuine
+    # availability, never re-add an unavailable provider. Fail closed on a bad
+    # context. Interactive path (no ROUTE_CONTEXT) is unchanged.
+    # Validate + filter whenever a context is set — even if the available set is
+    # empty, so an unknown context still fails closed (review r3-F2). With an
+    # empty input, --filter "" returns [] for a valid context and exit 3 for a
+    # bad one.
+    if [[ -n "${ROUTE_CONTEXT:-}" ]]; then
+        local _csv; _csv="$(IFS=,; echo "${final_available[*]:-}")"
+        local _filtered
+        if ! _filtered="$(_resolver --context "$ROUTE_CONTEXT" --filter "$_csv" --no-fallback)"; then
+            echo "filter_available_providers: unknown/invalid context '$ROUTE_CONTEXT' — aborting (fail closed)" >&2
+            return 3
+        fi
+        final_available=()
+        local _line
+        while IFS= read -r _line; do [[ -n "$_line" ]] && final_available+=("$_line"); done <<< "$_filtered"
+    fi
+
     # --- Output JSON Array ---
-    printf '%s\n' "${final_available[@]}" | jq -R . | jq -s .
+    if [[ ${#final_available[@]} -eq 0 ]]; then
+        echo "[]"
+    else
+        printf '%s\n' "${final_available[@]}" | jq -R . | jq -s .
+    fi
 }

--- a/scripts/coordination/routing/lib/tier_router.sh
+++ b/scripts/coordination/routing/lib/tier_router.sh
@@ -9,6 +9,20 @@
 ROUTER_CONFIG_DIR="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)/config}"
 ROUTING_CONFIG="${ROUTER_CONFIG_DIR}/agents/routing-config.yaml"
 
+# Single routing resolver (#3205) — the only forbid-policy interpreter.
+RESOLVER="${RESOLVER:-$(dirname "$ROUTER_CONFIG_DIR")/scripts/ai/routing_resolver.py}"
+
+# Invoke the resolver per the repo `uv run` contract, with a python3 fallback
+# (the resolver self-bootstraps pyyaml). Returns the resolver's exit code so
+# callers can fail closed on an unknown context (exit 3).
+_resolver() {
+    if command -v uv >/dev/null 2>&1; then
+        uv run --quiet "$RESOLVER" "$@"
+    else
+        python3 "$RESOLVER" "$@"
+    fi
+}
+
 # --- Default routing table (used if YAML config not found) ---
 declare -A TIER_PRIMARY=(
     [SIMPLE]="codex"
@@ -81,6 +95,25 @@ route_by_tier() {
         $dup || candidates+=("$fb")
     done
 
+    # Cost-ceiling enforcement (#3205): drop providers forbidden for the active
+    # execution context. Fail closed on an unknown/invalid context — never fall
+    # through to claude. Interactive path (no ROUTE_CONTEXT) is unchanged.
+    local forbidden=""
+    if [[ -n "${ROUTE_CONTEXT:-}" && ${#candidates[@]} -gt 0 ]]; then
+        local _csv; _csv="$(IFS=,; echo "${candidates[*]}")"
+        local _filtered
+        if ! _filtered="$(_resolver --context "$ROUTE_CONTEXT" --filter "$_csv")"; then
+            echo "route_by_tier: unknown/invalid context '$ROUTE_CONTEXT' — aborting (fail closed)" >&2
+            return 3
+        fi
+        mapfile -t candidates <<< "$_filtered"
+        # Defensive: drop any empty element introduced by a trailing newline.
+        local _clean=(); local c
+        for c in "${candidates[@]}"; do [[ -n "$c" ]] && _clean+=("$c"); done
+        candidates=("${_clean[@]}")
+        forbidden="$(_resolver --context "$ROUTE_CONTEXT" --forbidden | tr '\n' ' ' | sed 's/ *$//')"
+    fi
+
     for candidate in "${candidates[@]}"; do
         if check_provider_available "$candidate"; then
             chosen="$candidate"
@@ -93,10 +126,16 @@ route_by_tier() {
         fi
     done
 
-    # Emergency: no provider available
+    # Emergency: no provider available. Under a cost-ceiling context, NEVER
+    # default to claude — use the context's (CLI-normalized) primary instead.
     if [[ -z "$chosen" ]]; then
-        chosen="claude"
-        reason="Emergency: no CLI providers detected, defaulting to claude"
+        if [[ -n "${ROUTE_CONTEXT:-}" ]]; then
+            chosen="$(_resolver --context "$ROUTE_CONTEXT" --chain | head -1)"
+            reason="Emergency under context $ROUTE_CONTEXT: defaulting to context primary $chosen"
+        else
+            chosen="claude"
+            reason="Emergency: no CLI providers detected, defaulting to claude"
+        fi
     fi
 
     # Select best model for chosen provider (adaptive EWMA)
@@ -125,6 +164,8 @@ route_by_tier() {
         --arg model "${selected_model:-}" \
         --arg model_ewma "${model_ewma:-}" \
         --arg model_selection "$model_selection" \
+        --arg context "${ROUTE_CONTEXT:-}" \
+        --arg forbidden "${forbidden:-}" \
         '{
             provider: $provider,
             tier: $tier,
@@ -134,6 +175,8 @@ route_by_tier() {
             routing_chain: [$primary, $fallback1, $fallback2],
             model: $model,
             model_ewma: $model_ewma,
-            model_selection: $model_selection
+            model_selection: $model_selection,
+            context: $context,
+            forbidden: ($forbidden | if . == "" then [] else split(" ") end)
         }'
 }

--- a/scripts/coordination/routing/orchestrate.sh
+++ b/scripts/coordination/routing/orchestrate.sh
@@ -29,8 +29,16 @@ source "$LIB_DIR/usage_bootstrap.sh"
 
 # --- Main Logic ---
 main() {
+    # Optional execution-context cost ceiling (#3205): `--context NAME` excludes
+    # forbidden providers (e.g. hermes_batch forbids claude). Honored by
+    # route_by_tier + filter_available_providers via the ROUTE_CONTEXT env.
+    if [[ "${1:-}" == "--context" ]]; then
+        export ROUTE_CONTEXT="$2"
+        shift 2
+    fi
+
     if [[ $# -eq 0 ]]; then
-        echo "Usage: $0 \"<task_description>\""
+        echo "Usage: $0 [--context NAME] \"<task_description>\""
         exit 1
     fi
 

--- a/scripts/coordination/routing/route.sh
+++ b/scripts/coordination/routing/route.sh
@@ -5,6 +5,8 @@
 #
 # Options:
 #   --execute     Classify, recommend, and dispatch to agent
+#   --context NAME Apply an execution-context cost ceiling (e.g. hermes_batch);
+#                  forbidden providers are excluded; unknown context fails closed (#3205)
 #   --wrk WRK-NNN  Route a work queue item by its ID
 #   --rate <1-5> [provider/model]  Rate last routed agent (1=poor, 5=excellent)
 #   --stats       Show routing decision history and agent ratings
@@ -53,6 +55,7 @@ RATE_PROVIDER=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --execute)  EXECUTE=true; shift ;;
+        --context)  export ROUTE_CONTEXT="$2"; shift 2 ;;
         --wrk)      WRK_ID="$2"; shift 2 ;;
         --rate)     RATE_SCORE="$2"; RATE_PROVIDER="${3:-}"; shift 2; [[ -n "$RATE_PROVIDER" ]] && shift ;;
         --stats)    SHOW_STATS=true; shift ;;

--- a/tests/ai/test_overnight_planner_cost_ceiling.py
+++ b/tests/ai/test_overnight_planner_cost_ceiling.py
@@ -1,0 +1,67 @@
+"""Cost-ceiling enforcement in the overnight batch planner (#3205, r1-F9/r2-C4).
+
+Overnight/overnight-batch issues run in the hermes_batch context, where claude
+is forbidden. The planner must:
+  - never DEFAULT an overnight issue to claude (downgrade to the context primary),
+  - HARD-ERROR on an explicit `agent:claude` label for an overnight issue,
+  - keep `--dry-run` usable (its synthetic set must not contain a now-erroring
+    agent:claude+overnight issue).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "ai" / "overnight-batch-planner.py"
+spec = importlib.util.spec_from_file_location("overnight_batch_planner", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["overnight_batch_planner"] = module
+spec.loader.exec_module(module)
+
+resolve_agent = module.resolve_agent
+
+
+def _issue(labels, body="design a complex architecture"):
+    return {"number": 1, "title": "t", "body": body,
+            "labels": [{"name": n} for n in labels]}
+
+
+def test_overnight_no_claude_default():
+    # Heuristic would pick claude (architecture/design/complex); under the
+    # overnight ceiling it must downgrade to the context primary (codex).
+    agent = resolve_agent(_issue(["overnight", "refactor"]))
+    assert agent != "claude"
+    assert agent == "codex"
+
+
+def test_overnight_explicit_agent_claude_errors():
+    with pytest.raises(ValueError):
+        resolve_agent(_issue(["overnight", "agent:claude"]))
+
+
+def test_overnight_explicit_codex_ok():
+    assert resolve_agent(_issue(["overnight", "agent:codex"])) == "codex"
+
+
+def test_overnight_multilabel_prefers_allowed_over_error():
+    # review r3-F4: claude + codex both explicit under the ceiling -> pick codex,
+    # do NOT hard-error just because claude was listed first.
+    assert resolve_agent(_issue(["overnight", "agent:claude", "agent:codex"])) == "codex"
+
+
+def test_non_overnight_issue_not_ceilinged():
+    # Outside the overnight context the ceiling does not apply.
+    assert resolve_agent(_issue(["agent:claude"])) == "claude"
+
+
+def test_dry_run_synthetic_set_has_no_claude_overnight_issue():
+    # r2-C4: every bundled synthetic overnight issue must resolve without error
+    # and never to claude, so `--dry-run` stays usable.
+    for issue in module._synthetic_issues():
+        agent = resolve_agent(issue)
+        assert agent != "claude", f"issue {issue['number']} resolved to claude"

--- a/tests/ai/test_routing_resolver.py
+++ b/tests/ai/test_routing_resolver.py
@@ -1,0 +1,144 @@
+"""Unit + CLI tests for the single routing resolver (#3205).
+
+The resolver is the ONE place execution-context forbid policy is interpreted.
+These tests pin: forbid parsing, order-preserving filtering, CLI-token
+normalization (openai-codex -> codex), fail-closed on unknown explicit context,
+and the bash-facing CLI surface.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RESOLVER = REPO_ROOT / "scripts" / "ai" / "routing_resolver.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ai"))
+import routing_resolver as rr  # noqa: E402
+
+
+# --- pure API ---------------------------------------------------------------
+
+def test_forbidden_providers_hermes_batch():
+    assert rr.forbidden_providers("hermes_batch") == {"claude"}
+
+
+def test_forbidden_providers_interactive_none():
+    assert rr.forbidden_providers("interactive_dev") == set()
+
+
+def test_filter_drops_claude_preserves_order():
+    assert rr.filter_candidates(["claude", "codex", "gemini"], "hermes_batch") == ["codex", "gemini"]
+
+
+def test_filter_no_context_passthrough():
+    assert rr.filter_candidates(["claude", "codex"], None) == ["claude", "codex"]
+
+
+def test_filter_unknown_context_fails_closed():
+    # r2-C2: an explicit but unknown context must NOT pass claude through.
+    with pytest.raises(rr.UnknownContextError):
+        rr.filter_candidates(["claude"], "hermes-batch")  # typo (hyphen)
+
+
+def test_filter_all_forbidden_falls_to_context_chain():
+    # Only claude offered under a ceiling context -> fall to the context chain.
+    assert rr.filter_candidates(["claude"], "hermes_batch") == ["codex", "gemini"]
+
+
+def test_filter_no_fallback_returns_empty_when_all_forbidden():
+    # provider_filter semantics: report genuine availability, do not re-add.
+    assert rr.filter_candidates(["claude"], "hermes_batch", fallback=False) == []
+    # non-forbidden survivors are still kept under no-fallback.
+    assert rr.filter_candidates(["claude", "codex"], "hermes_batch", fallback=False) == ["codex"]
+
+
+def test_chain_is_cli_normalized():
+    # r2-C3/r1-F4: openai-codex (provider token) -> codex (CLI token).
+    chain = rr.context_chain("hermes_batch")
+    assert "openai-codex" not in chain
+    assert chain == ["codex", "gemini"]
+
+
+def test_cli_helper_normalizes():
+    assert rr.cli("openai-codex") == "codex"
+    assert rr.cli("claude") == "claude"
+
+
+def test_cli_helper_normalizes_full_token_space():
+    # review r3-F3: a forbid authored in provider tokens must not fail open.
+    assert rr.cli("anthropic") == "claude"
+    assert rr.cli("copilot") == "gemini"
+
+
+def test_is_cost_ceiling_true_false():
+    assert rr.is_cost_ceiling("hermes_batch") is True
+    assert rr.is_cost_ceiling("interactive_dev") is False
+
+
+# --- CLI surface (bash-facing) ----------------------------------------------
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(RESOLVER), *args],
+        capture_output=True, text=True,
+    )
+
+
+def test_cli_filter_mode():
+    r = _run("--context", "hermes_batch", "--filter", "claude,codex,gemini")
+    assert r.returncode == 0
+    assert r.stdout.split() == ["codex", "gemini"]
+
+
+def test_cli_chain_mode():
+    r = _run("--context", "hermes_batch", "--chain")
+    assert r.returncode == 0
+    assert r.stdout.split() == ["codex", "gemini"]
+
+
+def test_cli_forbidden_mode():
+    r = _run("--context", "hermes_batch", "--forbidden")
+    assert r.returncode == 0
+    assert r.stdout.split() == ["claude"]
+
+
+def test_cli_unknown_context_exits_3():
+    # r2-C2: fail closed at the CLI boundary too.
+    r = _run("--context", "hermes-batch", "--filter", "claude,codex")
+    assert r.returncode == 3
+    assert "claude" not in r.stdout  # nothing usable emitted on stdout
+
+
+def test_cli_empty_filter_is_empty_not_blank_string():
+    # r1-F7: `--filter ""` must parse to [] (-> context chain), never a "" candidate.
+    r = _run("--context", "hermes_batch", "--filter", "")
+    assert r.returncode == 0
+    assert "" not in r.stdout.split()
+    # empty input -> context chain
+    assert r.stdout.split() == ["codex", "gemini"]
+
+
+def test_cli_forbidden_unknown_context_fails_closed():
+    # review r3-F1: --forbidden must fail closed on an unknown context, like the
+    # other modes (was the one mode that exited 0).
+    r = _run("--context", "hermes-batch", "--forbidden")
+    assert r.returncode == 3
+
+
+def test_cli_chain_unknown_context_fails_closed():
+    r = _run("--context", "nope", "--chain")
+    assert r.returncode == 3
+
+
+def test_cli_json_mode():
+    r = _run("--context", "hermes_batch", "--json")
+    assert r.returncode == 0
+    obj = json.loads(r.stdout)
+    assert obj["cost_ceiling"] is True
+    assert obj["primary_cli"] == "codex"
+    assert "claude" in obj["forbid_cli"]

--- a/tests/ai/test_task_dispatcher_cost_ceiling.py
+++ b/tests/ai/test_task_dispatcher_cost_ceiling.py
@@ -1,0 +1,50 @@
+"""Cost-ceiling enforcement in the task dispatcher (#3205).
+
+Drives the real dispatcher CLI. Under the hermes_batch context the dispatcher
+must never recommend claude; without a context the interactive path is unchanged
+(claude remains selectable).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DISPATCHER = REPO_ROOT / "scripts" / "ai" / "task-dispatcher.py"
+
+
+def _run(*args: str) -> dict:
+    r = subprocess.run(
+        [sys.executable, str(DISPATCHER), *args],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    return json.loads(r.stdout)
+
+
+def test_dispatcher_hermes_context_excludes_claude():
+    out = _run("--task", "summarize this quarterly report", "--tier", "complex",
+               "--context", "hermes_batch")
+    assert out["recommended_agent"] != "claude"
+    assert all(a["agent"] != "claude" for a in out["alternatives"])
+    assert "claude" in out["forbidden"]
+    assert out["context"] == "hermes_batch"
+
+
+def test_dispatcher_no_context_can_pick_claude():
+    # No regression: the interactive path may still pick claude. We pick a task
+    # whose keywords strongly favour claude (architecture/design) at a high tier.
+    out = _run("--task", "design new auth architecture and refactor", "--tier", "reasoning")
+    assert out["recommended_agent"] == "claude"
+    assert out.get("context") in (None, "")
+
+
+def test_dispatcher_unknown_context_fails_closed():
+    r = subprocess.run(
+        [sys.executable, str(DISPATCHER), "--task", "x", "--tier", "simple",
+         "--context", "hermes-batch"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode != 0

--- a/tests/config/test_cost_ceiling_policy.py
+++ b/tests/config/test_cost_ceiling_policy.py
@@ -48,7 +48,8 @@ def test_cost_policy_reference_resolves():
     doc = REPO_ROOT / ref
     assert doc.exists(), f"cost-ceiling policy doc missing: {ref}"
     text = doc.read_text().lower()
-    assert "advisory only" in text, "policy doc must state the ceiling is advisory only"
+    # #3205 flipped the ceiling from advisory to runtime-enforced.
+    assert "enforced" in text, "policy doc must state the ceiling is enforced"
 
 
 def test_provider_caps_hermes_aligned():

--- a/tests/coordination/test_orchestrate_and_provider_filter_cost_ceiling.py
+++ b/tests/coordination/test_orchestrate_and_provider_filter_cost_ceiling.py
@@ -1,0 +1,98 @@
+"""Cost-ceiling coverage for the other two executed surfaces (#3205).
+
+r1-F1: orchestrate.sh is a second caller of route_by_tier — driven end-to-end
+       here with --context to prove claude is excluded.
+r1-F2: provider_filter.sh::filter_available_providers unconditionally re-added
+       claude — driven here to prove the ceiling removes it.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ORCHESTRATE = REPO_ROOT / "scripts" / "coordination" / "routing" / "orchestrate.sh"
+PROVIDER_FILTER = REPO_ROOT / "scripts" / "coordination" / "routing" / "lib" / "provider_filter.sh"
+RESOLVER = REPO_ROOT / "scripts" / "ai" / "routing_resolver.py"
+
+_USAGE = json.dumps({"requests_percent": 5, "tokens_percent": 5,
+                     "cost_today": 1, "daily_budget": 100})
+
+
+# --- r1-F1: orchestrate.sh end-to-end ---------------------------------------
+
+def _orchestrate(*args: str) -> str:
+    r = subprocess.run(["bash", str(ORCHESTRATE), *args],
+                       capture_output=True, text=True, timeout=120)
+    assert r.returncode == 0, r.stderr
+    return r.stdout
+
+
+def _available_line(out: str) -> str:
+    m = re.search(r"Available providers: (\[.*\])", out)
+    return m.group(1) if m else ""
+
+
+def _routed(out: str) -> str:
+    m = re.search(r"Routed to: (\S+)", out)
+    return m.group(1) if m else ""
+
+
+def test_orchestrate_with_context_excludes_claude():
+    out = _orchestrate("--context", "hermes_batch",
+                       "design a complex multi-file architecture refactor")
+    assert "claude" not in _available_line(out)
+    assert _routed(out) != "claude"
+
+
+def test_orchestrate_without_context_can_include_claude():
+    # Baseline: without the ceiling, claude is an available provider (proves the
+    # exclusion above is the ceiling's doing, not an unrelated availability gap).
+    out = _orchestrate("design a complex multi-file architecture refactor")
+    assert "claude" in _available_line(out)
+
+
+# --- r1-F2: provider_filter.sh ----------------------------------------------
+
+def _filter_available(tmp_path: Path, context: str | None) -> list[str]:
+    for prov in ("codex", "gemini", "claude"):
+        (tmp_path / f"{prov}_usage.json").write_text(_USAGE)
+    ctx_assign = f'ROUTE_CONTEXT="{context}" ' if context else ""
+    script = f"""
+set -o pipefail
+export CONFIG_DIR="{tmp_path}"
+export RESOLVER="{RESOLVER}"
+source "{PROVIDER_FILTER}"
+{ctx_assign}filter_available_providers
+"""
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    return json.loads(r.stdout)
+
+
+def test_provider_filter_drops_claude_under_context(tmp_path):
+    avail = _filter_available(tmp_path, "hermes_batch")
+    assert "claude" not in avail
+    assert "codex" in avail and "gemini" in avail
+
+
+def test_provider_filter_keeps_claude_without_context(tmp_path):
+    avail = _filter_available(tmp_path, None)
+    assert "claude" in avail
+
+
+def test_provider_filter_unknown_context_fails_closed(tmp_path):
+    # review r3-F2: a bad context must fail closed even on the empty-available path.
+    for prov in ("codex", "gemini", "claude"):
+        (tmp_path / f"{prov}_usage.json").write_text(_USAGE)
+    script = f"""
+set -o pipefail
+export CONFIG_DIR="{tmp_path}"
+export RESOLVER="{RESOLVER}"
+source "{PROVIDER_FILTER}"
+ROUTE_CONTEXT="hermes-batch" filter_available_providers
+"""
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 3

--- a/tests/coordination/test_tier_router_cost_ceiling.py
+++ b/tests/coordination/test_tier_router_cost_ceiling.py
@@ -1,0 +1,88 @@
+"""Runtime cost-ceiling enforcement in the REAL tier router (#3205, acceptance #2).
+
+These tests source the actual `scripts/coordination/routing/lib/tier_router.sh`
+and call the real `route_by_tier` function (the executed path reached by both
+route.sh and orchestrate.sh). `check_provider_available` is overridden per-test
+to control availability; `route_by_tier` itself — candidate building, the
+resolver filter, the emergency default, the JSON emit — is the real code.
+
+Assertions are POSITIVE (which provider is selected), not merely "!= claude",
+so a green run cannot be satisfied by the emergency fall-through alone (r1-F5).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TIER_ROUTER = REPO_ROOT / "scripts" / "coordination" / "routing" / "lib" / "tier_router.sh"
+
+STUBS = {
+    "all": "check_provider_available() { return 0; }",
+    "only_codex": 'check_provider_available() { [[ "$1" == codex ]]; }',
+    "none": "check_provider_available() { return 1; }",
+}
+
+
+def _route(tier: str, context: str | None, stub: str) -> tuple[dict | None, int]:
+    """Run the real route_by_tier; return (parsed_json_or_None, return_code)."""
+    ctx_assign = f'ROUTE_CONTEXT="{context}" ' if context else ""
+    script = f"""
+set -o pipefail
+source "{TIER_ROUTER}"
+{STUBS[stub]}
+out=$({ctx_assign}route_by_tier "{tier}" "" 0.9); rc=$?
+printf '%s' "$out"
+echo "__RC__=$rc"
+"""
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    body, _, tail = r.stdout.rpartition("__RC__=")
+    rc = int(tail.strip() or r.returncode)
+    obj = json.loads(body) if body.strip() else None
+    return obj, rc
+
+
+def test_no_context_interactive_path_unchanged():
+    # Baseline: COMPLEX primary is claude; with all providers available and no
+    # context, claude is still selected (no regression to the interactive path).
+    obj, rc = _route("COMPLEX", None, "all")
+    assert rc == 0
+    assert obj["provider"] == "claude"
+
+
+def test_context_filters_claude_selects_next_available():
+    # Same COMPLEX route under hermes_batch: claude is filtered; the next
+    # available candidate (gemini) is chosen via the FILTER path, not emergency.
+    obj, rc = _route("COMPLEX", "hermes_batch", "all")
+    assert rc == 0
+    assert obj["provider"] == "gemini"
+    assert obj["provider"] != "claude"
+    assert "Emergency" not in obj["reason"]
+    assert obj["context"] == "hermes_batch"
+    assert "claude" in obj["forbidden"]
+
+
+def test_context_only_codex_available_selects_codex():
+    # Proves CLI-token normalization end-to-end: with ONLY codex reachable, the
+    # filtered route resolves to codex (not the openai-codex provider token).
+    obj, rc = _route("COMPLEX", "hermes_batch", "only_codex")
+    assert rc == 0
+    assert obj["provider"] == "codex"
+
+
+def test_emergency_default_under_ceiling_is_not_claude():
+    # No provider reachable + ceiling context: emergency default must be the
+    # context primary (codex), NEVER claude.
+    obj, rc = _route("COMPLEX", "hermes_batch", "none")
+    assert rc == 0
+    assert obj["provider"] == "codex"
+    assert obj["provider"] != "claude"
+    assert "Emergency" in obj["reason"]
+
+
+def test_unknown_context_fails_closed():
+    # An explicit but invalid context aborts the route (rc 3) — never claude.
+    obj, rc = _route("COMPLEX", "hermes-batch", "all")
+    assert rc == 3
+    assert obj is None


### PR DESCRIPTION
Closes #3205. Follow-up to #3192, under epic #3058. Deferred tier-table reconciliation: #3209.

## What
Turns the routing cost ceiling (`execution_contexts.hermes_batch.forbid:[claude]`) from **advisory** into **runtime-enforced**. A single resolver `scripts/ai/routing_resolver.py` is the only place forbid policy is interpreted; every executed surface consults it via `--context` / `ROUTE_CONTEXT`:

| Surface | Behavior under `hermes_batch` |
|---|---|
| `tier_router.sh::route_by_tier` (route.sh **and** orchestrate.sh) | filters candidates; context-aware emergency default — never claude |
| `provider_filter.sh::filter_available_providers` | drops forbidden from the available set |
| `task-dispatcher.py` | `--context` drops forbidden agents |
| `overnight-batch-planner.py` | overnight issues = `hermes_batch`; no claude default; explicit `agent:claude` = hard error |

**Fail-closed:** an explicit unknown context (e.g. typo `hermes-batch`) errors with exit 3 on every surface/CLI mode — never falls through to claude. Provider tokens CLI-normalized in one place (`openai-codex→codex`, `anthropic→claude`, `copilot→gemini`).

## Scope
Cost-ceiling (context) routing only. The per-tier table (`tiers.*`) reconciliation — YAML claude-everywhere vs executed bash codex-cheap → cost-aligned codex-cheap — is deferred to **#3209** (operator-approved). Acceptance #1 re-scoped to "context routing" per issue comment.

## Reviews (adversarial, both stages)
- **Plan r1 (Claude): MAJOR** — caught orchestrate.sh + provider_filter + overnight-planner leaks; addressed.
- **Plan r2 (Codex): MAJOR** — fail-open-on-unknown-context, bare-python3 vs uv, dry-run fixture conflict, duplicated forbid logic; addressed.
- **Code r3 (Claude): MINOR** — empirically verified no claude leak on any path; hardened fail-closed contract gaps (--forbidden mode, provider_filter empty-set, token-space completeness, multi-label) + IndexError guard.

## Tests
27 new tests drive the **real** surfaces (positive selection assertions, not just `≠ claude`): `tests/ai/test_routing_resolver.py`, `test_task_dispatcher_cost_ceiling.py`, `test_overnight_planner_cost_ceiling.py`, `tests/coordination/test_tier_router_cost_ceiling.py`, `test_orchestrate_and_provider_filter_cost_ceiling.py`. Full `tests/{config,ai,coordination}` green except one **pre-existing, unrelated** failure (`test_agents_and_review_policy_reference_all_three_reviewers`, fails on bare main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)