### PR TITLE
chore(agents): refresh codex AGENTS.runtime.md skill index

### DIFF
--- a/config/agents/codex/AGENTS.runtime.md
+++ b/config/agents/codex/AGENTS.runtime.md
@@ -197,15 +197,15 @@ The fix is `scripts/agents/install-soul-runtime.sh` (per [#2719](https://github.
 - **ai/** — 15 skill(s); `ls .claude/skills/ai/*/SKILL.md` to enumerate
 - **apple/** — 5 skill(s); `ls .claude/skills/apple/*/SKILL.md` to enumerate
 - **autonomous-ai-agents/** — 9 skill(s); `ls .claude/skills/autonomous-ai-agents/*/SKILL.md` to enumerate
+- **business/** — 74 skill(s); `ls .claude/skills/business/*/SKILL.md` to enumerate
+- **business_admin/** — 2 skill(s); `ls .claude/skills/business_admin/*/SKILL.md` to enumerate
 - **business-finance/** — 1 skill(s); `ls .claude/skills/business-finance/*/SKILL.md` to enumerate
 - **business-marketing/** — 1 skill(s); `ls .claude/skills/business-marketing/*/SKILL.md` to enumerate
-- **business/** — 74 skill(s); `ls .claude/skills/business/*/SKILL.md` to enumerate
-- **business_admin/** — 1 skill(s); `ls .claude/skills/business_admin/*/SKILL.md` to enumerate
 - **coordination/** — 59 skill(s); `ls .claude/skills/coordination/*/SKILL.md` to enumerate
 - **corporate-tax-form-fill** — Programmatically fill IRS tax form PDFs (Form 1120, etc.) using pymupdf/fitz. Covers field discovery, mapping, filling, cross-chec
 - **creative/** — 20 skill(s); `ls .claude/skills/creative/*/SKILL.md` to enumerate
+- **data/** — 82 skill(s); `ls .claude/skills/data/*/SKILL.md` to enumerate
 - **data-science/** — 1 skill(s); `ls .claude/skills/data-science/*/SKILL.md` to enumerate
-- **data/** — 81 skill(s); `ls .claude/skills/data/*/SKILL.md` to enumerate
 - **development/** — 71 skill(s); `ls .claude/skills/development/*/SKILL.md` to enumerate
 - **devops/** — 7 skill(s); `ls .claude/skills/devops/*/SKILL.md` to enumerate
 - **devtools/** — 1 skill(s); `ls .claude/skills/devtools/*/SKILL.md` to enumerate
@@ -219,23 +219,24 @@ The fix is `scripts/agents/install-soul-runtime.sh` (per [#2719](https://github.
 - **gaming/** — 2 skill(s); `ls .claude/skills/gaming/*/SKILL.md` to enumerate
 - **github/** — 19 skill(s); `ls .claude/skills/github/*/SKILL.md` to enumerate
 - **leisure/** — 1 skill(s); `ls .claude/skills/leisure/*/SKILL.md` to enumerate
-- **marketing/** — 1 skill(s); `ls .claude/skills/marketing/*/SKILL.md` to enumerate
+- **marketing/** — 7 skill(s); `ls .claude/skills/marketing/*/SKILL.md` to enumerate
 - **mcp/** — 2 skill(s); `ls .claude/skills/mcp/*/SKILL.md` to enumerate
 - **media/** — 5 skill(s); `ls .claude/skills/media/*/SKILL.md` to enumerate
-- **memory/** — 2 skill(s); `ls .claude/skills/memory/*/SKILL.md` to enumerate
+- **memory/** — 3 skill(s); `ls .claude/skills/memory/*/SKILL.md` to enumerate
 - **mlops/** — 21 skill(s); `ls .claude/skills/mlops/*/SKILL.md` to enumerate
 - **operations/** — 17 skill(s); `ls .claude/skills/operations/*/SKILL.md` to enumerate
 - **productivity/** — 11 skill(s); `ls .claude/skills/productivity/*/SKILL.md` to enumerate
 - **red-teaming/** — 1 skill(s); `ls .claude/skills/red-teaming/*/SKILL.md` to enumerate
 - **research/** — 15 skill(s); `ls .claude/skills/research/*/SKILL.md` to enumerate
 - **science/** — 6 skill(s); `ls .claude/skills/science/*/SKILL.md` to enumerate
+- **session-logs/** — 0 skill(s); `ls .claude/skills/session-logs/*/SKILL.md` to enumerate
 - **smart-home/** — 1 skill(s); `ls .claude/skills/smart-home/*/SKILL.md` to enumerate
 - **social-media/** — 2 skill(s); `ls .claude/skills/social-media/*/SKILL.md` to enumerate
 - **software-development/** — 35 skill(s); `ls .claude/skills/software-development/*/SKILL.md` to enumerate
 - **test-dummy-validation/** — 1 skill(s); `ls .claude/skills/test-dummy-validation/*/SKILL.md` to enumerate
 - **travel/** — 8 skill(s); `ls .claude/skills/travel/*/SKILL.md` to enumerate
+- **workspace-hub/** — 149 skill(s); `ls .claude/skills/workspace-hub/*/SKILL.md` to enumerate
 - **workspace-hub-learned/** — 69 skill(s); `ls .claude/skills/workspace-hub-learned/*/SKILL.md` to enumerate
-- **workspace-hub/** — 146 skill(s); `ls .claude/skills/workspace-hub/*/SKILL.md` to enumerate
 
 ## Universal rules (inlined for Codex)
 > Claude reads .claude/rules/ natively; these are inlined here because Codex has no native rules loader. Domain/Claude-only rules (goal-invocation, calc-citation, wiki-routing) stay path-references.


### PR DESCRIPTION
Regenerates `config/agents/codex/AGENTS.runtime.md` via `build-soul-runtime.sh` — the committed skill index had drifted from `.claude/skills/` sources (marketing 1→7 from the new marketing suite, workspace-hub 146→149, +session-logs, data 81→82, etc.). Idempotent regen, no source edits; `check-soul-runtime-drift.sh` now reports all artifacts up to date. Resolves the dev-primary `harness` drift flagged by reconcile-ecosystem.