### PR TITLE
chore(skill-graph): drop 8 stale curated nodes + edge-integrity check (#3214 part A)

### DIFF
--- a/.planning/skills/skills-knowledge-graph.yaml
+++ b/.planning/skills/skills-knowledge-graph.yaml
@@ -357,31 +357,6 @@ nodes:
     python_packages: []
 
   # ── workspace-hub / Operations ────────────
-  - id: "workspace-hub/agent-orchestration"
-    repo: workspace-hub
-    category: workspace_ops
-    domain: workspace_ops
-    sub_domains: [orchestration]
-    input_types: [task_spec, agent_config]
-    output_types: [orchestration_results, agent_logs]
-    capabilities:
-      - "Orchestrate AI agents via Claude Flow"
-      - "Swarm coordination and multi-agent workflows"
-      - "Task decomposition and parallel execution"
-    python_packages: []
-
-  - id: "workspace-hub/compliance-check"
-    repo: workspace-hub
-    category: workspace_ops
-    domain: workspace_ops
-    sub_domains: [compliance]
-    input_types: [codebase_path, rule_set]
-    output_types: [compliance_report, violation_list]
-    capabilities:
-      - "Verify coding standards and AI guidelines"
-      - "Enforce workspace compliance rules"
-    python_packages: []
-
   - id: "workspace-hub/repo-sync"
     repo: workspace-hub
     category: workspace_ops
@@ -394,57 +369,7 @@ nodes:
       - "Bulk pull, push, and status operations"
     python_packages: []
 
-  - id: "workspace-hub/sparc-workflow"
-    repo: workspace-hub
-    category: workspace_ops
-    domain: development
-    sub_domains: [workflows]
-    input_types: [task_description]
-    output_types: [spec, pseudocode, architecture, refinement, completion]
-    capabilities:
-      - "Apply SPARC methodology (Spec, Pseudocode, Architecture, Refinement, Completion)"
-      - "Systematic TDD-driven development workflow"
-    python_packages: []
-
-  - id: "workspace-hub/workspace-cli"
-    repo: workspace-hub
-    category: workspace_ops
-    domain: workspace_ops
-    sub_domains: [cli]
-    input_types: [cli_command]
-    output_types: [cli_output]
-    capabilities:
-      - "Unified CLI for repository management"
-      - "System configuration and status"
-    python_packages: []
-
   # ── digitalmodel ──────────────────────────
-  - id: "digitalmodel/orcaflex-modeling"
-    repo: digitalmodel
-    category: engineering
-    domain: marine_offshore
-    sub_domains: [mooring, riser, structural, hydrodynamics]
-    input_types: [yaml_config, orcaflex_model, csv_data]
-    output_types: [orcaflex_results, dat_files, sim_files]
-    capabilities:
-      - "Setup and configure OrcaFlex hydrodynamic simulations"
-      - "Universal runner for batch simulation execution"
-      - "Model parameterization from YAML configs"
-    python_packages: [OrcFxAPI]
-
-  - id: "digitalmodel/orcaflex-post-processing"
-    repo: digitalmodel
-    category: engineering
-    domain: marine_offshore
-    sub_domains: [mooring, riser, structural]
-    input_types: [sim_files, orcaflex_results, yaml_config]
-    output_types: [statistics_csv, html_report, plotly_figures]
-    capabilities:
-      - "Extract statistics from OrcaFlex results"
-      - "Generate graphs and HTML reports via OPP"
-      - "Batch post-processing across load cases"
-    python_packages: [OrcFxAPI, plotly, pandas]
-
   - id: "digitalmodel/mooring-design"
     repo: digitalmodel
     category: engineering
@@ -522,19 +447,6 @@ nodes:
       - "Wave spectra generation and manipulation"
       - "RAO interpolation and OCIMF loading calculation"
     python_packages: [numpy, scipy]
-
-  - id: "digitalmodel/aqwa-analysis"
-    repo: digitalmodel
-    category: engineering
-    domain: marine_offshore
-    sub_domains: [aqwa, hydrodynamics]
-    input_types: [aqwa_model, vessel_geometry]
-    output_types: [rao_data, hydrodynamic_coefficients, aqwa_results]
-    capabilities:
-      - "Integrate with AQWA for diffraction/radiation analysis"
-      - "Extract RAOs and hydrodynamic databases"
-      - "Convert AQWA output to OrcaFlex format"
-    python_packages: []
 
   - id: "digitalmodel/signal-analysis"
     repo: digitalmodel
@@ -716,18 +628,6 @@ nodes:
       - "Format conversion and transformation utilities"
     python_packages: [pandas, pyyaml]
 
-  - id: "assetutilities/pdf-utilities"
-    repo: assetutilities
-    category: utilities
-    domain: document_generation
-    sub_domains: [pdf]
-    input_types: [pdf_file]
-    output_types: [pdf_file, extracted_text]
-    capabilities:
-      - "PDF processing utilities (merge, split, extract)"
-      - "Lightweight alternative to full pdf skill"
-    python_packages: [pypdf]
-
   - id: "assetutilities/plotly-visualization"
     repo: assetutilities
     category: utilities
@@ -754,50 +654,10 @@ nodes:
 edges:
 
   # ── Marine/offshore pipeline flows ────────
-  - from: "digitalmodel/orcaflex-modeling"
-    to: "digitalmodel/orcaflex-post-processing"
-    type: feeds
-    note: "Simulation output (.sim) feeds into post-processing for statistics and reports"
-
-  - from: "digitalmodel/mooring-design"
-    to: "digitalmodel/orcaflex-modeling"
-    type: feeds
-    note: "Mooring configuration generates OrcaFlex model for dynamic analysis"
-
-  - from: "digitalmodel/catenary-riser"
-    to: "digitalmodel/orcaflex-modeling"
-    type: feeds
-    note: "Riser configuration generates OrcaFlex model for dynamic analysis"
-
-  - from: "digitalmodel/hydrodynamics"
-    to: "digitalmodel/orcaflex-modeling"
-    type: dependency
-    note: "OrcaFlex models require hydrodynamic coefficients and wave spectra"
-
-  - from: "digitalmodel/aqwa-analysis"
-    to: "digitalmodel/hydrodynamics"
-    type: feeds
-    note: "AQWA produces RAOs and hydrodynamic databases consumed by hydrodynamics skill"
-
-  - from: "digitalmodel/aqwa-analysis"
-    to: "digitalmodel/orcaflex-modeling"
-    type: feeds
-    note: "AQWA RAOs imported into OrcaFlex vessel types"
-
-  - from: "digitalmodel/orcaflex-post-processing"
-    to: "digitalmodel/fatigue-analysis"
-    type: feeds
-    note: "Post-processed stress histories feed fatigue damage calculations"
-
   - from: "digitalmodel/signal-analysis"
     to: "digitalmodel/fatigue-analysis"
     type: feeds
     note: "Rainflow cycle counts from signal analysis used in fatigue assessment"
-
-  - from: "digitalmodel/orcaflex-post-processing"
-    to: "digitalmodel/structural-analysis"
-    type: feeds
-    note: "Extracted loads feed structural stress and buckling checks"
 
   - from: "digitalmodel/viv-analysis"
     to: "digitalmodel/fatigue-analysis"
@@ -911,17 +771,7 @@ edges:
     type: dependency
     note: "Invoice generation uses python-docx for document creation"
 
-  - from: "workspace-hub/pdf"
-    to: "assetutilities/pdf-utilities"
-    type: alternative
-    note: "Both handle PDF operations; workspace-hub/pdf is more comprehensive"
-
   # ── Cross-domain data flows ───────────────
-  - from: "digitalmodel/orcaflex-post-processing"
-    to: "workspace-hub/engineering-report-generator"
-    type: feeds
-    note: "OrcaFlex results formatted into engineering reports"
-
   - from: "assetutilities/plotly-visualization"
     to: "workspace-hub/engineering-report-generator"
     type: feeds
@@ -959,30 +809,10 @@ edges:
     note: "Expense reports commonly exported as Excel spreadsheets"
 
   # ── Development/workspace flows ───────────
-  - from: "workspace-hub/skill-creator"
-    to: "workspace-hub/compliance-check"
-    type: composition
-    note: "New skills validated against compliance rules"
-
   - from: "workspace-hub/yaml-workflow-executor"
     to: "workspace-hub/data-pipeline-processor"
     type: composition
     note: "YAML workflows often orchestrate data pipeline steps"
-
-  - from: "workspace-hub/sparc-workflow"
-    to: "workspace-hub/webapp-testing"
-    type: composition
-    note: "SPARC TDD workflow uses testing skill for validation"
-
-  - from: "workspace-hub/agent-orchestration"
-    to: "workspace-hub/parallel-file-processor"
-    type: composition
-    note: "Multi-agent workflows may use parallel processing"
-
-  - from: "workspace-hub/repo-sync"
-    to: "workspace-hub/workspace-cli"
-    type: shared_infra
-    note: "Both operate on the multi-repo workspace infrastructure"
 
   - from: "workspace-hub/frontend-design"
     to: "workspace-hub/web-artifacts-builder"
@@ -1031,15 +861,12 @@ edges:
 coverage:
   marine_offshore:
     skills:
-      - "digitalmodel/orcaflex-modeling"
-      - "digitalmodel/orcaflex-post-processing"
       - "digitalmodel/mooring-design"
       - "digitalmodel/catenary-riser"
       - "digitalmodel/structural-analysis"
       - "digitalmodel/fatigue-analysis"
       - "digitalmodel/viv-analysis"
       - "digitalmodel/hydrodynamics"
-      - "digitalmodel/aqwa-analysis"
       - "digitalmodel/signal-analysis"
     gaps:
       - "Corrosion and cathodic protection analysis (exists as SKILL.md but not in SKILLS_INDEX)"
@@ -1075,7 +902,6 @@ coverage:
       - "workspace-hub/xlsx"
       - "workspace-hub/doc-coauthoring"
       - "workspace-hub/engineering-report-generator"
-      - "assetutilities/pdf-utilities"
       - "aceengineer-admin/invoice-automation"
     gaps:
       - "LaTeX document generation"
@@ -1089,7 +915,6 @@ coverage:
       - "workspace-hub/yaml-workflow-executor"
       - "workspace-hub/skill-creator"
       - "workspace-hub/web-artifacts-builder"
-      - "workspace-hub/sparc-workflow"
     gaps:
       - "CI/CD pipeline configuration (GitHub Actions authoring)"
       - "Database migration management"
@@ -1118,10 +943,7 @@ coverage:
 
   workspace_ops:
     skills:
-      - "workspace-hub/agent-orchestration"
-      - "workspace-hub/compliance-check"
       - "workspace-hub/repo-sync"
-      - "workspace-hub/workspace-cli"
       - "workspace-hub/ai-tool-assessment"
     gaps:
       - "Automated backup and disaster recovery"
@@ -1155,14 +977,14 @@ coverage:
 # Statistics
 # ─────────────────────────────────────────────
 stats:
-  total_nodes: 51
-  total_edges: 52
+  total_nodes: 43
+  total_edges: 38
   edge_type_counts:
-    feeds: 23
-    composition: 15
-    dependency: 3
-    alternative: 3
-    shared_infra: 3
+    feeds: 15
+    composition: 12
+    dependency: 2
+    alternative: 2
+    shared_infra: 2
     see_also: 5
   domains_covered: 8
   domains_with_gaps_only: 1  # gis

--- a/config/agents/skill-graph-index.yaml
+++ b/config/agents/skill-graph-index.yaml
@@ -1,6 +1,6 @@
 # Pre-computed index from .planning/skills/skills-knowledge-graph.yaml
 # Regenerate: scripts/coordination/routing/lib/skill_graph.sh --rebuild-index
-generated_at: "2026-03-26"
+generated_at: "2026-06-19"
 source: .planning/skills/skills-knowledge-graph.yaml
 
 by_domain:
@@ -24,12 +24,10 @@ by_domain:
   development:
     - workspace-hub/mcp-builder
     - workspace-hub/skill-creator
-    - workspace-hub/sparc-workflow
     - workspace-hub/webapp-testing
     - workspace-hub/web-artifacts-builder
     - workspace-hub/yaml-workflow-executor
   document_generation:
-    - assetutilities/pdf-utilities
     - workspace-hub/doc-coauthoring
     - workspace-hub/docx
     - workspace-hub/engineering-report-generator
@@ -47,26 +45,18 @@ by_domain:
     - worldenergydata/web-scraper-energy
     - worldenergydata/well-production-dashboard
   marine_offshore:
-    - digitalmodel/aqwa-analysis
     - digitalmodel/catenary-riser
     - digitalmodel/fatigue-analysis
     - digitalmodel/hydrodynamics
     - digitalmodel/mooring-design
-    - digitalmodel/orcaflex-modeling
-    - digitalmodel/orcaflex-post-processing
     - digitalmodel/signal-analysis
     - digitalmodel/structural-analysis
     - digitalmodel/viv-analysis
   workspace_ops:
-    - workspace-hub/agent-orchestration
     - workspace-hub/ai-tool-assessment
-    - workspace-hub/compliance-check
     - workspace-hub/repo-sync
-    - workspace-hub/workspace-cli
 
 by_input_type:
-  agent_config:
-    - workspace-hub/agent-orchestration
   analysis_results:
     - workspace-hub/engineering-report-generator
   announcement_brief:
@@ -75,8 +65,6 @@ by_input_type:
     - worldenergydata/bsee-data-extractor
   api_spec:
     - workspace-hub/mcp-builder
-  aqwa_model:
-    - digitalmodel/aqwa-analysis
   audience_context:
     - workspace-hub/internal-comms
   bank_statements:
@@ -87,19 +75,14 @@ by_input_type:
     - workspace-hub/brand-guidelines
   cash_flow_data:
     - worldenergydata/npv-analyzer
-  cli_command:
-    - workspace-hub/workspace-cli
   client_data:
     - aceengineer-admin/invoice-automation
-  codebase_path:
-    - workspace-hub/compliance-check
   cost_estimates:
     - worldenergydata/fdas-economics
   csv_data:
     - aceengineer-admin/expense-tracking
     - assetutilities/data-management
     - assetutilities/plotly-visualization
-    - digitalmodel/orcaflex-modeling
     - digitalmodel/signal-analysis
     - workspace-hub/data-pipeline-processor
     - workspace-hub/engineering-report-generator
@@ -163,12 +146,7 @@ by_input_type:
     - digitalmodel/structural-analysis
   modal_data:
     - digitalmodel/viv-analysis
-  orcaflex_model:
-    - digitalmodel/orcaflex-modeling
-  orcaflex_results:
-    - digitalmodel/orcaflex-post-processing
   pdf_file:
-    - assetutilities/pdf-utilities
     - workspace-hub/pdf
   price_scenarios:
     - worldenergydata/fdas-economics
@@ -192,16 +170,12 @@ by_input_type:
   riser_properties:
     - digitalmodel/catenary-riser
     - digitalmodel/viv-analysis
-  rule_set:
-    - workspace-hub/compliance-check
   scrape_config:
     - worldenergydata/web-scraper-energy
   section_properties:
     - digitalmodel/structural-analysis
   seed_value:
     - workspace-hub/algorithmic-art
-  sim_files:
-    - digitalmodel/orcaflex-post-processing
   skill_template:
     - workspace-hub/skill-creator
   slide_content:
@@ -216,10 +190,6 @@ by_input_type:
     - workspace-hub/repo-sync
   tabular_data:
     - workspace-hub/xlsx
-  task_description:
-    - workspace-hub/sparc-workflow
-  task_spec:
-    - workspace-hub/agent-orchestration
   template_docx:
     - workspace-hub/docx
   template_pptx:
@@ -249,7 +219,6 @@ by_input_type:
   vessel_data:
     - digitalmodel/mooring-design
   vessel_geometry:
-    - digitalmodel/aqwa-analysis
     - digitalmodel/hydrodynamics
   wave_data:
     - digitalmodel/hydrodynamics
@@ -265,8 +234,6 @@ by_input_type:
     - assetutilities/plotly-visualization
     - digitalmodel/catenary-riser
     - digitalmodel/mooring-design
-    - digitalmodel/orcaflex-modeling
-    - digitalmodel/orcaflex-post-processing
     - workspace-hub/data-pipeline-processor
     - workspace-hub/docx
     - workspace-hub/engineering-report-generator
@@ -275,8 +242,6 @@ by_input_type:
     - workspace-hub/yaml-workflow-executor
 
 by_output_type:
-  agent_logs:
-    - workspace-hub/agent-orchestration
   aggregation_report:
     - workspace-hub/parallel-file-processor
   analysis_report:
@@ -288,10 +253,6 @@ by_output_type:
     - worldenergydata/marine-safety-incidents
   announcement:
     - workspace-hub/internal-comms
-  aqwa_results:
-    - digitalmodel/aqwa-analysis
-  architecture:
-    - workspace-hub/sparc-workflow
   assessment_report:
     - workspace-hub/ai-tool-assessment
   benchmarking_results:
@@ -306,12 +267,6 @@ by_output_type:
     - aceengineer-admin/expense-tracking
   change_log:
     - workspace-hub/doc-coauthoring
-  cli_output:
-    - workspace-hub/workspace-cli
-  completion:
-    - workspace-hub/sparc-workflow
-  compliance_report:
-    - workspace-hub/compliance-check
   component_code:
     - workspace-hub/frontend-design
   conflict_report:
@@ -330,8 +285,6 @@ by_output_type:
     - digitalmodel/signal-analysis
   damage_summary:
     - digitalmodel/fatigue-analysis
-  dat_files:
-    - digitalmodel/orcaflex-modeling
   directory_structure:
     - workspace-hub/skill-creator
   docx_file:
@@ -345,7 +298,6 @@ by_output_type:
   extracted_tables:
     - workspace-hub/pdf
   extracted_text:
-    - assetutilities/pdf-utilities
     - workspace-hub/pdf
   fatigue_damage:
     - digitalmodel/viv-analysis
@@ -368,10 +320,8 @@ by_output_type:
     - workspace-hub/frontend-design
     - workspace-hub/web-artifacts-builder
   html_report:
-    - digitalmodel/orcaflex-post-processing
     - workspace-hub/engineering-report-generator
   hydrodynamic_coefficients:
-    - digitalmodel/aqwa-analysis
     - digitalmodel/hydrodynamics
   incident_database:
     - worldenergydata/marine-safety-incidents
@@ -393,23 +343,17 @@ by_output_type:
   orcaflex_model:
     - digitalmodel/catenary-riser
     - digitalmodel/mooring-design
-  orcaflex_results:
-    - digitalmodel/orcaflex-modeling
-  orchestration_results:
-    - workspace-hub/agent-orchestration
   p5js_sketch:
     - workspace-hub/algorithmic-art
   parquet_data:
     - workspace-hub/data-pipeline-processor
   pdf_file:
-    - assetutilities/pdf-utilities
     - workspace-hub/canvas-design
     - workspace-hub/pdf
   pdf_invoice:
     - aceengineer-admin/invoice-automation
   plotly_figures:
     - assetutilities/plotly-visualization
-    - digitalmodel/orcaflex-post-processing
     - workspace-hub/engineering-report-generator
     - worldenergydata/energy-data-visualizer
     - worldenergydata/field-analyzer
@@ -423,13 +367,8 @@ by_output_type:
   production_csv:
     - worldenergydata/bsee-data-extractor
     - worldenergydata/sodir-data-extractor
-  pseudocode:
-    - workspace-hub/sparc-workflow
   rao_data:
-    - digitalmodel/aqwa-analysis
     - digitalmodel/hydrodynamics
-  refinement:
-    - workspace-hub/sparc-workflow
   revised_document:
     - workspace-hub/doc-coauthoring
   riser_config:
@@ -440,16 +379,10 @@ by_output_type:
     - workspace-hub/webapp-testing
   sensitivity_results:
     - worldenergydata/fdas-economics
-  sim_files:
-    - digitalmodel/orcaflex-modeling
   skill_md:
     - workspace-hub/skill-creator
   spectral_results:
     - digitalmodel/signal-analysis
-  spec:
-    - workspace-hub/sparc-workflow
-  statistics_csv:
-    - digitalmodel/orcaflex-post-processing
   statistics:
     - digitalmodel/signal-analysis
   stress_results:
@@ -473,8 +406,6 @@ by_output_type:
     - assetutilities/data-management
   utilization_ratios:
     - digitalmodel/structural-analysis
-  violation_list:
-    - workspace-hub/compliance-check
   viv_response:
     - digitalmodel/viv-analysis
   wave_spectra:
@@ -487,12 +418,6 @@ by_output_type:
     - workspace-hub/xlsx
 
 feed_chains:
-  - [digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing, digitalmodel/fatigue-analysis]
-  - [digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing, digitalmodel/structural-analysis]
-  - [digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing, workspace-hub/engineering-report-generator]
-  - [digitalmodel/mooring-design, digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing]
-  - [digitalmodel/catenary-riser, digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing]
-  - [digitalmodel/aqwa-analysis, digitalmodel/orcaflex-modeling, digitalmodel/orcaflex-post-processing]
   - [worldenergydata/bsee-data-extractor, worldenergydata/field-analyzer, worldenergydata/fdas-economics]
   - [worldenergydata/bsee-data-extractor, worldenergydata/field-analyzer, worldenergydata/energy-data-visualizer]
   - [worldenergydata/sodir-data-extractor, worldenergydata/field-analyzer, worldenergydata/fdas-economics]
@@ -501,7 +426,6 @@ feed_chains:
   - [worldenergydata/web-scraper-energy, worldenergydata/bsee-data-extractor, worldenergydata/well-production-dashboard]
   - [worldenergydata/web-scraper-energy, worldenergydata/sodir-data-extractor, worldenergydata/field-analyzer]
   - [worldenergydata/web-scraper-energy, worldenergydata/sodir-data-extractor, worldenergydata/well-production-dashboard]
-  - [digitalmodel/aqwa-analysis, digitalmodel/hydrodynamics]
   - [digitalmodel/signal-analysis, digitalmodel/fatigue-analysis]
   - [digitalmodel/viv-analysis, digitalmodel/fatigue-analysis]
   - [workspace-hub/xlsx, workspace-hub/engineering-report-generator]

--- a/scripts/enforcement/check-skill-index-coherence.py
+++ b/scripts/enforcement/check-skill-index-coherence.py
@@ -41,17 +41,20 @@ KNOWLEDGE_GRAPH = REPO / ".planning" / "skills" / "skills-knowledge-graph.yaml"
 GRAPH_INDEX = REPO / "config" / "agents" / "skill-graph-index.yaml"
 BUILDER = REPO / "scripts" / "ai" / "build_skill_index.py"
 
-# Curated graph references skills not present in .claude/skills. Allowlisted
-# pending the curated-graph cleanup (#3208 follow-up). New unlisted drift fails.
-KNOWN_STALE_CURATED = {
-    "workspace-hub/agent-orchestration",
-    "workspace-hub/compliance-check",
-    "workspace-hub/sparc-workflow",
-    "workspace-hub/workspace-cli",
-    "digitalmodel/orcaflex-modeling",
-    "digitalmodel/orcaflex-post-processing",
-    "digitalmodel/aqwa-analysis",
-    "assetutilities/pdf-utilities",
+# Curated graph references skills not present in .claude/skills. Emptied by #3214
+# (the 8 stale nodes were removed from the graph). New unlisted drift fails (a).
+KNOWN_STALE_CURATED: set[str] = set()
+
+# Pre-existing dangling EDGE endpoints (edges referencing node ids that were never
+# defined as nodes) — a SEPARATE drift class from the #3214 stale-node removal,
+# needing per-edge judgment (some are real skills missing a node def, some are
+# absent). Allowlisted pending the follow-up; NEW dangling edges fail check (d).
+KNOWN_DANGLING_EDGE_REFS = {
+    "eng/diffraction-spec-converter",
+    "engineering/marine-offshore/diffraction-analysis",
+    "engineering/marine-offshore/cathodic-protection",
+    "engineering/marine-offshore/risk-assessment",
+    "engineering/asset-integrity/fitness-for-service",
 }
 
 # Loose when-to-use/trigger heading the GENERATOR may not recognize (it matches
@@ -106,6 +109,27 @@ def check_b_advisory() -> list[str]:
     return advisories
 
 
+def check_d_graph_integrity(failures: list[str]) -> None:
+    """(d) BLOCKING — no dangling EDGE endpoints (#3214). Every edge from/to must
+    be a defined node id. Pre-existing dangling refs are allowlisted
+    (KNOWN_DANGLING_EDGE_REFS) pending the follow-up; a NEW dangling edge fails.
+
+    Coverage `coverage.*.skills` is intentionally NOT node-constrained (it lists a
+    domain's skills broadly, incl. non-curated ones) — so it is not checked here.
+    """
+    kg = _load_yaml(KNOWLEDGE_GRAPH)
+    node_ids = {n["id"] for n in kg.get("nodes", []) if isinstance(n, dict) and n.get("id")}
+    for e in kg.get("edges", []) or []:
+        if not isinstance(e, dict):
+            continue
+        for ep in (e.get("from"), e.get("to")):
+            if ep and ep not in node_ids and ep not in KNOWN_DANGLING_EDGE_REFS:
+                failures.append(
+                    f"(d) edge endpoint '{ep}' is not a defined node (dangling edge "
+                    f"{e.get('from')}->{e.get('to')}). Add the node, remove the edge, "
+                    f"or allowlist in KNOWN_DANGLING_EDGE_REFS with a tracking issue.")
+
+
 def check_c_determinism(failures: list[str]) -> None:
     cmd = (["uv", "run", "--quiet", str(BUILDER)] if _has_uv() else [sys.executable, str(BUILDER)])
     out = subprocess.run(cmd + ["--check"], capture_output=True, text=True, cwd=REPO)
@@ -128,6 +152,7 @@ def _has_uv() -> bool:
 def main() -> int:
     failures: list[str] = []
     check_a_coherence(failures)
+    check_d_graph_integrity(failures)
     check_c_determinism(failures)
     advisories = check_b_advisory()
 

--- a/tests/enforcement/test_skill_graph_integrity.py
+++ b/tests/enforcement/test_skill_graph_integrity.py
@@ -1,0 +1,78 @@
+"""Curated-graph integrity tests (#3214 Part A): 8 stale nodes removed, empty
+allowlist, edge-integrity check (allowlist pre-existing, fail new dangling)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOD = REPO_ROOT / "scripts" / "enforcement" / "check-skill-index-coherence.py"
+spec = importlib.util.spec_from_file_location("check_skill_index_coherence", MOD)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_skill_index_coherence"] = mod
+spec.loader.exec_module(mod)
+
+STALE8 = {
+    "workspace-hub/agent-orchestration", "workspace-hub/compliance-check",
+    "workspace-hub/sparc-workflow", "workspace-hub/workspace-cli",
+    "digitalmodel/orcaflex-modeling", "digitalmodel/orcaflex-post-processing",
+    "digitalmodel/aqwa-analysis", "assetutilities/pdf-utilities",
+}
+
+
+def test_known_stale_curated_emptied():
+    assert mod.KNOWN_STALE_CURATED == set()
+
+
+def test_eight_stale_nodes_gone_from_graph_and_index():
+    kg = yaml.safe_load(open(mod.KNOWLEDGE_GRAPH))
+    node_ids = {n["id"] for n in kg["nodes"]}
+    assert STALE8.isdisjoint(node_ids)
+    # no edge references any of the 8
+    for e in kg.get("edges", []):
+        assert e["from"] not in STALE8 and e["to"] not in STALE8
+    gi_text = mod.GRAPH_INDEX.read_text()
+    for sid in STALE8:
+        assert sid not in gi_text
+
+
+def test_coherence_a_passes_with_empty_allowlist():
+    fails: list[str] = []
+    mod.check_a_coherence(fails)
+    assert fails == [], fails
+
+
+def test_graph_integrity_passes_on_current_graph():
+    # the 5 pre-existing dangling edges are allowlisted; no NEW dangling.
+    fails: list[str] = []
+    mod.check_d_graph_integrity(fails)
+    assert fails == [], fails
+
+
+def test_graph_integrity_fails_on_new_dangling(tmp_path, monkeypatch):
+    g = tmp_path / "kg.yaml"
+    g.write_text(yaml.safe_dump({
+        "nodes": [{"id": "a/x"}, {"id": "a/y"}],
+        "edges": [{"from": "a/x", "to": "a/y"},
+                  {"from": "a/x", "to": "a/ghost"}],  # ghost not a node, not allowlisted
+    }))
+    monkeypatch.setattr(mod, "KNOWLEDGE_GRAPH", g)
+    fails: list[str] = []
+    mod.check_d_graph_integrity(fails)
+    assert any("a/ghost" in f for f in fails)
+
+
+def test_graph_integrity_allowlist_suppresses(tmp_path, monkeypatch):
+    g = tmp_path / "kg.yaml"
+    g.write_text(yaml.safe_dump({
+        "nodes": [{"id": "a/x"}],
+        "edges": [{"from": "a/x", "to": "a/allowed"}],
+    }))
+    monkeypatch.setattr(mod, "KNOWLEDGE_GRAPH", g)
+    monkeypatch.setattr(mod, "KNOWN_DANGLING_EDGE_REFS", {"a/allowed"})
+    fails: list[str] = []
+    mod.check_d_graph_integrity(fails)
+    assert fails == []


### PR DESCRIPTION
Part A of #3214 (Part B = #3219, merged). Under epic #3058.

## What
The curated graph (`.planning/skills/skills-knowledge-graph.yaml`) referenced 8 skills with no SKILL.md in the active tree (2 archived, 6 absent) — allowlisted in `KNOWN_STALE_CURATED`. This removes them so the coherence gate `(a)` passes with an **empty allowlist**, and adds a self-enforcing edge-integrity check.

- **Line-based surgery** (preserves the hand-maintained formatting — a ruamel round-trip reformatted the whole file, 1857-line diff): removed the 8 node blocks + the 14 edges referencing them + their `coverage:` skill lines; recomputed `stats:` (nodes 51→43, edges 52→38, edge_type_counts). 192-line surgical diff.
- **Regenerated** `skill-graph-index.yaml` (`skill_graph.sh --rebuild-index`) — purges the 8 from all derived sections.
- **`check-skill-index-coherence.py`:** `KNOWN_STALE_CURATED` emptied; new BLOCKING **(d) edge-integrity** check (every edge `from`/`to` must be a defined node). `coverage:` is intentionally NOT node-constrained (it lists domain skills broadly).

## Pre-existing drift surfaced → #3220
The integrity check found **5 pre-existing dangling edges** (endpoints never defined as nodes — a *separate* drift class needing add-node-vs-delete-edge judgment: `diffraction-analysis`/`cathodic-protection` are real uncurated skills, others absent). Allowlisted in `KNOWN_DANGLING_EDGE_REFS` pending **#3220**; new dangling edges fail.

## Verified
Graph parses; 43 nodes, no stale; no dangling beyond the 5 allowlisted; checker green (a empty-allowlist + d integrity + c determinism); 14 enforcement tests pass.

## Reviews
- **Plan r1 (Claude): MAJOR** — corrected the integrity scope (coverage lenient, not node-constrained), the `stats:`/`coverage:` structure (vs the plan's misdescription), and flagged the ruamel reformat hazard → line-based surgery. All folded in; the pre-existing dangling-edge drift was discovered during implementation and split to #3220.
- **Codex r2: UNAVAILABLE** (env timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)