### PR TITLE
feat(equivalence): skill-link-health matrix line item (#3251)

### DIFF
--- a/.claude/state/skill-link-health-dev-primary.json
+++ b/.claude/state/skill-link-health-dev-primary.json
@@ -1,0 +1,16 @@
+{
+  "machine": "dev-primary",
+  "audited_at": "2026-06-27T00:20:21+00:00",
+  "platform": "unix",
+  "repos_total": 14,
+  "healthy": 16,
+  "missing": 12,
+  "dangling": 0,
+  "flattened": 0,
+  "modified_real_dir": 0,
+  "template_absent": 14,
+  "repairable": 12,
+  "unexpected_missing_repos": ["CAD-DEVELOPMENTS", "deckhand", "deckhand-live", "llm-wiki", "sabithaandkrishnaestates", "worldenergydata"],
+  "worst_state": "MISSING",
+  "schema_version": 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ data/document-index/*.jsonl.backup-*
 !.claude/state/skill-currency-*.json
 !.claude/state/skill-drift-*.json
 !.claude/state/memory-freshness-*.json
+!.claude/state/skill-link-health-*.json
 !.claude/state/reflect-history/
 !.claude/state/trends/
 !.claude/state/session-signals/

--- a/scripts/curation/curate-session-memory.ps1
+++ b/scripts/curation/curate-session-memory.ps1
@@ -116,6 +116,17 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     if ($LASTEXITCODE -ne 0) { Write-Warning 'memory-freshness audit failed (soft)' }
 }
 
+# ── 1e. skill-link-health audit (#3251) — BASH engine via Git Bash; best-effort ──
+# resync-skill-links.sh is bash; invoke it through the resolved Git Bash. If Git Bash is absent the
+# skill_link_health cell stays MISSING-EVIDENCE (honest scoping — no silent green).
+$bashForSkills = Resolve-GitBash
+if ($null -ne $bashForSkills) {
+    $resync = (Join-Path $RepoRoot 'scripts/skills/resync-skill-links.sh') -replace '\\', '/'
+    try { & $bashForSkills $resync 2>$null | Out-Null } catch { Write-Warning 'skill-link-health audit failed (soft)' }
+} else {
+    Write-Warning 'skill-link-health audit skipped — Git Bash not found'
+}
+
 # ── 2. refresh THIS box's equality column (Windows collector + matrix build) ──
 $collector = (Join-Path $ScriptDir '..\readiness\collect-equality.ps1')
 & $collector

--- a/scripts/curation/curate-session-memory.sh
+++ b/scripts/curation/curate-session-memory.sh
@@ -54,6 +54,10 @@ elif command -v python3 >/dev/null 2>&1; then
   python3 "$MEM_FRESH" || echo "memory-freshness audit failed (soft)" >&2
 fi
 
+# Audit shared-skill-link health (#3251) — report-only; writes skill-link-health-<machine>.json for
+# the skill_link_health matrix cell. Best-effort; the default mode mutates nothing.
+bash "$REPO_ROOT/scripts/skills/resync-skill-links.sh" || echo "skill-link-health audit failed (soft)" >&2
+
 # Refresh this box's equality column so the freshness cell + render are current. The matrix
 # build is NOT optional — skipping it would freeze the rendered cell (weakening the dead-man's
 # switch) while still reporting pass. So fail loudly if no python can build it.

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -314,6 +314,9 @@ def skill_link_health_verdict(report: dict) -> str:
         return "MISSING-EVIDENCE"
     if not isinstance(slh.get("audited_at"), str):
         return "MISSING-EVIDENCE"
+    repos = slh.get("repos_total")
+    if isinstance(repos, bool) or not isinstance(repos, int) or repos <= 0:
+        return "MISSING-EVIDENCE"        # nothing discovered ⇒ no evidence, NOT silently 'healthy'
     repairable = slh.get("repairable")
     if isinstance(repairable, bool) or not isinstance(repairable, int):
         return "MISSING-EVIDENCE"

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -304,6 +304,22 @@ def memory_freshness_verdict(report: dict, now: datetime | None = None) -> str:
     return "MEMORY-EXPIRED"
 
 
+# ── skill-link-health verdict (#3251) — are shared-skill links propagated? ───
+def skill_link_health_verdict(report: dict) -> str:
+    """Map the resync-skill-links.sh facts to a verdict: SKILL-LINKS-DRIFTED when any shared-skill
+    link is repairable (dangling/flattened/missing) on a real ecosystem clone — propagate-ecosystem
+    needs re-running — else SKILL-LINKS-OK. Fail-closed MISSING-EVIDENCE on missing/garbled facts."""
+    slh = report.get("dimensions", {}).get("skill_link_health")
+    if not isinstance(slh, dict):
+        return "MISSING-EVIDENCE"
+    if not isinstance(slh.get("audited_at"), str):
+        return "MISSING-EVIDENCE"
+    repairable = slh.get("repairable")
+    if isinstance(repairable, bool) or not isinstance(repairable, int):
+        return "MISSING-EVIDENCE"
+    return "SKILL-LINKS-DRIFTED" if repairable > 0 else "SKILL-LINKS-OK"
+
+
 # ── value extraction for uniform dims ────────────────────────────────────────
 def extract_value(dim: str, report: dict):
     d = report.get("dimensions", {})
@@ -413,6 +429,8 @@ def verdict_for(dim: str, machine: str, reports: dict, baselines: dict,
         return skill_currency_verdict(rep)
     if dim == "memory_freshness":           # memory-staleness family — recomputed vs now
         return memory_freshness_verdict(rep)
+    if dim == "skill_link_health":          # shared-skill-link propagation — per-box facts
+        return skill_link_health_verdict(rep)
     if dim in COLD_DIMS:
         return cold_verdict(dim, rep, baselines.get(machine), probed_repos)
     # Stale peers are EXCLUDED from the uniform value list so a stale report can never
@@ -439,7 +457,7 @@ def load_reports() -> dict[str, dict]:
 
 BASE_DISPLAY_DIMS = ["compute", "data_access", "solvers", "harness", "python_cmd", "skills",
                      "kanban", "memory", "behavior", "scheduler", "session_curation",
-                     "skill_currency", "memory_freshness"]
+                     "skill_currency", "memory_freshness", "skill_link_health"]
 DISPLAY_DIMS = BASE_DISPLAY_DIMS + provider_rows()
 
 # ── render grouping (#2801 collapsible-rows enhancement) ─────────────────────
@@ -461,6 +479,7 @@ GROUPS = [
     ("curation", "Session analysis &amp; memory curation — daily freshness", ["session_curation"]),
     ("skills-currency", "Skill currency — all providers up to date vs canonical", ["skill_currency"]),
     ("memory-freshness", "Memory freshness — memory surfaces refreshed recently", ["memory_freshness"]),
+    ("skill-links", "Skill-link health — shared skills propagated to ecosystem repos", ["skill_link_health"]),
 ]
 
 # Worst-of severity for the collapsed group rollup. Higher = more operator attention.
@@ -469,10 +488,12 @@ GROUPS = [
 ROLLUP_SEVERITY = {
     "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6, "SKILLS-DRIFTED": 6, "MEMORY-EXPIRED": 6,
     "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5, "SKILLS-INDEX-STALE": 5, "MEMORY-STALE": 5,
+    "SKILL-LINKS-DRIFTED": 5,
     "MISSING-EVIDENCE": 4, "PENDING": 4,
     "STALE-CHECKOUT": 3,
     "EXPECTED-DIFF": 1, "EXPECTED-DIVERGENCE": 1, "UNREACHABLE": 1, "ABSENT": 1,
     "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0, "SKILLS-CURRENT": 0, "MEMORY-FRESH": 0,
+    "SKILL-LINKS-OK": 0,
 }
 
 
@@ -490,7 +511,8 @@ def rollup_verdict(verdicts: list[str]) -> tuple[str, str]:
 # ── remediation playbook (verdict → action) — keep in sync with the verdict→fix table in
 #    .claude/skills/workspace-hub/ecosystem-equivalence-reconcile/SKILL.md + reconcile-ecosystem.sh
 OK_VERDICTS = {"CONFORMS", "EQUAL", "PARITY", "EXPECTED-DIFF", "EXPECTED-DIVERGENCE",
-               "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT", "MEMORY-FRESH"}
+               "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT", "MEMORY-FRESH",
+               "SKILL-LINKS-OK"}
 
 
 def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
@@ -548,6 +570,10 @@ def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
     if verdict in ("MEMORY-STALE", "MEMORY-EXPIRED"):
         return ("memory surfaces are stale (>36h orange / >72h red) — run the memory bridge "
                 "(scripts/memory/bridge-hermes-claude.sh) or repair its cron", "this box", False)
+    if verdict == "SKILL-LINKS-DRIFTED":
+        return ("shared-skill links are missing/broken on ecosystem repos (froze at link time) — "
+                "re-sync via scripts/skills/resync-skill-links.sh --apply (or propagate-ecosystem.sh "
+                "--skills-only)", "this box", False)
     return ("investigate this cell's report", "operator", False)
 
 
@@ -667,7 +693,7 @@ def main() -> None:
 <style>body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;max-width:1100px}}table{{border-collapse:collapse;width:100%}}
 th,td{{border:1px solid #ddd;padding:.4rem .6rem;font-size:.8rem;text-align:center}}thead th{{background:#2d3748;color:#fff}}
 tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh,.skills-current,.memory-fresh{{background:#c6f6d5}}.ok{{font-weight:700}}
-.below-baseline,.diverges,.curated-expired,.skills-drifted,.memory-expired{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale,.memory-stale{{background:#feebc8}}
+.below-baseline,.diverges,.curated-expired,.skills-drifted,.memory-expired{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale,.memory-stale,.skill-links-drifted{{background:#feebc8}}.skill-links-ok{{background:#c6f6d5}}
 .expected-diff,.expected-divergence{{background:#e9d8fd}}
 .pending,.missing-evidence{{background:#fffaf0}}.unreachable,.absent,.na{{background:#f7fafc;color:#a0aec0}}
 .stale-checkout{{background:#e2e8f0;color:#4a5568;font-style:italic}}
@@ -710,6 +736,7 @@ to refresh <i>every</i> active machine's report, then re-judge what genuinely di
 <span class="curated-fresh">CURATED-FRESH ≤12h</span><span class="curated-stale">CURATED-STALE &gt;12h</span><span class="curated-expired">CURATED-EXPIRED &gt;24h</span>
 <span class="skills-current">SKILLS-CURRENT</span><span class="skills-index-stale">SKILLS-INDEX-STALE</span><span class="skills-drifted">SKILLS-DRIFTED</span>
 <span class="memory-fresh">MEMORY-FRESH ≤36h</span><span class="memory-stale">MEMORY-STALE &gt;36h</span><span class="memory-expired">MEMORY-EXPIRED &gt;72h</span>
+<span class="skill-links-ok">SKILL-LINKS-OK</span><span class="skill-links-drifted">SKILL-LINKS-DRIFTED</span>
 <span class="absent">UNREACHABLE / ABSENT / n/a</span></p>
 <script>
 document.querySelectorAll('tr.grp').forEach(function(h){{

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -196,6 +196,21 @@ if [[ -f "$mf_file" ]] && have jq; then
   [[ -n "$_mff" ]] && mf_fresh="\"$(yesc "$_mff")\""
 fi
 
+# ── 6e. SKILL-LINK HEALTH — shared-skill links propagated to ecosystem repos (#3251) ──
+# References resync-skill-links.sh state (never re-runs it). Missing/garbled -> null/0 -> the matrix
+# grades MISSING-EVIDENCE. repairable stays in the canonical payload so a fresh audit forces a rewrite.
+slh_file="${STATE_DIR}/skill-link-health-${MACHINE}.json"
+slh_audited="null"; slh_repos=0; slh_healthy=0; slh_repairable=0; slh_worst="null"
+if [[ -f "$slh_file" ]] && have jq; then
+  _sla=$(jq -r '.audited_at // empty' "$slh_file" 2>/dev/null)
+  [[ -n "$_sla" ]] && slh_audited="\"$(yesc "$_sla")\""
+  slh_repos=$(jq -r '.repos_total // 0' "$slh_file" 2>/dev/null); [[ "$slh_repos" =~ ^[0-9]+$ ]] || slh_repos=0
+  slh_healthy=$(jq -r '.healthy // 0' "$slh_file" 2>/dev/null); [[ "$slh_healthy" =~ ^[0-9]+$ ]] || slh_healthy=0
+  slh_repairable=$(jq -r '.repairable // 0' "$slh_file" 2>/dev/null); [[ "$slh_repairable" =~ ^[0-9]+$ ]] || slh_repairable=0
+  _slw=$(jq -r '.worst_state // empty' "$slh_file" 2>/dev/null)
+  [[ -n "$_slw" ]] && slh_worst="\"$(yesc "$_slw")\""
+fi
+
 # ── 7. BEHAVIOR — deterministic, SANDBOXED probe corpus (DG4/DC1) ────────────
 # CC3: guard mktemp (never let SBX become /sbx → rm -rf /). GC4: trap-based cleanup.
 SBX_PARENT="$(mktemp -d 2>/dev/null)" || { echo "mktemp failed" >&2; exit 1; }
@@ -406,6 +421,12 @@ ${provider_harness_yaml}
     audited_at: ${mf_audited}
     worst_age_hours: ${mf_worst}
     freshness: ${mf_fresh}
+  skill_link_health:
+    audited_at: ${slh_audited}
+    repos_total: ${slh_repos}
+    healthy: ${slh_healthy}
+    repairable: ${slh_repairable}
+    worst_state: ${slh_worst}
 YAML
 FULL="generated_at: \"${RUN_TS}\""$'\n'"${BODY}"
 

--- a/scripts/readiness/reconcile-ecosystem.sh
+++ b/scripts/readiness/reconcile-ecosystem.sh
@@ -201,7 +201,7 @@ equality_plan() {
     local dim verdict; dim=$(printf '%s' "$line" | sed -E 's/^"([^"]+)".*/\1/')
     verdict=$(printf '%s' "$line" | sed -E 's/.*"([A-Z-]+)"$/\1/')
     case "$verdict" in
-      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT|CURATED-FRESH|SKILLS-CURRENT|MEMORY-FRESH) continue ;;
+      CONFORMS|EQUAL|PARITY|EXPECTED-DIFF|EXPECTED-DIVERGENCE|UNREACHABLE|ABSENT|CURATED-FRESH|SKILLS-CURRENT|MEMORY-FRESH|SKILL-LINKS-OK) continue ;;
     esac
     case "$verdict" in
       STALE-CHECKOUT)

