### PR TITLE
ci(domain-matrix): python-setup input + non-PR base-SHA fallback

### DIFF
--- a/.github/workflows/domain-matrix.yml
+++ b/.github/workflows/domain-matrix.yml
@@ -31,6 +31,16 @@ on:
         type: string
         required: false
         default: "3.11"
+      python-setup:
+        description: >-
+          How to provision the Python interpreter in the domain jobs. "uv"
+          (default — current behavior) installs a uv-MANAGED interpreter via
+          `uv python install` (NOT on PATH as the system python). "setup-python"
+          uses actions/setup-python to put the interpreter ON PATH as the system
+          interpreter, which `uv pip install --system` requires (e.g. assethold).
+        type: string
+        required: false
+        default: "uv"
       install-cmd:
         description: "Command to install dependencies in each domain job."
         type: string
@@ -70,10 +80,42 @@ jobs:
         id: sel
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
           SELECTOR: ${{ inputs.selector }}
         run: |
           # Stdlib only — no dependency install needed (keeps discovery fast).
-          git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+          #
+          # Resolve the changed-files set. On `pull_request` (the primary,
+          # required path) BASE_SHA is the PR base and the diff below is
+          # BYTE-FOR-BYTE the original behavior. On `push` / `workflow_dispatch`
+          # BASE_SHA is EMPTY, which would yield an empty/spurious matrix — so we
+          # fall back, in order, to: the push event's `before` SHA, then
+          # HEAD~1...HEAD. If even that is unavailable/invalid (e.g. an orphan or
+          # first commit), we treat it as a CORE change and fan out the full tree
+          # by feeding the selector a synthetic core path (pyproject.toml), which
+          # every repo's selector classifies as core -> scope=full.
+          set -o pipefail
+          if [ -n "$BASE_SHA" ]; then
+            # --- PRIMARY (pull_request): unchanged from the original behavior ---
+            git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+          else
+            echo "::notice::PR base SHA empty (non-PR event) — using fallback diff"
+            DIFF_BASE=""
+            if [ -n "$PUSH_BEFORE" ] \
+               && [ "$PUSH_BEFORE" != "0000000000000000000000000000000000000000" ] \
+               && git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+              DIFF_BASE="$PUSH_BEFORE"
+            elif git rev-parse --verify -q "HEAD~1^{commit}" >/dev/null; then
+              DIFF_BASE="HEAD~1"
+            fi
+            if [ -n "$DIFF_BASE" ]; then
+              echo "Fallback diff base: $DIFF_BASE"
+              git diff --name-only "${DIFF_BASE}"...HEAD > changed-files.txt
+            else
+              echo "::notice::no usable base commit — full fan-out via synthetic core path"
+              echo "pyproject.toml" > changed-files.txt
+            fi
+          fi
           echo "Changed files:"; cat changed-files.txt
           python3 "$SELECTOR" \
             --emit-matrix --files-from changed-files.txt >> "$GITHUB_OUTPUT"
@@ -99,8 +141,20 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - name: Set up Python
+      # Python provisioning is selected by `python-setup`:
+      #  * "uv" (default) — uv-MANAGED interpreter, NOT on PATH as system python.
+      #    Preserves the original behavior exactly for existing callers.
+      #  * "setup-python" — actions/setup-python puts the interpreter ON PATH as
+      #    the system python, which `uv pip install --system` requires.
+      - name: Set up Python (uv-managed)
+        if: ${{ inputs.python-setup == 'uv' }}
         run: uv python install ${{ inputs.python-version }}
