### PR TITLE
chore(cron): port git-lock-reaper to ace-linux-2 (#3187)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -94,9 +94,9 @@ tasks:
       design — a SessionEnd hook would only fire after Claude.
 
   - id: git-lock-reaper
-    label: Reap orphan .git/index.lock on dev-primary (#3187)
+    label: Reap orphan .git/index.lock (dev-primary + dev-secondary) (#3187)
     schedule: "*/5 * * * *"
-    machines: [dev-primary, ace-linux-1]
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2]
     roles: [control-plane]
     requires: [bash, git]
     command: >-
@@ -107,11 +107,13 @@ tasks:
     log: logs/maintenance/git-lock-reaper-*.log
     is_claude_task: false
     description: >-
-      Every 5 min on dev-primary: detect a .git/index.lock that is BOTH older than
+      Every 5 min: detect a .git/index.lock that is BOTH older than
       LOCK_REAPER_AGE_MINUTES (default 10) AND has no live `git` process, then remove it
       with a stderr alert (cron -> mail). A zero-byte orphan lock silently froze ALL git
-      automation on ace-linux-1 for ~5h on 2026-06-17 (#3187). Dual-guard (age + no-live-git)
+      automation on ace-linux-1 for ~5h on 2026-06-17 (#3187), and recurred on ace-linux-2
+      on 2026-06-18 (blocked commits twice) — hence porting here. Dual-guard (age + no-live-git)
       so it can never race-reap a live op's lock — unlike git-safe.sh:git_heal_index().
+      The reaper script is machine-agnostic (resolves its own repo via git rev-parse).
 
   - id: return-to-main-guard
     label: Restore dev-primary workspace-hub checkout to main when idle off-branch (#3187)


### PR DESCRIPTION
Follow-up to #3187 (closed). The orphan-`.git/index.lock` reaper was scheduled on dev-primary only; a stale zero-byte lock recurred on **ace-linux-2** on 2026-06-18 and blocked commits twice this session (hand-cleared each time).

## Change
Add `dev-secondary, ace-linux-2` to the `git-lock-reaper` task's `machines:` list in `config/scheduled-tasks/schedule-tasks.yaml` (+ generalize label/description). The reaper script is already in-repo and machine-agnostic (resolves its own repo via `git rev-parse --show-toplevel`); cron selection is machines-based (`cron_render.select_machine_tasks`), so this is the only catalog change needed.

## Already applied to this box
Installed into ace-linux-2's crontab via `cron_apply.py --apply --allow-live-reload` (transactional, fail-closed):
- delta = **+1 line (the `*/5` reaper), −0 removed**
- external deckhand/hermes comms crons (member-audit, escalation-sweep, …) **preserved verbatim** (zero-net-removal asserted post-cutover)
- live-reload override was required because the box runs live comms daemons; the cutover installs a maintenance cron and does not touch the running daemon processes.

Verified: reaper line live in `crontab -l`; reaper smoke run exits 0 (no lock present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)