### PR TITLE
feat(equivalence): skill-drift detector + alert (#3250)

### DIFF
--- a/.claude/state/skill-drift-dev-primary.json
+++ b/.claude/state/skill-drift-dev-primary.json
@@ -1,0 +1,6 @@
+{
+  "signature": "CLEAN",
+  "drift_present": false,
+  "first_seen": "2026-06-26T23:52:20+00:00",
+  "updated_at": "2026-06-26T23:52:20+00:00"
+}

--- a/.claude/state/skill-drift-report-dev-primary.json
+++ b/.claude/state/skill-drift-report-dev-primary.json
@@ -1,0 +1,14 @@
+{
+  "machine": "dev-primary",
+  "evaluated_at": "2026-06-26T23:52:20+00:00",
+  "signature": "CLEAN",
+  "drift_present": false,
+  "new_drift": false,
+  "recovered": false,
+  "include_index": false,
+  "gemini_present": true,
+  "gemini_unexpected": 0,
+  "gemini_unexpected_families": [],
+  "index_dangling": 202,
+  "schema_version": 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/state/session-curation-*.json
 !.claude/state/session-curation-*.md
 !.claude/state/skill-currency-*.json
+!.claude/state/skill-drift-*.json
 !.claude/state/reflect-history/
 !.claude/state/trends/
 !.claude/state/session-signals/

--- a/scripts/curation/audit_skill_currency.py
+++ b/scripts/curation/audit_skill_currency.py
@@ -126,7 +126,9 @@ def audit(machine: str) -> dict:
     # the same basis as the comparison so a working-tree delete during skill-dev can't silently
     # disable drift detection (the module's stated WIP-immunity).
     gemini_present = gemini is not None and len(gemini) > 0
+    # init BEFORE the guard so the gemini-absent path can't NameError on these (#3250 review)
     gemini_unexpected = gemini_expected = 0
+    unexpected_families: list[str] = []
     if canonical is not None and gemini is not None and gemini_present:
         diff = canonical ^ gemini
         # Allowlist match: an entry ending in '-' is an explicit PREFIX (e.g. 'source-command-');
@@ -135,8 +137,10 @@ def audit(machine: str) -> dict:
         def _allowed(f: str) -> bool:
             return any(f.startswith(p) if p.endswith("-") else f == p for p in allow)
         expected = {f for f in diff if _allowed(f)}
+        unexpected = diff - expected
         gemini_expected = len(expected)
-        gemini_unexpected = len(diff - expected)
+        gemini_unexpected = len(unexpected)
+        unexpected_families = sorted(unexpected)            # named for the #3250 drift alert
 
     dangling = _index_dangling()
     return {
@@ -145,12 +149,13 @@ def audit(machine: str) -> dict:
         "canonical_count": (len(canonical) if canonical is not None else None),
         "gemini_present": gemini_present,
         "gemini_unexpected": gemini_unexpected,
+        "gemini_unexpected_families": unexpected_families,   # names for the #3250 drift detector
         "gemini_expected": gemini_expected,
         "codex_present": (Path.home() / ".codex" / "skills").exists(),
         "hermes_present": (REPO / CANONICAL_PREFIX).exists(),
         "index_dangling": (dangling if dangling is not None else None),
         "index_stale": (dangling is not None and dangling > 0),
-        "schema_version": 1,
+        "schema_version": 2,
     }
 
 

--- a/scripts/curation/curate-session-memory.ps1
+++ b/scripts/curation/curate-session-memory.ps1
@@ -90,20 +90,20 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
 $skillAudit = (Join-Path $RepoRoot 'scripts/curation/audit_skill_currency.py')
 if (Get-Command uv -ErrorAction SilentlyContinue) {
     & uv run --no-project --with pyyaml python $skillAudit
-    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-currency audit failed (soft)' }
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'skill-currency audit failed (soft)' }
 } elseif (Get-Command python -ErrorAction SilentlyContinue) {
     & python $skillAudit
-    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-currency audit failed (soft)' }
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'skill-currency audit failed (soft)' }
 }
 
 # ── 1c. skill-drift detect + alert (#3250) — best-effort, after the audit ────
 $skillDrift = (Join-Path $RepoRoot 'scripts/curation/detect_skill_drift.py')
 if (Get-Command uv -ErrorAction SilentlyContinue) {
     & uv run --no-project --with pyyaml python $skillDrift
-    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-drift detect failed (soft)' }
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'skill-drift detect failed (soft)' }
 } elseif (Get-Command python -ErrorAction SilentlyContinue) {
     & python $skillDrift
-    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-drift detect failed (soft)' }
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'skill-drift detect failed (soft)' }
 }
 
 # ── 2. refresh THIS box's equality column (Windows collector + matrix build) ──

