### PR TITLE
fix(equivalence): add CURATED-FRESH + SKILLS-CURRENT to reconcile OK-skip

### DIFF
--- a/scripts/readiness/reconcile-ecosystem.sh
+++ b/scripts/readiness/reconcile-ecosystem.sh
@@ -201,7 +201,7 @@ equality_plan() {
     local dim verdict; dim=$(printf '%s' "$line" | sed -E 's/^"([^"]+)".*/\1/')
     verdict=$(printf '%s' "$line" | sed -E 's/.*"([A-Z-]+)"$/\1/')
     case "$verdict" in
-      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT) continue ;;
+      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT|CURATED-FRESH|SKILLS-CURRENT) continue ;;
     esac
     case "$verdict" in
       STALE-CHECKOUT)


### PR DESCRIPTION
reconcile-ecosystem.sh's OK-skip list drifted from build-equality-matrix.py `OK_VERDICTS` — the new green verdicts `CURATED-FRESH` (#3246) and `SKILLS-CURRENT` (#3249) were missing, so a **healthy** box's green session/skill cells fell through to the catch-all and emitted spurious `verdict X — investigate` reconcile actions. Found by the #3255 plan review. One-line fix; now in sync.