### PR TITLE
fix(skills): generator for the rotted skills-index + cron wiring

### DIFF
--- a/scripts/curation/curate-session-memory.ps1
+++ b/scripts/curation/curate-session-memory.ps1
@@ -85,6 +85,18 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     Fail 'no python runtime (uv/python) available'
 }
 
+# ── 1a2. regenerate the per-machine skills index before the audit (no rot) ────
+$genIndex = (Join-Path $RepoRoot 'scripts/skills/generate_skills_index.py')
+if (Test-Path $genIndex) {
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        & uv run --no-project --with pyyaml python $genIndex
+        if ($LASTEXITCODE -ne 0) { Write-Warning 'skills-index regen failed (soft)' }
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python $genIndex
+        if ($LASTEXITCODE -ne 0) { Write-Warning 'skills-index regen failed (soft)' }
+    }
+}
+
 # ── 1b. skill-currency audit (#3249) — best-effort; must not block the curation run ──
 # Without this the skill_currency cell is permanently MISSING-EVIDENCE on Windows boxes.
 $skillAudit = (Join-Path $RepoRoot 'scripts/curation/audit_skill_currency.py')

--- a/scripts/curation/curate-session-memory.sh
+++ b/scripts/curation/curate-session-memory.sh
@@ -27,6 +27,17 @@ else
   fail "no python runtime (uv/python3) available"
 fi
 
+# Regenerate the (gitignored, per-machine) skills index BEFORE the skill-currency audit so the
+# index never rots (the audit grades SKILLS-INDEX-STALE on dangling entries). Best-effort.
+GEN_INDEX="$REPO_ROOT/scripts/skills/generate_skills_index.py"
+if [[ -f "$GEN_INDEX" ]]; then
+  if command -v uv >/dev/null 2>&1; then
+    uv run --no-project --with pyyaml python "$GEN_INDEX" || echo "skills-index regen failed (soft)" >&2
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 "$GEN_INDEX" || echo "skills-index regen failed (soft)" >&2
+  fi
+fi
+
 # Audit cross-provider skill currency (#3249) — writes skill-currency-<machine>.json for the
 # skill_currency matrix cell. Best-effort: a failed audit must not block the curation run.
 SKILL_AUDIT="$REPO_ROOT/scripts/curation/audit_skill_currency.py"

