### PR TITLE
ci: reusable domain-matrix workflow (worldenergydata#526, #530)

### DIFF
--- a/.github/workflows/domain-matrix.yml
+++ b/.github/workflows/domain-matrix.yml
@@ -1,0 +1,185 @@
+name: Domain Matrix (reusable)
+
+# Reusable "modular per-domain CI" workflow (worldenergydata#526 / #530, P4).
+#
+# Encapsulates the discover -> test-domain (matrix) -> aggregate scaffolding that
+# was duplicated across worldenergydata, assetutilities, and assethold. A PR fans
+# out into one job per touched domain (+ the always-on cross-cutting core), so a
+# red domain no longer blocks green siblings and they run in parallel.
+#
+# The caller keeps its OWN repo-specific selector (module layouts differ); only
+# the multi-job scaffolding + quarantine/exit-5 mechanics live here. The selector
+# must support `--emit-matrix --files-from <file>` and write `matrix=<json>` and
+# `scope=<str>` lines to $GITHUB_OUTPUT using the stdlib only (no install).
+#
+# CAVEAT: a reusable workflow's status-check name becomes
+# "<caller-job-id> / <reusable-job-name>" (e.g. "ci / Aggregate domain results").
+# This CHANGES required-check names. Repos WITHOUT branch protection adopt freely;
+# repos WITH protection need a one-time required-check rename on migration.
+# See docs/ci/domain-matrix-reusable-workflow.md.
+
+on:
+  workflow_call:
+    inputs:
+      selector:
+        description: "Path to the caller's stdlib selector supporting --emit-matrix."
+        type: string
+        required: false
+        default: "scripts/ci/select_test_targets.py"
+      python-version:
+        description: "Python version to install for the domain jobs."
+        type: string
+        required: false
+        default: "3.11"
+      install-cmd:
+        description: "Command to install dependencies in each domain job."
+        type: string
+        required: false
+        default: "uv sync --all-extras"
+      test-runner:
+        description: "Command prefix used to run pytest on the shard targets."
+        type: string
+        required: false
+        default: "uv run --with pytest-xdist pytest"
+      max-parallel:
+        description: "Bound on the matrix fan-out (core changes can be many domains)."
+        type: number
+        required: false
+        default: 10
+      quarantine-file:
+        description: "File of known-broken node-ids to --deselect (one per line, # comments)."
+        type: string
+        required: false
+        default: "scripts/ci/quarantine.txt"
+
+jobs:
+  # --------------------------------------------------------------- discover --
+  discover:
+    name: Discover domains
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.sel.outputs.matrix }}
+      scope: ${{ steps.sel.outputs.scope }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the base commit to diff changed files
+
+      - name: Select domain matrix
+        id: sel
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SELECTOR: ${{ inputs.selector }}
+        run: |
+          # Stdlib only — no dependency install needed (keeps discovery fast).
+          git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+          echo "Changed files:"; cat changed-files.txt
+          python3 "$SELECTOR" \
+            --emit-matrix --files-from changed-files.txt >> "$GITHUB_OUTPUT"
+          echo "--- matrix ---"; grep '^matrix=' "$GITHUB_OUTPUT" || true
+          echo "--- scope ---";  grep '^scope='  "$GITHUB_OUTPUT" || true
+
+  # ------------------------------------------------------------ test-domain --
+  test-domain:
+    name: Domain ${{ matrix.name }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one red domain must not cancel the others
+      max-parallel: ${{ inputs.max-parallel }}
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        run: ${{ inputs.install-cmd }}
+
+      - name: Run domain tests (${{ matrix.name }})
+        env:
+          TARGETS: ${{ matrix.targets }}
+          MODE: ${{ matrix.mode }}
+          SHARD: ${{ matrix.name }}
+          TEST_RUNNER: ${{ inputs.test-runner }}
+          QUARANTINE_FILE: ${{ inputs.quarantine-file }}
+        run: |
+          # Build --deselect args for quarantined tests (known-broken on main,
+          # tracked by issues). They still RUN but do not block, at test
+          # granularity (never whole shards). The quarantine file may list
+          # node-ids in EITHER form — `tests/`-prefixed or rootdir-relative
+          # (some repos set rootdir=tests/ in pytest.ini, which strips the
+          # leading `tests/`). We emit a --deselect for BOTH forms so a single
+          # line matches regardless of the caller's rootdir.
+          DESELECT=()
+          if [ -f "$QUARANTINE_FILE" ]; then
+            while IFS= read -r raw; do
+              line="${raw%%#*}"
+              line="$(echo "$line" | xargs || true)"
+              [ -z "$line" ] && continue
+              DESELECT+=(--deselect "$line")
+              # Also emit the alternate rootdir-relative / tests-prefixed form.
+              if [ "${line#tests/}" != "$line" ]; then
+                DESELECT+=(--deselect "${line#tests/}")
+              else
+                DESELECT+=(--deselect "tests/${line}")
+              fi
+            done < "$QUARANTINE_FILE"
+          fi
+          [ "${#DESELECT[@]}" -gt 0 ] && echo "Quarantine: ${DESELECT[*]}"
+          XDIST=()
+          [ "$MODE" = "xdist" ] && XDIST=(-n auto)
+          echo "Shard '$SHARD' ($MODE): $TARGETS"
+          set +e
+          # shellcheck disable=SC2086 (TARGETS / TEST_RUNNER are intentional lists)
+          $TEST_RUNNER $TARGETS "${XDIST[@]}" "${DESELECT[@]}" \
+            --tb=short --junitxml="test-results-${SHARD}.xml"
+          rc=$?
+          set -e
+          # exit code 5 = "no tests collected" (empty / norecursedirs-excluded
+          # shard) — not a failure for a per-domain shard.
+          if [ "$rc" -eq 5 ]; then
+            echo "::notice::shard '$SHARD' collected no tests — treating as pass"
+            rc=0
+          fi
+          exit "$rc"
+
+      - name: Upload domain test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-results-${{ matrix.name }}
+          path: test-results-*.xml
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------- aggregate --
+  aggregate:
+    name: Aggregate domain results
+    needs: [discover, test-domain]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate domain results
+        run: |
+          echo "discover:    ${{ needs.discover.result }}"
+          echo "test-domain: ${{ needs.test-domain.result }}"
+          echo "scope:       ${{ needs.discover.outputs.scope }}"
+          if [ "${{ needs.discover.result }}" != "success" ]; then
+            echo "::error::domain discovery failed"; exit 1
+          fi
+          # test-domain is a matrix; its result is 'success' only when every
+          # domain job passed (fail-fast is off, so all run to completion).
+          if [ "${{ needs.test-domain.result }}" != "success" ]; then
+            echo "::error::one or more domain jobs failed — see the Domain * jobs"
+            exit 1
+          fi
+          echo "All domains green ✅"

--- a/docs/ci/domain-matrix-reusable-workflow.md
+++ b/docs/ci/domain-matrix-reusable-workflow.md
@@ -1,0 +1,110 @@
+# Domain Matrix — reusable CI workflow
+
+Shared "modular per-domain CI" scaffolding, hosted in `workspace-hub` so
+`worldenergydata`, `assetutilities`, `assethold` (and `digitalmodel`) stop
+maintaining near-identical copies of the same three jobs.
+
+- Workflow: [`.github/workflows/domain-matrix.yml`](../../.github/workflows/domain-matrix.yml)
+- Epic: worldenergydata#526 · P4: worldenergydata#530
+- Reference implementation: worldenergydata#531
+
+## What it does
+
+A PR fans out into **one CI job per touched domain** (plus the always-on
+cross-cutting core), so a red domain no longer blocks green siblings and they
+run in parallel:
+
+```
+discover  ->  test-domain (matrix, fail-fast: false)  ->  aggregate
+```
+
+- **`discover`** — checks out with `fetch-depth: 0`, diffs the PR base against
+  `HEAD`, and runs the caller's selector with `--emit-matrix` to produce
+  `matrix=<json>` and `scope=<str>` outputs. Stdlib only — no dependency install,
+  so discovery stays fast.
+- **`test-domain`** — `fromJSON(matrix)`, `fail-fast: false`, `max-parallel`
+  from input. Installs deps, builds `--deselect` args from the quarantine file
+  (supporting both `tests/`-prefixed and rootdir-relative node-id forms), runs
+  the test-runner on `matrix.targets`, and **treats pytest exit code 5
+  ("no tests collected") as a pass**. Uploads a JUnit artifact per shard.
+- **`aggregate`** — `needs: [discover, test-domain]`, `if: always()`. Fails iff
+  `discover != success` **or** `test-domain != success`. This is the single job
+  to wire as the required status check.
+
+## Inputs
+
+| Input | Default | Purpose |
+|-------|---------|---------|
+| `selector` | `scripts/ci/select_test_targets.py` | Caller's stdlib selector supporting `--emit-matrix --files-from <file>`. |
+| `python-version` | `"3.11"` | Python version installed for the domain jobs. |
+| `install-cmd` | `uv sync --all-extras` | Dependency install command per domain job. |
+| `test-runner` | `uv run --with pytest-xdist pytest` | Command prefix used to run pytest on the shard targets. |
+| `max-parallel` | `10` | Bound on the matrix fan-out (core changes can be many domains). |
+| `quarantine-file` | `scripts/ci/quarantine.txt` | Known-broken node-ids to `--deselect` (one per line, `#` comments). |
+
+## Minimal caller example
+
+In the calling repo (e.g. `worldenergydata/.github/workflows/ci.yml`):
+
+```yaml
+name: CI
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  ci:
+    uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
+    with:
+      selector: scripts/ci/select_test_targets.py
+      python-version: "3.11"
+      install-cmd: uv sync --all-extras
+      test-runner: uv run --with pytest-xdist pytest
+      max-parallel: 10
+      quarantine-file: scripts/ci/quarantine.txt
+```
+
+All inputs have sensible defaults, so a repo that follows the conventions can
+call it with no `with:` block at all.
+
+## Resulting status-check names — read this before migrating
+
+> **CRITICAL CAVEAT.** A reusable workflow's status-check name is
+> **`<caller-job-id> / <reusable-job-name>`** — *not* the reusable job name on
+> its own. With the caller job above named `ci`, the checks become:
+>
+> - `ci / Discover domains`
+> - `ci / Domain <name>`
+> - `ci / Aggregate domain results`   ← the one to require
+>
+> Inlining the same jobs in the caller (the pre-migration layout) produces
+> bare names like `Aggregate domain results`. **Adopting the reusable workflow
+> therefore RENAMES every check.**
+
+### Branch-protection migration
+
+- **Repos WITHOUT branch protection — `assetutilities`, `assethold`** — adopt
+  freely. No required checks exist, so the rename is harmless. Just switch the
+  `ci.yml` to `uses:` the reusable workflow and delete the inlined jobs.
+- **Repos WITH branch protection — `worldenergydata`, `digitalmodel`** — the
+  required check (e.g. `Test (PR gate)`) will no longer report under that name
+  once jobs move into the reusable workflow. Perform a **one-time required-check
+  rename** when migrating:
+  1. Open the migration PR (caller switched to `uses:`).
+  2. Let it run once so the new check name (`ci / Aggregate domain results`)
+     appears in the repo's check history.
+  3. In branch-protection settings, add the new name to required checks and
+     remove the old one.
+  4. Merge.
+
+  Until step 3, a stale required check can block merges (it never reports), so
+  coordinate the protection edit with the merge.
+
+## Why the selector stays per-repo
+
+Only the multi-job scaffolding + quarantine/exit-5 mechanics are shared. Each
+repo keeps its **own** `scripts/ci/select_test_targets.py` because module
+layouts differ (`src/worldenergydata/<m>/` vs `src/assetutilities/...`, distinct
+core paths, distinct always-on sets). The selector is the single source of truth
+for *that repo's* file -> target mapping; the reusable workflow only needs it to
+emit `matrix=<json>` and `scope=<str>` to `$GITHUB_OUTPUT` using the stdlib.


### PR DESCRIPTION
## What

A **reusable GitHub Actions workflow** (`on: workflow_call`) that encapsulates the "modular per-domain CI" pattern currently duplicated across **worldenergydata**, **assetutilities**, and **assethold** (4 near-identical copies). Repos call it instead of maintaining their own `discover` -> `test-domain` -> `aggregate` scaffolding.

Reference implementation: worldenergydata#531. Epic: worldenergydata#526. P4: worldenergydata#530.

## Files

- `.github/workflows/domain-matrix.yml` — the reusable workflow.
- `docs/ci/domain-matrix-reusable-workflow.md` — adoption guide.

## Jobs

`discover` (stdlib selector `--emit-matrix` against PR base diff; `fetch-depth: 0`; no install) -> `test-domain` (matrix `fromJSON`, `fail-fast: false`, `max-parallel` from input; install deps; quarantine `--deselect`; **pytest exit 5 = pass**; upload junit) -> `aggregate` (`needs: [discover, test-domain]`, `if: always()`, fails iff `discover != success` or `test-domain != success`).

## Inputs (with defaults)

| Input | Default |
|-------|---------|
| `selector` | `scripts/ci/select_test_targets.py` |
| `python-version` | `"3.11"` |
| `install-cmd` | `uv sync --all-extras` |
| `test-runner` | `uv run --with pytest-xdist pytest` |
| `max-parallel` | `10` |
| `quarantine-file` | `scripts/ci/quarantine.txt` |

The quarantine deselect builder emits `--deselect` for **both** `tests/`-prefixed and rootdir-relative node-id forms (repos differ on `rootdir`).

## CRITICAL caveat: required-check rename

A reusable workflow's status-check name becomes **`<caller-job-id> / <reusable-job-name>`** (e.g. `ci / Aggregate domain results`), which **CHANGES required-check names**.

- Repos **without** branch protection (**assetutilities**, **assethold**) — adopt freely.
- Repos **with** protection (**worldenergydata**, **digitalmodel**) — need a **one-time required-check rename** on migration (let the new check report once, add it to required checks, remove the old, then merge). Detailed in the doc.

## Why the selector stays per-repo

Module layouts differ, so each repo keeps its own `select_test_targets.py`; only the multi-job scaffolding + quarantine/exit-5 mechanics are shared here.

## Validation

YAML parses via `yaml.safe_load` (6 inputs, 3 jobs, `aggregate.needs == [discover, test-domain]` all asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)