### PR TITLE
fix(reconcile): scope worktree_guard to target repo cwd

### DIFF
--- a/scripts/readiness/reconcile-ecosystem.sh
+++ b/scripts/readiness/reconcile-ecosystem.sh
@@ -134,7 +134,7 @@ scan_repo() {
     b="${b#"${b%%[![:space:]]*}"}"; b="${b#\* }"; [ -z "$b" ] && continue
     [ "$b" = "$cur" ] && continue
     [[ "$b" =~ $SAFE_BRANCH_RE ]] || continue
-    if [ "$DESTRUCTIVE_OK" = 1 ] && python3 "$GUARD" safe-delete-branch "$b" >/dev/null 2>&1 </dev/null; then
+    if [ "$DESTRUCTIVE_OK" = 1 ] && ( cd "$repo" && python3 "$GUARD" safe-delete-branch "$b" ) >/dev/null 2>&1 </dev/null; then
       add AUTO-SAFE "$name" "delete merged safe-pattern branch '$b'" \
         "git -C '$repo' branch -d '$b'"
     else
@@ -163,12 +163,12 @@ scan_repo() {
         [ "$b" = "main" ] && continue
         grep -qx "$b" <<< "$merged_prs" || continue                         # PR merged ⇒ in main
         git -C "$repo" merge-base --is-ancestor "$b" origin/main 2>/dev/null && continue  # ancestry pass owns it
-        if [ "$DESTRUCTIVE_OK" = 1 ] && python3 "$GUARD" safe-delete-branch "$b" >/dev/null 2>&1 </dev/null; then
+        if [ "$DESTRUCTIVE_OK" = 1 ] && ( cd "$repo" && python3 "$GUARD" safe-delete-branch "$b" ) >/dev/null 2>&1 </dev/null; then
           add AUTO-SAFE "$name" "delete squash-merged branch '$b' (PR merged, not in ancestry)" \
             "git -C '$repo' branch -D '$b'"
         else
           add NEEDS-APPROVAL "$name" "squash-merged branch '$b' (guard/host policy held)" \
-            "python3 '$GUARD' safe-delete-branch '$b'"
+            "cd '$repo' && python3 '$GUARD' safe-delete-branch '$b'"
         fi
       done <<< "$all_b"
     fi
@@ -178,7 +178,7 @@ scan_repo() {
   local wt; wt=$(git -C "$repo" worktree list --porcelain 2>/dev/null | grep -c '^worktree ' || true)
   if [ "${wt:-0}" -gt 1 ]; then
     add NEEDS-APPROVAL "$name" "$((wt-1)) linked worktree(s) — prune only via guard ownership" \
-      "git -C '$repo' worktree list  # then: python3 '$GUARD' safe-remove-worktree <dir> <owner>"
+      "git -C '$repo' worktree list  # then: cd '$repo' && python3 '$GUARD' safe-remove-worktree <dir> <owner>"
   fi
 
   # stale stashes (≥ STALE_DAYS): surface only, never auto-drop

--- a/tests/readiness/test_reconcile_ecosystem.py
+++ b/tests/readiness/test_reconcile_ecosystem.py
@@ -61,6 +61,16 @@ def test_destructive_ops_are_guard_gated():
     assert "safe-remove-worktree" in TEXT
 
 
+def test_guard_is_invoked_in_target_repo_cwd():
+    # worktree_guard reads `git worktree list` from CWD, so for a SIBLING repo it must run
+    # with that repo as cwd — otherwise it checks workspace-hub's worktrees (wrong repo) and
+    # a sibling branch checked out in a worktree would wrongly pass the guard.
+    assert re.search(r"cd \"\$repo\" && python3 \"\$GUARD\" safe-delete-branch", TEXT), \
+        "guard execution must be repo-scoped (cd \"$repo\")"
+    # the printed NEEDS-APPROVAL command must be repo-scoped too
+    assert "cd '$repo' && python3 '$GUARD' safe-delete-branch" in TEXT
+
+
 def test_dirty_work_is_never_silently_discarded():
     # The only thing the driver does with a dirty tree is `stash push` (recoverable) or surface it.
     assert "stash push" in TEXT


### PR DESCRIPTION
Follow-up correctness fix found while pruning stale worktrees.

`worktree_guard.py` reads `git worktree list` from the current directory. The reconciler called it from `workspace-hub`'s cwd even for **sibling** repos, so the deny-by-default guard was inspecting the wrong repo's worktrees — a sibling branch checked out in a worktree wrongly passed `safe-delete-branch`. No harm occurred (git itself refuses to delete a checked-out branch, and the PR-merged gate meant the work was already shipped), but the load-bearing guard wasn't actually protecting sibling-repo worktrees.

Fix: wrap both execution call sites in `( cd "$repo" && python3 "$GUARD" ... )` and repo-scope the printed NEEDS-APPROVAL command. New test pins the repo-scoped invocation. `16 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)