--- a/scripts/skills/resync-skill-links.sh
+++ b/scripts/skills/resync-skill-links.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# resync-skill-links.sh — verify (REPORT, default) + guard-gated re-sync (--apply) of the
+# shared-skill links propagate-ecosystem.sh creates across ecosystem repos (#3251, epic #3248).
+#
+# REPORT mode (default) mutates NOTHING. It re-discovers every ecosystem repo (nested + flat-sibling
+# layouts) and classifies each shared-skill link's WORKING-TREE state into one of:
+#   HEALTHY            — link resolves to the canonical _internal/<dir> template
+#   DANGLING           — symlink present but target unresolved / wrong (rotted link)
+#   FLATTENED          — symlink materialized as a regular text file (Windows core.symlinks=false)
+#   MISSING            — nothing there (new repo / never propagated)
+#   MODIFIED-REAL-DIR  — a real dir whose content diverges from the template (benign, never auto-fixed)
+#   TEMPLATE-ABSENT    — a SHARED_SKILL_DIRS entry with no _internal/<dir> template (surfaced, not healthy)
+# It writes .claude/state/skill-link-health-<machine>.json with per-state COUNTS + a worst_state.
+#
+# --apply (guard-gated) re-propagates the repairable cells via propagate-ecosystem.sh --skills-only.
+#
+# Working-tree basis (NOT git tree): the shared dirs are gitignored, so link health can only be
+# assessed against the filesystem.
+#
+# Usage: bash scripts/skills/resync-skill-links.sh [--apply] [--dry-run] [--only <repo>]
+#                                                  [--machine <label>] [--json] [--verbose]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# WORKSPACE_HUB env override is the test seam (sandbox); else resolve from the script location.
+WS_HUB="${WORKSPACE_HUB:-$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)}"
+STATE_DIR="$WS_HUB/.claude/state"
+INTERNAL_DIR="$WS_HUB/.claude/skills/_internal"
+PROPAGATE="$WS_HUB/scripts/propagate-ecosystem.sh"
+
+# Discovery contract — replicated inline from propagate-ecosystem.sh (which CANNOT be sourced: it
+# ends with both `main "$@"` and `exit 0`, either of which would hijack/terminate this script).
+SHARED_SKILL_DIRS=("guidelines" "meta" "workflows")
+EXCLUDE_DIRS=(".claude" "scripts" "specs" "docs" "node_modules" ".git"
+              "_archive" "_temp" "config" "coordination" "data" "docker"
+              "examples" "logs" "modules" "monitoring-dashboard" "reports"
+              "skills" "src" "templates" "tests" "flow-nexus" "ruv-swarm" "claude-flow")
+
+OPT_APPLY=false; OPT_DRY_RUN=false; OPT_ONLY=""; OPT_MACHINE=""; OPT_JSON=false; OPT_VERBOSE=false
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/skills/resync-skill-links.sh [OPTIONS]
+
+Verify (REPORT, default) or re-sync (--apply) shared-skill links across ecosystem repos.
+
+Options:
+  --apply          Re-propagate repairable links via propagate-ecosystem.sh --skills-only (guard-gated)
+  --dry-run        Under --apply, make no changes (no-op preview)
+  --only <repo>    Limit to a single ecosystem repo (by directory name)
+  --machine <lbl>  Override the machine label (else derived; EQ_MACHINE env also honored)
+  --json           Also print the state JSON to stdout
+  --verbose        Show the per-cell classification table
+  --help, -h       Show this help
+EOF
+}
+
+parse_arguments() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply)   OPT_APPLY=true;;
+      --dry-run) OPT_DRY_RUN=true;;
+      --only)    OPT_ONLY="${2:-}"; shift;;
+      --machine) OPT_MACHINE="${2:-}"; shift;;
+      --json)    OPT_JSON=true;;
+      --verbose) OPT_VERBOSE=true;;
+      --help|-h) usage; exit 0;;
+      *) echo "Unknown option: $1" >&2; usage; exit 1;;
+    esac; shift
+  done
+}
+
+# ── platform + machine label ────────────────────────────────────────────────
+# OS detection mirrors collect-equality.sh; EQ_*_OVERRIDE are TEST SEAMS ONLY (they affect the
+# derived LABEL, never graded data — EQ_MACHINE already fully overrides the label).
+case "$(uname -s 2>/dev/null)" in
+  Linux) OS="linux";; Darwin) OS="macos";; MINGW*|MSYS*|CYGWIN*) OS="windows";; *) OS="unknown";;
+esac
+[[ -n "${EQ_OS_OVERRIDE:-}" ]] && OS="$EQ_OS_OVERRIDE"
+HOST="${EQ_HOST_OVERRIDE:-$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')}"
+PLATFORM="unix"; [[ "$OS" == "windows" ]] && PLATFORM="windows"
+
+MACHINE=""
+resolve_machine() {
+  # Reuses the EXACT mapping collect-equality.sh uses, INCLUDING its fail-closed exit-1 for an
+  # unrecognized Windows host (an unknown Windows box must NOT silently get a default label).
+  # Set as a global (no command-substitution subshell) so the exit-1 actually terminates the script.
+  if [[ -n "$OPT_MACHINE" ]]; then MACHINE="$OPT_MACHINE"; return; fi
+  if [[ -n "${EQ_MACHINE:-}" ]]; then MACHINE="$EQ_MACHINE"; return; fi
+  case "$HOST" in
+    ace-linux-1*) MACHINE="dev-primary";;
+    ace-linux-2*) MACHINE="dev-secondary";;
+    *macbook*)    MACHINE="macbook-portable";;
+    ace-win-1*|licensed-win-1*|acma-ansys05*) MACHINE="ace-win-1";;
+    ace-win-2*|licensed-win-2*|acma-ws014*)   MACHINE="ace-win-2";;
+    *)
+      if [[ "$OS" == "windows" ]]; then
+        echo "resync-skill-links.sh: unknown Windows host '$HOST'; pass --machine ace-win-1 or ace-win-2" >&2
+        exit 1
+      fi
+      MACHINE="${HOST:-unknown}";;
+  esac
+}
+
+# ── filesystem classification helpers ───────────────────────────────────────
+is_link() {
+  # symlink (unix) or junction+marker (windows) — minimal replica of propagate's is_link.
+  local path="$1"
+  if [[ "$PLATFORM" == "windows" ]]; then
+    local marker; marker="$(dirname "$path")/.$(basename "$path")-link-marker"
+    [[ -d "$path" && -f "$marker" ]] && return 0
+    [[ -d "$path" ]] && fsutil reparsepoint query "$path" >/dev/null 2>&1 && return 0
+    return 1
+  fi
+  [[ -L "$path" ]]
+}
+
+_strip_fm() {
+  # Echo a file's body with a leading YAML frontmatter block (--- ... ---) removed, matching
+  # propagate's directory_matches_template (internal copies carry metadata headers).
+  awk 'NR==1 && $0=="---"{infm=1; next} infm && $0=="---"{infm=0; next} !infm{print}' "$1"
+}
+
+directory_matches_template() {
+  # 0 if every template file is present in sub_dir with matching content (.md compared frontmatter-blind).
+  local sub="$1" tmpl="$2" f rel
+  [[ -d "$sub" && -d "$tmpl" ]] || return 1
+  while IFS= read -r f; do
+    rel="${f#"$tmpl"/}"
+    [[ -f "$sub/$rel" ]] || return 1
+    if [[ "$f" == *.md ]]; then
+      [[ "$(_strip_fm "$f")" == "$(_strip_fm "$sub/$rel")" ]] || return 1
+    else
+      cmp -s "$f" "$sub/$rel" || return 1
+    fi
+  done < <(find "$tmpl" -type f)
+  return 0
+}
+
+classify() {
+  # classify <link_path> <target_dir> -> echoes one state token
+  local link="$1" target="$2"
+  if [[ ! -d "$target" ]]; then echo "TEMPLATE-ABSENT"; return; fi
+  if is_link "$link"; then
+    if [[ "$PLATFORM" == "windows" ]]; then echo "HEALTHY"; return; fi
+    if [[ -d "$link" && "$(realpath "$link" 2>/dev/null)" == "$(realpath "$target" 2>/dev/null)" ]]; then
+      echo "HEALTHY"; return
+    fi
+    echo "DANGLING"; return
+  fi
+  if [[ -e "$link" && ! -d "$link" ]]; then echo "FLATTENED"; return; fi
+  if [[ -d "$link" ]]; then
+    directory_matches_template "$link" "$target" && echo "HEALTHY" || echo "MODIFIED-REAL-DIR"
+    return
+  fi
+  echo "MISSING"
+}
+
+# ── repo discovery (inline replica of propagate's discover_submodules) ───────
+discover_repos() {
+  local hub_name hub_parent dir_name repo_dir ex excluded
+  hub_name="$(basename "$WS_HUB")"
+  hub_parent="$(dirname "$WS_HUB")"
+  {
+    for repo_dir in "$WS_HUB"/*/;     do echo "$repo_dir"; done
+    for repo_dir in "$hub_parent"/*/; do echo "$repo_dir"; done
+  } | while IFS= read -r repo_dir; do
+    [[ ! -d "$repo_dir" ]] && continue
+    dir_name="$(basename "$repo_dir")"
+    [[ "$dir_name" == "$hub_name" ]] && continue
+    excluded=false
+    for ex in "${EXCLUDE_DIRS[@]}"; do [[ "$dir_name" == "$ex" ]] && excluded=true && break; done
+    [[ "$excluded" == "true" ]] && continue
+    # Skip git WORKTREES — their .git is a FILE (gitdir pointer), not a dir. A worktree only carries
+    # .claude/skills/ because it's a checkout of a repo that has it; it is NOT a propagation target,
+    # and counting its un-linked shared dirs as "MISSING" would keep the cell permanently red on every
+    # box that has worktrees in flight. Only canonical clones (.git is a dir) are real link targets.
+    [[ -f "$repo_dir/.git" ]] && continue
+    [[ -d "$repo_dir/.claude/skills" ]] && echo "${repo_dir%/}"
+  done | sort -u
+}
+
+# ── allowlist (repos that legitimately carry no shared-skill links) ──────────
+read_allowlist() {
+  # EQ_SKILL_LINK_ALLOWLIST (space/newline separated) is the test seam; else best-effort read of
+  # harness-config.yaml::expected_skill_link_divergence (key may not exist yet — fail-soft to empty).
+  if [[ -n "${EQ_SKILL_LINK_ALLOWLIST+x}" ]]; then
+    printf '%s\n' ${EQ_SKILL_LINK_ALLOWLIST}
+    return
+  fi
+  local cfg="$WS_HUB/scripts/readiness/harness-config.yaml"
+  [[ -f "$cfg" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  python3 - "$cfg" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import yaml
+except Exception:
+    sys.exit(0)
+try:
+    data = yaml.safe_load(open(sys.argv[1])) or {}
+except Exception:
+    sys.exit(0)
+allow = data.get("expected_skill_link_divergence") or []
+if isinstance(allow, list):
+    for a in allow:
+        print(a)
+PY
+}
+
+# ── classification pass (sets the count globals) ─────────────────────────────
+C_HEALTHY=0; C_MISSING=0; C_DANGLING=0; C_FLATTENED=0; C_MODIFIED=0; C_TEMPLATE_ABSENT=0
+REPOS_TOTAL=0
+declare -a MISSING_REPOS=()       # basenames of repos with >=1 MISSING cell
+declare -a TABLE=()               # verbose per-cell rows
+
+run_classification() {
+  C_HEALTHY=0; C_MISSING=0; C_DANGLING=0; C_FLATTENED=0; C_MODIFIED=0; C_TEMPLATE_ABSENT=0
+  REPOS_TOTAL=0; MISSING_REPOS=(); TABLE=()
+  local repo repo_name shared link target state repo_has_missing
+  while IFS= read -r repo; do
+    [[ -z "$repo" ]] && continue
+    repo_name="$(basename "$repo")"
+    if [[ -n "$OPT_ONLY" && "$repo_name" != "$OPT_ONLY" ]]; then continue; fi
+    REPOS_TOTAL=$((REPOS_TOTAL + 1))
+    repo_has_missing=false
+    for shared in "${SHARED_SKILL_DIRS[@]}"; do
+      link="$repo/.claude/skills/$shared"
+      target="$INTERNAL_DIR/$shared"
+      state="$(classify "$link" "$target")"
+      case "$state" in
+        HEALTHY)           C_HEALTHY=$((C_HEALTHY + 1));;
+        MISSING)           C_MISSING=$((C_MISSING + 1)); repo_has_missing=true;;
+        DANGLING)          C_DANGLING=$((C_DANGLING + 1));;
+        FLATTENED)         C_FLATTENED=$((C_FLATTENED + 1));;
+        MODIFIED-REAL-DIR) C_MODIFIED=$((C_MODIFIED + 1));;
+        TEMPLATE-ABSENT)   C_TEMPLATE_ABSENT=$((C_TEMPLATE_ABSENT + 1));;
+      esac
+      TABLE+=("$(printf '%-22s %-10s %s' "$repo_name" "$shared" "$state")")
+    done
+    [[ "$repo_has_missing" == "true" ]] && MISSING_REPOS+=("$repo_name")
+  done < <(discover_repos)
+}
+
+# ── JSON assembly (counts/bools/basenames only — no abs paths, no tokens) ────
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+compute_unexpected_missing() {
+  # echo basenames of MISSING repos NOT in the allowlist, one per line
+  local allow repo a hit
+  allow="$(read_allowlist)"
+  for repo in "${MISSING_REPOS[@]:-}"; do
+    [[ -z "$repo" ]] && continue
+    hit=false
+    while IFS= read -r a; do [[ -n "$a" && "$a" == "$repo" ]] && { hit=true; break; }; done <<< "$allow"
+    [[ "$hit" == "false" ]] && echo "$repo"
+  done
+}
+
+worst_state() {
+  local s
+  for s in DANGLING FLATTENED MISSING MODIFIED-REAL-DIR TEMPLATE-ABSENT; do
+    case "$s" in
+      DANGLING)          [[ $C_DANGLING -gt 0 ]] && { echo "$s"; return; };;
+      FLATTENED)         [[ $C_FLATTENED -gt 0 ]] && { echo "$s"; return; };;
+      MISSING)           [[ $C_MISSING -gt 0 ]] && { echo "$s"; return; };;
+      MODIFIED-REAL-DIR) [[ $C_MODIFIED -gt 0 ]] && { echo "$s"; return; };;
+      TEMPLATE-ABSENT)   [[ $C_TEMPLATE_ABSENT -gt 0 ]] && { echo "$s"; return; };;
+    esac
+  done
+  echo "HEALTHY"
+}
+
+build_json() {
+  local repairable unexpected arr first u worst stamp
+  repairable=$((C_MISSING + C_DANGLING + C_FLATTENED))
+  worst="$(worst_state)"
+  stamp="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+  arr="["; first=1
+  while IFS= read -r u; do
+    [[ -z "$u" ]] && continue
+    [[ $first -eq 1 ]] && first=0 || arr+=", "
+    arr+="\"$(json_escape "$u")\""
+  done < <(compute_unexpected_missing)
+  arr+="]"
+  cat <<EOF
+{
+  "machine": "$(json_escape "$MACHINE")",
+  "audited_at": "$stamp",
+  "platform": "$PLATFORM",
+  "repos_total": $REPOS_TOTAL,
+  "healthy": $C_HEALTHY,
+  "missing": $C_MISSING,
+  "dangling": $C_DANGLING,
+  "flattened": $C_FLATTENED,
+  "modified_real_dir": $C_MODIFIED,
+  "template_absent": $C_TEMPLATE_ABSENT,
+  "repairable": $repairable,
+  "unexpected_missing_repos": $arr,
+  "worst_state": "$worst",
+  "schema_version": 1
+}
+EOF
+}
+
+write_state() {
+  mkdir -p "$STATE_DIR"
+  build_json > "$STATE_DIR/skill-link-health-$MACHINE.json"
+}
+
+print_report() {
+  local repairable; repairable=$((C_MISSING + C_DANGLING + C_FLATTENED))
+  if [[ "$OPT_VERBOSE" == "true" ]]; then
+    printf '%s\n' "${TABLE[@]:-}"
+    echo ""
+  fi
+  printf 'skill-link-health [%s]: repos=%d healthy=%d missing=%d dangling=%d flattened=%d modified=%d template-absent=%d (repairable=%d, worst=%s)\n' \
+    "$MACHINE" "$REPOS_TOTAL" "$C_HEALTHY" "$C_MISSING" "$C_DANGLING" "$C_FLATTENED" \
+    "$C_MODIFIED" "$C_TEMPLATE_ABSENT" "$repairable" "$(worst_state)"
+}
+
+guard_ok() {
+  # Never let --apply run blind in a bad state.
+  GUARD_REASON=""
+  if [[ ! -d "$INTERNAL_DIR" ]]; then GUARD_REASON="_internal/ template root absent"; return 1; fi
+  if [[ ! -f "$PROPAGATE" ]]; then GUARD_REASON="propagate-ecosystem.sh not found"; return 1; fi
+  return 0
+}
+
+main() {
+  parse_arguments "$@"
+  resolve_machine
+
+  run_classification
+  write_state
+  print_report
+  [[ "$OPT_JSON" == "true" ]] && build_json
+
+  if [[ "$OPT_APPLY" != "true" ]]; then
+    return 0
+  fi
+
+  local repairable; repairable=$((C_MISSING + C_DANGLING + C_FLATTENED))
+  if [[ $repairable -eq 0 ]]; then
+    echo "apply: nothing to repair"
+    return 0
+  fi
+  if ! guard_ok; then
+    echo "apply: guard blocked apply ($GUARD_REASON) — no changes made"
+    return 0
+  fi
+  if [[ "$OPT_DRY_RUN" == "true" ]]; then
+    echo "apply: --dry-run — would re-propagate $repairable repairable cell(s); no changes made"
+    return 0
+  fi
+
+  echo "apply: re-propagating $repairable repairable cell(s) via propagate-ecosystem.sh --skills-only"
+  if [[ -n "$OPT_ONLY" ]]; then
+    bash "$PROPAGATE" --skills-only --only "$OPT_ONLY" || true
+  else
+    bash "$PROPAGATE" --skills-only || true
+  fi
+  run_classification
+  write_state
+  print_report
+  return 0
+}
+
+main "$@"

--- a/scripts/skills/resync-skill-links.sh
+++ b/scripts/skills/resync-skill-links.sh
@@ -171,11 +171,13 @@ discover_repos() {
     excluded=false
     for ex in "${EXCLUDE_DIRS[@]}"; do [[ "$dir_name" == "$ex" ]] && excluded=true && break; done
     [[ "$excluded" == "true" ]] && continue
-    # Skip git WORKTREES — their .git is a FILE (gitdir pointer), not a dir. A worktree only carries
-    # .claude/skills/ because it's a checkout of a repo that has it; it is NOT a propagation target,
-    # and counting its un-linked shared dirs as "MISSING" would keep the cell permanently red on every
-    # box that has worktrees in flight. Only canonical clones (.git is a dir) are real link targets.
-    [[ -f "$repo_dir/.git" ]] && continue
+    # Skip git WORKTREES (but NOT submodules). A worktree's .git is a FILE whose gitdir points into a
+    # ".../worktrees/<name>" path; a submodule's .git file points into ".../modules/<name>". We only
+    # drop worktrees — they carry .claude/skills/ as transient checkouts, are not stable propagation
+    # targets, and counting their un-linked shared dirs as MISSING would keep the cell permanently red
+    # on every box with worktrees in flight. (propagate-ecosystem.sh may still touch a worktree
+    # idempotently under --apply; we simply don't audit worktree link health here.)
+    if [[ -f "$repo_dir/.git" ]] && grep -q '/worktrees/' "$repo_dir/.git" 2>/dev/null; then continue; fi
     [[ -d "$repo_dir/.claude/skills" ]] && echo "${repo_dir%/}"
   done | sort -u
 }

--- a/scripts/skills/tests/test_resync_skill_links.sh
+++ b/scripts/skills/tests/test_resync_skill_links.sh
@@ -210,6 +210,17 @@ hub="$(new_sandbox meta)"; add_repo "$hub" repo-x nested >/dev/null
 WORKSPACE_HUB="$hub" bash "$RESYNC" --machine custom-label >/dev/null 2>&1
 assert_file "test_machine_arg_override" "$hub/.claude/state/skill-link-health-custom-label.json"
 
+# ── T17: WORKTREE excluded (.git file → /worktrees/), SUBMODULE + clone KEPT ──
+# The worktree-skip must drop only worktrees, never genuine submodules (whose .git is ALSO a file).
+hub="$(new_sandbox meta)"
+add_repo "$hub" real-clone nested >/dev/null                                # no .git ⇒ a real target
+wt="$hub/wt-checkout"; mkdir -p "$wt/.claude/skills"
+printf 'gitdir: /somewhere/.git/worktrees/wt-checkout\n' > "$wt/.git"        # worktree ⇒ EXCLUDED
+sm="$hub/a-submodule"; mkdir -p "$sm/.claude/skills"
+printf 'gitdir: ../.git/modules/a-submodule\n' > "$sm/.git"                  # submodule ⇒ KEPT
+json="$(run_report "$hub")"
+assert_eq "test_worktree_excluded_submodule_kept" "$(jget "$json" repos_total)" "2"
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "================================"

--- a/scripts/skills/tests/test_resync_skill_links.sh
+++ b/scripts/skills/tests/test_resync_skill_links.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# test_resync_skill_links.sh — SANDBOXED tests for scripts/skills/resync-skill-links.sh (#3251).
+#
+# CONTRACT: every test builds a throwaway ecosystem under `mktemp -d` and points the script at it
+# via WORKSPACE_HUB. It NEVER scans the real workspace-hub ecosystem or any parent dir, and writes
+# NOTHING under the real .claude/state/. The outer script intentionally does NOT use `set -e` so
+# expected-failure tests don't abort the run.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RESYNC="${REPO_ROOT}/scripts/skills/resync-skill-links.sh"
+PROPAGATE_SRC="${REPO_ROOT}/scripts/propagate-ecosystem.sh"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+assert_eq()       { [[ "$2" == "$3" ]] && pass "$1" || fail "$1 (expected '$3', got '$2')"; }
+assert_contains() { case "$2" in *"$3"*) pass "$1";; *) fail "$1 (missing '$3' in: $2)";; esac; }
+assert_file()     { [[ -f "$2" ]] && pass "$1" || fail "$1 (no file $2)"; }
+
+SANDBOXES=()
+cleanup() { for d in "${SANDBOXES[@]:-}"; do [[ -n "$d" && -d "$d" ]] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+# new_sandbox [template_dirs...] — echoes <sbx>/wshub. Templates default to "meta" so workflows +
+# guidelines slots resolve to TEMPLATE-ABSENT (keeps single-cell classify tests isolated).
+new_sandbox() {
+  local sbx hub tdir
+  sbx="$(mktemp -d)"; SANDBOXES+=("$sbx")
+  hub="$sbx/wshub"
+  mkdir -p "$hub/.claude/skills/_internal" "$hub/scripts"
+  local templates=("$@"); [[ ${#templates[@]} -eq 0 ]] && templates=("meta")
+  for tdir in "${templates[@]}"; do
+    mkdir -p "$hub/.claude/skills/_internal/$tdir"
+    printf -- '---\nname: %s\n---\nshared %s template body\n' "$tdir" "$tdir" \
+      > "$hub/.claude/skills/_internal/$tdir/SKILL.md"
+  done
+  echo "$hub"
+}
+
+# add_repo <hub> <name> [nested|flat] — create an empty ecosystem repo with .claude/skills/
+add_repo() {
+  local hub="$1" name="$2" loc="${3:-nested}" base
+  if [[ "$loc" == "flat" ]]; then base="$(dirname "$hub")/$name"; else base="$hub/$name"; fi
+  mkdir -p "$base/.claude/skills"
+  echo "$base"
+}
+
+link_healthy()  { ln -s "$1/.claude/skills/_internal/$3" "$2/.claude/skills/$3"; } # hub repo shared
+link_dangling() { ln -s "$1/.claude/skills/_internal/does-not-exist-$3" "$2/.claude/skills/$3"; }
+make_flattened(){ printf 'IntxLNK\1../../wshub/.claude/skills/_internal/%s' "$3" > "$2/.claude/skills/$3"; }
+make_modified() { mkdir -p "$2/.claude/skills/$3"; printf -- '---\nname: %s\n---\nLOCALLY EDITED body\n' "$3" > "$2/.claude/skills/$3/SKILL.md"; }
+make_matching() { mkdir -p "$2/.claude/skills/$3"; cp "$1/.claude/skills/_internal/$3/SKILL.md" "$2/.claude/skills/$3/SKILL.md"; }
+
+run_report() {
+  # run_report <hub> [extra args...] — report mode, fixed machine label; echoes the state JSON
+  local hub="$1"; shift
+  WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="" \
+    bash "$RESYNC" "$@" >/dev/null 2>&1
+  cat "$hub/.claude/state/skill-link-health-test-box.json" 2>/dev/null
+}
+
+jget() { # jget <json> <key> -> integer/string value (naive but sufficient for the flat shape)
+  printf '%s' "$1" | grep -o "\"$2\": *[^,}]*" | head -1 | sed 's/.*: *//; s/^"//; s/"$//'
+}
+
+# ── T1: classify HEALTHY ────────────────────────────────────────────────────
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-healthy nested)"; link_healthy "$hub" "$r" meta
+json="$(run_report "$hub")"
+assert_eq "test_classify_healthy" "$(jget "$json" healthy)" "1"
+
+# ── T2: classify MISSING ────────────────────────────────────────────────────
+hub="$(new_sandbox meta)"
+add_repo "$hub" repo-missing flat >/dev/null
+json="$(run_report "$hub")"
+assert_eq "test_classify_missing" "$(jget "$json" missing)" "1"
+
+# ── T3: classify DANGLING ───────────────────────────────────────────────────
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-dangling nested)"; link_dangling "$hub" "$r" meta
+json="$(run_report "$hub")"
+assert_eq "test_classify_dangling" "$(jget "$json" dangling)" "1"
+
+# ── T4: classify FLATTENED ──────────────────────────────────────────────────
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-flattened flat)"; make_flattened "$hub" "$r" meta
+json="$(run_report "$hub")"
+assert_eq "test_classify_flattened" "$(jget "$json" flattened)" "1"
+
+# ── T5: classify MODIFIED-REAL-DIR ──────────────────────────────────────────
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-modified nested)"; make_modified "$hub" "$r" meta
+json="$(run_report "$hub")"
+assert_eq "test_classify_modified_real_dir" "$(jget "$json" modified_real_dir)" "1"
+
+# A real dir matching the template classifies HEALTHY (not MODIFIED).
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-realmatch nested)"; make_matching "$hub" "$r" meta
+json="$(run_report "$hub")"
+assert_eq "test_classify_matching_real_dir_healthy" "$(jget "$json" healthy)" "1"
+
+# ── T6: classify TEMPLATE-ABSENT (guidelines/workflows have no _internal template) ──
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-ta nested)"; link_healthy "$hub" "$r" meta
+json="$(run_report "$hub")"
+# 1 repo x 3 shared dirs: meta=HEALTHY, workflows+guidelines=TEMPLATE-ABSENT
+assert_eq "test_classify_template_absent" "$(jget "$json" template_absent)" "2"
+
+# ── T7: state JSON shape + counts sum to repos x dirs ───────────────────────
+hub="$(new_sandbox meta)"
+r1="$(add_repo "$hub" repo-h nested)"; link_healthy "$hub" "$r1" meta
+r2="$(add_repo "$hub" repo-m flat)"   # all missing/template-absent
+r3="$(add_repo "$hub" repo-d nested)"; link_dangling "$hub" "$r3" meta
+json="$(run_report "$hub")"
+for k in machine audited_at platform repos_total healthy missing dangling flattened \
+         modified_real_dir template_absent repairable unexpected_missing_repos worst_state schema_version; do
+  assert_contains "test_state_json_has_key_$k" "$json" "\"$k\""
+done
+assert_eq "test_state_json_schema_version" "$(jget "$json" schema_version)" "1"
+rt="$(jget "$json" repos_total)"
+sum=$(( $(jget "$json" healthy) + $(jget "$json" missing) + $(jget "$json" dangling) \
+      + $(jget "$json" flattened) + $(jget "$json" modified_real_dir) + $(jget "$json" template_absent) ))
+assert_eq "test_state_json_counts_sum" "$sum" "$(( rt * 3 ))"
+assert_eq "test_state_json_repairable" "$(jget "$json" repairable)" \
+  "$(( $(jget "$json" missing) + $(jget "$json" dangling) + $(jget "$json" flattened) ))"
+assert_eq "test_state_json_worst_dangling" "$(jget "$json" worst_state)" "DANGLING"
+
+# ── T8: report writes state ONLY under the sandbox (real .claude/state untouched) ──
+REAL_STATE="${REPO_ROOT}/.claude/state"
+before="$(ls "$REAL_STATE"/skill-link-health-* 2>/dev/null | wc -l)"
+hub="$(new_sandbox meta)"; add_repo "$hub" repo-x nested >/dev/null
+run_report "$hub" >/dev/null
+after="$(ls "$REAL_STATE"/skill-link-health-* 2>/dev/null | wc -l)"
+assert_eq "test_state_written_under_sandbox_only_real_untouched" "$after" "$before"
+assert_file "test_state_written_under_sandbox" "$hub/.claude/state/skill-link-health-test-box.json"
+
+# ── T9: report mode makes no filesystem changes to links ────────────────────
+hub="$(new_sandbox meta)"
+r="$(add_repo "$hub" repo-missing nested)"
+run_report "$hub" >/dev/null
+if [[ ! -e "$r/.claude/skills/meta" ]]; then pass "test_report_mode_makes_no_changes"
+else fail "test_report_mode_makes_no_changes (report created a link)"; fi
+
+# ── T10: allowlist suppresses a MISSING repo from unexpected_missing_repos ───
+hub="$(new_sandbox meta)"
+add_repo "$hub" repo-allowed nested >/dev/null
+json="$(WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="repo-allowed" \
+        bash "$RESYNC" >/dev/null 2>&1; cat "$hub/.claude/state/skill-link-health-test-box.json")"
+assert_eq "test_allowlist_suppresses_missing" "$(jget "$json" unexpected_missing_repos)" "[]"
+# Without the allowlist the same repo IS unexpected.
+json2="$(run_report "$hub")"
+assert_contains "test_unexpected_missing_without_allowlist" "$json2" "repo-allowed"
+
+# ── T11: --apply repairs MISSING + DANGLING (needs propagate copied into sandbox) ──
+hub="$(new_sandbox meta)"
+cp "$PROPAGATE_SRC" "$hub/scripts/propagate-ecosystem.sh"
+r1="$(add_repo "$hub" repo-missing nested)"
+r2="$(add_repo "$hub" repo-dangling nested)"; link_dangling "$hub" "$r2" meta
+WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="" \
+  bash "$RESYNC" --apply >/dev/null 2>&1
+json="$(cat "$hub/.claude/state/skill-link-health-test-box.json")"
+assert_eq "test_apply_repairs_missing_and_dangling" "$(jget "$json" repairable)" "0"
+if [[ -L "$r1/.claude/skills/meta" ]]; then pass "test_apply_created_symlink"
+else fail "test_apply_created_symlink (no symlink at repo-missing/meta)"; fi
+
+# ── T12: --apply never clobbers a MODIFIED-REAL-DIR ─────────────────────────
+hub="$(new_sandbox meta)"
+cp "$PROPAGATE_SRC" "$hub/scripts/propagate-ecosystem.sh"
+add_repo "$hub" repo-missing nested >/dev/null   # gives a repairable cell so apply runs
+r="$(add_repo "$hub" repo-mod nested)"; make_modified "$hub" "$r" meta
+WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="" \
+  bash "$RESYNC" --apply >/dev/null 2>&1
+if [[ -d "$r/.claude/skills/meta" && ! -L "$r/.claude/skills/meta" ]] \
+   && grep -q "LOCALLY EDITED" "$r/.claude/skills/meta/SKILL.md"; then
+  pass "test_apply_skips_modified_real_dir"
+else fail "test_apply_skips_modified_real_dir (modified dir was altered)"; fi
+
+# ── T13: guard blocks --apply when propagate is unavailable ─────────────────
+hub="$(new_sandbox meta)"   # no propagate copied in
+add_repo "$hub" repo-missing nested >/dev/null
+out="$(WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="" \
+       bash "$RESYNC" --apply 2>&1)"
+rc=$?
+assert_contains "test_apply_guard_blocks" "$out" "guard blocked"
+assert_eq "test_apply_guard_exit_zero" "$rc" "0"
+if [[ ! -e "$hub/repo-missing/.claude/skills/meta" ]]; then pass "test_apply_guard_no_changes"
+else fail "test_apply_guard_no_changes (link created despite guard)"; fi
+
+# ── T14: --apply --dry-run is a no-op ───────────────────────────────────────
+hub="$(new_sandbox meta)"
+cp "$PROPAGATE_SRC" "$hub/scripts/propagate-ecosystem.sh"
+r="$(add_repo "$hub" repo-missing nested)"
+out="$(WORKSPACE_HUB="$hub" EQ_MACHINE="test-box" EQ_SKILL_LINK_ALLOWLIST="" \
+       bash "$RESYNC" --apply --dry-run 2>&1)"
+assert_contains "test_dry_run_under_apply_message" "$out" "dry-run"
+if [[ ! -e "$r/.claude/skills/meta" ]]; then pass "test_dry_run_under_apply_is_noop"
+else fail "test_dry_run_under_apply_is_noop (dry-run created a link)"; fi
+
+# ── T15: fail-closed on an unrecognized Windows host (no silent default label) ──
+hub="$(new_sandbox meta)"
+out="$(WORKSPACE_HUB="$hub" EQ_OS_OVERRIDE="windows" EQ_HOST_OVERRIDE="some-unknown-box" \
+       bash "$RESYNC" 2>&1)"
+rc=$?
+assert_eq "test_machine_label_fail_closed_windows_rc" "$rc" "1"
+assert_contains "test_machine_label_fail_closed_windows_msg" "$out" "unknown Windows host"
+
+# ── T16: --machine override + EQ_MACHINE drive the state filename ────────────
+hub="$(new_sandbox meta)"; add_repo "$hub" repo-x nested >/dev/null
+WORKSPACE_HUB="$hub" bash "$RESYNC" --machine custom-label >/dev/null 2>&1
+assert_file "test_machine_arg_override" "$hub/.claude/state/skill-link-health-custom-label.json"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "================================"
+echo "PASS: $PASS  FAIL: $FAIL"
+echo "================================"
+[[ $FAIL -eq 0 ]]

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -102,3 +102,9 @@ dimensions:
     audited_at: "2026-05-30T03:55:12+00:00"
     worst_age_hours: 8.5
     freshness: MEMORY-FRESH
