### PR TITLE
chore(equality): register the licensed Windows host as ace-win-1 + fix Windows matrix UTF-8 crash

### DIFF
--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -770,11 +770,11 @@ function copyGenPrompt(btn){{
 
     REPORTS.mkdir(parents=True, exist_ok=True)
     out = REPORTS / f"{date.today().isoformat()}-machine-equality-matrix.html"
-    out.write_text(html)
+    out.write_text(html, encoding="utf-8")
     # Stable (undated) alias so GitHub Pages serves a fixed "latest" URL that never
     # changes as the dated reports roll over (published by scripts/build_pages.py).
     latest = REPORTS / "machine-equality-matrix.html"
-    latest.write_text(html)
+    latest.write_text(html, encoding="utf-8")
     print(f"wrote {out} (+ {latest.name} alias) ({reporting}/{active} active reporting)")
     if "--open" in sys.argv:
         import webbrowser

--- a/scripts/readiness/collect-equality.ps1
+++ b/scripts/readiness/collect-equality.ps1
@@ -102,6 +102,7 @@ function Resolve-EqualityMachineLabel {
     switch -Wildcard ($hostName) {
         "ace-win-1" { return "ace-win-1" }
         "acma-ansys05*" { return "ace-win-1" }
+        "acma-hou-rds02*" { return "ace-win-1" }
         "ace-win-2" { return "ace-win-2" }
         "acma-ws014*" { return "ace-win-2" }
         default { throw "Unknown Windows equality collector host '$hostName'; pass -Machine explicitly" }

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -44,7 +44,7 @@ if [[ -z "$MACHINE" ]]; then
   case "$HOST" in
     ace-linux-1*) MACHINE="dev-primary";; ace-linux-2*) MACHINE="dev-secondary";;
     *macbook*) MACHINE="macbook-portable";;
-    ace-win-1*|licensed-win-1*|acma-ansys05*) MACHINE="ace-win-1";;
+    ace-win-1*|licensed-win-1*|acma-ansys05*|acma-hou-rds02*) MACHINE="ace-win-1";;
     ace-win-2*|licensed-win-2*|acma-ws014*) MACHINE="ace-win-2";;
     *)
       if [[ "$OS" == "windows" ]]; then

--- a/scripts/readiness/reconcile-ecosystem.sh
+++ b/scripts/readiness/reconcile-ecosystem.sh
@@ -67,7 +67,7 @@ case "$HOST" in
   ace-linux-1*) MACHINE="dev-primary" ;;
   ace-linux-2*) MACHINE="dev-secondary" ;;
   *macbook*)    MACHINE="macbook-portable" ;;
-  ace-win-1*|licensed-win-1*|acma-ansys05*) MACHINE="ace-win-1" ;;
+  ace-win-1*|licensed-win-1*|acma-ansys05*|acma-hou-rds02*) MACHINE="ace-win-1" ;;
   ace-win-2*|licensed-win-2*|acma-ws014*)   MACHINE="ace-win-2" ;;
   *) MACHINE="${RECONCILE_MACHINE:-$HOST}" ;;
 esac

--- a/scripts/windows/equality-report.ps1
+++ b/scripts/windows/equality-report.ps1
@@ -63,6 +63,7 @@ function Get-EqualityMachineLabel {
     switch -Wildcard ($hostName) {
         "ace-win-1" { return "ace-win-1" }
         "acma-ansys05*" { return "ace-win-1" }
+        "acma-hou-rds02*" { return "ace-win-1" }
         "ace-win-2" { return "ace-win-2" }
         "acma-ws014*" { return "ace-win-2" }
         default { throw "Unknown Windows equality host '$hostName'; refusing to assume a ace-win-* identity" }


### PR DESCRIPTION
## What

Two cross-platform fixes for the machine-equality matrix, surfaced while reconciling the Windows box `ace-win-1` (operated as the `ace-win-1` column).

1. **Host-map**: add `ace-win-1*` -> `ace-win-1` in all four maps (`collect-equality.sh`, `collect-equality.ps1`, `reconcile-ecosystem.sh`, `windows/equality-report.ps1`). Autodetect previously threw `unknown host` / refused to assume an identity, forcing a `-Machine` override on every collect.
2. **UTF-8 build fix**: `build-equality-matrix.py` wrote the matrix HTML via `Path.write_text(html)` with no encoding -> on Windows (cp1252 default) the build crashed with `UnicodeEncodeError` on emoji glyphs in the report. Linux (utf-8 default) masked it. Pin `encoding="utf-8"` on both the dated report and the stable alias.

## Verification

- Re-collected `equality-ace-win-1.yaml` from clean `main` (ahead 0 / behind 0) and rebuilt the matrix locally with both fixes -> 4/4 machines reporting, no crash.

_Note: committer identity auto-derived as `vamseea@ACMA-INC.LOCAL` (machine default)._