+
+      - name: Set up Python (setup-python)
+        if: ${{ inputs.python-setup == 'setup-python' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
 
       - name: Install dependencies
         run: ${{ inputs.install-cmd }}

--- a/docs/ci/domain-matrix-reusable-workflow.md
+++ b/docs/ci/domain-matrix-reusable-workflow.md
@@ -21,7 +21,9 @@ discover  ->  test-domain (matrix, fail-fast: false)  ->  aggregate
 - **`discover`** — checks out with `fetch-depth: 0`, diffs the PR base against
   `HEAD`, and runs the caller's selector with `--emit-matrix` to produce
   `matrix=<json>` and `scope=<str>` outputs. Stdlib only — no dependency install,
-  so discovery stays fast.
+  so discovery stays fast. On non-PR events (`push` / `workflow_dispatch`) the PR
+  base SHA is empty, so it falls back to a usable base — see
+  [Non-PR events](#non-pr-events-push--workflow_dispatch).
 - **`test-domain`** — `fromJSON(matrix)`, `fail-fast: false`, `max-parallel`
   from input. Installs deps, builds `--deselect` args from the quarantine file
   (supporting both `tests/`-prefixed and rootdir-relative node-id forms), runs
@@ -37,6 +39,7 @@ discover  ->  test-domain (matrix, fail-fast: false)  ->  aggregate
 |-------|---------|---------|
 | `selector` | `scripts/ci/select_test_targets.py` | Caller's stdlib selector supporting `--emit-matrix --files-from <file>`. |
 | `python-version` | `"3.11"` | Python version installed for the domain jobs. |
+| `python-setup` | `"uv"` | How to provision the interpreter in the domain jobs. See [Choosing `python-setup`](#choosing-python-setup). |
 | `install-cmd` | `uv sync --all-extras` | Dependency install command per domain job. |
 | `test-runner` | `uv run --with pytest-xdist pytest` | Command prefix used to run pytest on the shard targets. |
 | `max-parallel` | `10` | Bound on the matrix fan-out (core changes can be many domains). |
@@ -66,6 +69,69 @@ jobs:
 
 All inputs have sensible defaults, so a repo that follows the conventions can
 call it with no `with:` block at all.
+
+## Choosing `python-setup`
+
+The domain jobs need a Python interpreter before `install-cmd` runs. How that
+interpreter is provisioned matters because some install commands require the
+interpreter to be the **system** python on `PATH`:
+
+| `python-setup` | What runs | Interpreter location | Use when |
+|----------------|-----------|----------------------|----------|
+| `"uv"` *(default)* | `uv python install <version>` | uv-MANAGED — **not** on `PATH` as the system python | `install-cmd` is `uv sync …` / `uv run …` (the venv-based path; `worldenergydata`, `assetutilities`, `digitalmodel`). |
+| `"setup-python"` | `actions/setup-python@v5` (the `uv python install` step is **skipped**) | ON `PATH` as the system python | `install-cmd` is `uv pip install --system …` or any command that installs into the system interpreter (e.g. `assethold`). |
+
+`"uv"` is the original, unchanged behavior — existing callers are completely
+unaffected (a caller passing nothing, or `python-setup: uv`, runs exactly the
+same two steps as before).
+
+### Why `setup-python` is needed for `uv pip install --system`
+
+`uv python install` installs a **uv-managed** interpreter that is *not* exposed
+as the system `python` on `PATH`. `uv pip install --system` targets whatever
+interpreter is on `PATH` as the system python — with only a uv-managed
+interpreter present, it falls through to the runner's Debian `/usr` python, which
+is PEP-668 **externally-managed** and refuses the install. `actions/setup-python`
+puts a real interpreter on `PATH` as the system python, so `--system` installs
+land there. Repos on the `uv pip install --system` path (e.g. `assethold`)
+therefore pass `python-setup: setup-python`:
+
+```yaml
+jobs:
+  ci:
+    uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
+    with:
+      python-setup: setup-python
+      install-cmd: uv pip install --system -e ".[test]"
+```
+
+Implementation: the two provisioning steps are guarded by step-level `if:`
+conditions keyed on `inputs.python-setup` (`== 'uv'` vs `== 'setup-python'`), so
+exactly one runs. The `discover` job is unaffected — it runs the stdlib selector
+with the runner's system `python3` and needs no interpreter setup.
+
+## Non-PR events (push / workflow_dispatch)
+
+The `discover` job diffs the changed files to build the matrix. On
+`pull_request` (the primary, required path) it diffs the PR base SHA against
+`HEAD` — **unchanged**. On `push` / `workflow_dispatch` the PR base SHA is empty,
+which would otherwise yield an empty/spurious matrix, so `discover` falls back in
+order:
+
+1. **`pull_request`** — diff `github.event.pull_request.base.sha`...`HEAD`
+   (byte-for-byte the original behavior).
+2. **`push`** — if the base SHA is empty, diff the push event's `before` SHA
+   (`github.event.before`)...`HEAD`, provided it is a real, reachable commit
+   (not the all-zeros "new branch" sentinel).
+3. **`HEAD~1`** — if `before` is unusable, diff `HEAD~1`...`HEAD`.
+4. **Full fan-out** — if no usable base commit exists (orphan / first commit),
+   feed the selector a synthetic **core** path (`pyproject.toml`). Every repo's
+   selector classifies a core path as `scope=full`, so this fans out the whole
+   tree — the safe, fail-open default. (The selectors have no `--all` flag; the
+   synthetic-core-path trick is the portable way to force a full run.)
+
+The PR path is untouched; the fallback logic only executes when the PR base SHA
+is empty.
 
 ## Resulting status-check names — read this before migrating
 


### PR DESCRIPTION
## Summary

Two backward-compatible enhancements to the reusable `domain-matrix.yml` workflow, found while adopting it. Default behavior is unchanged for existing callers (`worldenergydata`, `assetutilities`).

Refs worldenergydata#530 (P4).

## Enhancement 1 — `python-setup` input

Some repos install with `uv pip install --system` (e.g. `assethold`), which requires the interpreter to be ON PATH as the **system** python. The workflow's `uv python install <version>` installs a uv-MANAGED interpreter that is *not* on PATH as system, so `uv pip install --system` falls through to the runner's Debian `/usr` python — PEP-668 externally-managed — and refuses the install.

- New string input **`python-setup`**, default **`"uv"`** (preserves exact current behavior).
- Value **`"setup-python"`** runs `actions/setup-python@v5` with `python-version: ${{ inputs.python-version }}` (interpreter ON PATH) and **skips** `uv python install`.
- Implemented in `test-domain` with two step-level `if:` guards:
  - `Set up Python (uv-managed)` — `if: ${{ inputs.python-setup == 'uv' }}` → `uv python install`
  - `Set up Python (setup-python)` — `if: ${{ inputs.python-setup == 'setup-python' }}` → `actions/setup-python@v5`
- Exactly one runs. `discover` is unaffected (uses the runner's system `python3`).

## Enhancement 2 — discover base-SHA fallback for non-PR events

`discover` diffs `${{ github.event.pull_request.base.sha }}`, which is **empty** on `push`/`workflow_dispatch`, yielding an empty/spurious matrix. The PR path is now byte-for-byte unchanged; only the empty-base case falls back, in order:

1. `pull_request` — `base.sha`...`HEAD` (**unchanged**).
2. `push` — `github.event.before`...`HEAD` (if a real, reachable commit; not the all-zeros sentinel).
3. `HEAD~1`...`HEAD`.
4. Full fan-out — feed the selector a synthetic **core** path (`pyproject.toml`), which every repo's selector classifies as `scope=full`. (The selectors expose no `--all` flag; this is the portable way to force a full run.)

## Backward compatibility

Default `python-setup: uv` + empty-base-only fallback ⇒ existing callers (notably `assetutilities`) behave **identically** to today. The `"$BASE_SHA"...HEAD` PR diff is preserved verbatim.

## Validation

YAML parsed with `yaml.safe_load`; the two new `Set up Python` steps and the `python-setup` input were inspected programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