--- a/scripts/curation/curate-session-memory.ps1
+++ b/scripts/curation/curate-session-memory.ps1
@@ -96,6 +96,16 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     if ($LASTEXITCODE -ne 0) { Write-Error 'skill-currency audit failed (soft)' }
 }
 
+# ── 1c. skill-drift detect + alert (#3250) — best-effort, after the audit ────
+$skillDrift = (Join-Path $RepoRoot 'scripts/curation/detect_skill_drift.py')
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    & uv run --no-project --with pyyaml python $skillDrift
+    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-drift detect failed (soft)' }
+} elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    & python $skillDrift
+    if ($LASTEXITCODE -ne 0) { Write-Error 'skill-drift detect failed (soft)' }
+}
+
 # ── 2. refresh THIS box's equality column (Windows collector + matrix build) ──
 $collector = (Join-Path $ScriptDir '..\readiness\collect-equality.ps1')
 & $collector

--- a/scripts/curation/curate-session-memory.sh
+++ b/scripts/curation/curate-session-memory.sh
@@ -36,6 +36,15 @@ elif command -v python3 >/dev/null 2>&1; then
   python3 "$SKILL_AUDIT" || echo "skill-currency audit failed (soft)" >&2
 fi
 
+# Detect NEW cross-provider skill drift + alert (#3250) — reads the skill-currency state above,
+# alerts via notify.sh only on newly-appeared unexpected drift. Best-effort, after the audit.
+SKILL_DRIFT="$REPO_ROOT/scripts/curation/detect_skill_drift.py"
+if command -v uv >/dev/null 2>&1; then
+  uv run --no-project --with pyyaml python "$SKILL_DRIFT" || echo "skill-drift detect failed (soft)" >&2
+elif command -v python3 >/dev/null 2>&1; then
+  python3 "$SKILL_DRIFT" || echo "skill-drift detect failed (soft)" >&2
+fi
+
 # Refresh this box's equality column so the freshness cell + render are current. The matrix
 # build is NOT optional — skipping it would freeze the rendered cell (weakening the dead-man's
 # switch) while still reporting pass. So fail loudly if no python can build it.

--- a/scripts/curation/detect_skill_drift.py
+++ b/scripts/curation/detect_skill_drift.py
@@ -223,10 +223,13 @@ def _default_notify(alert: dict) -> None:
     """Real notifier: append one JSONL event via scripts/notify.sh (source=cron, job=skill-drift)."""
     status = alert.get("status", "fail")
     detail = f"{alert.get('kind', '?')}: {alert.get('detail', '')}"