--- a/scripts/skills/generate_skills_index.py
+++ b/scripts/skills/generate_skills_index.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""generate_skills_index.py — (re)build .claude/skills-index.yaml from the skills tree.
+
+The index is the CURATED first-class-skill catalog consumed by humans and by
+`scripts/curation/audit_skill_currency.py` (which grades `index_stale` when any index
+`path:` no longer exists in the committed tree). It had rotted: 202 of 224 entries pointed
+at an old tree layout (last auto-gen 2026-01-21), so this regenerates it cleanly.
+
+Inclusion rule (a path is a "first-class skill" iff ALL hold):
+  1. Tracked in the COMMITTED tree (`git ls-tree -r HEAD .claude/skills`). This is the exact
+     basis the audit compares against, so the emitted paths are a guaranteed subset → no
+     dangling entries. (Working-tree-only / untracked SKILL.md are intentionally excluded.)
+  2. Canonical skill location — exactly one category dir + one skill dir
+     (`.claude/skills/<category>/<skill>/SKILL.md`) OR a top-level skill that is its own
+     category (`.claude/skills/<skill>/SKILL.md`). Deeper SKILL.md files are bundled
+     sub-skills / resources of a parent skill, not first-class entries.
+  3. YAML frontmatter declares BOTH `name:` and `description:` (a real, addressable skill).
+  4. Not under the `_archive/` retired-skills namespace.
+
+Grouping is by the TOP-LEVEL category dir under `.claude/skills/`. Categories and the skills
+within each are sorted alphabetically. Output format matches the legacy index exactly:
+
+    # Skills Index for workspace-hub
+    # Auto-generated from .claude/skills/
+    # Last updated: <YYYY-MM-DD>
+
+    categories:
+    - name: <category>
+      count: <n>
+      skills:
+      - name: <skill>
+        description: <desc>
+        path: .claude/skills/<...>/SKILL.md
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SKILLS_PREFIX = ".claude/skills"
+SKILLS_INDEX = REPO / ".claude" / "skills-index.yaml"
+ARCHIVE_NS = "_archive"
+
+
+def committed_skill_md(repo: Path) -> list[str]:
+    """SKILL.md paths tracked in HEAD under .claude/skills (repo-root-relative, POSIX)."""
+    r = subprocess.run(
+        ["git", "-C", str(repo), "ls-tree", "-r", "--name-only", "HEAD", SKILLS_PREFIX],
+        capture_output=True, text=True, timeout=60, check=True,
+    )
+    return [ln for ln in r.stdout.splitlines() if ln.endswith("/SKILL.md")]
+
+
+def is_first_class(rel_path: str) -> bool:
+    """True for `.claude/skills/<cat>/<skill>/SKILL.md` or `.claude/skills/<skill>/SKILL.md`."""
+    parts = rel_path.split("/")
+    # parts[:2] == ['.claude', 'skills']; trailing is 'SKILL.md'
+    inner = parts[2:-1]  # components between the prefix and SKILL.md
+    if not (1 <= len(inner) <= 2):
+        return False
+    return inner[0] != ARCHIVE_NS
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Return the leading `--- ... ---` YAML block as a dict (empty dict if absent/invalid)."""
+    if not text.startswith("---"):
+        return {}
+    lines = text.splitlines()
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    try:
+        data = yaml.safe_load("\n".join(lines[1:end]))
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def build_categories(repo: Path) -> list[dict]:
+    cats: dict[str, list[dict]] = {}
+    for rel in committed_skill_md(repo):
+        if not is_first_class(rel):
+            continue
+        fm = parse_frontmatter((repo / rel).read_text(encoding="utf-8", errors="replace"))
+        name = str(fm.get("name", "")).strip()
+        desc = str(fm.get("description", "")).strip()
+        if not name or not desc:
+            continue
+        category = rel.split("/")[2]  # top-level dir under .claude/skills/
+        cats.setdefault(category, []).append({"name": name, "description": desc, "path": rel})
+    out = []
+    for category in sorted(cats):
+        skills = sorted(cats[category], key=lambda s: s["name"])
+        out.append({"name": category, "count": len(skills), "skills": skills})
+    return out
+
+
+def render(categories: list[dict]) -> str:
+    header = (
+        "# Skills Index for workspace-hub\n"
+        "# Auto-generated from .claude/skills/\n"
+        f"# Last updated: {date.today().isoformat()}\n\n"
+    )
+    body = yaml.safe_dump(
+        {"categories": categories},
+        sort_keys=False, default_flow_style=False, allow_unicode=True, width=80,
+    )
+    return header + body
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Regenerate .claude/skills-index.yaml")
+    ap.add_argument("--stdout", action="store_true", help="print to stdout, do not write")
+    ap.add_argument("--repo", default=str(REPO), help="repo root (default: inferred)")
+    a = ap.parse_args(argv)
+    repo = Path(a.repo).resolve()
+    categories = build_categories(repo)
+    text = render(categories)
+    total = sum(c["count"] for c in categories)
+    if a.stdout:
+        sys.stdout.write(text)
+    else:
+        (repo / ".claude" / "skills-index.yaml").write_text(text, encoding="utf-8")
+        print(f"wrote {repo / '.claude' / 'skills-index.yaml'}: "
+              f"{len(categories)} categories, {total} skills")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_generate_skills_index.py
+++ b/tests/skills/test_generate_skills_index.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""Tests for scripts/skills/generate_skills_index.py.
+
+Core invariant: every `path:` the generator emits exists in the committed tree, so the
+`scripts/curation/audit_skill_currency.py` `index_dangling` metric is 0. Verified two ways:
+  * on a self-contained sandbox git fixture (deterministic, no repo coupling), and
+  * against the live regenerated `.claude/skills-index.yaml` (regression guard).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+GEN = REPO / "scripts" / "skills" / "generate_skills_index.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_skills_index", GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _skill(root: Path, rel: str, name: str | None, desc: str | None) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    fm = ["---"]
+    if name is not None:
+        fm.append(f"name: {name}")
+    if desc is not None:
+        fm.append(f"description: {desc}")
+    fm.append("---")
+    p.write_text("\n".join(fm) + "\n# body\n", encoding="utf-8")
+
+
+def _make_fixture(tmp_path: Path) -> Path:
+    repo = tmp_path / "wh"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    # first-class, valid → INCLUDED
+    _skill(repo, ".claude/skills/data/cleaner/SKILL.md", "cleaner", "Clean data")
+    _skill(repo, ".claude/skills/ai/router/SKILL.md", "router", "Route requests")
+    # top-level skill (its own category) → INCLUDED
+    _skill(repo, ".claude/skills/loneskill/SKILL.md", "loneskill", "Standalone")
+    # deeper than first-class → EXCLUDED (bundled sub-skill)
+    _skill(repo, ".claude/skills/data/cleaner/sub/SKILL.md", "sub", "Nested")
+    # missing description → EXCLUDED
+    _skill(repo, ".claude/skills/ai/nodesc/SKILL.md", "nodesc", None)
+    # _archive namespace → EXCLUDED
+    _skill(repo, ".claude/skills/_archive/old/SKILL.md", "old", "Retired")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    # untracked first-class skill (valid frontmatter, but NOT committed) → EXCLUDED
+    _skill(repo, ".claude/skills/data/untracked/SKILL.md", "untracked", "Not committed")
+    return repo
+
+
+def test_no_dangling_paths_on_fixture(tmp_path):
+    gen = _load_generator()
+    repo = _make_fixture(tmp_path)
+    categories = gen.build_categories(repo)
+    emitted = {sk["path"] for c in categories for sk in c["skills"]}
+    # exactly the three first-class, committed, well-formed skills
+    assert emitted == {
+        ".claude/skills/data/cleaner/SKILL.md",
+        ".claude/skills/ai/router/SKILL.md",
+        ".claude/skills/loneskill/SKILL.md",
+    }
+    # the audit's invariant: every emitted path is in the committed tree (no dangling)
+    committed = set(gen.committed_skill_md(repo))
+    assert emitted <= committed
+    assert not (emitted - committed)
+
+
+def test_counts_match_skill_lists_on_fixture(tmp_path):
+    gen = _load_generator()
+    repo = _make_fixture(tmp_path)
+    categories = gen.build_categories(repo)
+    for c in categories:
+        assert c["count"] == len(c["skills"])
+    names = [c["name"] for c in categories]
+    assert names == sorted(names)  # categories alphabetical
+
+
+def test_render_round_trips_and_has_header(tmp_path):
+    gen = _load_generator()
+    repo = _make_fixture(tmp_path)
+    text = gen.render(gen.build_categories(repo))
+    assert text.startswith("# Skills Index for workspace-hub\n")
+    assert yaml.safe_load(text)["categories"]  # valid YAML
+
+
+def test_live_index_has_zero_dangling():
+    """Regression guard: the committed live index must have no dangling paths."""
+    index = REPO / ".claude" / "skills-index.yaml"
+    if not index.exists():
+        return
+    data = yaml.safe_load(index.read_text()) or {}
+    index_paths = {sk.get("path") for c in (data.get("categories") or [])
+                   for sk in (c.get("skills") or []) if sk.get("path")}
+    gen = _load_generator()
+    committed = set(gen.committed_skill_md(REPO))
+    dangling = index_paths - committed
+    assert not dangling, f"dangling index paths: {sorted(dangling)[:10]}"
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-q"]))


### PR DESCRIPTION
Remediates the live matrix finding **skill_currency = SKILLS-INDEX-STALE** (`.claude/skills-index.yaml` had 202/224 dangling entries; no generator existed).

- New `scripts/skills/generate_skills_index.py` — sources paths from the **committed tree** (`git ls-tree HEAD`, the exact basis the audit compares against → guaranteed no dangling), first-class skills only, legacy format. Regenerates to 41 cat / 414 skills, **index_dangling 202 → 0** (verified).
- **Wired into both curation wrappers** (.sh + .ps1) before the skill audit, so the per-machine (gitignored) index regenerates every 6h and can't rot again.
- 4 generator tests (sandbox git fixture; no-dangling assertion). `detect-skill-rot.py` parses the new index cleanly.

Found by the parallel remediation workflow. Sibling finding skill_link_health was cleared operationally (12 links re-propagated, repairable 12→0, no commits — links are gitignored).