### PR TITLE
docs(handoff): epic #3248 deferred-children impl session (clean extract, supersedes #3280)

### DIFF
--- a/docs/session-handoffs/2026-06-27-epic-3248-deferred-children-impl.md
+++ b/docs/session-handoffs/2026-06-27-epic-3248-deferred-children-impl.md
@@ -1,0 +1,71 @@
+# Session handoff — epic #3248 deferred-children: planned → reviewed → implemented → (merge in progress)
+
+**Date:** 2026-06-27
+**Epic:** #3248 — robust cross-provider self-improvement & skill-currency ecosystem
+**Predecessor handoff:** `docs/session-handoffs/2026-06-27-self-improvement-epic-3248-and-matrix-line-items.md` (the 4 *shipped* children #3249/#3250/#3251/#3255)
+
+---
+
+## What this session did
+
+Took the **4 deferred children** of epic #3248 from "approved-in-principle" all the way to merge-ready PRs, using parallel agents + a dynamic workflow at each phase:
+
+1. **Plan** — dynamic Workflow (20 agents): draft → 2 adversarial review rounds → finalize, one lane per child. Plans merged as **PR #3272**. All 4 issues set `status:plan-approved` on owner's explicit "approve all".
+2. **Implement** — 4 parallel worktree-isolated agents, TDD-first. One PR per child.
+3. **Review** — 4 parallel independent adversarial code reviewers (each re-ran the real test suite in the PR's worktree). **All 4 APPROVE-WITH-NITS.**
+4. **Fix** — the one real blocker (a vacuous test) fixed; the pre-existing baseline-red check fixed separately.
+5. **Merge** — baseline PR merged; the 4 impl PRs are updated-from-main with CI re-running.
+
+## PR status (at handoff)
+
+| PR | Issue | What | Tests | Review | State |
+|----|-------|------|-------|--------|-------|
+| **#3272** | (plans) | 4 child plans | — | 2-round | **MERGED** |
+| **#3277** | (#3208 baseline) | regen `config/agents/skill-index-full.yaml` (coherence rc1→rc0) | — | — | **MERGED** |
+| **#3273** | #3254 | recurring drift → parked candidates | 30+16 ✓ | APPROVE-WITH-NITS | OPEN, updated-from-main, CI running |
+| **#3274** | #3253 | Hermes pattern → skill/memory candidates | 37 ✓ | APPROVE-WITH-NITS | OPEN, updated-from-main, CI running |
+| **#3275** | #3252 | auto-graduate corrections → owner-gated drafts | 35 ✓ | APPROVE-WITH-NITS + blocker fixed | OPEN, updated-from-main, CI running |
+| **#3276** | #3256 | adaptive threshold + Gemini-specific detection | 85 ✓ | APPROVE-WITH-NITS | OPEN, updated-from-main, CI running |
+
+All four impl PRs use `Closes #<issue>` → merging auto-closes #3252/#3253/#3254/#3256. None adds a matrix dimension; each hooks into existing nightly/bridge/candidate machinery.
+
+## DO NEXT — finish the merge (owner action)
+
+Auto-merge is **disabled** on this repo (`enablePullRequestAutoMerge` off), so each impl PR needs a **direct** merge once its CI is green. The branches were already `update-branch`'d from main (so they carry the #3277 index fix → the `Skill-Index Coherence` check passes). When checks show green:
+
+```bash
+cd $WORKSPACE_HUB
+R=vamseeachanta/workspace-hub
+for pr in 3273 3274 3275 3276; do
+  gh pr merge $pr --squash --delete-branch --repo $R
+done
+```
+
+If any still shows the old `Skill-Index Coherence` failure, re-run `gh pr update-branch $pr` first (it must include #3277 from main). At handoff all checks were trending green — **no FAILUREs**, only pending — so this should be a clean sweep.
+
+After merge, the epic's final gate is owner-only: apply `status:completeness-verified` (#2798) to each issue if you want the formal completion marker.
+
+## Verified facts / what's load-bearing
+
+- **De-dup blocker (#3253) genuinely fixed** — reviewer toggled `strip_bridge_block` to identity and watched the regression test fail; placement-independent by construction.
+- **#3256's 3 round-2 majors all resolved** — empirically re-checked: no fatal `source`, sidecar JSON (never mutates auto-gen `skill-candidates.md`), `reviewed_by` defined + adaptation no-op-safe @80 until a writer lands (gap #6 "closeable," not nominally closed).
+- **#3254 threshold validated on live data** — ≥3 distinct UTC days / 14-day window; `git_non_conventional`=3 (fires), `file_placement`=1 (silent), `python_runtime`=59 sessions but only 10 days (proves day-grained > session-grained).
+- **#3252 blocker** — `test_machine_guard_noop_off_dev_primary` was vacuous (passed with guard deleted); rewritten to keep eligible rows so guard-removal fails it (HEAD `9723a354`).
+
+## Non-blocking follow-ups (reviewers cleared for merge)
+
+- #3253: extractor slurps whole lines into candidate queue (noisier, gated); one wiring test brittle to comment edits; long-run candidate-file growth (out of scope per plan §Risks).
+- #3256: `_read_candidate_families` untested until real candidates exist; consumer validation band `[0,100]` wider than producer `[80,90]` (manual-tamper only); stray `scripts/testing/coverage-reports/WRK-1067-coverage-20260627.txt` residue.
+- #3254: midnight-straddle day-split edge (immaterial — stamps cluster ~07:00 UTC); no exact-window-boundary test.
+- Consider opening a polish issue per the above.
+
+## Environment gotchas confirmed this session
+
+- **Agent `isolation:"worktree"` FAILS here** — CWD `/mnt/local-analysis` isn't the repo + parallel creates race `index.lock`. Pre-make worktrees **sequentially in the background** (~2 min each; 21,905-file checkout).
+- **Pre-push hook hangs ~always** on this repo → agents used `GIT_PRE_PUSH_SKIP=1` after running tests locally (bypass logged to `logs/hooks/pre-push-bypass.jsonl`).
+- **`gh pr merge` of agent-authored PRs is auto-mode DENIED** until the owner says so per-PR (owner's "approve all" unblocked this batch).
+- **Working tree carries ~190 files of background churn** (auto-memory topics, dashboards, provider state) — never `git add -A`; stage by explicit pathspec. Don't `pull --ff-only` over the dirty tree (autostash lock race).
+
+## Worktrees (disposable once PRs merge)
+
+`/mnt/local-analysis/wt-3252`, `wt-3253`, `wt-3254`, `wt-3256`, `wt-skillidx` — clean them with `git worktree remove` after merge.


### PR DESCRIPTION
Lands ONLY the hand-authored handoff doc `docs/session-handoffs/2026-06-27-epic-3248-deferred-children-impl.md` (71 lines, no PII) from #3280.

#3280's remaining 100+ files are regenerated nightly-pipeline state (`.claude/state/*`, `config/ai-tools/*.json`, `provider-*` reports, `.claude/memory/` mirror, and a now-stale `machine-equality-matrix.html` that conflicts with main) — the cron re-commits those, so merging the snapshot would revert newer state. This PR keeps the durable artifact and drops the churn.

Refs #3248. Supersedes #3280.