### PR TITLE
chore(hooks): activate the session-review-page hook (generate-only)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -260,6 +260,24 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/gsd-session-state.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash \"${WORKSPACE_HUB:-$(git rev-parse --show-toplevel)}/.claude/hooks/session-review-page.sh\" start 2>/dev/null || true",
+            "timeout": 5,
+            "statusMessage": "Session-review base ref"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${WORKSPACE_HUB:-$(git rev-parse --show-toplevel)}/.claude/hooks/session-review-page.sh\" emit 2>/dev/null || true",
+            "timeout": 60,
+            "statusMessage": "Emit session-review live-link page"
           }
         ]
       }


### PR DESCRIPTION
User-approved activation (generate-only) of the #3316 SessionEnd auto-emit hook. Registers `.claude/hooks/session-review-page.sh` on **SessionStart** (record git base) + **SessionEnd** (render the lean live-link page from the session's git footprint, then notify). Fail-open; **no auto-commit/push** — you commit to publish. Refs #3316.