### PR TITLE
feat(session): lean reference-layer session-review (refines #3298)

### DIFF
--- a/docs/governance/SESSION-GOVERNANCE.md
+++ b/docs/governance/SESSION-GOVERNANCE.md
@@ -548,31 +548,45 @@ The workspace-hub version is canonical for detailed signal analysis.
 
 ## Per-session live-link work-review doc (#3298)
 
-Every session ships a **human-facing, live-linked HTML review** so the user can
-quickly see what that session did. It is the companion to the machine-readable
-session-close report (#2110): #2110 emits the structured payload, #3298 renders
-the reviewable page.
+Every session ships a **live-linked HTML review** so the user can quickly see
+what that session did. As of #3306 it is a **lean reference layer**: at session
+end it *references* the session's artifacts by linking to their canonical
+repo-ecosystem homes and otherwise dies as lean as possible. It restates nothing
+beyond an optional one-line headline.
+
+**Canonical homes (the page links these, never holds their content):**
+
+| Artifact | Canonical home |
+|---|---|
+| Code | PRs / commits (GitHub/git) |
+| Plans | `docs/plans/<file>` |
+| Decisions | the issue/PR thread where decided (durable/architectural → `docs/governance/<date>-<slug>-decision.md`) |
+| Session log + decisions narrative | the `docs/session-handoffs/<date>-<slug>.md` **record** (one canonical per-session doc) |
+| Reports | `docs/reports/<file>` |
 
 **Emit → land flow:**
-1. A session builds a payload JSON (`{slug, date, title, lane, summary, kpis,
-   issues, prs, decisions, artifacts, next_steps}`) — full-fidelity, kept LOCAL
-   (`docs/reports/sessions/payloads/` is gitignored; payloads may name clients).
+1. A session writes a **reference payload** JSON: `{slug, date, title, lane,
+   headline?, refs:[{type, label, num|path|href}]}` where `type ∈
+   issue|pr|commit|plan|decision|handoff|report|link`. Full-fidelity payloads
+   stay LOCAL (`docs/reports/sessions/payloads/` is gitignored). It also writes
+   its `docs/session-handoffs/` record (the log + decisions narrative).
 2. `uv run python scripts/workflow/build_session_review.py <payload.json>` renders
-   `docs/reports/sessions/<date>-<slug>.html`, updates `manifest.json`, and
-   regenerates `index.html`.
+   a lean grouped link-index `docs/reports/sessions/<date>-<slug>.html`, updates
+   `manifest.json`, and regenerates `index.html`. `num` → GitHub issue/PR/commit
+   URL; `path` → `blob/main/<path>` and is verified present at build (missing →
+   visible ⚠, never a silent broken link); `href` → verbatim. A v1 payload
+   (`issues[]`/`prs[]`) is shimmed to refs so it still renders lean.
 3. **Publish mode = sanitized-public.** The renderer runs `session_review_sanitize`
    (deny-list from `.legal-deny-list.yaml` + abs-path/IP/hostname scrub) and a
-   fail-closed `assert_clean` gate before writing — published pages carry only
-   issue/PR numbers, verdicts, and abstract slugs. The test
-   `test_committed_session_pages_pass_sanitization` re-verifies every committed
-   page against the live deny-list.
+   fail-closed `assert_clean` gate before writing. `test_committed_session_pages_pass_sanitization`
+   re-verifies every committed page against the live deny-list; CI's
+   `check-client-pii.py` (private map) is the strict backstop.
 4. `scripts/build_pages.py` copies the index + each manifest-enumerated page
    (no glob) into `public/sessions/` → live at
    `vamseeachanta.github.io/workspace-hub/sessions/index.html`.
 
-Full-fidelity detail stays in the local payload; only the sanitized page is
-published. Markdown session-handoffs (`docs/session-handoffs/`) remain for deep
-narrative; the HTML review is for quick at-a-glance review.
+The page is the index of pointers; the substance lives — and is edited and
+versioned — in each artifact's canonical home.
 
 ## References
 

--- a/docs/plans/2026-06-28-issue-3306-lean-session-review.md
+++ b/docs/plans/2026-06-28-issue-3306-lean-session-review.md
@@ -1,0 +1,65 @@
+# Plan for #3306: Lean reference-layer session-review doc
+
+> **Status:** plan-approved (design forks resolved by user in-window 2026-06-28; see below)
+> **Complexity:** T2
+> **Date:** 2026-06-28
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3306
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Refines:** #3298 (shipped v1)
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+- Found: `scripts/workflow/build_session_review.py` (#3298, in main) — v1 renderer RESTATES content inline (`summary`, `kpis[]`, prose `decisions[]`/`artifacts[]`/`next_steps[]`, PR descriptions). This is what makes the page heavy.
+- Found: `scripts/workflow/session_review_sanitize.py` — fail-closed sanitizer; unchanged by this issue.
+- Found: `scripts/build_pages.py::build_sessions()` — publish path; unchanged (still copies index + manifest pages).
+- Found canonical homes already in repo: `docs/plans/` (plans), `docs/governance/*-decision.md` (durable decisions; 6+ exist), `docs/session-handoffs/` (handoffs), `.claude/state/sessions/` (raw logs), `docs/reports/` (reports).
+- Gap: no reference-based payload schema; renderer holds prose instead of pointers.
+
+### Standards / Wiki
+Not applicable (harness artifact; out of wiki-sibling scope).
+
+### Documents consulted
+- #3306 (source), #3298 (v1), #2110 (machine-readable session-close — **NOT yet implemented**, so the page references artifacts directly, never via #2110).
+- `.legal-deny-list.yaml` + `scripts/legal/check-client-pii.py` (the CI PII gate that caught v1's own leak — lean labels reduce leak surface).
+- `config/agents/claude/SOUL.runtime.md` (HTML-default #2663; legal gate).
+
+## Design forks (RESOLVED by user 2026-06-28)
+- **Decisions home = where decided (issue/PR).** The page links the GitHub issue/PR comment where a decision was made; durable/architectural forks additionally link `docs/governance/<date>-<slug>-decision.md`. No new per-session decisions file.
+- **Session log home = the handoff doc IS the log.** `docs/session-handoffs/<date>-<slug>.md` is the single canonical per-session record (handoff + log + decisions narrative). The page links it once as the "record".
+
+## Target page shape (lean)
+A grouped link-index — one line/label per artifact, no restated prose beyond an optional one-line `headline`:
+```
+Session — <title>           2026-06-28 · lane:claude
+Issues     #3306 · #2110
+PRs        #3299 · #3304
+Plans      docs/plans/2026-06-28-issue-3306-…md
+Decisions  publish-mode=sanitized-public → #3298 (comment)
+Record     docs/session-handoffs/2026-06-28-…md   (handoff = log = decisions)
+Reports    docs/reports/sessions/…
+```
+
+## Implementation (TDD)
+1. **Payload v2 = reference entries.** `refs: [{type, label, num?|path?|href?}]`, `type ∈ {issue,pr,commit,plan,decision,handoff,report,link}`. Plus optional one-line `headline`. Deprecate inline `summary/kpis/decisions/artifacts/next_steps` (renderer ignores them; v1 payloads still render via a thin back-compat shim that maps known fields → refs). *(tests: schema acceptance; v1→v2 shim)*
+2. **Link resolution** in the renderer:
+   - `num` + type issue/pr/commit → `REPO/issues|pull|commit/{num}`.
+   - `path` → `REPO/blob/main/{path}` AND verified to exist at build time (missing → rendered with a ⚠ marker + logged, never silently broken).
+   - `href` → used verbatim.
+   *(tests: each type resolves; missing path flagged)*
+3. **Lean render.** Group refs by type into a compact link list; drop KPI tiles and prose sections. Keep self-contained inline CSS + the sanitize-then-`assert_clean` gate (labels only → smaller leak surface). *(tests: no prose blocks; grouped links present; self-contained; sanitized)*
+4. **Regenerate** this session's page from a v2 payload (lean) so main carries a worked example.
+5. **Docs.** Update `SESSION-GOVERNANCE.md`: payload is reference-only; decisions→issue/PR(+governance), log=handoff doc.
+
+## Acceptance criteria
+- Page is a grouped link-index; zero restated prose beyond one `headline`.
+- Every ref resolves (GitHub URL or `blob/main` path); path refs verified present at build (missing → visible ⚠, not silent).
+- Decisions link the issue/PR (or governance decision); the handoff doc is linked as the session record.
+- Sanitized-public gate + `check-client-pii` still pass; tests cover the reference schema, link resolution, and the v1→v2 shim.
+
+## Out of scope
+- #2110 machine-readable report (separate; not a dependency).
+- Auto-emitting the handoff/log (separate session-close hook work).

--- a/docs/reports/sessions/2026-06-28-ecosystem-workflow-and-pr-backlog.html
+++ b/docs/reports/sessions/2026-06-28-ecosystem-workflow-and-pr-backlog.html
@@ -1,32 +1,30 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Session Review · 2026-06-28 · Ecosystem workflow directive + PR backlog merge</title>
+<title>Session · 2026-06-28 · Session live-link (lean) + PR backlog clear</title>
 <style>
-:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--ok:#1a7f4b;--warn:#b06a00;--hold:#9a3412}
+:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--warn:#b06a00}
 *{box-sizing:border-box}
 body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
-header{padding:22px;background:var(--card);border-bottom:1px solid var(--line)}
-header h1{font-size:22px;margin:0 0 4px}
-header .meta{color:var(--muted);font-size:14px}
+header{padding:20px 22px;background:var(--card);border-bottom:1px solid var(--line)}
+header h1{font-size:20px;margin:0 0 4px}
+header .meta{color:var(--muted);font-size:13px}
 header .home{color:var(--brand);text-decoration:none;font-size:13px}
-main{max-width:920px;margin:0 auto;padding:24px 22px}
-section{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:18px 20px;margin:0 0 18px}
-section h2{font-size:16px;margin:0 0 12px;border-bottom:1px solid var(--line);padding-bottom:8px}
-.kpis{display:flex;gap:10px;flex-wrap:wrap}
-.kpi{flex:1 1 120px;background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:12px 14px}
-.kpi .n{font-size:26px;font-weight:700}
-.kpi .l{font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
-table{border-collapse:collapse;width:100%;font-size:14px}
-th,td{border:1px solid var(--line);padding:7px 10px;text-align:left;vertical-align:top}
-th{background:#f0f3f7}
-a{color:var(--brand)}
-ul{margin:6px 0;padding-left:20px}li{margin:3px 0}
-footer{color:var(--muted);font-size:13px;text-align:center;padding:18px}
+header .headline{margin:8px 0 0;font-size:15px}
+main{max-width:860px;margin:0 auto;padding:20px 22px}
+.refs{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:4px 18px}
+.row{display:flex;gap:14px;padding:9px 0;border-bottom:1px solid var(--line);align-items:baseline}
+.row:last-child{border-bottom:0}
+.k{flex:0 0 92px;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.v{flex:1;font-size:14px}
+.v a{color:var(--brand);text-decoration:none}.v a:hover{text-decoration:underline}
+.sep{color:var(--line);margin:0 3px}
+.warn{color:var(--warn)}
+footer{color:var(--muted);font-size:12px;text-align:center;padding:16px}
 .idx{list-style:none;padding:0}.idx li{margin:0 0 10px;padding:0}
 .idx a{font-weight:600;font-size:16px}.idx .d{color:var(--muted);font-size:13px}
 </style></head>
 <body>
-<header><a class="home" href="../index.html">← workspace-hub</a><h1>Session Review — Ecosystem workflow directive + PR backlog merge</h1><div class="meta">2026-06-28 · workspace-hub · lane:claude · public-safe (issue/PR numbers + verdicts only)</div></header>
-<main><section><h2>At a glance</h2><div class="kpis"><div class="kpi"><div class="n">9</div><div class="l">PRs merged</div></div><div class="kpi"><div class="n">2</div><div class="l">conflicts resolved</div></div><div class="kpi"><div class="n">1</div><div class="l">issue filed</div></div><div class="kpi"><div class="n">approved</div><div class="l">plan #3298</div></div><div class="kpi"><div class="n">1</div><div class="l">PR needs a call</div></div></div><p>Stopped the sync-cycle churn: routed work through the repo workflow, cleared the PR backlog (9 of 10 merged), and stood up the per-session live-link review doc (#3298). This page is the first generator-produced instance of that deliverable.</p></section><section><h2>Pull requests</h2><table><thead><tr><th>PR</th><th>What</th><th>Status</th></tr></thead><tbody><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3273">#3273</a></td><td>recurring drift classes → parked skill-update candidates (#3254)</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3274">#3274</a></td><td>Hermes pattern → skill/memory candidate emitter (#3253)</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3275">#3275</a></td><td>auto-graduate correction candidates to DRAFT skills (#3252)</td><td>merged (conflict resolved)</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3276">#3276</a></td><td>adaptive correction-confidence threshold + Gemini skill detection (#3256)</td><td>merged (conflict resolved)</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3017">#3017</a></td><td>incident-to-issue evidence-research skill ref</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3003">#3003</a></td><td>epic #2998 Windows-rollout entry prompt handoff</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3020">#3020</a></td><td>epic #2998 Windows-host cutover runbook + handoff</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/2982">#2982</a></td><td>F3 registry-driven dispatch + provider-routing policy (#2970)</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3244">#3244</a></td><td>ecosystem reconcile handoff; baseline-red check fixed via branch update</td><td>merged</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/pull/3280">#3280</a></td><td>100+ file bridge-managed memory sweep; conflicts on generated matrix HTML</td><td>HELD — user call</td></tr></tbody></table></section><section><h2>Issues &amp; plans</h2><table><thead><tr><th>Issue</th><th>State</th><th>Note</th></tr></thead><tbody><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/issues/3298">#3298</a></td><td>plan-approved</td><td>per-session live-link HTML review doc; publish mode = sanitized-public; implemented this session (TDD)</td></tr><tr><td><a href="https://github.com/vamseeachanta/workspace-hub/issues/2110">#2110</a></td><td>cross-linked</td><td>machine-readable session-close report; #3298 consumes its payload</td></tr></tbody></table></section><section><h2>Decisions</h2><ul><li>Publish mode = sanitized-public: live Pages link carries only issue/PR numbers + verdicts; full-fidelity stays local; fail-closed sanitization gate.</li><li>Did NOT --admin-override a failing required check (#3244) — fixed the cause (branch staleness) instead.</li><li>Did NOT self-approve the plan gate — user approved the mode in-window before implementation.</li></ul></section><section><h2>Artifacts</h2><ul><li>feedback-ecosystem-workflow-and-session-live-link.md (memory directive)</li><li>docs/plans/2026-06-28-issue-3298-session-review-html.md (approved plan)</li><li>scripts/workflow/session_review_sanitize.py + build_session_review.py (generator, 15 tests)</li><li>docs/reports/sessions/ (this page, index, manifest) + build_pages.py publish wire-up</li></ul></section><section><h2>Next steps</h2><ul><li>Merge PR #3299 once green — it lands the generator + this page + Pages wire-up.</li><li>Decide on #3280 (merge the memory sweep or close/repackage).</li><li>Future sessions: emit a payload → run build_session_review.py → page auto-publishes to the live index.</li></ul></section></main><footer>workspace-hub · session review · generated by build_session_review.py · ecosystem-workflow-and-pr-backlog</footer>
+<header><a class="home" href="../index.html">← workspace-hub</a><h1>Session live-link (lean) + PR backlog clear</h1><div class="meta">2026-06-28 · session record · lane:claude · public-safe (references only)</div><p class="headline">Cleared the PR backlog (9 merged), shipped the per-session live-link doc (#3298), then refined it to a lean reference layer (#3306). Substance lives in canonical homes; this page just points.</p></header>
+<main><div class="refs"><div class="row"><span class="k">Issues</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/issues/3306">lean reference-layer refinement</a> <span class="sep">·</span> <a href="https://github.com/vamseeachanta/workspace-hub/issues/3298">live-link session-review (v1)</a> <span class="sep">·</span> <a href="https://github.com/vamseeachanta/workspace-hub/issues/2110">machine-readable session-close (sibling)</a></span></div><div class="row"><span class="k">PRs</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/pull/3299">feature (merged)</a> <span class="sep">·</span> <a href="https://github.com/vamseeachanta/workspace-hub/pull/3304">handoff extract (merged)</a></span></div><div class="row"><span class="k">Plans</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/blob/main/docs/plans/2026-06-28-issue-3306-lean-session-review.md">lean-design plan</a> <span class="sep">·</span> <a href="https://github.com/vamseeachanta/workspace-hub/blob/main/docs/plans/2026-06-28-issue-3298-session-review-html.md">v1 plan</a></span></div><div class="row"><span class="k">Decisions</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/issues/3298">publish-mode = sanitized-public</a> <span class="sep">·</span> <a href="https://github.com/vamseeachanta/workspace-hub/issues/3306">lean reference layer + canonical homes</a></span></div><div class="row"><span class="k">Record</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/blob/main/docs/session-handoffs/2026-06-28-session-live-link-lean-and-pr-backlog.md">session record (log + decisions)</a></span></div><div class="row"><span class="k">Reports</span><span class="v"><a href="https://github.com/vamseeachanta/workspace-hub/blob/main/docs/reports/sessions/index.html">all session reviews</a></span></div></div></main><footer>workspace-hub · session record · references canonical homes (code→PRs · plans→docs/plans · decisions→issue/PR · log→handoff) · ecosystem-workflow-and-pr-backlog</footer>
 </body></html>

--- a/docs/reports/sessions/index.html
+++ b/docs/reports/sessions/index.html
@@ -3,30 +3,28 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Session Reviews · workspace-hub</title>
 <style>
-:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--ok:#1a7f4b;--warn:#b06a00;--hold:#9a3412}
+:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--warn:#b06a00}
 *{box-sizing:border-box}
 body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
-header{padding:22px;background:var(--card);border-bottom:1px solid var(--line)}
-header h1{font-size:22px;margin:0 0 4px}
-header .meta{color:var(--muted);font-size:14px}
+header{padding:20px 22px;background:var(--card);border-bottom:1px solid var(--line)}
+header h1{font-size:20px;margin:0 0 4px}
+header .meta{color:var(--muted);font-size:13px}
 header .home{color:var(--brand);text-decoration:none;font-size:13px}
-main{max-width:920px;margin:0 auto;padding:24px 22px}
-section{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:18px 20px;margin:0 0 18px}
-section h2{font-size:16px;margin:0 0 12px;border-bottom:1px solid var(--line);padding-bottom:8px}
-.kpis{display:flex;gap:10px;flex-wrap:wrap}
-.kpi{flex:1 1 120px;background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:12px 14px}
-.kpi .n{font-size:26px;font-weight:700}
-.kpi .l{font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
-table{border-collapse:collapse;width:100%;font-size:14px}
-th,td{border:1px solid var(--line);padding:7px 10px;text-align:left;vertical-align:top}
-th{background:#f0f3f7}
-a{color:var(--brand)}
-ul{margin:6px 0;padding-left:20px}li{margin:3px 0}
-footer{color:var(--muted);font-size:13px;text-align:center;padding:18px}
+header .headline{margin:8px 0 0;font-size:15px}
+main{max-width:860px;margin:0 auto;padding:20px 22px}
+.refs{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:4px 18px}
+.row{display:flex;gap:14px;padding:9px 0;border-bottom:1px solid var(--line);align-items:baseline}
+.row:last-child{border-bottom:0}
+.k{flex:0 0 92px;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.v{flex:1;font-size:14px}
+.v a{color:var(--brand);text-decoration:none}.v a:hover{text-decoration:underline}
+.sep{color:var(--line);margin:0 3px}
+.warn{color:var(--warn)}
+footer{color:var(--muted);font-size:12px;text-align:center;padding:16px}
 .idx{list-style:none;padding:0}.idx li{margin:0 0 10px;padding:0}
 .idx a{font-weight:600;font-size:16px}.idx .d{color:var(--muted);font-size:13px}
 </style></head>
 <body>
 <header><a class="home" href="../index.html">← workspace-hub</a><h1>Session Reviews</h1><div class="meta">Per-session work-review docs (#3298) · newest first · public-safe</div></header>
-<main><section><ul class="idx"><li><a href="2026-06-28-ecosystem-workflow-and-pr-backlog.html">Ecosystem workflow directive + PR backlog merge</a><div class="d">2026-06-28 · lane:claude</div></li></ul></section></main><footer>workspace-hub · session reviews</footer>
+<main><section><ul class="idx"><li><a href="2026-06-28-ecosystem-workflow-and-pr-backlog.html">Session live-link (lean) + PR backlog clear</a><div class="d">2026-06-28 · lane:claude</div></li></ul></section></main><footer>workspace-hub · session reviews</footer>
 </body></html>

--- a/docs/reports/sessions/manifest.json
+++ b/docs/reports/sessions/manifest.json
@@ -2,7 +2,7 @@
   {
     "slug": "ecosystem-workflow-and-pr-backlog",
     "date": "2026-06-28",
-    "title": "Ecosystem workflow directive + PR backlog merge",
+    "title": "Session live-link (lean) + PR backlog clear",
     "lane": "claude",
     "file": "2026-06-28-ecosystem-workflow-and-pr-backlog.html"
   }

--- a/docs/session-handoffs/2026-06-28-session-live-link-lean-and-pr-backlog.md
+++ b/docs/session-handoffs/2026-06-28-session-live-link-lean-and-pr-backlog.md
@@ -1,0 +1,25 @@
+# Session record — session live-link (#3298 → #3306 lean) + PR backlog clear
+
+**Date:** 2026-06-28 · **Lane:** claude
+**Canonical per-session record** (handoff = log = decisions narrative). The live-link page references this; it does not restate it.
+
+## What this session did
+- Cleared the open PR backlog: 9 merged (#3273 #3274 #3275 #3276 #3017 #3003 #3020 #2982 #3244), resolving two additive cron/plan conflicts. #3280 closed as superseded by #3304 (clean handoff extract); the rest of #3280 was regenerated nightly-pipeline state.
+- Stood up the **per-session live-link work-review doc**: #3298 (PR #3299, merged) → now refined to a **lean reference layer** by #3306 (this PR). Live at `vamseeachanta.github.io/workspace-hub/sessions/`.
+- Saved the standing directive memory (route work through gh issue→plan→review; real deliverables over sync churn; PRs mergeable; every session ships a live link).
+
+## Decisions (canonical — referenced by the live-link page)
+- **Publish mode = sanitized-public** (decided in #3298): live page carries only issue/PR numbers + verdicts + abstract slugs; full-fidelity payloads stay local; fail-closed sanitization gate.
+- **Lean reference-layer design** (decided in #3306): the page references artifacts in their canonical homes and dies lean.
+  - **Decisions** live where decided — the issue/PR thread (durable/architectural forks → `docs/governance/*-decision.md`).
+  - **Session log** = this handoff doc (one canonical per-session record).
+  - Code → PRs/commits · plans → `docs/plans/` · reports → `docs/reports/`.
+- **No `--admin` bypass of a failing required check** — fix the cause (e.g. branch-staleness → `gh pr update-branch`).
+
+## Incidents handled
+- Shared-checkout HEAD switched mid-push (twice) — a commit landed on a parallel branch; reverted off cleanly (no force-push), cherry-picked onto the correct branch. Remaining work done in isolated worktrees.
+- The Client-PII Gate caught the #3298 plan naming real clients — scrubbed plan + public issue body. Working as designed.
+
+## Next steps
+- Merge #3306 (this PR) when green → the live page becomes the lean reference layer.
+- Future sessions: write a v2 reference payload + a handoff record like this one → run `build_session_review.py` → the page auto-publishes pointing at canonical homes.

--- a/scripts/workflow/build_session_review.py
+++ b/scripts/workflow/build_session_review.py
@@ -35,41 +35,88 @@ import session_review_sanitize as sani  # noqa: E402
 REPO = "https://github.com/vamseeachanta/workspace-hub"
 
 _STYLE = """
-:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--ok:#1a7f4b;--warn:#b06a00;--hold:#9a3412}
+:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6;--warn:#b06a00}
 *{box-sizing:border-box}
 body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
-header{padding:22px;background:var(--card);border-bottom:1px solid var(--line)}
-header h1{font-size:22px;margin:0 0 4px}
-header .meta{color:var(--muted);font-size:14px}
+header{padding:20px 22px;background:var(--card);border-bottom:1px solid var(--line)}
+header h1{font-size:20px;margin:0 0 4px}
+header .meta{color:var(--muted);font-size:13px}
 header .home{color:var(--brand);text-decoration:none;font-size:13px}
-main{max-width:920px;margin:0 auto;padding:24px 22px}
-section{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:18px 20px;margin:0 0 18px}
-section h2{font-size:16px;margin:0 0 12px;border-bottom:1px solid var(--line);padding-bottom:8px}
-.kpis{display:flex;gap:10px;flex-wrap:wrap}
-.kpi{flex:1 1 120px;background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:12px 14px}
-.kpi .n{font-size:26px;font-weight:700}
-.kpi .l{font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
-table{border-collapse:collapse;width:100%;font-size:14px}
-th,td{border:1px solid var(--line);padding:7px 10px;text-align:left;vertical-align:top}
-th{background:#f0f3f7}
-a{color:var(--brand)}
-ul{margin:6px 0;padding-left:20px}li{margin:3px 0}
-footer{color:var(--muted);font-size:13px;text-align:center;padding:18px}
+header .headline{margin:8px 0 0;font-size:15px}
+main{max-width:860px;margin:0 auto;padding:20px 22px}
+.refs{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:4px 18px}
+.row{display:flex;gap:14px;padding:9px 0;border-bottom:1px solid var(--line);align-items:baseline}
+.row:last-child{border-bottom:0}
+.k{flex:0 0 92px;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.v{flex:1;font-size:14px}
+.v a{color:var(--brand);text-decoration:none}.v a:hover{text-decoration:underline}
+.sep{color:var(--line);margin:0 3px}
+.warn{color:var(--warn)}
+footer{color:var(--muted);font-size:12px;text-align:center;padding:16px}
 .idx{list-style:none;padding:0}.idx li{margin:0 0 10px;padding:0}
 .idx a{font-weight:600;font-size:16px}.idx .d{color:var(--muted);font-size:13px}
 """
+
+# Ordered reference groups: (payload type, plural heading). The page is a lean
+# index of pointers — substance lives in each ref's canonical home.
+_REF_GROUPS = [
+    ("issue", "Issues"), ("pr", "PRs"), ("commit", "Commits"),
+    ("plan", "Plans"), ("decision", "Decisions"), ("handoff", "Record"),
+    ("report", "Reports"), ("link", "Links"),
+]
+_REPO_PATH_FOR = {"issue": "issues", "pr": "pull", "commit": "commit"}
 
 
 def _esc(s) -> str:
     return html.escape(str(s if s is not None else ""))
 
 
-def _issue_link(num) -> str:
-    return f'<a href="{REPO}/issues/{_esc(num)}">#{_esc(num)}</a>'
+def _ref_href(ref: dict, repo_root=None):
+    """Resolve a reference to (href, missing). Substance is NOT inlined — the
+    href points at the artifact's canonical home (GitHub issue/PR/commit, or a
+    repo blob path). `missing` flags a `path` ref absent from disk at build."""
+    if ref.get("href"):
+        return str(ref["href"]), False
+    t = ref.get("type")
+    if t in _REPO_PATH_FOR and ref.get("num") not in (None, ""):
+        return f"{REPO}/{_REPO_PATH_FOR[t]}/{ref['num']}", False
+    if ref.get("path"):
+        path = str(ref["path"])
+        missing = repo_root is not None and not (Path(repo_root) / path).exists()
+        return f"{REPO}/blob/main/{path}", missing
+    if t == "decision" and ref.get("num") not in (None, ""):
+        return f"{REPO}/issues/{ref['num']}", False  # decided in an issue/PR thread
+    return "", False
 
 
-def _pr_link(num) -> str:
-    return f'<a href="{REPO}/pull/{_esc(num)}">#{_esc(num)}</a>'
+def _ref_label(ref: dict) -> str:
+    if ref.get("label"):
+        return _esc(ref["label"])
+    if ref.get("num") not in (None, ""):
+        return f"#{_esc(ref['num'])}"
+    if ref.get("path"):
+        return _esc(ref["path"])
+    return _esc(ref.get("href", "?"))
+
+
+def _ref_anchor(ref: dict, repo_root=None) -> str:
+    href, missing = _ref_href(ref, repo_root)
+    label = _ref_label(ref)
+    warn = '<span class="warn" title="path not found at build">⚠ </span>' if missing else ""
+    return f'{warn}<a href="{_esc(href)}">{label}</a>' if href else f"{warn}{label}"
+
+
+def _normalize_refs(payload: dict) -> list[dict]:
+    """Return the v2 `refs` list. v2 payloads pass through; v1 payloads
+    (issues[]/prs[]) are shimmed into refs so older payloads still render lean."""
+    if payload.get("refs"):
+        return list(payload["refs"])
+    refs: list[dict] = []
+    for i in payload.get("issues") or []:
+        refs.append({"type": "issue", "num": i.get("num"), "label": i.get("note")})
+    for p in payload.get("prs") or []:
+        refs.append({"type": "pr", "num": p.get("num"), "label": p.get("what")})
+    return refs
 
 
 def _shell(title: str, body: str, home: str = "../index.html") -> str:
@@ -82,67 +129,44 @@ def _shell(title: str, body: str, home: str = "../index.html") -> str:
     )
 
 
-def render_session_html(payload: dict) -> str:
-    """Render a self-contained session-review page. Assumes payload is already
-    sanitized (call `build` for the sanitize-then-render path)."""
+def render_session_html(payload: dict, repo_root=None) -> str:
+    """Render a LEAN reference-layer session page: a grouped index of links to
+    each artifact's canonical home (code→PRs/commits, plans→docs/plans,
+    decisions→issue/PR, log→handoff doc). Restates nothing beyond an optional
+    one-line headline. Assumes payload is already sanitized (use `build`)."""
     slug = _esc(payload.get("slug", "session"))
     date = _esc(payload.get("date", ""))
     title = _esc(payload.get("title", "Session Review"))
     lane = _esc(payload.get("lane", ""))
-    parts: list[str] = []
-    parts.append(
+    headline = payload.get("headline") or payload.get("summary") or ""
+    refs = _normalize_refs(payload)
+
+    body = (
         f'<header><a class="home" href="../index.html">← workspace-hub</a>'
-        f"<h1>Session Review — {title}</h1>"
-        f'<div class="meta">{date} · workspace-hub'
+        f"<h1>{title}</h1>"
+        f'<div class="meta">{date} · session record'
         + (f" · lane:{lane}" if lane else "")
-        + " · public-safe (issue/PR numbers + verdicts only)</div></header>\n<main>"
+        + " · public-safe (references only)</div>"
+        + (f'<p class="headline">{_esc(headline)}</p>' if headline else "")
+        + '</header>\n<main><div class="refs">'
     )
 
-    kpis = payload.get("kpis") or []
-    if kpis:
-        cells = "".join(
-            f'<div class="kpi"><div class="n">{_esc(k.get("n"))}</div>'
-            f'<div class="l">{_esc(k.get("l"))}</div></div>'
-            for k in kpis
-        )
-        parts.append(f'<section><h2>At a glance</h2><div class="kpis">{cells}</div>'
-                     + (f"<p>{_esc(payload['summary'])}</p>" if payload.get("summary") else "")
-                     + "</section>")
-    elif payload.get("summary"):
-        parts.append(f"<section><h2>At a glance</h2><p>{_esc(payload['summary'])}</p></section>")
+    known = {g[0] for g in _REF_GROUPS}
+    rows: list[str] = []
+    for t, heading in _REF_GROUPS:
+        group = [r for r in refs if r.get("type") == t]
+        if group:
+            anchors = ' <span class="sep">·</span> '.join(_ref_anchor(r, repo_root) for r in group)
+            rows.append(f'<div class="row"><span class="k">{heading}</span><span class="v">{anchors}</span></div>')
+    other = [r for r in refs if r.get("type") not in known]  # never silently drop a ref
+    if other:
+        anchors = ' <span class="sep">·</span> '.join(_ref_anchor(r, repo_root) for r in other)
+        rows.append(f'<div class="row"><span class="k">Other</span><span class="v">{anchors}</span></div>')
 
-    prs = payload.get("prs") or []
-    if prs:
-        rows = "".join(
-            f"<tr><td>{_pr_link(p.get('num'))}</td><td>{_esc(p.get('what'))}</td>"
-            f"<td>{_esc(p.get('status'))}</td></tr>"
-            for p in prs
-        )
-        parts.append("<section><h2>Pull requests</h2><table><thead><tr>"
-                     "<th>PR</th><th>What</th><th>Status</th></tr></thead><tbody>"
-                     + rows + "</tbody></table></section>")
-
-    issues = payload.get("issues") or []
-    if issues:
-        rows = "".join(
-            f"<tr><td>{_issue_link(i.get('num'))}</td><td>{_esc(i.get('state'))}</td>"
-            f"<td>{_esc(i.get('note'))}</td></tr>"
-            for i in issues
-        )
-        parts.append("<section><h2>Issues &amp; plans</h2><table><thead><tr>"
-                     "<th>Issue</th><th>State</th><th>Note</th></tr></thead><tbody>"
-                     + rows + "</tbody></table></section>")
-
-    for key, heading in (("decisions", "Decisions"), ("artifacts", "Artifacts"),
-                         ("next_steps", "Next steps")):
-        items = payload.get(key) or []
-        if items:
-            lis = "".join(f"<li>{_esc(x)}</li>" for x in items)
-            parts.append(f"<section><h2>{heading}</h2><ul>{lis}</ul></section>")
-
-    parts.append("</main><footer>workspace-hub · session review · "
-                 f"generated by build_session_review.py · {slug}</footer>")
-    return _shell(f"Session Review · {date} · {title}", "".join(parts))
+    body += ("".join(rows) or '<div class="row"><span class="v">No artifacts referenced.</span></div>')
+    body += ("</div></main><footer>workspace-hub · session record · references canonical homes "
+             "(code→PRs · plans→docs/plans · decisions→issue/PR · log→handoff) · " + slug + "</footer>")
+    return _shell(f"Session · {date} · {title}", body)
 
 
 def render_index_html(entries: list[dict]) -> str:
@@ -177,9 +201,11 @@ def update_manifest(manifest_path: Path, entry: dict) -> list[dict]:
 
 
 def build(payload: dict, sessions_dir: Path, patterns: list[tuple[str, bool]],
-          public: bool = True) -> dict:
+          public: bool = True, repo_root=None) -> dict:
     """Sanitize (if public), render the page + index, update the manifest.
 
+    `repo_root` (when given) lets the renderer verify `path` refs exist on disk
+    and flag missing ones; pass None to skip verification (e.g. in unit tests).
     Returns the manifest entry. Raises SanitizationError if a denied client
     pattern survives into the public page (fail-closed)."""
     if public:
@@ -189,7 +215,7 @@ def build(payload: dict, sessions_dir: Path, patterns: list[tuple[str, bool]],
     file_name = f"{date}-{slug}.html"
     sessions_dir.mkdir(parents=True, exist_ok=True)
 
-    page = render_session_html(payload)
+    page = render_session_html(payload, repo_root=repo_root)
     if public:
         sani.assert_clean(page, patterns)  # last-line fail-closed gate
     (sessions_dir / file_name).write_text(page, encoding="utf-8")
@@ -209,7 +235,7 @@ def main(argv: list[str]) -> int:
     payload = json.loads(Path(argv[0]).read_text(encoding="utf-8"))
     patterns = sani.load_deny_patterns(repo_root / ".legal-deny-list.yaml")
     sessions_dir = repo_root / "docs" / "reports" / "sessions"
-    entry = build(payload, sessions_dir, patterns, public=True)
+    entry = build(payload, sessions_dir, patterns, public=True, repo_root=repo_root)
     print(f"Wrote {sessions_dir / entry['file']} and refreshed index ({entry['slug']})")
     return 0
 

--- a/tests/workflow/test_build_session_review.py
+++ b/tests/workflow/test_build_session_review.py
@@ -1,4 +1,4 @@
-"""Tests for the #3298 session-review renderer + index + manifest."""
+"""Tests for the #3306 lean reference-layer session-review renderer."""
 import json
 import sys
 from pathlib import Path
@@ -16,73 +16,95 @@ PAYLOAD = {
     "date": "2026-06-28",
     "title": "Demo session",
     "lane": "claude",
-    "summary": "Did stuff.",
-    "kpis": [{"n": 3, "l": "PRs merged"}],
-    "prs": [{"num": 3273, "what": "thing", "status": "merged"}],
-    "issues": [{"num": 3298, "state": "filed", "note": "feature"}],
-    "decisions": ["chose option 1"],
-    "artifacts": ["a file"],
-    "next_steps": ["do the next thing"],
+    "headline": "One-line headline.",
+    "refs": [
+        {"type": "issue", "num": 3306, "label": "lean session review"},
+        {"type": "pr", "num": 3299},
+        {"type": "plan", "path": "docs/plans/2026-06-28-issue-3306-lean-session-review.md"},
+        {"type": "decision", "label": "publish-mode=sanitized-public", "num": 3298},
+        {"type": "handoff", "label": "session record", "path": "docs/session-handoffs/x.md"},
+        {"type": "report", "label": "sessions index", "path": "docs/reports/sessions/index.html"},
+    ],
 }
 
 
-def test_session_html_has_sections_and_links():
+def test_refs_resolve_to_canonical_homes():
     html = bsr.render_session_html(PAYLOAD)
-    assert "Demo session" in html
-    assert f"{bsr.REPO}/pull/3273" in html      # PR linked
-    assert f"{bsr.REPO}/issues/3298" in html    # issue linked
-    for label in ("At a glance", "Pull requests", "Issues", "Decisions",
-                  "Artifacts", "Next steps"):
-        assert label in html
+    assert f"{bsr.REPO}/issues/3306" in html          # issue
+    assert f"{bsr.REPO}/pull/3299" in html            # PR
+    assert f"{bsr.REPO}/blob/main/docs/plans/2026-06-28-issue-3306-lean-session-review.md" in html  # plan path
+    assert f"{bsr.REPO}/issues/3298" in html          # decision → issue thread
+    assert f"{bsr.REPO}/blob/main/docs/session-handoffs/x.md" in html  # handoff record
 
 
-def test_session_html_is_self_contained():
+def test_page_is_lean_no_restated_prose_blocks():
     html = bsr.render_session_html(PAYLOAD)
-    # no external stylesheet or script references — fully inline
-    assert "<link" not in html
-    assert "<script" not in html
-    assert "src=" not in html
+    # the lean page has no KPI tiles, no data tables, no bulleted prose sections
+    assert 'class="kpi"' not in html
+    assert "<table" not in html
+    assert "<ul>" not in html
+    assert 'class="refs"' in html  # grouped link index instead
+
+
+def test_grouped_headings_present():
+    html = bsr.render_session_html(PAYLOAD)
+    for heading in ("Issues", "PRs", "Plans", "Decisions", "Record", "Reports"):
+        assert f">{heading}</span>" in html
+
+
+def test_self_contained():
+    html = bsr.render_session_html(PAYLOAD)
+    assert "<link" not in html and "<script" not in html and "src=" not in html
     assert "<style>" in html
+
+
+def test_missing_path_ref_is_flagged_not_silent(tmp_path):
+    payload = {**PAYLOAD, "refs": [{"type": "plan", "path": "docs/plans/nope.md"}]}
+    html = bsr.render_session_html(payload, repo_root=tmp_path)  # file absent → flagged
+    assert "⚠" in html
+    # and a present file is NOT flagged
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    (tmp_path / "docs" / "plans" / "yes.md").write_text("x")
+    html2 = bsr.render_session_html(
+        {**PAYLOAD, "refs": [{"type": "plan", "path": "docs/plans/yes.md"}]}, repo_root=tmp_path)
+    assert "⚠" not in html2
+
+
+def test_v1_payload_shim_renders_lean():
+    # an old v1 payload (issues[]/prs[], no refs) still renders as lean links
+    v1 = {"slug": "old", "date": "2026-06-01", "title": "Old",
+          "issues": [{"num": 100, "note": "thing"}], "prs": [{"num": 200, "what": "fix"}]}
+    html = bsr.render_session_html(v1)
+    assert f"{bsr.REPO}/issues/100" in html
+    assert f"{bsr.REPO}/pull/200" in html
+    assert "<table" not in html  # not the old table render
+
+
+def test_unknown_ref_type_not_dropped():
+    html = bsr.render_session_html(
+        {**PAYLOAD, "refs": [{"type": "weird", "label": "keepme", "href": "https://x"}]})
+    assert "keepme" in html and "Other" in html
 
 
 def test_build_writes_page_manifest_and_index(tmp_path):
     entry = bsr.build(PAYLOAD, tmp_path, PATTERNS, public=True)
-    page = tmp_path / "2026-06-28-demo.html"
-    assert page.exists()
+    assert (tmp_path / "2026-06-28-demo.html").exists()
     assert entry["file"] == "2026-06-28-demo.html"
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest[0]["slug"] == "demo"
-    assert (tmp_path / "index.html").exists()
     assert "Session Reviews" in (tmp_path / "index.html").read_text()
 
 
-def test_manifest_newest_first_and_replace_by_slug(tmp_path):
-    bsr.build({**PAYLOAD, "slug": "older", "date": "2026-06-01"}, tmp_path, PATTERNS)
-    bsr.build({**PAYLOAD, "slug": "newer", "date": "2026-06-28"}, tmp_path, PATTERNS)
-    bsr.build({**PAYLOAD, "slug": "newer", "date": "2026-06-28", "title": "Newer v2"},
-              tmp_path, PATTERNS)  # replace, not duplicate
-    manifest = json.loads((tmp_path / "manifest.json").read_text())
-    assert [e["slug"] for e in manifest] == ["newer", "older"]  # newest first
-    assert sum(e["slug"] == "newer" for e in manifest) == 1     # replaced
-    assert manifest[0]["title"] == "Newer v2"
-
-
-def test_index_links_to_each_session_file(tmp_path):
-    bsr.build({**PAYLOAD, "slug": "s1", "date": "2026-06-28"}, tmp_path, PATTERNS)
-    idx = (tmp_path / "index.html").read_text()
-    assert 'href="2026-06-28-s1.html"' in idx  # relative sibling link (works published)
-
-
 def test_public_build_redacts_client_name(tmp_path):
-    dirty = {**PAYLOAD, "slug": "leaky", "summary": "Worked on Synthco Field today"}
+    dirty = {**PAYLOAD, "slug": "leaky",
+             "refs": [{"type": "issue", "num": 1, "label": "work on Synthco Field"}]}
     bsr.build(dirty, tmp_path, PATTERNS, public=True)
     page = (tmp_path / "2026-06-28-leaky.html").read_text()
     assert "Synthco Field" not in page
-    sani.assert_clean(page, PATTERNS)  # gate passes on the written page
+    sani.assert_clean(page, PATTERNS)
 
 
 def test_committed_session_pages_pass_sanitization():
-    """Every committed session page must be public-safe against the real deny-list."""
     repo_root = Path(__file__).resolve().parents[2]
     pats = sani.load_deny_patterns(repo_root / ".legal-deny-list.yaml")
     sessions = repo_root / "docs" / "reports" / "sessions"


### PR DESCRIPTION
Refines the per-session live-link doc (#3298) into a **lean reference layer** per the user directive: *"at session end the live link should reference all the artifacts and die as lean as possible, as the session logs, decisions, code will have their own place in the repo ecosystem."*

## What changes
- **Payload v2 = references, not prose.** `refs:[{type,label,num|path|href}]`, `type ∈ issue|pr|commit|plan|decision|handoff|report|link`. Optional one-line `headline`. Inline `summary/kpis/decisions/artifacts/next_steps` are gone; v1 payloads are shimmed to refs.
- **Renderer links each artifact to its canonical home.** `num`→GitHub issue/PR/commit URL; `path`→`blob/main/<path>` **verified present at build** (missing→visible ⚠, never a silent broken link); `href`→verbatim. Drops KPI tiles, tables, prose sections → a grouped link-index.
- **Canonical homes (user-approved):** code→PRs/commits · plans→`docs/plans/` · decisions→the issue/PR thread (durable→`docs/governance/*-decision.md`) · session log + decisions narrative→the `docs/session-handoffs/` **record** · reports→`docs/reports/`.
- This session's page regenerated lean (**4.1 KB vs 6.6 KB**) referencing its new handoff record; `SESSION-GOVERNANCE.md` updated.

## Verification
- **147 workflow tests pass** (reference schema, link resolution, missing-path flag, v1→v2 shim, sanitization). abs-path clean. Sanitized-public gate unchanged.

Plan: `docs/plans/2026-06-28-issue-3306-lean-session-review.md`. Closes #3306. Refines #3298.