### PR TITLE
feat(equivalence): memory-freshness matrix line item (#3255)

### DIFF
--- a/.claude/state/memory-freshness-dev-primary.json
+++ b/.claude/state/memory-freshness-dev-primary.json
@@ -1,0 +1,40 @@
+{
+  "machine": "dev-primary",
+  "audited_at": "2026-06-27T00:06:11+00:00",
+  "surfaces": {
+    "context_md": {
+      "present": true,
+      "refreshed_at": "2026-06-26T08:00:34-05:00",
+      "age_hours": 11.094,
+      "signal": "git-commit"
+    },
+    "agents_md": {
+      "present": true,
+      "refreshed_at": "2026-06-26T08:00:34-05:00",
+      "age_hours": 11.094,
+      "signal": "git-commit"
+    },
+    "codex_runtime": {
+      "present": true,
+      "refreshed_at": "2026-06-26T08:00:34-05:00",
+      "age_hours": 11.094,
+      "signal": "git-commit"
+    },
+    "gemini_runtime": {
+      "present": true,
+      "refreshed_at": "2026-06-26T08:00:34-05:00",
+      "age_hours": 11.094,
+      "signal": "git-commit"
+    },
+    "hermes_memories": {
+      "present": true,
+      "refreshed_at": "2026-06-26T09:25:02+00:00",
+      "age_hours": 14.686,
+      "signal": "file-mtime"
+    }
+  },
+  "newest_refresh": "2026-06-26T08:00:34-05:00",
+  "worst_age_hours": 14.686,
+  "freshness": "MEMORY-FRESH",
+  "schema_version": 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/state/session-curation-*.md
 !.claude/state/skill-currency-*.json
 !.claude/state/skill-drift-*.json
+!.claude/state/memory-freshness-*.json
 !.claude/state/reflect-history/
 !.claude/state/trends/
 !.claude/state/session-signals/

--- a/scripts/curation/audit_memory_freshness.py
+++ b/scripts/curation/audit_memory_freshness.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""audit_memory_freshness.py — cross-provider memory-freshness audit (#3255, epic #3248).
+
+Emits the FACTS for the machine-equality `memory_freshness` line item: how long ago was each
+memory surface last refreshed, and is any of them stale? The matrix
+(build-equality-matrix.py::memory_freshness_verdict) maps these facts → verdict. This module also
+carries a self-contained pure verdict (`categorize`) so the staleness tier is unit-testable here.
+
+Memory surfaces graded:
+  * .claude/memory/context.md          (git-bridged — written by bridge-hermes-claude.sh)
+  * .claude/memory/agents.md           (git-bridged)
+  * config/agents/codex/MEMORY.runtime.md   (git-bridged provider runtime slice)
+  * config/agents/gemini/MEMORY.runtime.md  (git-bridged provider runtime slice)
+  * ~/.hermes/memories/                (machine-LOCAL, NOT git-tracked)
+
+Design decision (locked by the #3255 adversarial review — same git-over-mtime posture as
+audit_skill_currency.py #3249):
+  * The four git-bridged surfaces take their last-refresh clock from `git log -1 --format=%cI`
+    (the path's last-COMMIT time), NOT from `st_mtime`. The bridge writes these files on the owner
+    box, commits, and every other box receives them by `git pull` — so on a fresh clone `st_mtime`
+    equals checkout time, not refresh time, and would false-red a perfectly healthy box. The commit
+    time, by contrast, travels with the repo (machine-invariant) and survives `git checkout`/`pull`.
+    (audit_skill_currency.py:24 — "mtime is non-deterministic on fresh checkouts".)
+  * Only `~/.hermes/memories/` (local, never checked out) uses real `st_mtime` — correct there.
+  * git unavailable / not-a-repo / hung ⇒ the runner returns None ⇒ those surfaces are absent
+    (fail-closed), never silently fresh.
+
+Leak posture: state carries surface KEYS (short role names) + ISO timestamps + ages + bools only —
+never absolute paths, file contents, prompt text, tokens, or client identifiers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+STATE = REPO / ".claude" / "state"
+
+# Make the sibling audit module importable so machine_label() can be REUSED (not re-implemented),
+# regardless of whether this file is run as a script or loaded by importlib from the test suite.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# ── Freshness thresholds ──────────────────────────────────────────────────────────────────────
+# The git-bridged memory surfaces are refreshed on a DAILY bridge cadence (provider-dream-bridge /
+# hermes-claude-bridge @ ~04:0x), not the 6-hourly curation cadence — so these tiers are looser than
+# session-curation's 12h/24h. 36h = one missed daily run (still amber-tolerant); 72h = three missed
+# daily runs ⇒ the bridge is effectively dead and the cell should go red. Tunable in one place.
+MEMORY_STALE_H = 36
+MEMORY_EXPIRED_H = 72
+
+MEMORY_FRESH = "MEMORY-FRESH"
+MEMORY_STALE = "MEMORY-STALE"
+MEMORY_EXPIRED = "MEMORY-EXPIRED"
+MISSING_EVIDENCE = "MISSING-EVIDENCE"
+
+# Surface key → repo-relative path; freshness clock = git last-commit time of the path.
+GIT_SURFACES = {
+    "context_md": ".claude/memory/context.md",
+    "agents_md": ".claude/memory/agents.md",
+    "codex_runtime": "config/agents/codex/MEMORY.runtime.md",
+    "gemini_runtime": "config/agents/gemini/MEMORY.runtime.md",
+}
+# Machine-LOCAL surface (not git-tracked) → freshness clock = newest file mtime.
+HERMES_DIR = Path.home() / ".hermes" / "memories"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds")
+
+
+def _parse_iso(s) -> datetime | None:
+    if not isinstance(s, str):
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _git_commit_iso(rel_path: str) -> str | None:
+    """Last-commit ISO time of a tracked path (survives checkout). None on git failure/untracked.
+
+    This is THE runner the tests monkeypatch — it is the only place a `git log` subprocess is run,
+    bounded and fail-soft so a hung/locked/missing git never stalls or false-greens the audit.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(REPO), "log", "-1", "--format=%cI", "--", rel_path],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None                       # hung/locked/absent git ⇒ no evidence (fail-closed)
+    if r.returncode != 0:
+        return None
+    out = r.stdout.strip()
+    return out or None                    # empty ⇒ untracked / never committed ⇒ surface absent
+
+
+def _hermes_mtime_iso() -> str | None:
+    """Newest st_mtime among ~/.hermes/memories/*.md as ISO. None if the surface is absent/empty.
+
+    mtime is the CORRECT clock here: this tree is machine-local and never git-checked-out, so its
+    mtime reflects the actual last Hermes write on this box.
+    """
+    if not HERMES_DIR.exists():
+        return None
+    mtimes: list[float] = []
+    for p in HERMES_DIR.glob("*.md"):
+        try:
+            mtimes.append(p.stat().st_mtime)
+        except OSError:
+            continue
+    if not mtimes:
+        return None
+    return _iso(datetime.fromtimestamp(max(mtimes), timezone.utc))
+
+
+def _surface_record(refreshed_at: str | None, signal: str, now: datetime) -> dict:
+    """One surface's facts: present/refreshed_at/age_hours/signal. Unparseable stamp ⇒ absent."""
+    dt = _parse_iso(refreshed_at)
+    if dt is None:
+        return {"present": False, "refreshed_at": None, "age_hours": None, "signal": signal}
+    age = round((now - dt).total_seconds() / 3600.0, 3)
+    return {"present": True, "refreshed_at": refreshed_at, "age_hours": age, "signal": signal}
+
+
+# ── Pure verdict ────────────────────────────────────────────────────────────────────────────────
+def freshness_category(worst_age_hours, stale_h: float = MEMORY_STALE_H,
+                       expired_h: float = MEMORY_EXPIRED_H) -> str:
+    """Pure tier map for a single worst (oldest) age. None ⇒ MISSING-EVIDENCE; a negative age
+    (future stamp ⇒ clock skew) ⇒ MISSING-EVIDENCE (fail-closed). Boundaries inclusive."""
+    if not isinstance(worst_age_hours, (int, float)):
+        return MISSING_EVIDENCE
+    if worst_age_hours < 0:
+        return MISSING_EVIDENCE
+    if worst_age_hours <= stale_h:
+        return MEMORY_FRESH
+    if worst_age_hours <= expired_h:
+        return MEMORY_STALE
+    return MEMORY_EXPIRED
+
+
+def categorize(ages, stale_h: float = MEMORY_STALE_H, expired_h: float = MEMORY_EXPIRED_H) -> str:
+    """Pure facts→verdict: `ages` = the per-surface age_hours of the PRESENT surfaces. The OLDEST
+    present surface dominates. Empty (no present surface proved a timestamp) ⇒ MISSING-EVIDENCE.
+    Any negative age (clock skew) ⇒ MISSING-EVIDENCE (fail-closed)."""
+    valid = [a for a in ages if isinstance(a, (int, float))]
+    if not valid:
+        return MISSING_EVIDENCE
+    if any(a < 0 for a in valid):
+        return MISSING_EVIDENCE
+    return freshness_category(max(valid), stale_h, expired_h)
+
+
+def audit(machine: str | None = None, now: datetime | None = None) -> dict:
+    if now is None:
+        now = _now()
+    if machine is None:
+        import audit_skill_currency            # REUSE machine_label at call time (monkeypatchable)
+        machine = audit_skill_currency.machine_label()
+
+    surfaces: dict[str, dict] = {}
+    for key, rel in GIT_SURFACES.items():
+        surfaces[key] = _surface_record(_git_commit_iso(rel), "git-commit", now)
+    surfaces["hermes_memories"] = _surface_record(_hermes_mtime_iso(), "file-mtime", now)
+
+    present = [s for s in surfaces.values() if s["present"] and s["age_hours"] is not None]
+    worst_age = max((s["age_hours"] for s in present), default=None)        # oldest present surface
+    newest = min(present, key=lambda s: s["age_hours"], default=None)       # most-recently refreshed
+    newest_refresh = newest["refreshed_at"] if newest else None
+    freshness = categorize([s["age_hours"] for s in present])
+
+    return {
+        "machine": machine,
+        "audited_at": _iso(now),
+        "surfaces": surfaces,
+        "newest_refresh": newest_refresh,
+        "worst_age_hours": worst_age,
+        "freshness": freshness,
+        "schema_version": 1,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Cross-provider memory-freshness audit (#3255)")
+    ap.add_argument("--machine", default=None)
+    ap.add_argument("--stdout", action="store_true", help="print state JSON, do not write")
+    a = ap.parse_args(argv)
+    state = audit(a.machine)
+    machine = state["machine"]
+    if a.stdout:
+        print(json.dumps(state, indent=2))
+        return 0
+    STATE.mkdir(parents=True, exist_ok=True)
+    (STATE / f"memory-freshness-{machine}.json").write_text(json.dumps(state, indent=2) + "\n")
+    present = sum(1 for s in state["surfaces"].values() if s["present"])
+    print(f"audited {machine}: {present}/{len(state['surfaces'])} surfaces present, "
+          f"worst_age={state['worst_age_hours']}h, freshness={state['freshness']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/curation/audit_memory_freshness.py
+++ b/scripts/curation/audit_memory_freshness.py
@@ -142,8 +142,8 @@ def freshness_category(worst_age_hours, stale_h: float = MEMORY_STALE_H,
                        expired_h: float = MEMORY_EXPIRED_H) -> str:
     """Pure tier map for a single worst (oldest) age. None ⇒ MISSING-EVIDENCE; a negative age
     (future stamp ⇒ clock skew) ⇒ MISSING-EVIDENCE (fail-closed). Boundaries inclusive."""
-    if not isinstance(worst_age_hours, (int, float)):
-        return MISSING_EVIDENCE
+    if isinstance(worst_age_hours, bool) or not isinstance(worst_age_hours, (int, float)):
+        return MISSING_EVIDENCE          # bool is an int subclass — exclude it (matrix-parity)
     if worst_age_hours < 0:
         return MISSING_EVIDENCE
     if worst_age_hours <= stale_h:
@@ -157,7 +157,7 @@ def categorize(ages, stale_h: float = MEMORY_STALE_H, expired_h: float = MEMORY_
     """Pure facts→verdict: `ages` = the per-surface age_hours of the PRESENT surfaces. The OLDEST
     present surface dominates. Empty (no present surface proved a timestamp) ⇒ MISSING-EVIDENCE.
     Any negative age (clock skew) ⇒ MISSING-EVIDENCE (fail-closed)."""
-    valid = [a for a in ages if isinstance(a, (int, float))]
+    valid = [a for a in ages if isinstance(a, (int, float)) and not isinstance(a, bool)]
     if not valid:
         return MISSING_EVIDENCE
     if any(a < 0 for a in valid):

--- a/scripts/curation/curate-session-memory.ps1
+++ b/scripts/curation/curate-session-memory.ps1
@@ -106,6 +106,16 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     if ($LASTEXITCODE -ne 0) { Write-Warning 'skill-drift detect failed (soft)' }
 }
 
+# ── 1d. memory-freshness audit (#3255) — best-effort, after skill drift ──────
+$memFresh = (Join-Path $RepoRoot 'scripts/curation/audit_memory_freshness.py')
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    & uv run --no-project --with pyyaml python $memFresh
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'memory-freshness audit failed (soft)' }
+} elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    & python $memFresh
+    if ($LASTEXITCODE -ne 0) { Write-Warning 'memory-freshness audit failed (soft)' }
+}
+
 # ── 2. refresh THIS box's equality column (Windows collector + matrix build) ──
 $collector = (Join-Path $ScriptDir '..\readiness\collect-equality.ps1')
 & $collector

--- a/scripts/curation/curate-session-memory.sh
+++ b/scripts/curation/curate-session-memory.sh
@@ -45,6 +45,15 @@ elif command -v python3 >/dev/null 2>&1; then
   python3 "$SKILL_DRIFT" || echo "skill-drift detect failed (soft)" >&2
 fi
 
+# Audit memory freshness (#3255) — writes memory-freshness-<machine>.json for the memory_freshness
+# matrix cell. Best-effort; must not block the curation run.
+MEM_FRESH="$REPO_ROOT/scripts/curation/audit_memory_freshness.py"
+if command -v uv >/dev/null 2>&1; then
+  uv run --no-project --with pyyaml python "$MEM_FRESH" || echo "memory-freshness audit failed (soft)" >&2
+elif command -v python3 >/dev/null 2>&1; then
+  python3 "$MEM_FRESH" || echo "memory-freshness audit failed (soft)" >&2
+fi
+
 # Refresh this box's equality column so the freshness cell + render are current. The matrix
 # build is NOT optional — skipping it would freeze the rendered cell (weakening the dead-man's
 # switch) while still reporting pass. So fail loudly if no python can build it.

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -60,6 +60,12 @@ EXPECTED_DIVERGENCE_REASONS = {"external_skill_dirs_configured", "gemini_skill_d
 # age a dead curation past green (the dead-man's-switch). See schedule-tasks.yaml equality-matrix-refresh.
 CURATION_STALE_H = 12
 CURATION_EXPIRED_H = 24
+# Memory-freshness thresholds (#3255) — keep in sync with audit_memory_freshness.py
+# (MEMORY_STALE_H / MEMORY_EXPIRED_H). The daily bridge cadence = 1 missed run at 36h,
+# ~3 at 72h. Recomputed at BUILD time (worst surface age + time-since-audit) so a dead audit
+# ages the cell past green — the same dead-man's-switch as session_curation.
+MEMORY_STALE_H = 36
+MEMORY_EXPIRED_H = 72
 
 # #2851 freshness guard: a report whose origin/main ref hasn't been refreshed within this
 # many hours can't be trusted to have a meaningful behind_main, so we fail closed. repo-sync
@@ -265,6 +271,39 @@ def skill_currency_verdict(report: dict) -> str:
     return "SKILLS-CURRENT"
 
 
+# ── memory-freshness verdict (#3255) — recomputed vs now (dead-man's-switch) ──
+def memory_freshness_verdict(report: dict, now: datetime | None = None) -> str:
+    """Grade memory staleness from the audit's worst (oldest) surface age, RECOMPUTED at build
+    time: current_age = worst_age_hours + (now - audited_at). So a dead audit cron ages the cell
+    (the frozen state file can't stay falsely green). MEMORY-FRESH ≤36h / MEMORY-STALE ≤72h /
+    MEMORY-EXPIRED >72h. Fail-closed MISSING-EVIDENCE on missing/garbled/future evidence."""
+    mf = report.get("dimensions", {}).get("memory_freshness")
+    if not isinstance(mf, dict):
+        return "MISSING-EVIDENCE"
+    stamp = mf.get("audited_at")
+    worst = mf.get("worst_age_hours")
+    if not isinstance(stamp, str) or isinstance(worst, bool) or not isinstance(worst, (int, float)):
+        return "MISSING-EVIDENCE"
+    try:
+        ts = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return "MISSING-EVIDENCE"
+    now = now or datetime.now(timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    since_audit_h = (now - ts).total_seconds() / 3600.0
+    if since_audit_h < 0 or worst < 0:          # future stamp / negative age ⇒ untrustworthy
+        return "MISSING-EVIDENCE"
+    current_age = worst + since_audit_h
+    if current_age <= MEMORY_STALE_H:
+        return "MEMORY-FRESH"
+    if current_age <= MEMORY_EXPIRED_H:
+        return "MEMORY-STALE"
+    return "MEMORY-EXPIRED"
+
+
 # ── value extraction for uniform dims ────────────────────────────────────────
 def extract_value(dim: str, report: dict):
     d = report.get("dimensions", {})
@@ -372,6 +411,8 @@ def verdict_for(dim: str, machine: str, reports: dict, baselines: dict,
         return freshness_verdict(rep)
     if dim == "skill_currency":             # cross-provider skill-drift family — per-box facts
         return skill_currency_verdict(rep)
+    if dim == "memory_freshness":           # memory-staleness family — recomputed vs now
+        return memory_freshness_verdict(rep)
     if dim in COLD_DIMS:
         return cold_verdict(dim, rep, baselines.get(machine), probed_repos)
     # Stale peers are EXCLUDED from the uniform value list so a stale report can never
@@ -398,7 +439,7 @@ def load_reports() -> dict[str, dict]:
 
 BASE_DISPLAY_DIMS = ["compute", "data_access", "solvers", "harness", "python_cmd", "skills",
                      "kanban", "memory", "behavior", "scheduler", "session_curation",
-                     "skill_currency"]
+                     "skill_currency", "memory_freshness"]
 DISPLAY_DIMS = BASE_DISPLAY_DIMS + provider_rows()
 
 # ── render grouping (#2801 collapsible-rows enhancement) ─────────────────────
@@ -419,18 +460,19 @@ GROUPS = [
     ("provider", "Provider capability parity — per runtime", provider_rows()),
     ("curation", "Session analysis &amp; memory curation — daily freshness", ["session_curation"]),
     ("skills-currency", "Skill currency — all providers up to date vs canonical", ["skill_currency"]),
+    ("memory-freshness", "Memory freshness — memory surfaces refreshed recently", ["memory_freshness"]),
 ]
 
 # Worst-of severity for the collapsed group rollup. Higher = more operator attention.
 # A group's rollup cell shows the worst verdict among its dims for that machine; an
 # all-good group collapses to a single green "OK" so a clean box reads at a glance.
 ROLLUP_SEVERITY = {
-    "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6, "SKILLS-DRIFTED": 6,
-    "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5, "SKILLS-INDEX-STALE": 5,
+    "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6, "SKILLS-DRIFTED": 6, "MEMORY-EXPIRED": 6,
+    "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5, "SKILLS-INDEX-STALE": 5, "MEMORY-STALE": 5,
     "MISSING-EVIDENCE": 4, "PENDING": 4,
     "STALE-CHECKOUT": 3,
     "EXPECTED-DIFF": 1, "EXPECTED-DIVERGENCE": 1, "UNREACHABLE": 1, "ABSENT": 1,
-    "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0, "SKILLS-CURRENT": 0,
+    "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0, "SKILLS-CURRENT": 0, "MEMORY-FRESH": 0,
 }
 
 
@@ -448,7 +490,7 @@ def rollup_verdict(verdicts: list[str]) -> tuple[str, str]:
 # ── remediation playbook (verdict → action) — keep in sync with the verdict→fix table in
 #    .claude/skills/workspace-hub/ecosystem-equivalence-reconcile/SKILL.md + reconcile-ecosystem.sh
 OK_VERDICTS = {"CONFORMS", "EQUAL", "PARITY", "EXPECTED-DIFF", "EXPECTED-DIVERGENCE",
-               "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT"}
+               "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT", "MEMORY-FRESH"}
 
 
 def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
@@ -503,6 +545,9 @@ def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
     if verdict == "SKILLS-INDEX-STALE":
         return ("the skills index has dangling entries (paths no longer in the tree) — regenerate "
                 ".claude/skills-index.yaml (skills-curation cron / generator)", "this box", False)
+    if verdict in ("MEMORY-STALE", "MEMORY-EXPIRED"):
+        return ("memory surfaces are stale (>36h orange / >72h red) — run the memory bridge "
+                "(scripts/memory/bridge-hermes-claude.sh) or repair its cron", "this box", False)
     return ("investigate this cell's report", "operator", False)
 
 
@@ -621,8 +666,8 @@ def main() -> None:
 <title>Machine-Equality Matrix — #2801</title>
 <style>body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;max-width:1100px}}table{{border-collapse:collapse;width:100%}}
 th,td{{border:1px solid #ddd;padding:.4rem .6rem;font-size:.8rem;text-align:center}}thead th{{background:#2d3748;color:#fff}}
-tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh,.skills-current{{background:#c6f6d5}}.ok{{font-weight:700}}
-.below-baseline,.diverges,.curated-expired,.skills-drifted{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale{{background:#feebc8}}
+tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh,.skills-current,.memory-fresh{{background:#c6f6d5}}.ok{{font-weight:700}}
+.below-baseline,.diverges,.curated-expired,.skills-drifted,.memory-expired{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale,.memory-stale{{background:#feebc8}}
 .expected-diff,.expected-divergence{{background:#e9d8fd}}
 .pending,.missing-evidence{{background:#fffaf0}}.unreachable,.absent,.na{{background:#f7fafc;color:#a0aec0}}
 .stale-checkout{{background:#e2e8f0;color:#4a5568;font-style:italic}}
@@ -664,6 +709,7 @@ to refresh <i>every</i> active machine's report, then re-judge what genuinely di
 <span class="expected-diff">EXPECTED-DIFF / EXPECTED-DIVERGENCE</span><span class="stale-checkout">STALE-CHECKOUT</span>
 <span class="curated-fresh">CURATED-FRESH ≤12h</span><span class="curated-stale">CURATED-STALE &gt;12h</span><span class="curated-expired">CURATED-EXPIRED &gt;24h</span>
 <span class="skills-current">SKILLS-CURRENT</span><span class="skills-index-stale">SKILLS-INDEX-STALE</span><span class="skills-drifted">SKILLS-DRIFTED</span>
+<span class="memory-fresh">MEMORY-FRESH ≤36h</span><span class="memory-stale">MEMORY-STALE &gt;36h</span><span class="memory-expired">MEMORY-EXPIRED &gt;72h</span>
 <span class="absent">UNREACHABLE / ABSENT / n/a</span></p>
 <script>
 document.querySelectorAll('tr.grp').forEach(function(h){{

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -181,6 +181,21 @@ if [[ -f "$skc_file" ]] && have jq; then
   [[ "$_skd" =~ ^[0-9]+$ ]] && skc_dangling="$_skd"
 fi
 
+# ── 6d. MEMORY FRESHNESS — staleness of memory surfaces (#3255) ───────────────
+# References the audit state from scripts/curation/audit_memory_freshness.py (never re-runs it).
+# audited_at null / worst_age_hours null -> matrix grades MISSING-EVIDENCE. worst_age_hours stays
+# in the canonical payload so a refreshed audit forces a rewrite.
+mf_file="${STATE_DIR}/memory-freshness-${MACHINE}.json"
+mf_audited="null"; mf_worst="null"; mf_fresh="null"
+if [[ -f "$mf_file" ]] && have jq; then
+  _mfa=$(jq -r '.audited_at // empty' "$mf_file" 2>/dev/null)
+  [[ -n "$_mfa" ]] && mf_audited="\"$(yesc "$_mfa")\""
+  _mfw=$(jq -r 'if (.worst_age_hours|type)=="number" then .worst_age_hours else "null" end' "$mf_file" 2>/dev/null)
+  [[ "$_mfw" =~ ^[0-9]+(\.[0-9]+)?$ ]] && mf_worst="$_mfw"
+  _mff=$(jq -r '.freshness // empty' "$mf_file" 2>/dev/null)
+  [[ -n "$_mff" ]] && mf_fresh="\"$(yesc "$_mff")\""
+fi
+
 # ── 7. BEHAVIOR — deterministic, SANDBOXED probe corpus (DG4/DC1) ────────────
 # CC3: guard mktemp (never let SBX become /sbx → rm -rf /). GC4: trap-based cleanup.
 SBX_PARENT="$(mktemp -d 2>/dev/null)" || { echo "mktemp failed" >&2; exit 1; }
@@ -387,6 +402,10 @@ ${provider_harness_yaml}
     codex_present: ${skc_cp}
     hermes_present: ${skc_hp}
     index_dangling: ${skc_dangling}
+  memory_freshness:
+    audited_at: ${mf_audited}
+    worst_age_hours: ${mf_worst}
+    freshness: ${mf_fresh}
 YAML
 FULL="generated_at: \"${RUN_TS}\""$'\n'"${BODY}"
 

--- a/scripts/readiness/reconcile-ecosystem.sh
+++ b/scripts/readiness/reconcile-ecosystem.sh
@@ -201,7 +201,7 @@ equality_plan() {
     local dim verdict; dim=$(printf '%s' "$line" | sed -E 's/^"([^"]+)".*/\1/')
     verdict=$(printf '%s' "$line" | sed -E 's/.*"([A-Z-]+)"$/\1/')
     case "$verdict" in
-      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT|CURATED-FRESH|SKILLS-CURRENT) continue ;;
+      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT|CURATED-FRESH|SKILLS-CURRENT|MEMORY-FRESH) continue ;;
     esac
     case "$verdict" in
       STALE-CHECKOUT)

--- a/tests/curation/test_audit_memory_freshness.py
+++ b/tests/curation/test_audit_memory_freshness.py
@@ -1,0 +1,212 @@
+"""TDD tests for #3255 — the memory-freshness audit engine (epic #3248).
+
+Targets scripts/curation/audit_memory_freshness.py: the pure verdict tiers (freshness_category /
+categorize) and the audit() fact-emitter. The git `git log` runner (`_git_commit_iso`) is
+monkeypatched everywhere so the suite never depends on real repo history; one regression test
+proves the bridged surfaces take their clock from the git commit time, NOT file mtime.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "curation" / "audit_memory_freshness.py"
+
+spec = importlib.util.spec_from_file_location("audit_memory_freshness", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+amf = importlib.util.module_from_spec(spec)
+sys.modules["audit_memory_freshness"] = amf
+spec.loader.exec_module(amf)
+
+NOW = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso_ago(hours: float) -> str:
+    return (NOW - timedelta(hours=hours)).isoformat(timespec="seconds")
+
+
+# ── pure verdict: freshness_category (single worst age) ──────────────────────────────────────────
+def test_fresh_at_1h():
+    assert amf.freshness_category(1) == "MEMORY-FRESH"
+
+
+def test_fresh_at_exactly_36h_boundary_inclusive():
+    assert amf.freshness_category(36) == "MEMORY-FRESH"
+
+
+def test_stale_at_36_5h():
+    assert amf.freshness_category(36.5) == "MEMORY-STALE"
+
+
+def test_stale_at_exactly_72h_boundary_inclusive():
+    assert amf.freshness_category(72) == "MEMORY-STALE"
+
+
+def test_expired_at_73h():
+    assert amf.freshness_category(73) == "MEMORY-EXPIRED"
+
+
+def test_category_none_is_missing_evidence():
+    assert amf.freshness_category(None) == "MISSING-EVIDENCE"
+
+
+def test_category_negative_is_missing_evidence():
+    assert amf.freshness_category(-3) == "MISSING-EVIDENCE"
+
+
+# ── pure verdict: categorize (list of present ages) ──────────────────────────────────────────────
+def test_worst_surface_dominates():
+    # one fresh (1h) + one expired (80h) ⇒ the oldest drives the verdict
+    assert amf.categorize([1, 80]) == "MEMORY-EXPIRED"
+
+
+def test_absent_surface_ignored():
+    # only the present surface (1h) is in the list ⇒ fresh
+    assert amf.categorize([1]) == "MEMORY-FRESH"
+
+
+def test_missing_evidence_no_present_surface():
+    assert amf.categorize([]) == "MISSING-EVIDENCE"
+
+
+def test_missing_evidence_future_stamp_failclosed():
+    # a future stamp anywhere (clock skew) fails the whole verdict closed
+    assert amf.categorize([1, -3, 50]) == "MISSING-EVIDENCE"
+
+
+def test_categorize_ignores_non_numeric():
+    assert amf.categorize([None, "x"]) == "MISSING-EVIDENCE"
+
+
+# ── audit() fact-emitter (git runner monkeypatched) ──────────────────────────────────────────────
+def _patch_git(monkeypatch, mapping):
+    """mapping: {rel_path: iso|None}; unmapped paths return None (fail-closed)."""
+    monkeypatch.setattr(amf, "_git_commit_iso", lambda rel: mapping.get(rel))
+
+
+def test_audit_all_git_surfaces_fresh(monkeypatch, tmp_path):
+    mapping = {rel: _iso_ago(2) for rel in amf.GIT_SURFACES.values()}
+    _patch_git(monkeypatch, mapping)
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")  # absent hermes
+    state = amf.audit(machine="dev-primary", now=NOW)
+    assert state["machine"] == "dev-primary"
+    assert state["freshness"] == "MEMORY-FRESH"
+    assert state["surfaces"]["context_md"]["present"] is True
+    assert state["surfaces"]["context_md"]["signal"] == "git-commit"
+    assert abs(state["surfaces"]["context_md"]["age_hours"] - 2.0) < 1e-6
+    assert state["surfaces"]["hermes_memories"]["present"] is False
+    assert state["worst_age_hours"] is not None
+
+
+def test_audit_worst_surface_drives_freshness(monkeypatch, tmp_path):
+    mapping = {
+        ".claude/memory/context.md": _iso_ago(1),
+        ".claude/memory/agents.md": _iso_ago(1),
+        "config/agents/codex/MEMORY.runtime.md": _iso_ago(1),
+        "config/agents/gemini/MEMORY.runtime.md": _iso_ago(80),  # stale provider runtime
+    }
+    _patch_git(monkeypatch, mapping)
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    state = amf.audit(machine="m", now=NOW)
+    assert state["freshness"] == "MEMORY-EXPIRED"
+    assert abs(state["worst_age_hours"] - 80.0) < 1e-6
+    # newest_refresh is the most-recently refreshed present surface (the 1h ones)
+    assert state["newest_refresh"] == _iso_ago(1)
+
+
+def test_audit_git_unavailable_failcloses(monkeypatch, tmp_path):
+    # git missing / not-a-repo ⇒ runner returns None ⇒ every bridged surface absent
+    monkeypatch.setattr(amf, "_git_commit_iso", lambda rel: None)
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    state = amf.audit(machine="m", now=NOW)
+    for key in amf.GIT_SURFACES:
+        assert state["surfaces"][key]["present"] is False
+    assert state["freshness"] == "MISSING-EVIDENCE"
+    assert state["worst_age_hours"] is None
+
+
+def test_audit_bridged_surface_uses_git_commit_not_mtime(monkeypatch, tmp_path):
+    """CORE must-fix #1: the freshness clock for a git-bridged surface is the git COMMIT time,
+    immune to a freshly-bumped file mtime. We feed an OLD commit iso through the runner; the audit
+    must report exactly that old stamp (signal git-commit), never a 'now' mtime."""
+    old = _iso_ago(100)
+    _patch_git(monkeypatch, {rel: old for rel in amf.GIT_SURFACES.values()})
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    state = amf.audit(machine="m", now=NOW)
+    rec = state["surfaces"]["context_md"]
+    assert rec["refreshed_at"] == old
+    assert rec["signal"] == "git-commit"
+    assert state["freshness"] == "MEMORY-EXPIRED"  # 100h > 72h, NOT fresh-from-mtime
+
+
+def test_audit_hermes_surface_uses_local_mtime(monkeypatch, tmp_path):
+    # local (non-git) surface: freshness clock = real file mtime
+    hdir = tmp_path / "hermes"
+    hdir.mkdir()
+    f = hdir / "MEMORY.md"
+    f.write_text("x")
+    target = NOW - timedelta(hours=5)
+    import os
+    os.utime(f, (target.timestamp(), target.timestamp()))
+    monkeypatch.setattr(amf, "HERMES_DIR", hdir)
+    monkeypatch.setattr(amf, "_git_commit_iso", lambda rel: None)  # isolate hermes
+    state = amf.audit(machine="m", now=NOW)
+    rec = state["surfaces"]["hermes_memories"]
+    assert rec["present"] is True
+    assert rec["signal"] == "file-mtime"
+    assert abs(rec["age_hours"] - 5.0) < 0.01
+    assert state["freshness"] == "MEMORY-FRESH"
+
+
+def test_audit_hermes_absent_marked(monkeypatch, tmp_path):
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "absent")
+    _patch_git(monkeypatch, {rel: _iso_ago(1) for rel in amf.GIT_SURFACES.values()})
+    state = amf.audit(machine="m", now=NOW)
+    assert state["surfaces"]["hermes_memories"]["present"] is False
+
+
+def test_audit_machine_label_reused(monkeypatch, tmp_path):
+    # machine label comes from audit_skill_currency.machine_label, not a re-impl
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "curation"))
+    import audit_skill_currency
+    monkeypatch.setattr(audit_skill_currency, "machine_label", lambda: "fake-box")
+    monkeypatch.setattr(amf, "_git_commit_iso", lambda rel: None)
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    state = amf.audit(now=NOW)  # machine=None ⇒ derives via reused label
+    assert state["machine"] == "fake-box"
+
+
+def test_audit_emits_no_abs_paths_and_iso_stamps(monkeypatch, tmp_path):
+    _patch_git(monkeypatch, {rel: _iso_ago(3) for rel in amf.GIT_SURFACES.values()})
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    state = amf.audit(machine="m", now=NOW)
+    blob = json.dumps(state)
+    assert "/mnt/" not in blob and str(REPO_ROOT) not in blob  # abs-path-allowed
+    # every present surface's refreshed_at parses as ISO
+    for s in state["surfaces"].values():
+        if s["present"]:
+            assert amf._parse_iso(s["refreshed_at"]) is not None
+    assert state["schema_version"] == 1
+
+
+def test_audit_writes_state_file(monkeypatch, tmp_path):
+    _patch_git(monkeypatch, {rel: _iso_ago(1) for rel in amf.GIT_SURFACES.values()})
+    monkeypatch.setattr(amf, "HERMES_DIR", tmp_path / "nope")
+    monkeypatch.setattr(amf, "STATE", tmp_path / "state")
+    monkeypatch.setattr(amf, "_now", lambda: NOW)
+    rc = amf.main(["--machine", "boxx"])
+    assert rc == 0
+    out = tmp_path / "state" / "memory-freshness-boxx.json"
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["machine"] == "boxx"
+    assert data["freshness"] == "MEMORY-FRESH"
+
+
+def test_thresholds_documented_constants():
+    assert amf.MEMORY_STALE_H == 36
+    assert amf.MEMORY_EXPIRED_H == 72

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -98,3 +98,7 @@ dimensions:
     codex_present: true
     hermes_present: true
     index_dangling: 0
+  memory_freshness:
+    audited_at: "2026-05-30T03:55:12+00:00"
+    worst_age_hours: 8.5
+    freshness: MEMORY-FRESH

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -59,7 +59,7 @@ def _win1_baseline() -> dict:
 # ════════════════════════════════════════════════════════════════════════════
 EXPECTED_DIMS = {"compute", "data_access", "solvers", "harness", "skills",
                  "kanban", "memory", "behavior", "scheduler", "provider_harness",
-                 "session_curation", "skill_currency"}
+                 "session_curation", "skill_currency", "memory_freshness"}
 
 
 def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
@@ -70,7 +70,7 @@ def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
     # provenance block present with the freshness fields is_stale() consumes
     p = d["provenance"]
     assert set(p) >= {"checkout_sha", "dirty", "behind_main", "ahead_main", "origin_ref_age_h"}
-    # all 12 dimensions present (session_curation added in the #2816 follow-on)
+    # all 13 dimensions present (session_curation added in the #2816 follow-on)
     assert set(d["dimensions"]) == EXPECTED_DIMS
     ph = d["dimensions"]["provider_harness"]
     assert ph["schema_version"] == 1

--- a/tests/readiness/test_memory_freshness_verdict.py
+++ b/tests/readiness/test_memory_freshness_verdict.py
@@ -1,0 +1,88 @@
+"""TDD tests for #3255 — memory_freshness matrix verdict (epic #3248).
+
+Targets build_equality_matrix.memory_freshness_verdict, which RECOMPUTES staleness at build time
+(worst surface age + time since the audit) so a dead audit cron ages the cell — the same
+dead-man's-switch as session_curation. Uses a fixed `now` for determinism.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "readiness" / "build-equality-matrix.py"
+
+spec = importlib.util.spec_from_file_location("build_equality_matrix", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+bem = importlib.util.module_from_spec(spec)
+sys.modules["build_equality_matrix"] = bem
+spec.loader.exec_module(bem)
+
+NOW = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _rep(audited="2026-06-26T12:00:00+00:00", worst=0.0) -> dict:
+    return {"dimensions": {"memory_freshness": {"audited_at": audited, "worst_age_hours": worst}}}
+
+
+# ── recompute: current_age = worst_age + (now - audited) ──
+def test_fresh_when_recent():
+    assert bem.memory_freshness_verdict(_rep(worst=10.0), now=NOW) == "MEMORY-FRESH"
+
+
+def test_fresh_at_threshold():
+    assert bem.memory_freshness_verdict(_rep(worst=36.0), now=NOW) == "MEMORY-FRESH"
+
+
+def test_stale_past_36h():
+    assert bem.memory_freshness_verdict(_rep(worst=40.0), now=NOW) == "MEMORY-STALE"
+
+
+def test_stale_at_72h():
+    assert bem.memory_freshness_verdict(_rep(worst=72.0), now=NOW) == "MEMORY-STALE"
+
+
+def test_expired_past_72h():
+    assert bem.memory_freshness_verdict(_rep(worst=100.0), now=NOW) == "MEMORY-EXPIRED"
+
+
+def test_dead_audit_ages_the_cell():
+    # audit ran 50h ago (2026-06-24T10:00 → 2026-06-26T12:00) reporting worst=10h → current age
+    # 60h → STALE (the dead-man's-switch: the frozen state file can't stay falsely green)
+    assert bem.memory_freshness_verdict(
+        _rep(audited="2026-06-24T10:00:00+00:00", worst=10.0), now=NOW) == "MEMORY-STALE"
+
+
+# ── fail-closed ──
+def test_missing_dimension():
+    assert bem.memory_freshness_verdict({"dimensions": {}}, now=NOW) == "MISSING-EVIDENCE"
+
+
+def test_non_dict():
+    for bad in ("x", 1, None, ["a"]):
+        assert bem.memory_freshness_verdict({"dimensions": {"memory_freshness": bad}}, now=NOW) == "MISSING-EVIDENCE"
+
+
+def test_missing_or_garbled_fields():
+    assert bem.memory_freshness_verdict({"dimensions": {"memory_freshness": {"worst_age_hours": 1.0}}}, now=NOW) == "MISSING-EVIDENCE"
+    assert bem.memory_freshness_verdict({"dimensions": {"memory_freshness": {"audited_at": "2026-06-26T12:00:00+00:00"}}}, now=NOW) == "MISSING-EVIDENCE"
+    assert bem.memory_freshness_verdict(_rep(audited="nope", worst=1.0), now=NOW) == "MISSING-EVIDENCE"
+    assert bem.memory_freshness_verdict(_rep(worst=True), now=NOW) == "MISSING-EVIDENCE"  # bool not a number
+
+
+def test_future_or_negative_failclosed():
+    assert bem.memory_freshness_verdict(_rep(audited="2026-06-26T18:00:00+00:00", worst=1.0), now=NOW) == "MISSING-EVIDENCE"
+    assert bem.memory_freshness_verdict(_rep(worst=-5.0), now=NOW) == "MISSING-EVIDENCE"
+
+
+# ── wiring ──
+def test_wiring():
+    assert "memory_freshness" in bem.BASE_DISPLAY_DIMS
+    assert "memory_freshness" in bem.DISPLAY_DIMS
+    assert "MEMORY-FRESH" in bem.OK_VERDICTS
+    groups = {g[0]: g for g in bem.GROUPS}
+    assert groups["memory-freshness"][2] == ["memory_freshness"]
+    sev = bem.ROLLUP_SEVERITY
+    assert sev["MEMORY-EXPIRED"] > sev["MEMORY-STALE"] > sev["MEMORY-FRESH"] == 0

--- a/tests/readiness/test_memory_freshness_verdict.py
+++ b/tests/readiness/test_memory_freshness_verdict.py
@@ -77,6 +77,17 @@ def test_future_or_negative_failclosed():
     assert bem.memory_freshness_verdict(_rep(worst=-5.0), now=NOW) == "MISSING-EVIDENCE"
 
 
+# ── threshold-drift guard: the engine + matrix duplicate MEMORY_STALE_H/EXPIRED_H ──
+def test_thresholds_in_sync_with_engine():
+    eng_path = REPO_ROOT / "scripts" / "curation" / "audit_memory_freshness.py"
+    espec = importlib.util.spec_from_file_location("audit_memory_freshness", eng_path)
+    eng = importlib.util.module_from_spec(espec)
+    sys.modules["audit_memory_freshness"] = eng
+    espec.loader.exec_module(eng)
+    assert eng.MEMORY_STALE_H == bem.MEMORY_STALE_H
+    assert eng.MEMORY_EXPIRED_H == bem.MEMORY_EXPIRED_H
+
+
 # ── wiring ──
 def test_wiring():
     assert "memory_freshness" in bem.BASE_DISPLAY_DIMS


### PR DESCRIPTION
Closes #3255 (epic #3248). New memory_freshness cell grading whether memory surfaces are being refreshed.

- audit_memory_freshness.py grades 5 surfaces: 4 git-bridged via **git-log %cI commit time (survives checkout — NOT mtime)** + the non-git ~/.hermes via mtime.
- Matrix verdict **recomputes** staleness at build time (worst age + time-since-audit) → dead-man's-switch (a dead audit ages the cell). MEMORY-FRESH <=36h / STALE <=72h / EXPIRED >72h; fail-closed.
- Wired both wrappers (.sh + .ps1 Write-Warning soft-fail), collect emit, fixture+EXPECTED_DIMS->13, reconcile OK-skip.

Both gates: plan adversarially reviewed (2 rounds); code adversarially reviewed (APPROVE-WITH-CHANGES — math verified against the live artifact incl. mixed-TZ; 2 nits folded). 420 readiness+curation tests green.