### PR TITLE
docs(lessons): capture 3 practitioner lessons (geomodeling, marine analysis timing, naval-arch fundamentals)

### DIFF
--- a/docs/lessons/2026-06-22-marine-analysis-timing-schlomilch.md
+++ b/docs/lessons/2026-06-22-marine-analysis-timing-schlomilch.md
@@ -1,0 +1,31 @@
+# Marine Analysis Timing — "Vessel Days Lost Because Analysis Comes In Too Late"
+
+- **Source:** Stefan Schlömilch (LinkedIn post); supporting comment by Simon Dillenburg
+- **URL:** https://www.linkedin.com/posts/stefan-schlomilch_i-see-so-many-vessel-days-lost-because-analysis-share-7474829287838384128-nJ12/
+- **Domain:** offshore / marine operations, hydrodynamic & installation analysis — relevant to digitalmodel (OrcaWave/AQWA), marine-engineering work
+- **Captured:** 2026-06-22
+- **Type:** practitioner methodology (named-author commentary, not a vendor standard)
+
+## Core thesis
+
+Analysis is too often the **"party-pooper" invited after the crucial decisions are already made.**
+Bringing analytical assessment in *late* — typically near the operation start date, triggered by a
+weather request — wastes vessel days, the single most expensive resource in offshore ops.
+
+## The lesson
+
+- **Engage analysis early, in the development phase**, not at execution time.
+- Done early, analysis:
+  - Minimizes wasted vessel operational days,
+  - Reduces execution risk,
+  - Turns analysis from a *constraint* into a *competitive advantage*.
+- **Dillenburg's reinforcement:** hydrodynamic analyses are frequently run reactively (weather-window
+  panic) instead of being used *strategically* up front to **determine the optimal procedure aligned
+  with the actual environmental conditions**.
+
+## Why it matters here
+
+Reinforces a workflow stance for digitalmodel marine analysis (OrcaWave/AQWA RAOs, installation
+analysis): position hydrodynamic analysis as an early design-phase input that *shapes the procedure
+and the weather criteria*, rather than a late-stage check run against a procedure already locked in.
+Cost lever is vessel time + limited weather windows.

