### PR TITLE
fix(pages): redeploy on session-page changes (completes #3306 live link)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/reports/machine-equality-matrix.html'
       - 'docs/reports/issue-workflow-lifecycle.html'
       - 'docs/reports/orcaflex-pipeline-worklog.html'
+      - 'docs/reports/sessions/**'
       - 'scripts/build_pages.py'
       - '.github/workflows/pages.yml'
   workflow_dispatch:


### PR DESCRIPTION
One-line trigger fix: `pages.yml` published session pages via `build_pages.py` but its `paths` filter omitted `docs/reports/sessions/**`, so a session-page change alone never triggered a redeploy (#3299 only deployed because it also touched `build_pages.py`; #3306's lean page did not). Adds the path so every future session's live link updates on merge. Refs #3306.