### PR TITLE
feat(session): auto-derive the lean reference payload from git footprint (--from-git)

### DIFF
--- a/docs/governance/SESSION-GOVERNANCE.md
+++ b/docs/governance/SESSION-GOVERNANCE.md
@@ -565,11 +565,18 @@ beyond an optional one-line headline.
 | Reports | `docs/reports/<file>` |
 
 **Emit → land flow:**
-1. A session writes a **reference payload** JSON: `{slug, date, title, lane,
-   headline?, refs:[{type, label, num|path|href}]}` where `type ∈
-   issue|pr|commit|plan|decision|handoff|report|link`. Full-fidelity payloads
-   stay LOCAL (`docs/reports/sessions/payloads/` is gitignored). It also writes
-   its `docs/session-handoffs/` record (the log + decisions narrative).
+1. A session gets its **reference payload** one of two ways:
+   - **Auto-derive from git (#3311, preferred):** `build_session_review.py --from-git
+     --since <ref>` derives `refs` from the session's commits + changed docs in
+     `<base>..HEAD` — PRs from the `(#NNN)` squash-merge subject, issues from other
+     `#NNN`, and `docs/plans|session-handoffs|governance/*-decision|reports` files
+     → typed refs. Add `--emit-payload <path>` to write a draft for curation.
+   - **By hand:** write the payload JSON `{slug, date, title, lane, headline?,
+     refs:[{type, label, num|path|href}]}`, `type ∈
+     issue|pr|commit|plan|decision|handoff|report|link`.
+   Either way the session also writes its `docs/session-handoffs/` record (the log
+   + decisions narrative). Full-fidelity payloads stay LOCAL
+   (`docs/reports/sessions/payloads/` is gitignored).
 2. `uv run python scripts/workflow/build_session_review.py <payload.json>` renders
    a lean grouped link-index `docs/reports/sessions/<date>-<slug>.html`, updates
    `manifest.json`, and regenerates `index.html`. `num` → GitHub issue/PR/commit

--- a/docs/plans/2026-06-28-issue-3311-derive-from-git.md
+++ b/docs/plans/2026-06-28-issue-3311-derive-from-git.md
@@ -1,0 +1,28 @@
+# Plan for #3311: Auto-derive the lean reference payload from git footprint
+
+> **Status:** plan-approved (approach approved by user in-window 2026-06-28: git range since a base)
+> **Complexity:** T1
+> **Date:** 2026-06-28
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3311
+> **Client:** N/A · **Lane:** lane:claude
+> **Refines/feeds:** #3306 (lean renderer), #2110 (session-close emit side)
+
+## Resource Intelligence
+- Found: `scripts/workflow/build_session_review.py` (#3306) — renders a lean page from a `refs` payload. This issue adds the *deriver* that builds that payload from git so the page is no longer hand-authored.
+- Found: squash-merge convention `subject (#NNN)` (every recent `main` commit) → reliable PR-number source, network-free.
+- Found canonical doc homes (path→type): `docs/plans/`, `docs/session-handoffs/`, `docs/governance/*-decision.md`, `docs/reports/` (per #3306).
+- Gap: no derivation; payloads are written by hand (as this stream's pages were).
+
+## Implementation (TDD) — DONE in this PR
+1. Pure `derive_refs(commit_messages, changed_files)`: PRs ← `(#NNN)` subject; issues ← other `#NNN`; changed docs → typed refs by path prefix; session-pages/manifest/index excluded; governance only `*-decision.md` counts. *(7 unit tests)*
+2. `derive_payload_from_git(base, repo_root, …)`: thin wrapper gathering `git log --format=%B` + `git diff --name-only <base>...HEAD`, builds the v2 payload (slug←branch, date←today).
+3. CLI: `--from-git --since <ref> [--slug/--title/--headline] [--emit-payload <path>]`. Default base = `merge-base(HEAD, origin/main)`. `--emit-payload` writes the derived payload for curation (the auto-draft path); else renders directly through the existing sanitize→render→manifest path.
+
+## Acceptance criteria
+- `--from-git --since <ref>` yields a lean page whose refs match the range's PRs/issues/changed-docs. ✓ (dogfooded on this branch)
+- Derivation pure + unit-tested (PR/issue split, dedup, path→type, exclusions). ✓
+- Sanitized-public gate unchanged. ✓
+
+## Out of scope (follow-on)
+- Stop/SessionEnd **hook** that runs `--from-git` automatically at session end (#2110 hook slice).
+- gh-based issue↔PR re-classification (the `(#NNN)` heuristic is network-free and sufficient).

--- a/scripts/workflow/build_session_review.py
+++ b/scripts/workflow/build_session_review.py
@@ -24,8 +24,12 @@ Payload schema (all fields optional except slug+date+title):
 """
 from __future__ import annotations
 
+import argparse
+import datetime
 import html
 import json
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -227,16 +231,120 @@ def build(payload: dict, sessions_dir: Path, patterns: list[tuple[str, bool]],
     return entry
 
 
+# ── #3311: derive the reference payload from the session's git footprint ──────
+
+# docs path prefix → ref type. Order matters: first match wins. The session
+# pages dir is excluded so a page never references itself.
+_PATH_RULES = [
+    ("docs/reports/sessions/", None),                 # skip: our own output
+    ("docs/plans/", "plan"),
+    ("docs/session-handoffs/", "handoff"),
+    ("docs/governance/", "decision"),                 # narrowed to *-decision.md below
+    ("docs/reports/", "report"),
+]
+_SUBJECT_PR_RE = re.compile(r"\(#(\d+)\)\s*$")         # squash-merge subject convention
+_ISSUE_RE = re.compile(r"#(\d+)")
+
+
+def _ordered_unique(nums):
+    seen, out = set(), []
+    for n in nums:
+        if n not in seen:
+            seen.add(n); out.append(n)
+    return out
+
+
+def derive_refs(commit_messages: list[str], changed_files: list[str]) -> list[dict]:
+    """Pure derivation of `refs` from a git range. PRs come from the
+    `(#NNN)` squash-merge subject convention; other `#NNN` tokens are issues;
+    changed docs map to typed refs by path. Network-free and deterministic."""
+    pr_nums, issue_nums = [], []
+    for msg in commit_messages:
+        lines = msg.splitlines()
+        m = _SUBJECT_PR_RE.search(lines[0]) if lines else None
+        if m:
+            pr_nums.append(int(m.group(1)))
+        issue_nums += [int(n) for n in _ISSUE_RE.findall(msg)]
+    prs = _ordered_unique(pr_nums)
+    issues = [n for n in _ordered_unique(issue_nums) if n not in set(prs)]
+
+    refs: list[dict] = [{"type": "pr", "num": n} for n in prs]
+    refs += [{"type": "issue", "num": n} for n in issues]
+    for f in changed_files:
+        f = f.strip()
+        if not f:
+            continue
+        for prefix, rtype in _PATH_RULES:
+            if f.startswith(prefix):
+                if rtype is None:
+                    break  # excluded
+                if rtype == "decision" and not f.endswith("-decision.md"):
+                    break  # only *-decision.md under governance are decisions
+                refs.append({"type": rtype, "label": f.rsplit("/", 1)[-1], "path": f})
+                break
+    return refs
+
+
+def _git(args: list[str], repo_root: Path) -> str:
+    return subprocess.run(["git", "-C", str(repo_root), *args],
+                          capture_output=True, text=True, check=True).stdout
+
+
+def derive_payload_from_git(base: str, repo_root: Path, *, slug=None, title=None,
+                            headline=None, date=None, lane="claude") -> dict:
+    """Gather commit messages + changed files in `<base>..HEAD` and build a v2
+    payload. Thin wrapper around the pure `derive_refs`."""
+    raw = _git(["log", "--format=%B%x00", f"{base}..HEAD"], repo_root)
+    commit_messages = [m.strip() for m in raw.split("\0") if m.strip()]
+    changed = _git(["diff", "--name-only", f"{base}...HEAD"], repo_root).splitlines()
+    refs = derive_refs(commit_messages, changed)
+    if slug is None:
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root).strip()
+        slug = re.sub(r"[^a-z0-9]+", "-", branch.lower()).strip("-") or "session"
+    return {
+        "slug": slug,
+        "date": date or datetime.date.today().isoformat(),
+        "title": title or slug.replace("-", " "),
+        "lane": lane,
+        "headline": headline or "",
+        "refs": refs,
+    }
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) != 1:
-        print("usage: build_session_review.py <payload.json>", file=sys.stderr)
-        return 2
+    p = argparse.ArgumentParser(description="Render a lean session-review page.")
+    p.add_argument("payload", nargs="?", help="payload JSON path (manual mode)")
+    p.add_argument("--from-git", action="store_true",
+                   help="derive the payload from the session's git footprint")
+    p.add_argument("--since", default="origin/main",
+                   help="base ref for --from-git (default: merge-base with origin/main)")
+    p.add_argument("--slug"); p.add_argument("--title"); p.add_argument("--headline")
+    p.add_argument("--date")
+    p.add_argument("--emit-payload", help="with --from-git: write the derived payload here "
+                                          "for curation instead of rendering")
+    a = p.parse_args(argv)
     repo_root = Path(__file__).resolve().parents[2]
-    payload = json.loads(Path(argv[0]).read_text(encoding="utf-8"))
     patterns = sani.load_deny_patterns(repo_root / ".legal-deny-list.yaml")
     sessions_dir = repo_root / "docs" / "reports" / "sessions"
+
+    if a.from_git:
+        base = _git(["merge-base", "HEAD", a.since], repo_root).strip() if "/" in a.since else a.since
+        payload = derive_payload_from_git(base, repo_root, slug=a.slug, title=a.title,
+                                          headline=a.headline, date=a.date)
+        if a.emit_payload:
+            Path(a.emit_payload).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            print(f"Wrote derived payload to {a.emit_payload} "
+                  f"({len(payload['refs'])} refs) — curate then render it.")
+            return 0
+    elif a.payload:
+        payload = json.loads(Path(a.payload).read_text(encoding="utf-8"))
+    else:
+        p.error("provide a payload JSON path, or --from-git")
+        return 2
+
     entry = build(payload, sessions_dir, patterns, public=True, repo_root=repo_root)
-    print(f"Wrote {sessions_dir / entry['file']} and refreshed index ({entry['slug']})")
+    print(f"Wrote {sessions_dir / entry['file']} and refreshed index "
+          f"({entry['slug']}, {len(payload.get('refs', []))} refs)")
     return 0
 
 

--- a/tests/workflow/test_session_review_derive.py
+++ b/tests/workflow/test_session_review_derive.py
@@ -1,0 +1,70 @@
+"""Tests for #3311 git-footprint derivation of the lean reference payload."""
+import sys
+from pathlib import Path
+
+SCRIPTS_WORKFLOW = Path(__file__).resolve().parents[2] / "scripts" / "workflow"
+sys.path.insert(0, str(SCRIPTS_WORKFLOW))
+
+import build_session_review as bsr  # noqa: E402
+
+
+def _types(refs):
+    return [(r["type"], r.get("num", r.get("path"))) for r in refs]
+
+
+def test_pr_from_squash_subject_issue_from_body():
+    msgs = ["feat(x): do a thing (#3299)\n\nCloses #3298. Refs #2110."]
+    refs = bsr.derive_refs(msgs, [])
+    assert ("pr", 3299) in _types(refs)
+    assert ("issue", 3298) in _types(refs)
+    assert ("issue", 2110) in _types(refs)
+    # the PR number is not also listed as an issue
+    assert ("issue", 3299) not in _types(refs)
+
+
+def test_prs_render_before_issues():
+    refs = bsr.derive_refs(["fix: y (#10)\n\nCloses #20."], [])
+    types = [r["type"] for r in refs]
+    assert types.index("pr") < types.index("issue")
+
+
+def test_dedup_across_commits():
+    msgs = ["a (#5)\n\n#9", "b (#5)\n\n#9"]
+    refs = bsr.derive_refs(msgs, [])
+    assert [r for r in refs if r["type"] == "pr"] == [{"type": "pr", "num": 5}]
+    assert [r for r in refs if r["type"] == "issue"] == [{"type": "issue", "num": 9}]
+
+
+def test_changed_files_map_to_typed_refs():
+    files = [
+        "docs/plans/2026-06-28-issue-3311-x.md",
+        "docs/session-handoffs/2026-06-28-rec.md",
+        "docs/governance/2026-06-28-publish-mode-decision.md",
+        "docs/reports/foo.html",
+        "scripts/workflow/build_session_review.py",   # not a doc → ignored
+    ]
+    refs = bsr.derive_refs([], files)
+    t = {(r["type"], r["path"]) for r in refs if "path" in r}
+    assert ("plan", "docs/plans/2026-06-28-issue-3311-x.md") in t
+    assert ("handoff", "docs/session-handoffs/2026-06-28-rec.md") in t
+    assert ("decision", "docs/governance/2026-06-28-publish-mode-decision.md") in t
+    assert ("report", "docs/reports/foo.html") in t
+    assert all(r.get("path") != "scripts/workflow/build_session_review.py" for r in refs)
+
+
+def test_session_pages_are_excluded():
+    files = ["docs/reports/sessions/2026-06-28-x.html",
+             "docs/reports/sessions/index.html",
+             "docs/reports/sessions/manifest.json"]
+    assert bsr.derive_refs([], files) == []
+
+
+def test_governance_non_decision_file_is_not_a_decision():
+    # a governance doc that is not *-decision.md must not become a decision ref
+    refs = bsr.derive_refs([], ["docs/governance/SESSION-GOVERNANCE.md"])
+    assert refs == []
+
+
+def test_labels_are_basenames():
+    refs = bsr.derive_refs([], ["docs/plans/2026-06-28-issue-3311-x.md"])
+    assert refs[0]["label"] == "2026-06-28-issue-3311-x.md"


### PR DESCRIPTION
The emit side of the live-link stream: the page now **assembles itself from git** instead of a hand-authored payload (which is how this stream's pages were built until now).

`build_session_review.py --from-git --since <ref>` derives the `refs` payload from `<base>..HEAD`:
- **PRs** ← the `(#NNN)` squash-merge subject; **issues** ← other `#NNN` in commit messages.
- **Changed docs → typed refs:** `docs/plans/`→plan · `docs/session-handoffs/`→handoff · `docs/governance/*-decision.md`→decision · `docs/reports/`→report (session pages excluded).
- `--emit-payload <path>` writes a draft for light curation (headline/prune) before publishing; else renders directly.

Pure `derive_refs()` (network-free, deterministic) + **7 unit tests**; 151 workflow tests pass; abs-path clean. **Dogfooded** on this branch — derived pr #3311 + issues #3306/#2110 + the plan ref. User-approved approach (git range since a base).

**Follow-on (not here):** a Stop/SessionEnd hook that runs `--from-git` automatically (#2110 hook slice).

Plan: `docs/plans/2026-06-28-issue-3311-derive-from-git.md`. Closes #3311. Refs #3306, #2110.