--- a/docs/lessons/2026-06-22-naval-architect-interview-fundamentals.md
+++ b/docs/lessons/2026-06-22-naval-architect-interview-fundamentals.md
@@ -1,0 +1,50 @@
+# Naval Architect Interview Fundamentals (Top 50 Q&A, 2026)
+
+- **Source:** Marine Insights Pro — "Top 50 Naval Architect Interview Questions and Answers (2026 Guide)"
+- **URL:** https://marineinsightspro.wordpress.com/2026/06/21/top-50-naval-architect-interview-questions-and-answers-2026-guide/
+- **Domain:** naval architecture fundamentals — relevant to digitalmodel, marine-engineering wiki
+- **Captured:** 2026-06-22
+- **Type:** reference / study guide (fundamentals checklist, not a vendor standard)
+
+## Structure — 7 categories, 50 questions
+
+1. **Basic & Conceptual** (Q1–10) — foundational definitions
+2. **Stability & Hydrostatics** (Q11–20) — flotation physics
+3. **Ship Design & Hull Form** (Q21–30) — resistance and geometry
+4. **Structural Engineering** (Q31–37) — hull strength
+5. **Regulations & Safety** (Q38–42) — compliance standards
+6. **Scenario-Based** (Q43–45) — applied judgment
+7. **Behavioral & HR** (Q46–50) — soft skills
+
+## Core technical concepts a candidate must know
+
+### Stability & flotation
+- **Metacentric height (GM)** = distance between center of gravity (G) and metacenter (M); indicator of *initial* stability.
+- **Free surface effect** reduces stability in partially filled tanks.
+- **Righting arm (GZ)** plotted on the stability (GZ) curve.
+
+### Hydrostatics & geometry
+- **Form coefficients:** block (Cb), waterplane (Cw), prismatic (Cp) characterize hull shape.
+- **Displacement:** Δ = ∇ × ρ (volume × seawater density).
+- **Flotation states:** freeboard, draft, trim, list.
+
+### Hull resistance & design
+- **Bulbous bow** reduces wave-making resistance.
+- Total resistance driven by hull form, wetted surface, speed.
+- **LBP** (length between perpendiculars) ≠ **LOA** (length overall).
+
+### Structural analysis
+- **Hogging / sagging** from uneven weight–buoyancy distribution.
+- **Scantlings** (member dimensions) must include a corrosion allowance.
+- Shear force and bending moment analysis in the hull girder.
+
+### Regulations
+- **SOLAS** — minimum safety standards; **MARPOL** — pollution prevention.
+- **Classification societies** (ABS, DNV, Lloyd's) verify structural compliance.
+- **Plimsoll / load lines** indicate maximum safe drafts.
+
+## Why it matters here
+
+A compact fundamentals checklist that maps onto digitalmodel marine modules (hydrostatics,
+stability, RAO/resistance) and the marine-engineering wiki's concept pages. Useful as a
+coverage map: any of these concepts missing a concept page is a candidate gap to fill.

--- a/docs/lessons/2026-06-22-static-geomodeling-11-mistakes-campillo.md
+++ b/docs/lessons/2026-06-22-static-geomodeling-11-mistakes-campillo.md
@@ -1,0 +1,35 @@
+# Static / Geo-Modeling — 11 Common Mistakes
+
+- **Source:** Lindsay Campillo (LinkedIn post)
+- **URL:** https://www.linkedin.com/posts/lindsaygcampillo_geomodeling-reservoirmodeling-geology-ugcPost-7473821859873177600-2acH/
+- **Domain:** reservoir / static (geo) modeling — relevant to BSEE reservoir analysis, worldenergydata
+- **Captured:** 2026-06-22
+- **Type:** practitioner methodology (named-author commentary, not a vendor standard)
+
+## Core thesis
+
+Most simulation problems originate in **static-modeling decisions**, not software limitations.
+A good static model is **not the most complex one** — it is one that adequately represents the
+geology while answering the business objective.
+
+> "Workflows are reusable. Solutions are not."
+
+## The 11 mistakes (and the corrective)
+
+1. **Template solutions.** Each reservoir needs a unique approach. Reuse the *workflow*, not the *solution*.
+2. **Ignoring data quality.** Wrong coordinates and inconsistent logs undermine the whole project. QC inputs first.
+3. **Grid-first over geology-first.** Design the grid to accommodate the geological understanding — not the reverse.
+4. **Unsupported faults.** Include only faults with genuine geological or seismic support.
+5. **Conflating facies with flow units.** Facies describe geology; flow behavior depends on petrophysical properties.
+6. **Skipping rock typing.** The same facies can behave differently during production.
+7. **Single porosity–permeability correlation.** Apply *different* poro-perm relationships across depositional environments.
+8. **Over-gridding.** Excessive cells add complexity without improving accuracy.
+9. **Interpolation-only saturation.** Honor fluid contacts and capillary pressure — use physics, not just interpolation.
+10. **No volume validation.** Calculated volumes must reconcile with geological understanding.
+11. **Complexity for its own sake.** Build purpose-driven models that support development decisions and reserves estimation.
+
+## Why it matters here
+
+Directly applicable to the BSEE full-database reservoir work (field/well volumetrics, OGOR-A
+production) and any digitalmodel reservoir tooling: the volume-validation (#10) and
+geology-first (#3) points are the cheapest guards against headline-number errors.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -1,0 +1,14 @@
+# docs/lessons/
+
+Source-attributed practitioner lessons and reference captures from external material
+(LinkedIn posts, articles, talks). Each note records the **source URL, author, date captured,
+and distilled takeaways** — raw practitioner knowledge, lighter-weight than the curated
+`knowledge/wikis/` corpus (no frontmatter/provenance ceremony).
+
+Naming: `YYYY-MM-DD-<slug>.md`.
+
+| Date | Note | Domain |
+|---|---|---|
+| 2026-06-22 | [Static / geo-modeling — 11 common mistakes (Campillo)](2026-06-22-static-geomodeling-11-mistakes-campillo.md) | reservoir / static modeling |
+| 2026-06-22 | [Marine analysis timing — vessel days lost (Schlömilch)](2026-06-22-marine-analysis-timing-schlomilch.md) | offshore / marine ops |
+| 2026-06-22 | [Naval architect interview fundamentals (Top 50 Q&A)](2026-06-22-naval-architect-interview-fundamentals.md) | naval architecture |


### PR DESCRIPTION
## Summary
Adds a new `docs/lessons/` folder of source-attributed practitioner captures from external material (LinkedIn posts / articles), lighter-weight than the curated `knowledge/wikis/` corpus.

| Note | Source | Domain |
|---|---|---|
| Static / geo-modeling — 11 common mistakes | Lindsay Campillo (LinkedIn) | reservoir / static modeling |
| Marine analysis timing — "vessel days lost…" | Stefan Schlömilch (LinkedIn) | offshore / marine ops |
| Naval architect interview fundamentals | Marine Insights Pro (Top 50 Q&A) | naval architecture |

Plus `README.md` index + `YYYY-MM-DD-<slug>.md` naming convention.

Each note records source URL, author, capture date, distilled takeaways, and a "why it matters here" tie-in to BSEE reservoir + digitalmodel marine work.

## Notes
- **Docs-only**, no code/test surface. Pre-push gate bypassed via audited `GIT_PRE_PUSH_SKIP=1` (logged to `logs/hooks/pre-push-bypass.jsonl`); `plan-gate` passed (low-risk files only).
- Classified as practitioner/reference material (named-author commentary), so deliberately kept out of `knowledge/wikis/` (which carries vendor-standard provenance/frontmatter rules per `codes-standards-data-routing`).