### PR TITLE
feat(equivalence): cross-provider skill-currency matrix line item (#3249)

### DIFF
--- a/.claude/state/skill-currency-dev-primary.json
+++ b/.claude/state/skill-currency-dev-primary.json
@@ -1,0 +1,13 @@
+{
+  "machine": "dev-primary",
+  "audited_at": "2026-06-26T19:16:20+00:00",
+  "canonical_count": 44,
+  "gemini_present": true,
+  "gemini_unexpected": 0,
+  "gemini_expected": 9,
+  "codex_present": true,
+  "hermes_present": true,
+  "index_dangling": 202,
+  "index_stale": true,
+  "schema_version": 1
+}

--- a/.claude/state/skill-currency-dev-primary.json
+++ b/.claude/state/skill-currency-dev-primary.json
@@ -1,6 +1,6 @@
 {
   "machine": "dev-primary",
-  "audited_at": "2026-06-26T19:16:20+00:00",
+  "audited_at": "2026-06-26T19:32:31+00:00",
   "canonical_count": 44,
   "gemini_present": true,
   "gemini_unexpected": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/state/equality-*.yaml
 !.claude/state/session-curation-*.json
 !.claude/state/session-curation-*.md
+!.claude/state/skill-currency-*.json
 !.claude/state/reflect-history/
 !.claude/state/trends/
 !.claude/state/session-signals/

--- a/scripts/curation/audit_skill_currency.py
+++ b/scripts/curation/audit_skill_currency.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""audit_skill_currency.py — cross-provider skill-currency audit (#3249, epic #3248).
+
+Emits the FACTS for the machine-equality `skill_currency` line item: are all providers' skill
+surfaces up to date vs canonical, and is the skills index intact? The matrix
+(build-equality-matrix.py::skill_currency_verdict) maps these facts → verdict.
+
+Design decisions (locked by the #3249 adversarial review):
+  * Compare the COMMITTED tree via `git ls-tree -r HEAD`, not the working tree — symlink-transparent
+    (`.codex/skills` is a symlink; Windows materializes it as a text file), deterministic, and
+    immune to skill-development WIP blinding the very alert you want during skill development.
+  * Compare at FAMILY granularity (top-level dir under each skills root) — skills nest up to 8 deep,
+    so leaf-path comparison is hopeless; families are the meaningful unit.
+  * Grade DRIFT only on UNEXPECTED family differences. Legitimate provider-specific families
+    (Gemini's `source-command-*`, `workspace_hub_learned`, …) are allowlisted in harness-config
+    `expected_skill_divergence` — the same posture as the provider_harness expected_divergence model.
+  * Hermes external dir == canonical `.claude/skills` (tautological) and Codex is an intentional
+    curated subset → graded present/absent only, NEVER count-compared.
+  * Index integrity = dangling entries (index paths no longer in the tree), NOT an mtime check
+    (mtime is non-deterministic on fresh checkouts).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+STATE = REPO / ".claude" / "state"
+HARNESS_CONFIG = REPO / "scripts" / "readiness" / "harness-config.yaml"
+SKILLS_INDEX = REPO / ".claude" / "skills-index.yaml"
+
+CANONICAL_PREFIX = ".claude/skills"          # Claude canonical (Hermes external dir aliases this)
+GEMINI_PREFIX = ".agents/skills"             # Gemini skill surface
+# Fallback allowlist if harness-config has none — the families that legitimately differ today.
+DEFAULT_GEMINI_ALLOW = ["source-command-", "workspace_hub_learned", "digitalmodel", "memory"]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def machine_label() -> str:
+    if os.environ.get("EQ_MACHINE"):
+        return os.environ["EQ_MACHINE"]
+    host = (os.uname().nodename if hasattr(os, "uname") else os.environ.get("COMPUTERNAME", "")).lower()
+    table = {"ace-linux-1": "dev-primary", "ace-linux-2": "dev-secondary",
+             "ace-win-1": "ace-win-1", "licensed-win-1": "ace-win-1", "acma-ansys05": "ace-win-1",
+             "ace-win-2": "ace-win-2", "licensed-win-2": "ace-win-2", "acma-ws014": "ace-win-2"}
+    for key, label in table.items():
+        if host.startswith(key):
+            return label
+    return ("macbook-portable" if "macbook" in host else (host or "unknown"))
+
+
+def _git_tree_skillmd(prefix: str) -> list[str] | None:
+    """Tracked SKILL.md paths under `prefix` in the committed tree (HEAD). None on git failure."""
+    r = subprocess.run(["git", "-C", str(REPO), "ls-tree", "-r", "--name-only", "HEAD", prefix],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        return None
+    return [ln for ln in r.stdout.splitlines() if ln.endswith("/SKILL.md")]
+
+
+def _families(prefix: str) -> set[str] | None:
+    """Top-level family dir names (the component right after `prefix`) that contain a SKILL.md."""
+    paths = _git_tree_skillmd(prefix)
+    if paths is None:
+        return None
+    plen = len(prefix.rstrip("/").split("/"))
+    fams = set()
+    for p in paths:
+        parts = p.split("/")
+        if len(parts) > plen:
+            fams.add(parts[plen])
+    return fams
+
+
+def _load_allow() -> list[str]:
+    try:
+        cfg = yaml.safe_load(HARNESS_CONFIG.read_text()) if HARNESS_CONFIG.exists() else {}
+        allow = ((cfg or {}).get("expected_skill_divergence") or {}).get("gemini")
+        if isinstance(allow, list) and allow:
+            return [str(a) for a in allow]
+    except (OSError, yaml.YAMLError):
+        pass
+    return list(DEFAULT_GEMINI_ALLOW)
+
+
+def _index_dangling() -> int | None:
+    """Count of skills-index.yaml `path:` entries that no longer exist in the committed tree.
+    None if the index can't be read or the tree can't be listed (→ MISSING-EVIDENCE upstream)."""
+    if not SKILLS_INDEX.exists():
+        return None
+    try:
+        data = yaml.safe_load(SKILLS_INDEX.read_text()) or {}
+    except yaml.YAMLError:
+        return None
+    index_paths = {sk.get("path") for cat in data.get("categories", []) or []
+                   for sk in (cat.get("skills") or []) if sk.get("path")}
+    tree = _git_tree_skillmd(CANONICAL_PREFIX)
+    if tree is None:
+        return None
+    return len(index_paths - set(tree))
+
+
+def audit(machine: str) -> dict:
+    canonical = _families(CANONICAL_PREFIX)
+    gemini = _families(GEMINI_PREFIX)
+    allow = _load_allow()
+
+    gemini_present = gemini is not None and (REPO / GEMINI_PREFIX).exists()
+    gemini_unexpected = gemini_expected = 0
+    if canonical is not None and gemini is not None and gemini_present:
+        diff = canonical ^ gemini
+        # Allowlist match: an entry ending in '-' is an explicit PREFIX (e.g. 'source-command-');
+        # any other entry must match EXACTLY (e.g. 'memory'), so a bare 'memory' can never silently
+        # allowlist an unrelated 'memory-bank' family and hide real drift (review axis #4).
+        def _allowed(f: str) -> bool:
+            return any(f.startswith(p) if p.endswith("-") else f == p for p in allow)
+        expected = {f for f in diff if _allowed(f)}
+        gemini_expected = len(expected)
+        gemini_unexpected = len(diff - expected)
+
+    dangling = _index_dangling()
+    return {
+        "machine": machine,
+        "audited_at": _now(),
+        "canonical_count": (len(canonical) if canonical is not None else None),
+        "gemini_present": gemini_present,
+        "gemini_unexpected": gemini_unexpected,
+        "gemini_expected": gemini_expected,
+        "codex_present": (Path.home() / ".codex" / "skills").exists(),
+        "hermes_present": (REPO / CANONICAL_PREFIX).exists(),
+        "index_dangling": (dangling if dangling is not None else None),
+        "index_stale": (dangling is not None and dangling > 0),
+        "schema_version": 1,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Cross-provider skill-currency audit")
+    ap.add_argument("--machine", default=None)
+    ap.add_argument("--stdout", action="store_true", help="print state JSON, do not write")
+    a = ap.parse_args(argv)
+    machine = a.machine or machine_label()
+    state = audit(machine)
+    if a.stdout:
+        print(json.dumps(state, indent=2))
+        return 0
+    STATE.mkdir(parents=True, exist_ok=True)
+    (STATE / f"skill-currency-{machine}.json").write_text(json.dumps(state, indent=2) + "\n")
+    print(f"audited {machine}: canonical={state['canonical_count']} families, "
+          f"gemini unexpected={state['gemini_unexpected']} expected={state['gemini_expected']}, "
+          f"index_dangling={state['index_dangling']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/curation/audit_skill_currency.py
+++ b/scripts/curation/audit_skill_currency.py
@@ -65,8 +65,11 @@ def machine_label() -> str:
 
 def _git_tree_skillmd(prefix: str) -> list[str] | None:
     """Tracked SKILL.md paths under `prefix` in the committed tree (HEAD). None on git failure."""
-    r = subprocess.run(["git", "-C", str(REPO), "ls-tree", "-r", "--name-only", "HEAD", prefix],
-                       capture_output=True, text=True)
+    try:
+        r = subprocess.run(["git", "-C", str(REPO), "ls-tree", "-r", "--name-only", "HEAD", prefix],
+                           capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, OSError):
+        return None                                      # hung/locked git ⇒ no evidence (fail-closed)
     if r.returncode != 0:
         return None
     return [ln for ln in r.stdout.splitlines() if ln.endswith("/SKILL.md")]
@@ -81,7 +84,7 @@ def _families(prefix: str) -> set[str] | None:
     fams = set()
     for p in paths:
         parts = p.split("/")
-        if len(parts) > plen:
+        if len(parts) > plen and parts[plen] != "SKILL.md":   # skip a SKILL.md directly under root
             fams.add(parts[plen])
     return fams
 
@@ -119,7 +122,10 @@ def audit(machine: str) -> dict:
     gemini = _families(GEMINI_PREFIX)
     allow = _load_allow()
 
-    gemini_present = gemini is not None and (REPO / GEMINI_PREFIX).exists()
+    # Presence from the COMMITTED tree (non-empty family set), NOT a working-tree stat — staying on
+    # the same basis as the comparison so a working-tree delete during skill-dev can't silently
+    # disable drift detection (the module's stated WIP-immunity).
+    gemini_present = gemini is not None and len(gemini) > 0
     gemini_unexpected = gemini_expected = 0
     if canonical is not None and gemini is not None and gemini_present:
         diff = canonical ^ gemini

--- a/scripts/curation/curate-session-memory.sh
+++ b/scripts/curation/curate-session-memory.sh
@@ -27,6 +27,15 @@ else
   fail "no python runtime (uv/python3) available"
 fi
 
+# Audit cross-provider skill currency (#3249) — writes skill-currency-<machine>.json for the
+# skill_currency matrix cell. Best-effort: a failed audit must not block the curation run.
+SKILL_AUDIT="$REPO_ROOT/scripts/curation/audit_skill_currency.py"
+if command -v uv >/dev/null 2>&1; then
+  uv run --no-project --with pyyaml python "$SKILL_AUDIT" || echo "skill-currency audit failed (soft)" >&2
+elif command -v python3 >/dev/null 2>&1; then
+  python3 "$SKILL_AUDIT" || echo "skill-currency audit failed (soft)" >&2
+fi
+
 # Refresh this box's equality column so the freshness cell + render are current. The matrix
 # build is NOT optional — skipping it would freeze the rendered cell (weakening the dead-man's
 # switch) while still reporting pass. So fail loudly if no python can build it.

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -227,6 +227,36 @@ def freshness_verdict(report: dict, now: datetime | None = None) -> str:
     return "CURATED-EXPIRED"
 
 
+# ── skill-currency verdict (cross-provider skill drift vs canonical; #3249) ──
+def skill_currency_verdict(report: dict) -> str:
+    """Map the audit FACTS (emitted by audit_skill_currency.py) to a verdict. Precedence:
+    SKILLS-DRIFTED (unexpected family diff) > SKILLS-INDEX-STALE (index has dangling entries) >
+    EXPECTED-DIVERGENCE (only allowlisted provider-specific families differ) > SKILLS-CURRENT.
+    Fail-closed (MISSING-EVIDENCE) when the audit couldn't read the tree or a count is garbled —
+    an unreadable surface must never grade green."""
+    sc = report.get("dimensions", {}).get("skill_currency")
+    if not isinstance(sc, dict):
+        return "MISSING-EVIDENCE"
+    if not isinstance(sc.get("audited_at"), str):
+        return "MISSING-EVIDENCE"
+    cc = sc.get("canonical_count")
+    if not isinstance(cc, int) or isinstance(cc, bool) or cc <= 0:   # tree unreadable ⇒ no evidence
+        return "MISSING-EVIDENCE"
+    if sc.get("gemini_present"):
+        unexpected = sc.get("gemini_unexpected")
+        if not isinstance(unexpected, int) or isinstance(unexpected, bool):
+            return "MISSING-EVIDENCE"
+    else:
+        unexpected = 0
+    if unexpected > 0:
+        return "SKILLS-DRIFTED"
+    if sc.get("index_stale") is True:
+        return "SKILLS-INDEX-STALE"
+    if isinstance(sc.get("gemini_expected"), int) and sc.get("gemini_expected", 0) > 0:
+        return "EXPECTED-DIVERGENCE"
+    return "SKILLS-CURRENT"
+
+
 # ── value extraction for uniform dims ────────────────────────────────────────
 def extract_value(dim: str, report: dict):
     d = report.get("dimensions", {})
@@ -332,6 +362,8 @@ def verdict_for(dim: str, machine: str, reports: dict, baselines: dict,
         return provider_row_verdict(dim, rep)
     if dim == "session_curation":           # freshness family — graded vs real now, not peers
         return freshness_verdict(rep)
+    if dim == "skill_currency":             # cross-provider skill-drift family — per-box facts
+        return skill_currency_verdict(rep)
     if dim in COLD_DIMS:
         return cold_verdict(dim, rep, baselines.get(machine), probed_repos)
     # Stale peers are EXCLUDED from the uniform value list so a stale report can never
@@ -357,7 +389,8 @@ def load_reports() -> dict[str, dict]:
 
 
 BASE_DISPLAY_DIMS = ["compute", "data_access", "solvers", "harness", "python_cmd", "skills",
-                     "kanban", "memory", "behavior", "scheduler", "session_curation"]
+                     "kanban", "memory", "behavior", "scheduler", "session_curation",
+                     "skill_currency"]
 DISPLAY_DIMS = BASE_DISPLAY_DIMS + provider_rows()
 
 # ── render grouping (#2801 collapsible-rows enhancement) ─────────────────────
@@ -377,18 +410,19 @@ GROUPS = [
         ["harness", "python_cmd", "behavior", "scheduler"]),
     ("provider", "Provider capability parity — per runtime", provider_rows()),
     ("curation", "Session analysis &amp; memory curation — daily freshness", ["session_curation"]),
+    ("skills-currency", "Skill currency — all providers up to date vs canonical", ["skill_currency"]),
 ]
 
 # Worst-of severity for the collapsed group rollup. Higher = more operator attention.
 # A group's rollup cell shows the worst verdict among its dims for that machine; an
 # all-good group collapses to a single green "OK" so a clean box reads at a glance.
 ROLLUP_SEVERITY = {
-    "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6,
-    "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5,
+    "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6, "SKILLS-DRIFTED": 6,
+    "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5, "SKILLS-INDEX-STALE": 5,
     "MISSING-EVIDENCE": 4, "PENDING": 4,
     "STALE-CHECKOUT": 3,
     "EXPECTED-DIFF": 1, "EXPECTED-DIVERGENCE": 1, "UNREACHABLE": 1, "ABSENT": 1,
-    "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0,
+    "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0, "SKILLS-CURRENT": 0,
 }
 
 
@@ -406,7 +440,7 @@ def rollup_verdict(verdicts: list[str]) -> tuple[str, str]:
 # ── remediation playbook (verdict → action) — keep in sync with the verdict→fix table in
 #    .claude/skills/workspace-hub/ecosystem-equivalence-reconcile/SKILL.md + reconcile-ecosystem.sh
 OK_VERDICTS = {"CONFORMS", "EQUAL", "PARITY", "EXPECTED-DIFF", "EXPECTED-DIVERGENCE",
-               "UNREACHABLE", "ABSENT", "CURATED-FRESH"}
+               "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT"}
 
 
 def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
@@ -454,6 +488,13 @@ def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
         return ("session analysis + memory curation is stale (>12h orange / >24h red) — run "
                 "the collector (bash scripts/curation/curate-session-memory.sh; "
                 "curate-session-memory.ps1 on Windows) or repair the every-6h cron", "this box", False)
+    if verdict == "SKILLS-DRIFTED":
+        return ("a provider's skill families UNEXPECTEDLY differ from canonical — reconcile via "
+                "scripts/propagate-ecosystem.sh, or if the difference is intended, allowlist it in "
+                "harness-config.yaml expected_skill_divergence", "this box", False)
+    if verdict == "SKILLS-INDEX-STALE":
+        return ("the skills index has dangling entries (paths no longer in the tree) — regenerate "
+                ".claude/skills-index.yaml (skills-curation cron / generator)", "this box", False)
     return ("investigate this cell's report", "operator", False)
 
 
@@ -572,8 +613,8 @@ def main() -> None:
 <title>Machine-Equality Matrix — #2801</title>
 <style>body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;max-width:1100px}}table{{border-collapse:collapse;width:100%}}
 th,td{{border:1px solid #ddd;padding:.4rem .6rem;font-size:.8rem;text-align:center}}thead th{{background:#2d3748;color:#fff}}
-tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh{{background:#c6f6d5}}.ok{{font-weight:700}}
-.below-baseline,.diverges,.curated-expired{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale{{background:#feebc8}}
+tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh,.skills-current{{background:#c6f6d5}}.ok{{font-weight:700}}
+.below-baseline,.diverges,.curated-expired,.skills-drifted{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale{{background:#feebc8}}
 .expected-diff,.expected-divergence{{background:#e9d8fd}}
 .pending,.missing-evidence{{background:#fffaf0}}.unreachable,.absent,.na{{background:#f7fafc;color:#a0aec0}}
 .stale-checkout{{background:#e2e8f0;color:#4a5568;font-style:italic}}
@@ -614,6 +655,7 @@ to refresh <i>every</i> active machine's report, then re-judge what genuinely di
 <span class="no-majority">NO-MAJORITY / MISSING-BASELINE</span><span class="missing-evidence">PENDING / MISSING-EVIDENCE</span>
 <span class="expected-diff">EXPECTED-DIFF / EXPECTED-DIVERGENCE</span><span class="stale-checkout">STALE-CHECKOUT</span>
 <span class="curated-fresh">CURATED-FRESH ≤12h</span><span class="curated-stale">CURATED-STALE &gt;12h</span><span class="curated-expired">CURATED-EXPIRED &gt;24h</span>
+<span class="skills-current">SKILLS-CURRENT</span><span class="skills-index-stale">SKILLS-INDEX-STALE</span><span class="skills-drifted">SKILLS-DRIFTED</span>
 <span class="absent">UNREACHABLE / ABSENT / n/a</span></p>
 <script>
 document.querySelectorAll('tr.grp').forEach(function(h){{

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -250,9 +250,17 @@ def skill_currency_verdict(report: dict) -> str:
         unexpected = 0
     if unexpected > 0:
         return "SKILLS-DRIFTED"
-    if sc.get("index_stale") is True:
+    # Index integrity via dangling-entry count. None ⇒ the index was UNREADABLE while the tree read
+    # fine — fail-closed to INDEX-STALE (a broken index needs regeneration), never silently green.
+    idx = sc.get("index_dangling")
+    if idx is None:
         return "SKILLS-INDEX-STALE"
-    if isinstance(sc.get("gemini_expected"), int) and sc.get("gemini_expected", 0) > 0:
+    if not isinstance(idx, int) or isinstance(idx, bool):
+        return "MISSING-EVIDENCE"
+    if idx > 0:
+        return "SKILLS-INDEX-STALE"
+    expected = sc.get("gemini_expected")
+    if isinstance(expected, int) and not isinstance(expected, bool) and expected > 0:
         return "EXPECTED-DIVERGENCE"
     return "SKILLS-CURRENT"
 

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -165,7 +165,7 @@ fi
 # References the audit state written by scripts/curation/audit_skill_currency.py (never re-runs it).
 # Missing/garbled file -> audited_at null / canonical_count 0 -> matrix grades MISSING-EVIDENCE.
 skc_file="${STATE_DIR}/skill-currency-${MACHINE}.json"
-skc_audited="null"; skc_cc=0; skc_gp=false; skc_gu=0; skc_ge=0; skc_cp=false; skc_hp=false; skc_idx=false
+skc_audited="null"; skc_cc=0; skc_gp=false; skc_gu=0; skc_ge=0; skc_cp=false; skc_hp=false; skc_dangling="null"
 if [[ -f "$skc_file" ]] && have jq; then
   _ska=$(jq -r '.audited_at // empty' "$skc_file" 2>/dev/null)
   [[ -n "$_ska" ]] && skc_audited="\"$(yesc "$_ska")\""
@@ -175,7 +175,10 @@ if [[ -f "$skc_file" ]] && have jq; then
   skc_gp=$(jq -r 'if .gemini_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_gp" == "true" ]] || skc_gp=false
   skc_cp=$(jq -r 'if .codex_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_cp" == "true" ]] || skc_cp=false
   skc_hp=$(jq -r 'if .hermes_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_hp" == "true" ]] || skc_hp=false
-  skc_idx=$(jq -r 'if .index_stale then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_idx" == "true" ]] || skc_idx=false
+  # index_dangling stays NULL when absent/unreadable so the matrix fails closed (a null index can
+  # never grade green). A clean index emits 0; a rotted one emits the dangling count.
+  _skd=$(jq -r 'if (.index_dangling|type)=="number" then .index_dangling else "null" end' "$skc_file" 2>/dev/null)
+  [[ "$_skd" =~ ^[0-9]+$ ]] && skc_dangling="$_skd"
 fi
 
 # ── 7. BEHAVIOR — deterministic, SANDBOXED probe corpus (DG4/DC1) ────────────
@@ -383,7 +386,7 @@ ${provider_harness_yaml}
     gemini_expected: ${skc_ge}
     codex_present: ${skc_cp}
     hermes_present: ${skc_hp}
-    index_stale: ${skc_idx}
+    index_dangling: ${skc_dangling}
 YAML
 FULL="generated_at: \"${RUN_TS}\""$'\n'"${BODY}"
 

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -161,6 +161,23 @@ if [[ -f "$sc_file" ]] && have jq; then
   sc_memchg=$(jq -r '.memory_files_changed // 0' "$sc_file" 2>/dev/null); [[ "$sc_memchg" =~ ^[0-9]+$ ]] || sc_memchg=0
 fi
 
+# ── 6c. SKILL CURRENCY — cross-provider skill drift vs canonical (#3249) ──────
+# References the audit state written by scripts/curation/audit_skill_currency.py (never re-runs it).
+# Missing/garbled file -> audited_at null / canonical_count 0 -> matrix grades MISSING-EVIDENCE.
+skc_file="${STATE_DIR}/skill-currency-${MACHINE}.json"
+skc_audited="null"; skc_cc=0; skc_gp=false; skc_gu=0; skc_ge=0; skc_cp=false; skc_hp=false; skc_idx=false
+if [[ -f "$skc_file" ]] && have jq; then
+  _ska=$(jq -r '.audited_at // empty' "$skc_file" 2>/dev/null)
+  [[ -n "$_ska" ]] && skc_audited="\"$(yesc "$_ska")\""
+  skc_cc=$(jq -r '.canonical_count // 0' "$skc_file" 2>/dev/null); [[ "$skc_cc" =~ ^[0-9]+$ ]] || skc_cc=0
+  skc_gu=$(jq -r '.gemini_unexpected // 0' "$skc_file" 2>/dev/null); [[ "$skc_gu" =~ ^[0-9]+$ ]] || skc_gu=0
+  skc_ge=$(jq -r '.gemini_expected // 0' "$skc_file" 2>/dev/null); [[ "$skc_ge" =~ ^[0-9]+$ ]] || skc_ge=0
+  skc_gp=$(jq -r 'if .gemini_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_gp" == "true" ]] || skc_gp=false
+  skc_cp=$(jq -r 'if .codex_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_cp" == "true" ]] || skc_cp=false
+  skc_hp=$(jq -r 'if .hermes_present then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_hp" == "true" ]] || skc_hp=false
+  skc_idx=$(jq -r 'if .index_stale then "true" else "false" end' "$skc_file" 2>/dev/null); [[ "$skc_idx" == "true" ]] || skc_idx=false
+fi
+
 # ── 7. BEHAVIOR — deterministic, SANDBOXED probe corpus (DG4/DC1) ────────────
 # CC3: guard mktemp (never let SBX become /sbx → rm -rf /). GC4: trap-based cleanup.
 SBX_PARENT="$(mktemp -d 2>/dev/null)" || { echo "mktemp failed" >&2; exit 1; }
@@ -358,6 +375,15 @@ ${provider_harness_yaml}
     sessions_24h: ${sc_24h}
     providers_active: "$(yesc "$sc_provs")"
     memory_files_changed: ${sc_memchg}
+  skill_currency:
+    audited_at: ${skc_audited}
+    canonical_count: ${skc_cc}
+    gemini_present: ${skc_gp}
+    gemini_unexpected: ${skc_gu}
+    gemini_expected: ${skc_ge}
+    codex_present: ${skc_cp}
+    hermes_present: ${skc_hp}
+    index_stale: ${skc_idx}
 YAML
 FULL="generated_at: \"${RUN_TS}\""$'\n'"${BODY}"
 

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -127,6 +127,18 @@ hermes:
     - external_skills_dir  # skills.external_dirs path exists and has SKILL.md files
     - config_managed_keys  # managed keys match template values
 
+# #3249 skill-currency line item: families that LEGITIMATELY differ between a provider's skill
+# surface and canonical `.claude/skills` are NOT drift. Listed as name-prefixes; a family whose
+# diff matches any prefix grades EXPECTED-DIVERGENCE (purple), only UNEXPECTED diffs grade
+# SKILLS-DRIFTED (red). When a provider intentionally adds/drops a family, update this list — that
+# review prompt is the point. Baseline captured 2026-06-26 from the live .agents/skills diff.
+expected_skill_divergence:
+  gemini:
+    - source-command-       # Gemini-CLI command-sourced skill families (gsd-*, compound, learn)
+    - workspace_hub_learned # Gemini-side learned-skill staging dir
+    - digitalmodel          # domain skill family not propagated to the Gemini surface
+    - memory                # memory-systems family not on the Gemini surface
+
 prerequisites:
   - jq
   - git

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -89,3 +89,12 @@ dimensions:
     sessions_24h: 47
     providers_active: "claude,codex,gemini,hermes"
     memory_files_changed: 6
+  skill_currency:
+    audited_at: "2026-05-30T03:55:12+00:00"
+    canonical_count: 44
+    gemini_present: true
+    gemini_unexpected: 0
+    gemini_expected: 9
+    codex_present: true
+    hermes_present: true
+    index_stale: false

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -97,4 +97,4 @@ dimensions:
     gemini_expected: 9
     codex_present: true
     hermes_present: true
-    index_stale: false
+    index_dangling: 0

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -55,11 +55,11 @@ def _win1_baseline() -> dict:
 
 
 # ════════════════════════════════════════════════════════════════════════════
-# 1. Golden fixture parses to schema_version 4 with provenance + all 11 dims
+# 1. Golden fixture parses to schema_version 4 with provenance + all 12 dims
 # ════════════════════════════════════════════════════════════════════════════
 EXPECTED_DIMS = {"compute", "data_access", "solvers", "harness", "skills",
                  "kanban", "memory", "behavior", "scheduler", "provider_harness",
-                 "session_curation"}
+                 "session_curation", "skill_currency"}
 
 
 def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
@@ -70,7 +70,7 @@ def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
     # provenance block present with the freshness fields is_stale() consumes
     p = d["provenance"]
     assert set(p) >= {"checkout_sha", "dirty", "behind_main", "ahead_main", "origin_ref_age_h"}
-    # all 11 dimensions present (session_curation added in the #2816 follow-on)
+    # all 12 dimensions present (session_curation added in the #2816 follow-on)
     assert set(d["dimensions"]) == EXPECTED_DIMS
     ph = d["dimensions"]["provider_harness"]
     assert ph["schema_version"] == 1

--- a/tests/readiness/test_skill_currency.py
+++ b/tests/readiness/test_skill_currency.py
@@ -1,0 +1,126 @@
+"""TDD tests for #3249 — the skill_currency matrix line item (epic #3248).
+
+Targets build_equality_matrix.skill_currency_verdict (the verdict state machine) in isolation,
+plus structural wiring, mirroring test_session_curation_freshness.py. The heavy audit (git-tree
+family diff, allowlist, index dangling-check) lives in scripts/curation/audit_skill_currency.py and
+emits FACTS into the dimension; the matrix maps facts→verdict, so the verdict is unit-testable here.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "readiness" / "build-equality-matrix.py"
+
+spec = importlib.util.spec_from_file_location("build_equality_matrix", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+bem = importlib.util.module_from_spec(spec)
+sys.modules["build_equality_matrix"] = bem
+spec.loader.exec_module(bem)
+
+
+def _rep(**sc) -> dict:
+    """A report carrying a skill_currency dimension built from the given fields."""
+    base = {"audited_at": "2026-06-26T12:00:00+00:00", "canonical_count": 44,
+            "gemini_present": True, "gemini_unexpected": 0, "gemini_expected": 0,
+            "codex_present": True, "hermes_present": True, "index_stale": False}
+    base.update(sc)
+    return {"dimensions": {"skill_currency": base}}
+
+
+# ── verdict precedence: DRIFTED > INDEX-STALE > EXPECTED-DIVERGENCE > CURRENT ──
+def test_current_when_clean():
+    assert bem.skill_currency_verdict(_rep()) == "SKILLS-CURRENT"
+
+
+def test_drifted_on_unexpected():
+    assert bem.skill_currency_verdict(_rep(gemini_unexpected=2)) == "SKILLS-DRIFTED"
+
+
+def test_drifted_dominates_index_stale_and_expected():
+    # unexpected drift is the highest-severity signal — it wins even with index stale + expected extras
+    assert bem.skill_currency_verdict(
+        _rep(gemini_unexpected=1, index_stale=True, gemini_expected=9)) == "SKILLS-DRIFTED"
+
+
+def test_index_stale_when_no_unexpected():
+    assert bem.skill_currency_verdict(_rep(index_stale=True)) == "SKILLS-INDEX-STALE"
+
+
+def test_index_stale_dominates_expected_divergence():
+    assert bem.skill_currency_verdict(
+        _rep(index_stale=True, gemini_expected=9)) == "SKILLS-INDEX-STALE"
+
+
+def test_expected_divergence_when_only_allowlisted_extras():
+    assert bem.skill_currency_verdict(_rep(gemini_expected=9)) == "EXPECTED-DIVERGENCE"
+
+
+def test_unexpected_ignored_when_gemini_absent():
+    # a stale gemini_unexpected count must not red the cell when the gemini surface isn't present
+    assert bem.skill_currency_verdict(
+        _rep(gemini_present=False, gemini_unexpected=5)) == "SKILLS-CURRENT"
+
+
+# ── fail-closed: missing / garbled evidence ──
+def test_missing_dimension():
+    assert bem.skill_currency_verdict({"dimensions": {}}) == "MISSING-EVIDENCE"
+
+
+def test_non_dict_dimension():
+    for bad in ("x", 1, ["a"], None):
+        assert bem.skill_currency_verdict({"dimensions": {"skill_currency": bad}}) == "MISSING-EVIDENCE"
+
+
+def test_missing_audited_at():
+    r = _rep()
+    del r["dimensions"]["skill_currency"]["audited_at"]
+    assert bem.skill_currency_verdict(r) == "MISSING-EVIDENCE"
+
+
+def test_unreadable_canonical_count():
+    # canonical_count absent / None / 0 ⇒ the tree couldn't be read ⇒ no evidence (fail-closed)
+    for bad in (None, 0, "44", -1):
+        assert bem.skill_currency_verdict(_rep(canonical_count=bad)) == "MISSING-EVIDENCE"
+
+
+def test_garbled_unexpected_with_gemini_present():
+    assert bem.skill_currency_verdict(_rep(gemini_unexpected="two")) == "MISSING-EVIDENCE"
+
+
+# ── structural wiring ──
+def test_dimension_registered():
+    assert "skill_currency" in bem.BASE_DISPLAY_DIMS
+    assert "skill_currency" in bem.DISPLAY_DIMS
+
+
+def test_current_is_ok_verdict():
+    assert "SKILLS-CURRENT" in bem.OK_VERDICTS
+    # EXPECTED-DIVERGENCE already an OK/expected verdict in the engine
+    assert "EXPECTED-DIVERGENCE" in bem.OK_VERDICTS
+
+
+def test_group_present():
+    groups = {g[0]: g for g in bem.GROUPS}
+    assert "skills-currency" in groups
+    assert groups["skills-currency"][2] == ["skill_currency"]
+
+
+def test_severity_ordering():
+    sev = bem.ROLLUP_SEVERITY
+    assert sev["SKILLS-DRIFTED"] > sev["SKILLS-INDEX-STALE"] > sev["SKILLS-CURRENT"]
+    assert sev["SKILLS-CURRENT"] == 0
+
+
+def test_verdict_routes_through_verdict_for():
+    # a fresh (non-stale) report graded via the public orchestrator returns the freshness-family verdict
+    from datetime import datetime  # noqa: F401  (ensure module import side-effects ok)
+    rep = _rep()
+    rep.update({"machine": "dev-primary", "os": "linux", "status": "active",
+                "provenance": {"checkout_sha": "abc", "dirty": False, "behind_main": 0,
+                               "ahead_main": 0, "origin_ref_age_h": 1}})
+    roster = {"dev-primary": {"status": "active"}}
+    v = bem.verdict_for("skill_currency", "dev-primary", {"dev-primary": rep}, {}, roster, [])
+    assert v == "SKILLS-CURRENT"

--- a/tests/readiness/test_skill_currency.py
+++ b/tests/readiness/test_skill_currency.py
@@ -25,7 +25,7 @@ def _rep(**sc) -> dict:
     """A report carrying a skill_currency dimension built from the given fields."""
     base = {"audited_at": "2026-06-26T12:00:00+00:00", "canonical_count": 44,
             "gemini_present": True, "gemini_unexpected": 0, "gemini_expected": 0,
-            "codex_present": True, "hermes_present": True, "index_stale": False}
+            "codex_present": True, "hermes_present": True, "index_dangling": 0}
     base.update(sc)
     return {"dimensions": {"skill_currency": base}}
 
@@ -42,16 +42,21 @@ def test_drifted_on_unexpected():
 def test_drifted_dominates_index_stale_and_expected():
     # unexpected drift is the highest-severity signal — it wins even with index stale + expected extras
     assert bem.skill_currency_verdict(
-        _rep(gemini_unexpected=1, index_stale=True, gemini_expected=9)) == "SKILLS-DRIFTED"
+        _rep(gemini_unexpected=1, index_dangling=5, gemini_expected=9)) == "SKILLS-DRIFTED"
 
 
 def test_index_stale_when_no_unexpected():
-    assert bem.skill_currency_verdict(_rep(index_stale=True)) == "SKILLS-INDEX-STALE"
+    assert bem.skill_currency_verdict(_rep(index_dangling=5)) == "SKILLS-INDEX-STALE"
 
 
 def test_index_stale_dominates_expected_divergence():
     assert bem.skill_currency_verdict(
-        _rep(index_stale=True, gemini_expected=9)) == "SKILLS-INDEX-STALE"
+        _rep(index_dangling=5, gemini_expected=9)) == "SKILLS-INDEX-STALE"
+
+
+def test_unreadable_index_not_green():
+    # index unreadable (null) while the tree read fine ⇒ INDEX-STALE, never silently green
+    assert bem.skill_currency_verdict(_rep(index_dangling=None)) == "SKILLS-INDEX-STALE"
 
 
 def test_expected_divergence_when_only_allowlisted_extras():


### PR DESCRIPTION
Closes #3249 (PRIMARY child of epic #3248).

## What
Adds a **`skill_currency`** matrix line item answering *"are all providers' skills up to date vs canonical?"* as a green/orange/red cell.
- 🟢 `SKILLS-CURRENT` · 🟠 `SKILLS-INDEX-STALE` · 🔴 `SKILLS-DRIFTED` · 🟣 `EXPECTED-DIVERGENCE` · `MISSING-EVIDENCE` (fail-closed).

## How
- **`audit_skill_currency.py`** compares the **committed tree** (`git ls-tree HEAD`) family sets of `.claude/skills` (canonical) vs `.agents/skills` (Gemini) — symlink/Windows/WIP-safe, deterministic.
- Grades `SKILLS-DRIFTED` only on **unexpected** family diffs; legitimate provider-specific families (`source-command-*`, `workspace_hub_learned`, `digitalmodel`, `memory`) are allowlisted in `harness-config.yaml` (exact-match unless the entry ends in `-`).
- `SKILLS-INDEX-STALE` on **dangling** `skills-index.yaml` entries (paths no longer in the tree) — index fails **closed** (null ⇒ stale, never silently green). Hermes/Codex graded present/absent (alias/subset of canonical), never counted.
- Folded into the 6h `session-curation` wrapper; `collect-equality.sh` emits the dimension; `.ps1` contract fixture + `EXPECTED_DIMS→12`.

## Reviews (both gates)
- **Plan**: adversarial NON-APPROVE on the v1 naive count+hash → redesigned to expected-divergence set-diff.
- **Code**: adversarial APPROVE-WITH-CHANGES → all 3 must-fixes folded (index fail-closed, committed-tree presence, git timeouts).

## Verification
- **360 readiness tests pass** (incl. the `.ps1` emission contract).
- Real result today on dev-primary: 0 unexpected drift, 9 allowlisted Gemini diffs, 202 dangling index entries → honest `SKILLS-INDEX-STALE`.