+  skill_link_health:
+    audited_at: "2026-05-30T03:55:12+00:00"
+    repos_total: 14
+    healthy: 42
+    repairable: 0
+    worst_state: HEALTHY

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -59,7 +59,7 @@ def _win1_baseline() -> dict:
 # ════════════════════════════════════════════════════════════════════════════
 EXPECTED_DIMS = {"compute", "data_access", "solvers", "harness", "skills",
                  "kanban", "memory", "behavior", "scheduler", "provider_harness",
-                 "session_curation", "skill_currency", "memory_freshness"}
+                 "session_curation", "skill_currency", "memory_freshness", "skill_link_health"}
 
 
 def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
@@ -70,7 +70,7 @@ def test_ps1_sample_output_parses_schema_v4_with_provider_harness():
     # provenance block present with the freshness fields is_stale() consumes
     p = d["provenance"]
     assert set(p) >= {"checkout_sha", "dirty", "behind_main", "ahead_main", "origin_ref_age_h"}
-    # all 13 dimensions present (session_curation added in the #2816 follow-on)
+    # all 14 dimensions present (session_curation added in the #2816 follow-on)
     assert set(d["dimensions"]) == EXPECTED_DIMS
     ph = d["dimensions"]["provider_harness"]
     assert ph["schema_version"] == 1

