### PR TITLE
docs(plans): link #3237 lifecycle reference from planning README

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,8 @@
 This document is the single onboarding reference for the mandatory issue planning workflow.
 All agents (Claude, Codex, Gemini, Hermes) must follow this workflow for every GitHub issue.
 
+> **One-page method reference:** [#3237](https://github.com/vamseeachanta/workspace-hub/issues/3237) is the timeless overview of the full issue lifecycle (plan → review → implement → HTML artifact → live link → close), with a live flowchart at <https://vamseeachanta.github.io/workspace-hub/issue-workflow-lifecycle.html>.
+
 ## Why Planning Is Mandatory
 
 Historical data shows that agents skipping the planning step produced incorrect implementations, wasted tokens, and created rework. The planning workflow catches problems before implementation begins, when they are cheapest to fix.


### PR DESCRIPTION
Adds a one-line **method reference** callout to `docs/plans/README.md` pointing to:

- Issue #3237 — timeless overview of the full GitHub-issue lifecycle
- Live flowchart — https://vamseeachanta.github.io/workspace-hub/issue-workflow-lifecycle.html

Makes the canonical one-page lifecycle reference discoverable from the planning onboarding guide. Satisfies the discoverability acceptance criterion on #3237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)