### PR TITLE
fix(equality-matrix): color-code group-summary rows for at-a-glance machine status

### DIFF
--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -700,8 +700,8 @@ tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.cura
 .expected-diff,.expected-divergence{{background:#e9d8fd}}
 .pending,.missing-evidence{{background:#fffaf0}}.unreachable,.absent,.na{{background:#f7fafc;color:#a0aec0}}
 .stale-checkout{{background:#e2e8f0;color:#4a5568;font-style:italic}}
-tr.grp{{cursor:pointer}}tr.grp th,tr.grp td{{background:#1a202c;color:#fff;border-color:#2d3748}}
-tr.grp .twist{{color:#90cdf4;font-size:.7rem}}tr.grp td{{font-weight:700}}
+tr.grp{{cursor:pointer}}tr.grp th{{background:#1a202c;color:#fff;border-color:#2d3748}}tr.grp td{{color:#1a202c;border-color:#cbd5e0;font-weight:800;box-shadow:inset 0 0 0 9999px rgba(0,0,0,.04)}}
+tr.grp .twist{{color:#90cdf4;font-size:.7rem}}
 tr.detail{{display:none}}tr.detail th{{padding-left:1.8rem;font-weight:400}}
 .note{{background:#fffaf0;border-left:4px solid #ed8936;padding:.5rem .9rem;margin:.6rem 0;border-radius:4px}}
 .legend span{{display:inline-block;padding:.15rem .5rem;margin:.12rem;border-radius:3px;font-size:.72rem;border:1px solid #ccc}}


### PR DESCRIPTION
## What
Group-summary (`tr.grp`) cells in the machine-equality matrix forced `background:#1a202c`, which **overrode the verdict color classes** — so the collapsed rows you scan first all read uniformly dark, defeating the color legend.

## Change (CSS-only, in `build-equality-matrix.py`)
- Label `<th>` keeps the dark clickable-header style (+ twistie).
- Summary `<td>` now shows its **verdict-class color** (green=parity/OK, red=diverges/below-baseline, amber=stale/no-majority, purple=expected-divergence, cream=missing-evidence, gray=stale-checkout/unreachable), with dark text, bold weight, and a subtle inset tint so the group band stays visually distinct from detail rows.
- Detail rows were already colored; this brings the summary band to parity.

## Safety
- **No row structure or cell text changed** — only the `tr.grp` CSS rule. The verdict-engine HTML contract (detail-row `<th>{dim}</th>` + cell verdicts) is untouched.
- `tests/readiness/test_build_equality_matrix.py`: **79/79 pass**.
- Regenerated dashboard verified in-browser: each machine's column is now scannable at a glance.

Purely presentational; no behavior change to collection or verdict logic.