### PR TITLE
feat(equality): add OS-paired refresh-equality-matrix wrappers (#2998)

### DIFF
--- a/scripts/readiness/refresh-equality-matrix.ps1
+++ b/scripts/readiness/refresh-equality-matrix.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+  refresh-equality-matrix.ps1 --- operator-driven refresh of THIS machine's equality
+  snapshot AND the live machine-equality matrix (Windows side; #2801 / #2998).
+
+.DESCRIPTION
+  Thin operator wrapper that does the manual-sync flow end to end:
+    1. Ensure the checkout is on a fresh `main` (switch + pull --rebase --autostash).
+    2. Run the Windows orchestrator scripts/windows/equality-report.ps1 -RefreshMatrix,
+       which collects via CIM + Git Bash, builds the matrix, and commits+pushes the state
+       yaml AND the matrix HTML in ONE commit so GitHub Pages redeploys.
+    3. Print provenance + the resulting commit for quick verification.
+
+  This is the manual equivalent of the scheduled task. The OS-paired Linux/macOS twin is
+  refresh-equality-matrix.sh (delegates to equality-matrix-cron.sh). The actual
+  collect/build/commit logic stays SINGLE-SOURCED in equality-report.ps1 --- this wrapper
+  only adds fresh-main + verification ergonomics, so it cannot drift from the orchestrator.
+
+.PARAMETER Machine
+  Optional label override (e.g. ace-win-1) passed through to equality-report.ps1.
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts\readiness\refresh-equality-matrix.ps1
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts\readiness\refresh-equality-matrix.ps1 -Machine ace-win-1
+
+.NOTES
+  ASCII-only on purpose: PS 5.1 reads BOM-less .ps1 as cp1252, so non-ASCII chars corrupt
+  string parsing. Must run from main (equality-report.ps1 enforces this).
+#>
+[CmdletBinding()]
+param(
+    [string]$Machine
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Repo root = two levels up (scripts/readiness/ -> repo root). No hardcoded absolute paths.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WS = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+
+function Step($m) { Write-Host "`n=== $m ===" -ForegroundColor Cyan }
+
+try {
+    Set-Location $WS
+
+    Step "1/3  Fresh main (switch + pull --rebase --autostash)"
+    git switch main
+    if ($LASTEXITCODE -ne 0) { throw "git switch main failed (exit $LASTEXITCODE)" }
+    git pull --rebase --autostash origin main
+    if ($LASTEXITCODE -ne 0) { throw "git pull failed (exit $LASTEXITCODE)" }
+
+    Step "2/3  equality-report.ps1 -RefreshMatrix"
+    $report = Join-Path $WS 'scripts\windows\equality-report.ps1'
+    if (-not (Test-Path $report)) { throw "orchestrator not found: $report" }
+    $reportArgs = @{ RefreshMatrix = $true }
+    if ($Machine) { $reportArgs['Machine'] = $Machine }
+    & $report @reportArgs
+    if ($LASTEXITCODE -ne 0) { throw "equality-report.ps1 failed (exit $LASTEXITCODE)" }
+
+    Step "3/3  Provenance + commit"
+    Write-Host "--- provenance (expect dirty=false, behind_main=0, ahead_main=0, origin_ref_age_h 0-48)" -ForegroundColor Yellow
+    Select-String -Path (Join-Path $WS '.claude\state\equality-*.yaml') `
+                  -Pattern 'dirty|behind_main|ahead_main|origin_ref_age_h'
+    Write-Host "`n--- last commit (expect 'chore: equality report from <machine>')" -ForegroundColor Yellow
+    git log -1 --oneline
+    Write-Host "`n--- status (expect clean, nothing ahead of origin/main)" -ForegroundColor Yellow
+    git status -sb
+
+    Write-Host "`nDONE. GitHub Pages redeploys in ~1-2 min:" -ForegroundColor Green
+    Write-Host "  https://vamseeachanta.github.io/workspace-hub/machine-equality-matrix.html"
+}
+catch {
+    Write-Host "`nFAILED: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "Fix the step above and re-run. Never hand-edit the state yaml." -ForegroundColor Red
+    exit 1
+}

--- a/scripts/readiness/refresh-equality-matrix.sh
+++ b/scripts/readiness/refresh-equality-matrix.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# refresh-equality-matrix.sh --- operator-driven refresh of THIS machine's equality
+# snapshot AND the live machine-equality matrix (Linux/macOS side; #2801 / #2998).
+#
+# OS-paired twin of refresh-equality-matrix.ps1. The manual equivalent of the scheduled
+# path: it runs the canonical builder (equality-matrix-cron.sh: collect-equality.sh +
+# build-equality-matrix.py) on a fresh main, then commits+pushes the state yaml + matrix
+# HTML so the operator can refresh the LIVE GitHub Pages matrix immediately rather than
+# waiting for repo-sync to pick it up.
+#
+# Divergence note (intentional, mirrors the OS split): on Windows equality-report.ps1
+# self-pushes because Windows has no repo-sync; on Linux the SCHEDULED matrix push is owned
+# by repo-sync, and equality-matrix-cron.sh only builds. This wrapper adds the commit+push
+# ONLY for the manual on-demand case, scoped by pathspec to the equality artifacts so it
+# cannot sweep unrelated working-tree changes.
+#
+# Usage: refresh-equality-matrix.sh [--machine <label>]
+set -uo pipefail
+
+MACHINE=""
+for ((i=1; i<=$#; i++)); do
+  case "${!i}" in
+    --machine) j=$((i+1)); MACHINE="${!j:-}";;
+  esac
+done
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "refresh-equality-matrix: not inside a git checkout" >&2
+  exit 1
+fi
+cd "$REPO_ROOT" || { echo "refresh-equality-matrix: cannot cd to repo root" >&2; exit 1; }
+
+step() { printf '\n=== %s ===\n' "$1"; }
+
+# ------ 1/3  fresh main ------------------------------------------------------------------
+step "1/3  Fresh main (switch + pull --rebase --autostash)"
+branch="$(git branch --show-current)"
+if [[ "$branch" != "main" ]]; then
+  git switch main || { echo "git switch main failed" >&2; exit 1; }
+fi
+git pull --rebase --autostash origin main || { echo "git pull failed" >&2; exit 1; }
+
+# ------ 2/3  collect + build (canonical, single-sourced) ---------------------------------
+step "2/3  equality-matrix-cron.sh (collect + build)"
+cron_args=()
+# equality-matrix-cron.sh has no --machine flag; if a label override is needed it flows
+# through the EQ env seam / collect-equality.sh autodetect. Pass-through kept for parity.
+if [[ -n "$MACHINE" ]]; then
+  echo "note: --machine '$MACHINE' relies on collect-equality.sh autodetect on Linux" >&2
+fi
+bash "$REPO_ROOT/scripts/readiness/equality-matrix-cron.sh" "${cron_args[@]}" \
+  || { echo "equality-matrix-cron.sh failed" >&2; exit 1; }
+
+# ------ 3/3  commit + push the equality artifacts (manual on-demand only) ----------------
+step "3/3  Commit + push equality artifacts"
+today="$(date +%F)"
+artifacts=(
+  "docs/reports/${today}-machine-equality-matrix.html"
+  "docs/reports/machine-equality-matrix.html"
+)
+# Stage the matrix HTML + any changed per-machine state yaml (scoped; no blanket add).
+git add -- "${artifacts[@]}" 2>/dev/null || true
+while IFS= read -r f; do
+  [[ -n "$f" ]] && git add -- "$f"
+done < <(git status --porcelain -- '.claude/state/equality-*.yaml' | awk '{print $2}')
+
+if git diff --cached --quiet; then
+  echo "No equality changes to commit (canonical payload unchanged)."
+else
+  host="$(hostname | tr '[:upper:]' '[:lower:]')"
+  git commit -m "chore: equality report from ${host}" || { echo "commit failed" >&2; exit 1; }
+  git push origin main || { echo "push failed; left local commit for repo-sync retry" >&2; exit 1; }
+  echo "Pushed equality artifacts; GitHub Pages will redeploy."
+fi
+
+# ------ verify --------------------------------------------------------------------------
+step "Provenance + commit"
+echo "--- provenance (expect dirty: false, behind_main: 0, ahead_main: 0, origin_ref_age_h 0-48)"
+grep -E 'dirty|behind_main|ahead_main|origin_ref_age_h' .claude/state/equality-*.yaml 2>/dev/null || true
+echo "--- last commit"
+git log -1 --oneline
+echo "--- status"
+git status -sb
+
+echo ""
+echo "DONE. GitHub Pages redeploys in ~1-2 min:"
+echo "  https://vamseeachanta.github.io/workspace-hub/machine-equality-matrix.html"


### PR DESCRIPTION
Promote the proven manual-refresh helper into the repo as an OS-equivalent
pair under scripts/readiness/ (matching the collect-equality.{ps1,sh}
precedent):

- refresh-equality-matrix.ps1 (Windows): fresh main -> equality-report.ps1
  -RefreshMatrix -> verify. Thin wrapper; collect/build/commit/push logic
  stays single-sourced in equality-report.ps1.
- refresh-equality-matrix.sh (Linux/macOS): fresh main ->
  equality-matrix-cron.sh (collect + build) -> scoped commit+push of the
  state yaml + matrix HTML -> verify. The commit+push is the manual
  on-demand equivalent of the Windows -RefreshMatrix; scheduled pushes stay
  owned by repo-sync.

Operator-driven counterpart to the scheduled task, with fresh-main +
provenance verification ergonomics. The .ps1 is the script used to refresh
ace-win-2 (verified live). Operator wrappers; no new automated test added
(the underlying collect/build logic is covered by tests/readiness/).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