-    subprocess.run(
-        ["bash", str(NOTIFY_SH), "cron", "skill-drift", status, detail],
-        check=False,
-    )
+    try:
+        subprocess.run(
+            ["bash", str(NOTIFY_SH), "cron", "skill-drift", status, detail],
+            check=False, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        pass                                         # a wedged notify.sh must never stall the cron
 
 
 def publish_drift(machine: str) -> str:
@@ -252,9 +255,12 @@ def publish_drift(machine: str) -> str:
 def run_cli(args: argparse.Namespace, notify_fn: Callable[[dict], None] = _default_notify) -> int:
     """Gather audit state, decide, persist, and fire one notify_fn per alert. Returns exit code.
 
-    Returns 1 when a NEW drift fired (so a cron can branch on it), else 0. notify_fn is injectable so
-    tests assert call counts without shelling out. The machine label is borrowed from the audit so
-    every filename keys off the SAME label that wrote skill-currency-<machine>.json.
+    Returns 0 on any SUCCESSFUL run — clean OR new-drift-detected — so the exit code is NOT
+    overloaded: the notify.sh alert is the drift signal, not the exit code. (A non-zero exit would
+    otherwise abort the Windows cron under $ErrorActionPreference='Stop' exactly when drift fires,
+    skipping the matrix rebuild.) A genuine internal error propagates as an exception → non-zero.
+    notify_fn is injectable so tests assert call counts without shelling out. The machine label is
+    borrowed from the audit so every filename keys off the SAME label that wrote skill-currency-<machine>.json.
     """
     machine = audit_skill_currency.machine_label()
     facts = _read_json(STATE / f"skill-currency-{machine}.json")
@@ -279,7 +285,7 @@ def run_cli(args: argparse.Namespace, notify_fn: Callable[[dict], None] = _defau
                   file=sys.stderr)
     else:
         print(f"skill-drift: no new alert (signature={sig})")
-    return 1 if result["new_drift"] else 0
+    return 0   # success (clean or drift-detected); the alert is the signal, not the exit code
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/curation/detect_skill_drift.py
+++ b/scripts/curation/detect_skill_drift.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""detect_skill_drift.py — cross-provider skill-drift detector + alert (#3250, epic #3248).
+
+Reads the FACTS emitted by ``audit_skill_currency.py`` (``.claude/state/skill-currency-<machine>.json``)
+and fires a ``scripts/notify.sh`` alert ONLY when NEW or CHANGED unexpected cross-provider family
+drift appears — never re-alerting on an unchanged standing divergence. Mirrors the
+``venue_absence_detector.py`` shape: a PURE decide-core (``drift_signature`` / ``evaluate_drift`` —
+no IO, no clock, no subprocess) plus a thin CLI that gathers inputs, calls the core, and routes each
+alert through an injectable ``notify_fn``.
+
+Design decisions (locked by the #3250 plan + adversarial review):
+  * The audit stays the sole fact emitter; this is a separate decide/alert/persist layer that READS
+    its state file (the same ``audit → matrix`` split already in place).
+  * Spam suppression via a persisted last-seen drift SIGNATURE
+    (``.claude/state/skill-drift-<machine>.json``). An alert fires only on a signature transition
+    into/within drift (new drift, or the drift SET changed); drift→clean emits one ``pass`` recovery.
+  * Index staleness is EXCLUDED from the default signature — ``.claude/skills-index.yaml`` is
+    known-rotted and would false-fire the detector's very first run. It folds into the signature
+    ONLY under the explicit ``--include-index`` opt-in. Index rot stays surfaced by the matrix
+    ``SKILLS-INDEX-STALE`` verdict.
+  * Fail-closed: an unreadable/missing audit state yields signature ``UNREADABLE`` and alerts once
+    (``audit-unreadable``) — never silently green.
+  * The machine label is BORROWED from the audit (``audit_skill_currency.machine_label()`` called at
+    runtime, not reimplemented) so the file the detector reads and the files it writes can never key
+    off a different label.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+REPO = Path(__file__).resolve().parents[2]
+STATE = REPO / ".claude" / "state"
+NOTIFY_SH = REPO / "scripts" / "notify.sh"
+EQUIVALENCE_CLI = REPO / "scripts" / "monitoring" / "equivalence_state.py"
+
+PUBLISH_TIMEOUT_S = 90
+DRIFT_REF = "skill-drift-state"
+
+# Import the audit module (not the function) so its machine_label() is resolved at CALL TIME and
+# remains monkeypatchable in tests. Same-dir module; ensure the curation dir is importable.
+_CURATION_DIR = str(Path(__file__).resolve().parent)
+if _CURATION_DIR not in sys.path:
+    sys.path.insert(0, _CURATION_DIR)
+import audit_skill_currency  # noqa: E402  (path set up above)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# --------------------------------------------------------------------------- #
+# PURE CORE — no IO, no clock, no subprocess
+# --------------------------------------------------------------------------- #
+
+
+def _pos_int(v) -> bool:
+    """True for a strictly-positive plain int (rejects bool, which is an int subclass)."""
+    return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+
+def _drift_count(facts: dict) -> int:
+    """Unexpected cross-provider family count, gated on gemini being present.
+
+    Returns 0 when gemini is absent (a stale count must not register as drift) or when the count is
+    missing/garbled. PURE.
+    """
+    if not bool(facts.get("gemini_present")):
+        return 0
+    n = facts.get("gemini_unexpected")
+    return n if _pos_int(n) else 0
+
+
+def _families(facts: dict) -> list[str]:
+    """Sorted, stringified list of unexpected family NAMES (optional audit field; [] if absent)."""
+    return sorted(str(f) for f in (facts.get("gemini_unexpected_families") or []))
+
+
+def drift_signature(facts: dict, *, include_index: bool = False) -> str:
+    """A stable, order-independent fingerprint of the current drift state. PURE.
+
+    Returns one of:
+      * ``"UNREADABLE"`` — the audit could not read the tree (``canonical_count`` not a positive int)
+        → fail-closed, alertable.
+      * ``"CLEAN"``      — no unexpected cross-provider drift (and, unless ``include_index``, index
+        rot is ignored).
+      * ``"fam:a,b[|idx:N]"`` — a pipe-joined signature naming the drifted families (and, only under
+        ``include_index``, the dangling-index count).
+
+    Index staleness is folded in ONLY when ``include_index=True`` so the standing index rot can never
+    trip the family-drift alert on a first run.
+    """
+    if not isinstance(facts, dict) or not _pos_int(facts.get("canonical_count")):
+        return "UNREADABLE"
+    parts: list[str] = []
+    n = _drift_count(facts)
+    if n > 0:
+        fams = _families(facts)
+        parts.append("fam:" + ",".join(fams) if fams else f"fam-count:{n}")
+    if include_index:
+        dang = facts.get("index_dangling")
+        if _pos_int(dang):
+            parts.append(f"idx:{dang}")
+    return "CLEAN" if not parts else "|".join(parts)
+
+
+def _human_summary(facts: dict, sig: str) -> str:
+    if sig == "UNREADABLE":
+        return "skill-currency audit state missing or unreadable (fail-closed)"
+    fams = _families(facts)
+    n = _drift_count(facts)
+    if fams:
+        return f"{n} unexpected gemini family(ies) vs canonical: {', '.join(fams)}"
+    if n:
+        return f"{n} unexpected gemini family(ies) vs canonical (names unavailable)"
+    return f"drift signature {sig}"
+
+
+def evaluate_drift(facts, last_seen, *, now_iso: str, include_index: bool = False) -> dict:
+    """Decide whether to alert, given current facts + the last-seen state. PURE — no IO/clock.
+
+    Spam-suppression contract (alert exactly once per distinct drift state):
+      * none → drift        : ``new_drift`` (one ``fail`` alert)
+      * drift → same drift  : suppressed (no alert)
+      * drift → changed set : ``new_drift`` (one ``fail`` alert)
+      * drift → clean        : ``recovered`` (one ``pass`` alert)
+
+    ``UNREADABLE`` counts as a (fail-closed) drift state, so a missing/garbled audit alerts once as
+    ``audit-unreadable`` and stays suppressed until it changes or recovers.
+    """
+    if not isinstance(facts, dict):
+        facts = {}
+    sig = drift_signature(facts, include_index=include_index)
+    drift_present = sig != "CLEAN"
+    last = last_seen if isinstance(last_seen, dict) else None
+    last_sig = (last or {}).get("signature")
+
+    new_drift = drift_present and sig != last_sig
+    recovered = (not drift_present) and last_sig not in (None, "CLEAN")
+
+    alerts: list[dict] = []
+    if new_drift:
+        kind = "audit-unreadable" if sig == "UNREADABLE" else "skill-drift"
+        alerts.append({
+            "kind": kind,
+            "detail": _human_summary(facts, sig),
+            "severity": "critical",
+            "status": "fail",
+        })
+    if recovered:
+        alerts.append({
+            "kind": "skill-drift-cleared",
+            "detail": f"cross-provider skill drift cleared (was {last_sig}, now CLEAN)",
+            "severity": "info",
+            "status": "pass",
+        })
+
+    if sig == last_sig and last and last.get("first_seen"):
+        first_seen = last["first_seen"]
+    else:
+        first_seen = now_iso
+    new_state = {
+        "signature": sig,
+        "drift_present": drift_present,
+        "first_seen": first_seen,
+        "updated_at": now_iso,
+    }
+
+    dang = facts.get("index_dangling")
+    report = {
+        "machine": facts.get("machine") if isinstance(facts.get("machine"), str) else None,
+        "evaluated_at": now_iso,
+        "signature": sig,
+        "drift_present": drift_present,
+        "new_drift": new_drift,
+        "recovered": recovered,
+        "include_index": bool(include_index),
+        "gemini_present": bool(facts.get("gemini_present")),
+        "gemini_unexpected": _drift_count(facts),
+        "gemini_unexpected_families": _families(facts),
+        "index_dangling": (dang if (isinstance(dang, int) and not isinstance(dang, bool)) else None),
+        "schema_version": 1,
+    }
+
+    return {
+        "signature": sig,
+        "drift_present": drift_present,
+        "new_drift": new_drift,
+        "recovered": recovered,
+        "alerts": alerts,
+        "report": report,
+        "new_state": new_state,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# THIN CLI — IO, clock, subprocess live here
+# --------------------------------------------------------------------------- #
+
+
+def _read_json(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _default_notify(alert: dict) -> None:
+    """Real notifier: append one JSONL event via scripts/notify.sh (source=cron, job=skill-drift)."""
+    status = alert.get("status", "fail")
+    detail = f"{alert.get('kind', '?')}: {alert.get('detail', '')}"
+    subprocess.run(
+        ["bash", str(NOTIFY_SH), "cron", "skill-drift", status, detail],
+        check=False,
+    )
+
+
+def publish_drift(machine: str) -> str:
+    """Publish this box's drift report to the dedicated git ref via the equivalence-state CLI, in a
+    BOUNDED subprocess. The git push can hang (network/auth/lock — a sibling publish was observed
+    stuck >1h), so we cap it and fail soft: a hung/failed publish must never stall curation. Mirrors
+    curate_session_memory.publish_fingerprint."""
+    report_file = STATE / f"skill-drift-report-{machine}.json"
+    if not report_file.exists() or not EQUIVALENCE_CLI.exists():
+        return "publish-skipped (no state/cli)"
+    try:
+        r = subprocess.run(
+            [sys.executable, str(EQUIVALENCE_CLI), "publish", "--repo", str(REPO),
+             "--role", machine, "--file", str(report_file), "--ref", DRIFT_REF],
+            capture_output=True, text=True, timeout=PUBLISH_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return f"publish-timeout ({PUBLISH_TIMEOUT_S}s)"
+    except Exception as e:  # noqa: BLE001 — best-effort fleet slice; never fail local detection
+        return f"publish-error: {str(e)[:80]}"
+    return "published" if r.returncode == 0 else f"publish-rc{r.returncode}"
+
+
+def run_cli(args: argparse.Namespace, notify_fn: Callable[[dict], None] = _default_notify) -> int:
+    """Gather audit state, decide, persist, and fire one notify_fn per alert. Returns exit code.
+
+    Returns 1 when a NEW drift fired (so a cron can branch on it), else 0. notify_fn is injectable so
+    tests assert call counts without shelling out. The machine label is borrowed from the audit so
+    every filename keys off the SAME label that wrote skill-currency-<machine>.json.
+    """
+    machine = audit_skill_currency.machine_label()
+    facts = _read_json(STATE / f"skill-currency-{machine}.json")
+    last = _read_json(STATE / f"skill-drift-{machine}.json")
+    result = evaluate_drift(facts, last, now_iso=_now(), include_index=getattr(args, "include_index", False))
+
+    # (a) report ALWAYS written, regardless of alert.
+    _write_json(STATE / f"skill-drift-report-{machine}.json", result["report"])
+    # (b) alerts gated by the dedup decision.
+    for alert in result["alerts"]:
+        notify_fn(alert)
+    # (c) persist the last-seen signature for next-run suppression.
+    _write_json(STATE / f"skill-drift-{machine}.json", result["new_state"])
+    # (d) optional bounded, fail-soft cross-machine publish.
+    if getattr(args, "publish", False):
+        print(publish_drift(machine), file=sys.stderr)
+
+    sig = result["signature"]
+    if result["alerts"]:
+        for alert in result["alerts"]:
+            print(f"skill-drift: [{alert['status']}] {alert['kind']}: {alert['detail']}",
+                  file=sys.stderr)
+    else:
+        print(f"skill-drift: no new alert (signature={sig})")
+    return 1 if result["new_drift"] else 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Cross-provider skill-drift detector — alerts once per distinct drift state."
+    )
+    p.add_argument("--include-index", action="store_true",
+                   help="Fold the dangling-index count into the drift signature (default OFF — index "
+                        "rot is surfaced by the matrix SKILLS-INDEX-STALE verdict instead).")
+    p.add_argument("--publish", action="store_true",
+                   help="Publish the drift report to the skill-drift-state git ref (bounded, fail-soft).")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return run_cli(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/curation/test_detect_skill_drift.py
+++ b/tests/curation/test_detect_skill_drift.py
@@ -1,0 +1,267 @@
+"""TDD tests for #3250 — the cross-provider skill-drift detector + alert (epic #3248).
+
+Targets scripts/curation/detect_skill_drift.py: the PURE decide-core
+(drift_signature / evaluate_drift) plus the thin CLI (run_cli, publish_drift). Pattern mirrors
+tests/readiness/test_skill_currency.py (importlib spec load + a small fixture builder).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "curation" / "detect_skill_drift.py"
+
+spec = importlib.util.spec_from_file_location("detect_skill_drift", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+det = importlib.util.module_from_spec(spec)
+sys.modules["detect_skill_drift"] = det
+spec.loader.exec_module(det)
+
+NOW = "2026-06-26T12:00:00+00:00"
+
+
+def _facts(**kw) -> dict:
+    """A skill-currency FACTS dict (as audit_skill_currency.py emits)."""
+    base = {
+        "machine": "dev-primary",
+        "audited_at": NOW,
+        "canonical_count": 44,
+        "gemini_present": True,
+        "gemini_unexpected": 0,
+        "gemini_expected": 0,
+        "gemini_unexpected_families": [],
+        "index_dangling": 0,
+        "index_stale": False,
+        "schema_version": 2,
+    }
+    base.update(kw)
+    return base
+
+
+def _drift_facts(families, **kw) -> dict:
+    return _facts(gemini_unexpected=len(families), gemini_unexpected_families=list(families), **kw)
+
+
+# ── drift_signature: PURE fingerprint ──────────────────────────────────────
+def test_signature_clean():
+    assert det.drift_signature(_facts()) == "CLEAN"
+
+
+def test_signature_names_sorted():
+    # order-independent + name-stable
+    a = det.drift_signature(_drift_facts(["b", "a"]))
+    b = det.drift_signature(_drift_facts(["a", "b"]))
+    assert a == b == "fam:a,b"
+
+
+def test_signature_index_excluded_by_default():
+    # standing index rot must NOT enter the default signature
+    assert det.drift_signature(_facts(index_dangling=200)) == "CLEAN"
+
+
+def test_signature_includes_index_optin():
+    sig = det.drift_signature(_facts(index_dangling=3), include_index=True)
+    assert "idx:3" in sig
+
+
+def test_signature_index_optin_ignores_zero_and_bool():
+    assert det.drift_signature(_facts(index_dangling=0), include_index=True) == "CLEAN"
+    assert det.drift_signature(_facts(index_dangling=True), include_index=True) == "CLEAN"
+
+
+def test_signature_unreadable():
+    for bad in (0, None, "44", -1, True):
+        assert det.drift_signature(_facts(canonical_count=bad)) == "UNREADABLE"
+
+
+def test_signature_gemini_absent_no_drift():
+    # a stale count/names list must be ignored when the gemini surface isn't present
+    assert det.drift_signature(
+        _facts(gemini_present=False, gemini_unexpected=5,
+               gemini_unexpected_families=["x"])) == "CLEAN"
+
+
+def test_signature_count_fallback_without_names():
+    # schema-1 audit (count but no names) still registers drift
+    f = _facts(gemini_unexpected=2)
+    f.pop("gemini_unexpected_families")
+    assert det.drift_signature(f) == "fam-count:2"
+
+
+# ── evaluate_drift: transition + spam suppression ──────────────────────────
+def test_first_run_no_falsefire_on_index_rot():
+    r = det.evaluate_drift(_facts(index_dangling=200), None, now_iso=NOW)
+    assert r["new_drift"] is False
+    assert r["alerts"] == []
+    assert r["signature"] == "CLEAN"
+
+
+def test_new_drift_alerts_once():
+    r = det.evaluate_drift(_drift_facts(["x"]), None, now_iso=NOW)
+    assert r["new_drift"] is True
+    assert len(r["alerts"]) == 1
+    assert r["alerts"][0]["status"] == "fail"
+    assert r["alerts"][0]["kind"] == "skill-drift"
+
+
+def test_same_drift_suppressed():
+    last = {"signature": "fam:x", "drift_present": True, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(_drift_facts(["x"]), last, now_iso="2026-06-26T18:00:00+00:00")
+    assert r["new_drift"] is False
+    assert r["alerts"] == []
+    # first_seen preserved across an unchanged standing drift
+    assert r["new_state"]["first_seen"] == NOW
+
+
+def test_changed_drift_realerts():
+    last = {"signature": "fam:a", "drift_present": True, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(_drift_facts(["a", "b"]), last, now_iso=NOW)
+    assert r["new_drift"] is True
+    assert len(r["alerts"]) == 1
+    assert r["new_state"]["signature"] == "fam:a,b"
+
+
+def test_recovery_emits_pass():
+    last = {"signature": "fam:a", "drift_present": True, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(_facts(), last, now_iso=NOW)
+    assert r["recovered"] is True
+    assert len(r["alerts"]) == 1
+    assert r["alerts"][0]["status"] == "pass"
+    assert r["alerts"][0]["kind"] == "skill-drift-cleared"
+
+
+def test_clean_stays_quiet():
+    last = {"signature": "CLEAN", "drift_present": False, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(_facts(), last, now_iso=NOW)
+    assert r["new_drift"] is False
+    assert r["recovered"] is False
+    assert r["alerts"] == []
+
+
+def test_full_transition_sequence_alerts_once_each():
+    # none -> drift -> same -> changed -> recovery: exactly one alert per distinct state
+    s0 = None
+    r1 = det.evaluate_drift(_drift_facts(["a"]), s0, now_iso=NOW)               # none -> drift
+    r2 = det.evaluate_drift(_drift_facts(["a"]), r1["new_state"], now_iso=NOW)  # drift -> same
+    r3 = det.evaluate_drift(_drift_facts(["a", "b"]), r2["new_state"], now_iso=NOW)  # changed
+    r4 = det.evaluate_drift(_facts(), r3["new_state"], now_iso=NOW)             # recovery
+    assert [len(r["alerts"]) for r in (r1, r2, r3, r4)] == [1, 0, 1, 1]
+    assert [r["alerts"][0]["status"] for r in (r1, r3, r4)] == ["fail", "fail", "pass"]
+
+
+def test_unreadable_alerts_failclosed():
+    last = {"signature": "CLEAN", "drift_present": False, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(_facts(canonical_count=None), last, now_iso=NOW)
+    assert len(r["alerts"]) == 1
+    assert r["alerts"][0]["kind"] == "audit-unreadable"
+    assert r["alerts"][0]["status"] == "fail"
+
+
+def test_unreadable_suppressed_when_unchanged():
+    last = {"signature": "UNREADABLE", "drift_present": True, "first_seen": NOW, "updated_at": NOW}
+    r = det.evaluate_drift(None, last, now_iso=NOW)
+    assert r["signature"] == "UNREADABLE"
+    assert r["alerts"] == []
+
+
+def test_gemini_absent_no_drift_evaluate():
+    r = det.evaluate_drift(
+        _facts(gemini_present=False, gemini_unexpected=5, gemini_unexpected_families=["x"]),
+        None, now_iso=NOW)
+    assert r["signature"] == "CLEAN"
+    assert r["alerts"] == []
+
+
+def test_evaluate_pure_no_io(monkeypatch):
+    # evaluate_drift must touch neither the filesystem nor subprocess.
+    def _boom(*a, **k):
+        raise AssertionError("evaluate_drift performed IO")
+    monkeypatch.setattr(det.subprocess, "run", _boom)
+    monkeypatch.setattr("builtins.open", _boom)
+    r = det.evaluate_drift(_drift_facts(["a"]), None, now_iso=NOW)
+    assert r["new_drift"] is True
+
+
+# ── run_cli: injected notify, machine-label borrow, report-always ──────────
+def _setup_state(tmp_path, monkeypatch, label, currency_facts=None):
+    state = tmp_path / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(det, "STATE", state)
+    monkeypatch.setattr(det.audit_skill_currency, "machine_label", lambda: label)
+    if currency_facts is not None:
+        (state / f"skill-currency-{label}.json").write_text(json.dumps(currency_facts))
+    return state
+
+
+def test_run_cli_injected_notify(tmp_path, monkeypatch):
+    state = _setup_state(tmp_path, monkeypatch, "dev-primary", _drift_facts(["x"]))
+    calls = []
+    rc = det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
+    assert rc == 1
+    assert len(calls) == 1
+    assert (state / "skill-drift-report-dev-primary.json").exists()
+    assert (state / "skill-drift-dev-primary.json").exists()
+
+
+def test_run_cli_uses_audit_machine_label(tmp_path, monkeypatch):
+    state = _setup_state(tmp_path, monkeypatch, "BOXLBL", _drift_facts(["y"]))
+    det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=lambda a: None)
+    # keyed entirely on the audit's machine_label()
+    assert (state / "skill-drift-report-BOXLBL.json").exists()
+    assert (state / "skill-drift-BOXLBL.json").exists()
+
+
+def test_run_cli_spam_suppressed_across_two_runs(tmp_path, monkeypatch):
+    _setup_state(tmp_path, monkeypatch, "dev-primary", _drift_facts(["x"]))
+    calls = []
+    det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
+    det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
+    assert len(calls) == 1  # second run on the same standing drift is silent
+
+
+def test_run_cli_report_always_written_when_clean(tmp_path, monkeypatch):
+    state = _setup_state(tmp_path, monkeypatch, "dev-primary", _facts())
+    calls = []
+    rc = det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
+    assert rc == 0
+    assert calls == []
+    assert (state / "skill-drift-report-dev-primary.json").exists()
+
+
+def test_run_cli_missing_audit_state_alerts_failclosed(tmp_path, monkeypatch):
+    # no skill-currency file written → unreadable → one audit-unreadable alert
+    _setup_state(tmp_path, monkeypatch, "dev-primary", None)
+    calls = []
+    det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
+    assert len(calls) == 1
+    assert calls[0]["kind"] == "audit-unreadable"
+
+
+def test_default_notify_uses_skill_drift_job(tmp_path, monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(det.subprocess, "run",
+                        lambda cmd, **k: recorded.setdefault("cmd", cmd))
+    det._default_notify({"kind": "skill-drift", "detail": "d", "status": "fail"})
+    cmd = recorded["cmd"]
+    assert cmd[1:5] == [str(det.NOTIFY_SH), "cron", "skill-drift", "fail"]
+
+
+# ── publish_drift: bounded + fail-soft ─────────────────────────────────────
+def test_publish_bounded_timeout(tmp_path, monkeypatch):
+    state = _setup_state(tmp_path, monkeypatch, "dev-primary")
+    (state / "skill-drift-report-dev-primary.json").write_text("{}")
+
+    def _timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="publish", timeout=det.PUBLISH_TIMEOUT_S)
+    monkeypatch.setattr(det.subprocess, "run", _timeout)
+    assert det.publish_drift("dev-primary") == f"publish-timeout ({det.PUBLISH_TIMEOUT_S}s)"
+
+
+def test_publish_skipped_when_no_report(tmp_path, monkeypatch):
+    _setup_state(tmp_path, monkeypatch, "dev-primary")
+    assert det.publish_drift("dev-primary").startswith("publish-skipped")

--- a/tests/curation/test_detect_skill_drift.py
+++ b/tests/curation/test_detect_skill_drift.py
@@ -202,7 +202,7 @@ def test_run_cli_injected_notify(tmp_path, monkeypatch):
     state = _setup_state(tmp_path, monkeypatch, "dev-primary", _drift_facts(["x"]))
     calls = []
     rc = det.run_cli(SimpleNamespace(include_index=False, publish=False), notify_fn=calls.append)
-    assert rc == 1
+    assert rc == 0   # success even on new-drift (exit code not overloaded; the alert is the signal)
     assert len(calls) == 1
     assert (state / "skill-drift-report-dev-primary.json").exists()
     assert (state / "skill-drift-dev-primary.json").exists()


### PR DESCRIPTION
Closes #3249's sibling #3250 (epic #3248). Reads the skill-currency audit and alerts via notify.sh ONLY on NEW unexpected cross-provider family drift (spam-suppressed). Index staleness excluded from the default signature (own cell + known-rotted). Fail-closed on unreadable audit. machine_label reused at call time so the detector reads the same machine's file the audit wrote.

Both gates: plan adversarially reviewed (2 rounds, NON-APPROVE→APPROVE-WITH-CHANGES); code adversarially reviewed (NON-APPROVE→fixed: exit-code de-overloaded so Windows cron isn't aborted on drift; .ps1 Write-Warning; notify timeout). 27 engine tests + 31 skill_currency/contract tests green.

Wired soft-fail into curate-session-memory.sh AND .ps1.