### PR TITLE
feat(routing): single-source the tier table, cost-aligned (#3209)

### DIFF
--- a/config/agents/routing-config.yaml
+++ b/config/agents/routing-config.yaml
@@ -4,15 +4,23 @@
 
 version: 2.0.0
 
+# Single source of truth for per-tier provider routing (#3209). Cost-aligned:
+# cheap tiers run codex (not claude) per the cost-ceiling policy. Authored in
+# CLI tokens (claude/codex/gemini); hermes is NOT a tier-CLI provider — it
+# routes via `dimensions` + `execution_contexts.hermes_batch`.
+# tier_router.sh's bash arrays are GENERATED from this block via
+#   uv run scripts/ai/routing_resolver.py --emit-bash-table
+# (CI drift-guard: tests/coordination/test_tier_table_no_drift.py). Do not let
+# the two diverge.
 tiers:
   SIMPLE:
-    primary: claude
-    fallbacks: [hermes, codex, gemini]
+    primary: codex
+    fallbacks: [gemini, claude]
     max_context_tokens: 8000
     description: Short factual queries, status checks, simple lookups
   STANDARD:
-    primary: claude
-    fallbacks: [codex, hermes, gemini]
+    primary: codex
+    fallbacks: [claude, gemini]
     max_context_tokens: 32000
     description: Implementation tasks, bug fixes, refactoring
   COMPLEX:

--- a/docs/plans/2026-06-17-issue-3209-tier-table-single-source.md
+++ b/docs/plans/2026-06-17-issue-3209-tier-table-single-source.md
@@ -1,0 +1,238 @@
+# Plan for #3209: Reconcile tier-table routing into one cost-aligned source
+
+> **Status:** adversarial-reviewed (r1 Claude MAJOR → revised; r2 Codex pending)
+> **Complexity:** T2
+> **Date:** 2026-06-17
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3209
+> **Client:** N/A
+> **Project:** (none)
+> **Lane:** lane:claude
+> **Review artifacts:** scripts/review/results/2026-06-17-plan-3209-claude.md | ...-codex.md
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+- Found: `config/agents/routing-config.yaml` `tiers.*` — **all primary=claude**, fallbacks include `hermes` (SIMPLE `[hermes,codex,gemini]`, STANDARD `[codex,hermes,gemini]`, COMPLEX/REASONING `[gemini,codex]`).
+- Found: `scripts/coordination/routing/lib/tier_router.sh:26-58` — the **executed** table is hardcoded bash arrays `TIER_PRIMARY/FALLBACK1/FALLBACK2`: SIMPLE/STANDARD primary=**codex** (fb gemini/claude), COMPLEX/REASONING primary=claude (fb gemini,codex). **No hermes** (the bash `check_provider_available` only knows claude/codex/gemini — line ~52). This is the cost-aligned reality.
+- Found: `scripts/ai/task-dispatcher.py:63-68` — `TIER_AGENT_PREFERENCE` dict, **claude-first for every tier** (`simple:[claude,hermes,codex,gemini]`, …). Advisory CLI; position-based scoring in `score_agents` (`tier_score = (len-index)/len`).
+- Found (**r1-F3 — a FOURTH copy, missed in draft**): `scripts/coordination/routing/route.sh:216-220` — the `--config` display prints a hardcoded "Routing Table:" string (`SIMPLE -> codex (fallback: gemini, claude)` …). Matches the cost-aligned table today but is a 4th hand-maintained drift surface. Must be reconciled/guarded.
+- Found (just landed, #3205): `scripts/ai/routing_resolver.py` — single resolver owning `execution_contexts`. This plan **extends** it to also own `tiers` (`tier_chain`/`--tier`), so one module is the source for both context AND tier routing.
+- Found: `scripts/dispatch/route.py` (#3030) — lane-quota, does not read `tiers`. Out of scope.
+
+### Standards
+Not applicable (harness/infrastructure).
+
+### LLM Wiki pages consulted
+None (Client: N/A).
+
+### Documents consulted
+- `docs/governance/2026-06-17-cost-ceiling-policy.md` — "Claude is the interactive-dev lane only"; the executed bash (codex on cheap tiers) is already consistent with this, the YAML is the stale outlier.
+- `docs/plans/2026-06-17-issue-3205-executed-router-consolidation.md` §Gaps/§Risks — this is the deferred tier half of #3205; the resolver substrate + `_resolver` bash helper already exist.
+- Memory `routing-config-is-advisory` (updated 2026-06-17) — confirms tier maps still advisory after #3205; this plan closes that.
+- Issue #3209 (body) — acceptance; operator decision recorded: cost-aligned codex-cheap.
+
+### Gaps identified
+- No `tier_chain`/`--tier` in the resolver yet (only execution_contexts).
+- Three tier copies (YAML, bash arrays, python dict) must collapse to the resolver-as-source.
+- `test_routing_config_observed_behavior.py::test_simple_and_standard_route_to_claude` pins the stale claude-everywhere YAML and must be updated.
+
+### Evidence (embedded verification)
+**Issue statuses** (verified 2026-06-17 via `gh issue view`): `#3209` OPEN (domain:harness, lane:claude); `#3205` CLOSED (merged PR #3210); `#3058` OPEN (epic).
+
+**File existence** (`ls` 2026-06-17): EXISTS `routing_resolver.py`, `tier_router.sh`, `task-dispatcher.py`, `tests/config/test_routing_config_observed_behavior.py`. MISSING (new): `tests/ai/test_tier_chain.py` (or extend `test_routing_resolver.py`), `tests/coordination/test_tier_router_cost_aligned.py`.
+
+**Line excerpts** — `tier_router.sh` bash arrays (SIMPLE/STANDARD primary=codex) vs `routing-config.yaml` tiers (primary=claude): the divergence table in this plan's header is taken verbatim from those two files.
+
+**Reproduction proof** (issue alleges "editing YAML doesn't change runtime tier routing"):
+```
+$ grep -n "TIER_PRIMARY\|ROUTING_CONFIG" scripts/coordination/routing/lib/tier_router.sh
+# arrays are hardcoded; YAML tiers.* is never read for routing.
+```
+Matches the claim: **YES**.
+
+<!-- distinct sources: issue + routing-config.yaml + tier_router.sh + task-dispatcher.py + cost-policy doc + #3205 plan + memory = 7 -->
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | docs/plans/2026-06-17-issue-3209-tier-table-single-source.md |
+| Resolver (extend) | `scripts/ai/routing_resolver.py` |
+| Resolver tests (extend) | `tests/ai/test_routing_resolver.py` |
+| Tier-router cost-aligned test (new) | `tests/coordination/test_tier_router_cost_aligned.py` |
+| Modify | `scripts/coordination/routing/lib/tier_router.sh` (load table from resolver) |
+| Modify | `scripts/ai/task-dispatcher.py` (derive tier preference from resolver) |
+| Reconcile | `config/agents/routing-config.yaml` (`tiers.*` → cost-aligned) |
+| Update | `tests/config/test_routing_config_observed_behavior.py` (SIMPLE/STANDARD → codex) |
+| Update | docs/plans/README.md (index) |
+| Update (memory) | `routing-config-is-advisory.md` (tier maps now enforced too) |
+
+---
+
+## Deliverable
+
+`scripts/ai/routing_resolver.py` becomes the single source for **both** context and tier routing; `tier_router.sh` and `task-dispatcher.py` derive their tier chains from it (no hardcoded tier copies); `routing-config.yaml` `tiers.*` is reconciled to the cost-aligned table (SIMPLE/STANDARD primary=codex), with a test that drives the real router proving no Claude on cheap tiers.
+
+---
+
+## Canonical cost-aligned table (proposed — matches the executed bash)
+
+| Tier | primary | fallbacks |
+|---|---|---|
+| SIMPLE | codex | [gemini, claude] |
+| STANDARD | codex | [claude, gemini] |
+| COMPLEX | claude | [gemini, codex] |
+| REASONING | claude | [gemini, codex] |
+
+**hermes is dropped from tier chains** (recommended): the executed bash never had it, and `check_provider_available` can't dispatch it; hermes routing lives in `dimensions` (research/data → hermes) and `execution_contexts` (hermes_batch), which are unchanged. This keeps runtime tier behavior identical to today's executed bash — the change is *single-sourcing*, not re-routing. (Decision flagged for approval; alternative = keep hermes in cheap-tier fallbacks.)
+
+---
+
+## Design — YAML is the single source; bash is GENERATED, not read at runtime (post-r1)
+
+r1-MAJOR-1: making `route_by_tier` read the YAML at runtime costs ~2s per `uv run` (measured 2.07s) × 4 tiers, on every `route.sh`/`orchestrate.sh` source. **Rejected.** Instead:
+
+- **YAML `tiers.*` is the single source of truth.**
+- **`tier_router.sh` bash arrays are GENERATED from the YAML** (resolver `--emit-bash-table`), committed, and a **CI drift-guard test** fails if they diverge. → zero runtime resolver calls on the hot path; the no-context interactive route stays as fast as today. (The #3205 cost-ceiling `_resolver --filter` call still runs only when `ROUTE_CONTEXT` is set — unchanged.)
+- **`route.sh --config` display (the 4th copy, r1-F3) is rendered live** from the resolver — `--config` is a rare human-inspection command, so one resolver call there is fine, and it removes the copy entirely rather than guarding it.
+- **`task-dispatcher.py` imports the resolver in-process** (no subprocess, fast) and derives its tier preference from `tier_chain`.
+
+This gives genuine single-source ("copies generated from it") with zero hot-path latency. The cost: editing the YAML table requires regenerating the bash arrays (one command); CI catches a forgotten regen.
+
+## Pseudocode
+
+Resolver additions (CLI-normalized, same `cli()` map as #3205; `ROUTING_CONFIG_PATH` env override for tests — r1-F2):
+```
+ROUTING_CONFIG = env ROUTING_CONFIG_PATH or <repo>/config/agents/routing-config.yaml
+KNOWN_TIERS = {SIMPLE, STANDARD, COMPLEX, REASONING}
+class UnknownTierError(ValueError)
+tier_chain(tier, cfg=None) -> list[str]:
+    t = (cfg or load()).tiers.get(tier.upper())
+    if t is None: raise UnknownTierError(tier)            # fail closed
+    return cli-normalized, dedup, order-preserving [t.primary, *t.fallbacks]
+emit_bash_table(cfg=None) -> str:                          # generator for tier_router.sh
+    # prints the exact `declare -A TIER_PRIMARY/FALLBACK1/FALLBACK2(...)` blocks
+CLI (top-level mutually-exclusive: --context | --tier | --all-tiers | --emit-bash-table) — r1-F4:
+    --tier NAME           -> chain, exit 3 on unknown tier
+    --all-tiers           -> JSON {tier: chain}            # one-call, used by --config render
+    --emit-bash-table     -> the declare -A blocks         # used by the generator/drift-guard
+```
+
+`tier_router.sh` — arrays GENERATED from YAML (committed), with a header marker so the drift-guard + regen target them:
+```
+# >>> GENERATED FROM routing-config.yaml tiers.* via routing_resolver.py --emit-bash-table — do not hand-edit
+declare -A TIER_PRIMARY=( [SIMPLE]="codex" [STANDARD]="codex" [COMPLEX]="claude" [REASONING]="claude" )
+declare -A TIER_FALLBACK1=( [SIMPLE]="gemini" [STANDARD]="claude" [COMPLEX]="gemini" [REASONING]="gemini" )
+declare -A TIER_FALLBACK2=( [SIMPLE]="claude" [STANDARD]="gemini" [COMPLEX]="codex" [REASONING]="codex" )
+# <<< END GENERATED
+```
+(No runtime resolver call added here. route_by_tier logic + the #3205 context filter unchanged.)
+
+`route.sh --config` — replace the hardcoded lines 217-220 with a live render:
+```
+echo "Routing Table:"
+_resolver --all-tiers | jq -r 'to_entries[] | "  \(.key): \(.value|join(" -> "))"'
+```
+
+`task-dispatcher.py` — in-process import, no subprocess:
+```
+def tier_preference(tier):
+    chain = routing_resolver.tier_chain(tier)                       # cost-aligned, cli tokens
+    return chain + [a for a in KNOWN_AGENTS if a not in chain]      # append hermes (dimension/keyword can still surface it)
+# replaces the hardcoded TIER_AGENT_PREFERENCE dict
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | `scripts/ai/routing_resolver.py` | `tier_chain`/`--tier`/`--all-tiers`/`--emit-bash-table`/`UnknownTierError`; `ROUTING_CONFIG_PATH` env override (r1-F2/F4) |
+| Modify | `scripts/coordination/routing/lib/tier_router.sh` | arrays GENERATED-from-YAML (committed) with marker block; no runtime resolver call (r1-F1) |
+| Modify | `scripts/coordination/routing/route.sh` | `--config` renders table live from resolver (removes 4th copy, r1-F3) |
+| Modify | `scripts/ai/task-dispatcher.py` | `tier_preference()` imports resolver; drop hardcoded dict |
+| Reconcile | `config/agents/routing-config.yaml` | `tiers.*` → cost-aligned table above (single source) |
+| Update | `tests/config/test_routing_config_observed_behavior.py` | SIMPLE/STANDARD primary now codex |
+| Create | `tests/coordination/test_tier_router_cost_aligned.py` | real route_by_tier: SIMPLE/STANDARD→codex, COMPLEX/REASONING→claude |
+| Create | `tests/coordination/test_tier_table_no_drift.py` | drift-guard: committed bash arrays == `--emit-bash-table`; route.sh display has no hardcoded tiers |
+| Modify | `tests/ai/test_routing_resolver.py` | tier_chain + --tier + --all-tiers + unknown-tier fail-closed + `ROUTING_CONFIG_PATH` proof |
+| Update | docs/plans/README.md | index |
+
+---
+
+## TDD Test List
+
+| Test | Verifies | Input | Expected |
+|---|---|---|---|
+| test_tier_chain_simple_cost_aligned | resolver tier chain | "SIMPLE" | ["codex","gemini","claude"] |
+| test_tier_chain_complex | | "COMPLEX" | ["claude","gemini","codex"] |
+| test_tier_chain_cli_normalized | no provider tokens | any | no "openai-codex" |
+| test_tier_unknown_fails_closed | unknown tier errors | "BOGUS" | UnknownTierError / CLI exit 3 |
+| test_cli_tier_mode | CLI `--tier SIMPLE` | — | "codex\ngemini\nclaude" |
+| test_cli_all_tiers_json | `--all-tiers` one-call | — | JSON, 4 tiers, cost-aligned |
+| test_config_path_override (r1-F2) | `ROUTING_CONFIG_PATH` points at a temp YAML | temp SIMPLE primary=gemini | tier_chain("SIMPLE")[0]=="gemini" |
+| test_router_simple_selects_codex (real) | route_by_tier SIMPLE, all avail, no context | — | provider=="codex" (not claude) |
+| test_router_standard_selects_codex (real) | route_by_tier STANDARD | — | provider=="codex" |
+| test_router_complex_selects_claude (real) | route_by_tier COMPLEX | — | provider=="claude" (unchanged) |
+| test_tier_table_no_drift (r1-F1/F3) | committed bash arrays == resolver `--emit-bash-table`; route.sh has no hardcoded SIMPLE/STANDARD lines | — | match; no drift |
+| test_simple_under_ceiling_still_codex (#3205 compose) | route_by_tier SIMPLE + ROUTE_CONTEXT=hermes_batch | — | provider=="codex", never claude |
+| test_dispatcher_simple_not_claude_first | advisory prefers cost-aligned | --tier simple, neutral task | recommended_agent != "claude" |
+| test_dispatcher_no_context_can_pick_claude (existing, must stay green) | reasoning+architecture | — | claude (verified survives codex-first preference) |
+| test_observed_behavior_simple_standard_codex (updated) | YAML reconciled | — | tiers.SIMPLE/STANDARD.primary=="codex" |
+
+`test_config_path_override` proves the resolver (python single-source) reads YAML at runtime; `test_tier_table_no_drift` proves the bash arrays are a CI-enforced generation of that same source (not reconciled-by-coincidence). Together they satisfy "single source; copies generated from it" without the rejected runtime-read latency.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `routing-config.yaml` `tiers.*` is the single source (cost-aligned: SIMPLE/STANDARD primary=codex); `task-dispatcher.py` dict removed (imports resolver); `tier_router.sh` arrays generated from it + CI drift-guarded; `route.sh --config` renders live (4th copy removed)
+- [ ] Real router selects codex (not claude) for SIMPLE/STANDARD; claude for COMPLEX/REASONING — proven by a test driving `route_by_tier`
+- [ ] `ROUTING_CONFIG_PATH` override proves the resolver reads YAML at runtime; `test_tier_table_no_drift` proves bash is a CI-enforced generation (no hot-path latency added — r1-MAJOR-1)
+- [ ] `test_routing_config_observed_behavior.py` updated + green
+- [ ] #3205 cost-ceiling tests still green; SIMPLE+hermes_batch still selects codex (compose test)
+- [ ] No regression: `uv run pytest tests/config/ tests/ai/ tests/coordination/` (pre-existing unrelated `test_agents_and_review_policy...` failure excepted); `bash -n` clean
+- [ ] Review artifacts posted
+
+---
+
+## Adversarial Review Summary
+
+**r1 — Claude (adversarial subagent), 2026-06-17:** verdict **MAJOR**. All findings verified against the live tree and incorporated:
+
+| # | Sev | Finding | Resolution |
+|---|---|---|---|
+| F1 | MAJOR | Source-time resolver loading = ~8s (4× `uv run` @ 2.07s) on every route.sh/orchestrate.sh | Rejected runtime-read; bash arrays now GENERATED from YAML + committed + CI drift-guard → zero hot-path latency |
+| F2 | MAJOR | No config-path override → the single-source proof test can't reach the bash/python path against a temp YAML | Added `ROUTING_CONFIG_PATH` env override + `test_config_path_override` |
+| F3 | MAJOR | A **4th** hardcoded tier copy at `route.sh:216-220` (the `--config` display), unaccounted | `--config` now renders live from `--all-tiers`; drift-guard asserts no hardcoded tier lines remain |
+| F4 | MINOR | argparse: `--context required=True` blocks adding `--tier` | top-level mutually-exclusive `--context|--tier|--all-tiers|--emit-bash-table` |
+| — | note | dispatcher codex-first preference must not break `test_dispatcher_no_context_can_pick_claude` | r1 traced the scoring: reasoning+architecture still yields claude (1.45 vs 0.75); kept as an explicit regression test |
+| — | note | hermes drop from tier chains verified safe (no reader depends on it; dimensions/contexts unchanged) | proceed |
+
+**r2 — Codex (fanout):** **UNAVAILABLE** — `codex exec` timed out at the 600s limit (stuck in sandbox PreToolUse hooks; SIGTERM/exit 143, empty output). Per SHARED_SOUL "Cross-Review Routing", provider outage degrades T2→T1 documented; r1 (MAJOR, verified) carries the review. Artifact: `scripts/review/results/2026-06-17-plan-3209-codex.md`.
+
+**Overall result after r1 revisions:** PASS (T1, r2 documented UNAVAILABLE).
+
+**Code-stage r3 — Claude (adversarial subagent), 2026-06-17:** verdict **MINOR** (no blockers). Verified across all vectors: cost-ceiling does not regress (claude impossible under hermes_batch on every tier incl. emergency), drift-guard fails correctly when YAML changes, fail-closed holds, live `--config` render works. Cleanliness fixes applied: removed dead `ROUTING_CONFIG` constant + `context_mode` var; `--tier`+`--context` now rejected (contract consistency); `task-dispatcher` honors `ROUTING_CONFIG_PATH` (no split-config); drift-guard test pins the repo config; strengthened the SIMPLE-dispatcher assertion to `==codex`.
+
+---
+
+## Risks and Open Questions
+
+- **Open (approval — only real fork left):** hermes dropped from tier chains (recommended — matches executed reality; check_provider_available can't dispatch hermes; it routes via `dimensions`/`execution_contexts`). Alternative: keep hermes in SIMPLE/STANDARD fallbacks. r1 verified dropping is safe (no reader depends on tier-hermes).
+- **Risk — `task-dispatcher` advisory behavior change:** today claude-first; after, codex-first on cheap tiers. Dimension/keyword boosts still let claude/hermes win on matching tasks. r1 traced + this plan pins `test_dispatcher_no_context_can_pick_claude` (reasoning+architecture → claude, 1.45 vs 0.75) as a regression guard; the #3205 hermes_batch dispatcher test stays valid.
+- **Risk — generated-array staleness:** if someone edits YAML `tiers.*` without regenerating the bash block, the executed router would lag the source. Mitigation: `test_tier_table_no_drift` fails CI on divergence; the GENERATED marker block + a one-command regen make the workflow explicit.
+- **Risk — cost-ceiling composition (#3205):** the filter runs on top of the (now-generated) tier chain; SIMPLE under hermes_batch = codex (primary already codex; claude filtered from fallback) — pinned by `test_simple_under_ceiling_still_codex`.
+- **Risk — `test_simple_and_standard_route_to_claude` update:** required, not optional; in Files to Change so it isn't missed.
+- **Resolved (r1):** hot-path latency (no runtime resolver call in bash); proof-test reachability (`ROUTING_CONFIG_PATH`); the 4th copy (route.sh `--config` rendered live).
+
+---
+
+## Complexity: T2
+
+**T2** — multi-file (resolver + bash + python + YAML + tests), TDD, cross-language, but built on the #3205 substrate. Plan review = 2 providers.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -489,3 +489,4 @@ Add one row per plan:
 | [#3191](https://github.com/vamseeachanta/workspace-hub/issues/3191) | Gated workflow templates + cross-provider review workflow | [Plan](2026-06-17-issue-3191-gated-workflow-templates.md) | plan-review | T2 | 2026-06-17 |
 | [#3192](https://github.com/vamseeachanta/workspace-hub/issues/3192) | Reconcile routing-config.yaml with operator cost policy | [Plan](2026-06-17-issue-3192-routing-config-cost-policy.md) | plan-review | T2 | 2026-06-17 |
 | [#3205](https://github.com/vamseeachanta/workspace-hub/issues/3205) | Executed-router consolidation — enforce the routing cost ceiling at runtime | [Plan](2026-06-17-issue-3205-executed-router-consolidation.md) | plan-approved | T2 | 2026-06-17 |
+| [#3209](https://github.com/vamseeachanta/workspace-hub/issues/3209) | Reconcile tier-table routing into one cost-aligned source | [Plan](2026-06-17-issue-3209-tier-table-single-source.md) | plan-approved | T2 | 2026-06-17 |

--- a/scripts/ai/routing_resolver.py
+++ b/scripts/ai/routing_resolver.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -44,7 +45,9 @@ except ImportError:  # pragma: no cover - exercised only without uv/pyyaml
     import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-ROUTING_CONFIG = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
+# The source-of-truth path is resolved per-call by _default_config_path() so the
+# ROUTING_CONFIG_PATH env override takes effect at runtime (tests point it at a
+# temp YAML to prove the table is read, not hardcoded — #3209 r1-F2).
 
 # Provider-token -> CLI-token. The single source of normalization. Carries the
 # full provider token-space (not just openai-codex) so a forbid authored in
@@ -57,9 +60,15 @@ TOKEN_TO_CLI = {
 
 EXIT_UNKNOWN_CONTEXT = 3
 
+KNOWN_TIERS = ("SIMPLE", "STANDARD", "COMPLEX", "REASONING")
+
 
 class UnknownContextError(ValueError):
     """Raised when an explicit context is not present in execution_contexts."""
+
+
+class UnknownTierError(ValueError):
+    """Raised when a tier is not present in routing-config.yaml tiers.*."""
 
 
 def cli(token: str) -> str:
@@ -70,8 +79,15 @@ def cli(token: str) -> str:
 _CACHE: dict[str, dict] = {}
 
 
+def _default_config_path() -> Path:
+    # Re-read the env each call so an in-process ROUTING_CONFIG_PATH override
+    # takes effect (subprocess callers get it via the env naturally).
+    return Path(os.environ.get(
+        "ROUTING_CONFIG_PATH", REPO_ROOT / "config" / "agents" / "routing-config.yaml"))
+
+
 def load_routing_config(path: Path | str | None = None) -> dict:
-    p = Path(path) if path is not None else ROUTING_CONFIG
+    p = Path(path) if path is not None else _default_config_path()
     key = str(p)
     if key not in _CACHE:
         with open(p) as fh:
@@ -118,6 +134,51 @@ def context_chain(name: str, cfg: dict | None = None) -> list[str]:
     return chain
 
 
+# ── Tier routing (#3209) ─────────────────────────────────────────────────────
+# routing-config.yaml `tiers.*` is the single source for the per-tier provider
+# chain. tier_router.sh's bash arrays are GENERATED from emit_bash_table() (not
+# read at runtime — avoids ~2s/call latency); task-dispatcher.py imports
+# tier_chain() directly. forbid is NOT applied here (that is context-only).
+
+def _tiers(cfg: dict | None) -> dict:
+    cfg = cfg if cfg is not None else load_routing_config()
+    return cfg.get("tiers", {}) or {}
+
+
+def tier_chain(tier: str, cfg: dict | None = None) -> list[str]:
+    """CLI-normalized [primary, *fallbacks] for `tier` (dedup, order-preserving)."""
+    t = _tiers(cfg).get(tier.upper())
+    if t is None:
+        raise UnknownTierError(tier)
+    chain: list[str] = []
+    for tok in [t.get("primary"), *(t.get("fallbacks") or [])]:
+        if not tok:
+            continue
+        c = cli(tok)
+        if c not in chain:
+            chain.append(c)
+    return chain
+
+
+def all_tier_chains(cfg: dict | None = None) -> dict[str, list[str]]:
+    return {tier: tier_chain(tier, cfg) for tier in _tiers(cfg)}
+
+
+def emit_bash_table(cfg: dict | None = None) -> str:
+    """Render the tier_router.sh `declare -A` blocks from the YAML (generator)."""
+    chains = {t: tier_chain(t, cfg) for t in KNOWN_TIERS}
+
+    def _row(idx: int) -> str:
+        return " ".join(f'[{t}]="{chains[t][idx] if idx < len(chains[t]) else ""}"'
+                        for t in KNOWN_TIERS)
+
+    return (
+        f"declare -A TIER_PRIMARY=( {_row(0)} )\n"
+        f"declare -A TIER_FALLBACK1=( {_row(1)} )\n"
+        f"declare -A TIER_FALLBACK2=( {_row(2)} )"
+    )
+
+
 def filter_candidates(candidates: list[str], context: str | None, cfg: dict | None = None,
                       fallback: bool = True) -> list[str]:
     """Drop forbidden providers from `candidates` for `context` (order-preserving).
@@ -147,31 +208,51 @@ def _parse_csv(value: str) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("--context", required=True)
+    # Context modes (need --context) and tier modes (need --tier or neither) are
+    # one top-level mutually-exclusive action group (#3209 r1-F4).
+    parser.add_argument("--context")
+    parser.add_argument("--no-fallback", dest="fallback", action="store_false", default=True,
+                        help="With --filter: return [] when all forbidden (no context-chain fallback).")
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--filter", dest="filter_csv", metavar="c1,c2,c3")
     mode.add_argument("--chain", action="store_true")
     mode.add_argument("--forbidden", action="store_true")
     mode.add_argument("--json", dest="json_mode", action="store_true")
-    parser.add_argument("--no-fallback", dest="fallback", action="store_false", default=True,
-                        help="With --filter: return [] when all forbidden (no context-chain fallback).")
+    mode.add_argument("--tier", metavar="SIMPLE|STANDARD|COMPLEX|REASONING")
+    mode.add_argument("--all-tiers", dest="all_tiers", action="store_true")
+    mode.add_argument("--emit-bash-table", dest="emit_bash", action="store_true")
     args = parser.parse_args(argv)
 
+    tier_mode = args.tier is not None or args.all_tiers or args.emit_bash
+    if tier_mode and args.context:
+        parser.error("--context does not apply to --tier/--all-tiers/--emit-bash-table "
+                     "(tier routing has no cost-ceiling forbid)")
+
     try:
-        # Uniform fail-closed: an explicit unknown context errors in EVERY mode
-        # (review r3-F1), not just --filter/--chain/--json.
+        # Tier modes (read tiers.*; no context needed) ------------------------
+        if args.tier is not None:
+            print("\n".join(tier_chain(args.tier)))
+            return 0
+        if args.all_tiers:
+            print(json.dumps(all_tier_chains()))
+            return 0
+        if args.emit_bash:
+            print(emit_bash_table())
+            return 0
+
+        # Context modes (need --context; fail closed on unknown) --------------
+        if not args.context:
+            parser.error("--context is required for --filter/--chain/--forbidden/--json")
+        # Uniform fail-closed: an explicit unknown context errors in EVERY mode.
         if resolve_context(args.context) is None:
             raise UnknownContextError(args.context)
         if args.filter_csv is not None:
-            out = filter_candidates(_parse_csv(args.filter_csv), args.context, fallback=args.fallback)
-            print("\n".join(out))
+            print("\n".join(filter_candidates(_parse_csv(args.filter_csv), args.context, fallback=args.fallback)))
         elif args.chain:
             print("\n".join(context_chain(args.context)))
         elif args.forbidden:
             print("\n".join(sorted(forbidden_providers(args.context))))
         elif args.json_mode:
-            if resolve_context(args.context) is None:
-                raise UnknownContextError(args.context)
             ctx = resolve_context(args.context)
             print(json.dumps({
                 "context": args.context,
@@ -182,6 +263,9 @@ def main(argv: list[str] | None = None) -> int:
             }))
     except UnknownContextError as exc:
         print(f"routing_resolver: unknown context '{exc}' — failing closed (exit {EXIT_UNKNOWN_CONTEXT})", file=sys.stderr)
+        return EXIT_UNKNOWN_CONTEXT
+    except UnknownTierError as exc:
+        print(f"routing_resolver: unknown tier '{exc}' — failing closed (exit {EXIT_UNKNOWN_CONTEXT})", file=sys.stderr)
         return EXIT_UNKNOWN_CONTEXT
     return 0
 

--- a/scripts/ai/task-dispatcher.py
+++ b/scripts/ai/task-dispatcher.py
@@ -32,7 +32,10 @@ except ImportError:
 # Paths
 # ---------------------------------------------------------------------------
 REPO_ROOT = Path(__file__).resolve().parents[2]
-ROUTING_CONFIG = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
+# Honor ROUTING_CONFIG_PATH so this tool and the resolver read the SAME config
+# when the override is set (#3209 review r3-F3).
+ROUTING_CONFIG = Path(os.environ.get(
+    "ROUTING_CONFIG_PATH", REPO_ROOT / "config" / "agents" / "routing-config.yaml"))
 PROVIDER_CAPS   = REPO_ROOT / "config" / "agents" / "provider-capabilities.yaml"
 
 # Single forbid-policy interpreter (#3205) — never re-implement forbid logic here.
@@ -64,12 +67,19 @@ KEYWORD_SIGNALS: dict[str, list[str]] = {
     ],
 }
 
-TIER_AGENT_PREFERENCE: dict[str, list[str]] = {
-    "simple":    ["claude", "hermes", "codex", "gemini"],
-    "standard":  ["claude", "codex",  "hermes", "gemini"],
-    "complex":   ["claude", "gemini", "hermes", "codex"],
-    "reasoning": ["claude", "gemini", "hermes", "codex"],
-}
+KNOWN_AGENTS: list[str] = list(KEYWORD_SIGNALS.keys())  # hermes, claude, codex, gemini
+
+
+def tier_preference(tier: str) -> list[str]:
+    """Cost-aligned agent preference for a tier, sourced from routing-config.yaml
+    tiers.* (#3209). The tier chain (claude/codex/gemini) leads; agents not in the
+    chain (hermes) are appended so keyword/dimension signals can still surface them.
+    """
+    try:
+        chain = routing_resolver.tier_chain(tier)
+    except routing_resolver.UnknownTierError:
+        chain = routing_resolver.tier_chain("STANDARD")
+    return chain + [a for a in KNOWN_AGENTS if a not in chain]
 
 # Hermes specialises in data/doc/batch work — boost it for COMPLEX data tasks
 HERMES_BOOST_TIERS = {"complex", "reasoning"}
@@ -125,7 +135,7 @@ def score_agents(task: str, tier: str, routing_cfg: dict, provider_caps: dict) -
     task_lower = task.lower()
     tier_lower = tier.lower()
 
-    tier_pref = TIER_AGENT_PREFERENCE.get(tier_lower, TIER_AGENT_PREFERENCE["standard"])
+    tier_pref = tier_preference(tier_lower)
     known_agents = list(KEYWORD_SIGNALS.keys())
 
     scores: list[dict] = []

--- a/scripts/coordination/routing/lib/tier_router.sh
+++ b/scripts/coordination/routing/lib/tier_router.sh
@@ -23,27 +23,14 @@ _resolver() {
     fi
 }
 
-# --- Default routing table (used if YAML config not found) ---
-declare -A TIER_PRIMARY=(
-    [SIMPLE]="codex"
-    [STANDARD]="codex"
-    [COMPLEX]="claude"
-    [REASONING]="claude"
-)
-
-declare -A TIER_FALLBACK1=(
-    [SIMPLE]="gemini"
-    [STANDARD]="claude"
-    [COMPLEX]="gemini"
-    [REASONING]="gemini"
-)
-
-declare -A TIER_FALLBACK2=(
-    [SIMPLE]="claude"
-    [STANDARD]="gemini"
-    [COMPLEX]="codex"
-    [REASONING]="codex"
-)
+# >>> GENERATED FROM config/agents/routing-config.yaml tiers.* — DO NOT HAND-EDIT (#3209)
+# Regenerate:  uv run scripts/ai/routing_resolver.py --emit-bash-table
+# Drift-guard: tests/coordination/test_tier_table_no_drift.py (fails CI on divergence)
+# Cost-aligned single source: cheap tiers route to codex, not claude.
+declare -A TIER_PRIMARY=( [SIMPLE]="codex" [STANDARD]="codex" [COMPLEX]="claude" [REASONING]="claude" )
+declare -A TIER_FALLBACK1=( [SIMPLE]="gemini" [STANDARD]="claude" [COMPLEX]="gemini" [REASONING]="gemini" )
+declare -A TIER_FALLBACK2=( [SIMPLE]="claude" [STANDARD]="gemini" [COMPLEX]="codex" [REASONING]="codex" )
+# <<< END GENERATED
 
 # --- Function: check_provider_available ---
 # Checks if a provider's CLI tool is installed and reachable

--- a/scripts/coordination/routing/route.sh
+++ b/scripts/coordination/routing/route.sh
@@ -213,11 +213,11 @@ if $SHOW_CONFIG; then
         fi
     done
     echo ""
-    echo "Routing Table:"
-    echo "  SIMPLE    -> codex  (fallback: gemini, claude)"
-    echo "  STANDARD  -> codex  (fallback: claude, gemini)"
-    echo "  COMPLEX   -> claude (fallback: gemini, codex)"
-    echo "  REASONING -> claude (fallback: gemini, codex)"
+    echo "Routing Table (live from routing-config.yaml tiers.*):"
+    # Rendered from the single source (#3209) — no hardcoded copy here.
+    _resolver --all-tiers 2>/dev/null \
+        | jq -r 'to_entries[] | "  \(.key): \(.value | join(" -> "))"' 2>/dev/null \
+        || echo "  (routing_resolver unavailable)"
     echo ""
     echo "Adaptive Routing: enabled (EWMA alpha=$_EWMA_ALPHA, min_ratings=$_EWMA_MIN_RATINGS)"
     echo ""

--- a/tests/ai/test_routing_resolver.py
+++ b/tests/ai/test_routing_resolver.py
@@ -8,6 +8,7 @@ and the bash-facing CLI surface.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -142,3 +143,85 @@ def test_cli_json_mode():
     assert obj["cost_ceiling"] is True
     assert obj["primary_cli"] == "codex"
     assert "claude" in obj["forbid_cli"]
+
+
+# --- tier routing (#3209) ---------------------------------------------------
+
+def test_tier_chain_simple_cost_aligned():
+    assert rr.tier_chain("SIMPLE") == ["codex", "gemini", "claude"]
+
+
+def test_tier_chain_standard_cost_aligned():
+    assert rr.tier_chain("STANDARD") == ["codex", "claude", "gemini"]
+
+
+def test_tier_chain_complex_claude_primary():
+    assert rr.tier_chain("COMPLEX") == ["claude", "gemini", "codex"]
+
+
+def test_tier_chain_has_no_hermes():
+    # hermes is dropped from tier chains (routes via dimensions/contexts).
+    for tier in rr.KNOWN_TIERS:
+        assert "hermes" not in rr.tier_chain(tier)
+
+
+def test_tier_chain_cli_normalized():
+    for tier in rr.KNOWN_TIERS:
+        assert "openai-codex" not in rr.tier_chain(tier)
+
+
+def test_tier_unknown_raises():
+    with pytest.raises(rr.UnknownTierError):
+        rr.tier_chain("BOGUS")
+
+
+def test_cli_tier_mode():
+    r = _run("--tier", "SIMPLE")
+    assert r.returncode == 0
+    assert r.stdout.split() == ["codex", "gemini", "claude"]
+
+
+def test_cli_tier_unknown_fails_closed():
+    r = _run("--tier", "BOGUS")
+    assert r.returncode == 3
+
+
+def test_cli_all_tiers_json():
+    r = _run("--all-tiers")
+    assert r.returncode == 0
+    obj = json.loads(r.stdout)
+    assert set(obj) == set(rr.KNOWN_TIERS)
+    assert obj["SIMPLE"][0] == "codex"
+    assert obj["COMPLEX"][0] == "claude"
+
+
+def test_cli_tier_with_context_rejected():
+    # review r3-F4: tier modes don't take --context (no forbid in tier routing).
+    r = _run("--tier", "SIMPLE", "--context", "hermes_batch")
+    assert r.returncode != 0
+
+
+def test_cli_emit_bash_table():
+    r = _run("--emit-bash-table")
+    assert r.returncode == 0
+    assert 'declare -A TIER_PRIMARY=(' in r.stdout
+    assert '[SIMPLE]="codex"' in r.stdout
+
+
+def test_config_path_override_reads_yaml_at_runtime(tmp_path):
+    # r1-F2: proves the resolver reads the YAML at runtime (single-source), via a
+    # temp config where SIMPLE primary is flipped to gemini.
+    cfg = tmp_path / "routing-config.yaml"
+    cfg.write_text(
+        "tiers:\n"
+        "  SIMPLE: {primary: gemini, fallbacks: [codex]}\n"
+        "  STANDARD: {primary: codex, fallbacks: [claude]}\n"
+        "  COMPLEX: {primary: claude, fallbacks: [codex]}\n"
+        "  REASONING: {primary: claude, fallbacks: [codex]}\n"
+    )
+    r = subprocess.run(
+        [sys.executable, str(RESOLVER), "--tier", "SIMPLE"],
+        capture_output=True, text=True, env={**os.environ, "ROUTING_CONFIG_PATH": str(cfg)},
+    )
+    assert r.returncode == 0
+    assert r.stdout.split()[0] == "gemini"

--- a/tests/ai/test_task_dispatcher_cost_ceiling.py
+++ b/tests/ai/test_task_dispatcher_cost_ceiling.py
@@ -41,6 +41,14 @@ def test_dispatcher_no_context_can_pick_claude():
     assert out.get("context") in (None, "")
 
 
+def test_dispatcher_simple_not_claude_first():
+    # #3209: cost-aligned tier preference — a neutral SIMPLE task is no longer
+    # claude-first (codex leads the SIMPLE chain).
+    out = _run("--task", "check the current status", "--tier", "simple")
+    assert out["recommended_agent"] != "claude"
+    assert out["recommended_agent"] == "codex"  # SIMPLE chain leads with codex
+
+
 def test_dispatcher_unknown_context_fails_closed():
     r = subprocess.run(
         [sys.executable, str(DISPATCHER), "--task", "x", "--tier", "simple",

--- a/tests/config/test_routing_config_observed_behavior.py
+++ b/tests/config/test_routing_config_observed_behavior.py
@@ -9,11 +9,15 @@ ROUTING = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
 CAPS = REPO_ROOT / "config" / "agents" / "provider-capabilities.yaml"
 
 
-def test_simple_and_standard_route_to_claude():
+def test_simple_and_standard_route_to_codex():
+    # #3209: tiers reconciled to cost-aligned — cheap tiers route to codex, not
+    # claude (matches the executed router + the cost-ceiling policy).
     with open(ROUTING) as handle:
         data = yaml.safe_load(handle)
-    assert data["tiers"]["SIMPLE"]["primary"] == "claude"
-    assert data["tiers"]["STANDARD"]["primary"] == "claude"
+    assert data["tiers"]["SIMPLE"]["primary"] == "codex"
+    assert data["tiers"]["STANDARD"]["primary"] == "codex"
+    assert data["tiers"]["COMPLEX"]["primary"] == "claude"
+    assert data["tiers"]["REASONING"]["primary"] == "claude"
 
 
 def test_research_and_data_dimensions_point_to_hermes():

--- a/tests/coordination/test_tier_router_cost_aligned.py
+++ b/tests/coordination/test_tier_router_cost_aligned.py
@@ -1,0 +1,66 @@
+"""Cost-aligned tier routing in the REAL router (#3209).
+
+Drives the actual `route_by_tier` (the generated bash table) and asserts cheap
+tiers route to codex, not claude — and that it composes with the #3205 cost
+ceiling.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TIER_ROUTER = REPO_ROOT / "scripts" / "coordination" / "routing" / "lib" / "tier_router.sh"
+
+ALL_AVAILABLE = "check_provider_available() { return 0; }"
+
+
+def _route(tier: str, context: str | None = None, stub: str = ALL_AVAILABLE) -> tuple[dict | None, int]:
+    ctx = f'ROUTE_CONTEXT="{context}" ' if context else ""
+    script = f"""
+set -o pipefail
+source "{TIER_ROUTER}"
+{stub}
+out=$({ctx}route_by_tier "{tier}" "" 0.9); rc=$?
+printf '%s' "$out"
+echo "__RC__=$rc"
+"""
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    body, _, tail = r.stdout.rpartition("__RC__=")
+    rc = int(tail.strip() or r.returncode)
+    return (json.loads(body) if body.strip() else None), rc
+
+
+def test_simple_routes_to_codex():
+    obj, rc = _route("SIMPLE")
+    assert rc == 0
+    assert obj["provider"] == "codex"
+    assert obj["provider"] != "claude"
+
+
+def test_standard_routes_to_codex():
+    obj, rc = _route("STANDARD")
+    assert rc == 0
+    assert obj["provider"] == "codex"
+
+
+def test_complex_routes_to_claude():
+    obj, rc = _route("COMPLEX")
+    assert rc == 0
+    assert obj["provider"] == "claude"
+
+
+def test_reasoning_routes_to_claude():
+    obj, rc = _route("REASONING")
+    assert rc == 0
+    assert obj["provider"] == "claude"
+
+
+def test_simple_under_ceiling_still_codex():
+    # Composes with #3205: SIMPLE primary is already codex; under hermes_batch,
+    # claude is filtered from the fallback and codex remains.
+    obj, rc = _route("SIMPLE", context="hermes_batch")
+    assert rc == 0
+    assert obj["provider"] == "codex"
+    assert obj["provider"] != "claude"

--- a/tests/coordination/test_tier_table_no_drift.py
+++ b/tests/coordination/test_tier_table_no_drift.py
@@ -1,0 +1,50 @@
+"""Drift-guard: the bash tier table is a faithful generation of the YAML (#3209).
+
+The `tier_router.sh` `declare -A TIER_*` arrays are GENERATED from
+routing-config.yaml tiers.* via `routing_resolver.py --emit-bash-table`. This
+test fails CI if someone edits the YAML without regenerating the bash block (or
+hand-edits the block), and asserts no hardcoded tier table lingers in route.sh.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RESOLVER = REPO_ROOT / "scripts" / "ai" / "routing_resolver.py"
+TIER_ROUTER = REPO_ROOT / "scripts" / "coordination" / "routing" / "lib" / "tier_router.sh"
+ROUTE_SH = REPO_ROOT / "scripts" / "coordination" / "routing" / "route.sh"
+REPO_CONFIG = REPO_ROOT / "config" / "agents" / "routing-config.yaml"
+
+
+def _generated_block() -> list[str]:
+    # Pin the config to the repo's (ignore any ambient ROUTING_CONFIG_PATH) so the
+    # guard always compares against the canonical source — review r3-F5.
+    env = {**os.environ, "ROUTING_CONFIG_PATH": str(REPO_CONFIG)}
+    r = subprocess.run([sys.executable, str(RESOLVER), "--emit-bash-table"],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr
+    return [ln.strip() for ln in r.stdout.strip().splitlines()]
+
+
+def _committed_block() -> list[str]:
+    text = TIER_ROUTER.read_text()
+    m = re.search(r">>> GENERATED.*?\n(.*?)# <<< END GENERATED", text, re.DOTALL)
+    assert m, "GENERATED marker block not found in tier_router.sh"
+    return [ln.strip() for ln in m.group(1).strip().splitlines()
+            if ln.strip().startswith("declare -A")]
+
+
+def test_committed_bash_table_matches_resolver():
+    assert _committed_block() == _generated_block()
+
+
+def test_route_sh_has_no_hardcoded_tier_table():
+    # The --config display must render live from the resolver, not hardcode tiers.
+    text = ROUTE_SH.read_text()
+    assert "_resolver --all-tiers" in text
+    # No hardcoded "SIMPLE -> codex"/"SIMPLE    -> codex" style rows remain.
+    assert not re.search(r'echo\s+"\s*SIMPLE\s+->', text)


### PR DESCRIPTION
Closes #3209. Follow-up to #3205 (merged), under epic #3058.

## What
Collapses the three drifted tier-routing copies into one source. `routing-config.yaml` `tiers.*` is now the single source of truth, reconciled to **cost-aligned** (matching the executed bash + the cost-ceiling policy):

| Tier | primary | fallbacks |
|---|---|---|
| SIMPLE | **codex** | gemini, claude |
| STANDARD | **codex** | claude, gemini |
| COMPLEX | claude | gemini, codex |
| REASONING | claude | gemini, codex |

- `routing_resolver.py`: `tier_chain`/`--tier`/`--all-tiers`/`--emit-bash-table`, `UnknownTierError` (fail-closed), `ROUTING_CONFIG_PATH` override
- `tier_router.sh`: bash arrays **generated** from YAML (committed marker block) — **no runtime resolver call added** (avoids ~2s/call latency); CI drift-guard fails if they diverge
- `route.sh --config`: renders the table **live** (removes a 4th hardcoded copy)
- `task-dispatcher.py`: imports the resolver; hardcoded `TIER_AGENT_PREFERENCE` dict removed
- **hermes dropped** from tier chains (routes via `dimensions`/`execution_contexts`; `check_provider_available` can't dispatch it)

## Behavior
Runtime tier routing is essentially **unchanged** (the executed bash already routed cheap tiers to codex) — the win is killing the drift and correcting the stale claude-everywhere YAML. Cost ceiling (#3205) composes unchanged: SIMPLE under `hermes_batch` still selects codex, never claude.

## Reviews
- **Plan r1 (Claude): MAJOR** — flagged ~8s latency if bash read YAML at runtime (→ generate+drift-guard), no config-override for the proof test (→ `ROUTING_CONFIG_PATH`), a 4th hardcoded copy in `route.sh` (→ live render). All addressed.
- **Plan r2 (Codex): UNAVAILABLE** — `codex exec` timed out (sandbox hooks); degraded T1 documented per policy.
- **Code r3 (Claude): MINOR** — no blockers; verified cost-ceiling intact + drift-guard works both ways; applied cleanliness fixes (dead code, `--tier`+`--context` rejection, split-config, test env pinning).

## Tests
20 new/updated tests drive the real router + drift-guard. Full `tests/{config,ai,coordination}` green except one **pre-existing, unrelated** failure (`test_agents_and_review_policy_reference_all_three_reviewers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)