--- a/tests/readiness/test_skill_link_health_verdict.py
+++ b/tests/readiness/test_skill_link_health_verdict.py
@@ -1,0 +1,65 @@
+"""TDD tests for #3251 — skill_link_health matrix verdict (epic #3248).
+
+Targets build_equality_matrix.skill_link_health_verdict: SKILL-LINKS-DRIFTED when any shared-skill
+link is repairable (missing/dangling/flattened) on a real ecosystem clone, else SKILL-LINKS-OK;
+fail-closed MISSING-EVIDENCE on missing/garbled facts.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "readiness" / "build-equality-matrix.py"
+
+spec = importlib.util.spec_from_file_location("build_equality_matrix", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+bem = importlib.util.module_from_spec(spec)
+sys.modules["build_equality_matrix"] = bem
+spec.loader.exec_module(bem)
+
+
+def _rep(**slh) -> dict:
+    base = {"audited_at": "2026-06-27T00:00:00+00:00", "repos_total": 14, "healthy": 42,
+            "repairable": 0, "worst_state": "HEALTHY"}
+    base.update(slh)
+    return {"dimensions": {"skill_link_health": base}}
+
+
+def test_ok_when_no_repairable():
+    assert bem.skill_link_health_verdict(_rep()) == "SKILL-LINKS-OK"
+
+
+def test_drifted_when_repairable():
+    assert bem.skill_link_health_verdict(_rep(repairable=12, worst_state="MISSING")) == "SKILL-LINKS-DRIFTED"
+
+
+def test_missing_dimension():
+    assert bem.skill_link_health_verdict({"dimensions": {}}) == "MISSING-EVIDENCE"
+
+
+def test_non_dict():
+    for bad in ("x", 1, None, ["a"]):
+        assert bem.skill_link_health_verdict({"dimensions": {"skill_link_health": bad}}) == "MISSING-EVIDENCE"
+
+
+def test_missing_audited_at():
+    r = _rep()
+    del r["dimensions"]["skill_link_health"]["audited_at"]
+    assert bem.skill_link_health_verdict(r) == "MISSING-EVIDENCE"
+
+
+def test_garbled_repairable():
+    for bad in (None, "12", True, 1.5):
+        assert bem.skill_link_health_verdict(_rep(repairable=bad)) == "MISSING-EVIDENCE"
+
+
+def test_wiring():
+    assert "skill_link_health" in bem.BASE_DISPLAY_DIMS
+    assert "skill_link_health" in bem.DISPLAY_DIMS
+    assert "SKILL-LINKS-OK" in bem.OK_VERDICTS
+    groups = {g[0]: g for g in bem.GROUPS}
+    assert groups["skill-links"][2] == ["skill_link_health"]
+    sev = bem.ROLLUP_SEVERITY
+    assert sev["SKILL-LINKS-DRIFTED"] > sev["SKILL-LINKS-OK"] == 0

--- a/tests/readiness/test_skill_link_health_verdict.py
+++ b/tests/readiness/test_skill_link_health_verdict.py
@@ -50,6 +50,12 @@ def test_missing_audited_at():
     assert bem.skill_link_health_verdict(r) == "MISSING-EVIDENCE"
 
 
+def test_zero_repos_is_no_evidence_not_healthy():
+    # nothing discovered ⇒ MISSING-EVIDENCE, never a silent green (fail-open guard)
+    for bad in (0, None, "0", True, -1):
+        assert bem.skill_link_health_verdict(_rep(repos_total=bad)) == "MISSING-EVIDENCE"
+
+
 def test_garbled_repairable():
     for bad in (None, "12", True, 1.5):
         assert bem.skill_link_health_verdict(_rep(repairable=bad)) == "MISSING-EVIDENCE"


### PR DESCRIPTION
Closes #3251 (epic #3248, final child). New skill_link_health cell: are shared skills still propagated to ecosystem repos, or did they freeze at link time?

- resync-skill-links.sh (report mode) classifies each shared-skill link across REAL ecosystem clones (worktrees excluded — narrowed to /worktrees/ so submodules are kept); --apply re-propagates (guard-gated).
- Verdict SKILL-LINKS-DRIFTED when repairable>0 else SKILL-LINKS-OK; MISSING-EVIDENCE when nothing discovered (no fail-open).
- Wired: verdict+group+CSS+legend+remediate, collect emit, fixture+EXPECTED_DIMS->14, both wrappers (.sh + .ps1 via Git Bash), reconcile OK-skip.

Both gates: plan adversarially reviewed (2 rounds); code adversarially reviewed (APPROVE-WITH-CHANGES -> 3 must-fixes folded: repos_total fail-open, worktree-vs-submodule, worktree test). Today: 14 repos, 12 missing links -> honest SKILL-LINKS-DRIFTED. 42 engine + 428 full-suite tests green.