### PR TITLE
docs(handoff): reconcile dev-primary equality + matrix color-coding

### DIFF
--- a/docs/session-handoffs/2026-06-30-reconcile-dev-primary-equality-and-matrix-color-coding.md
+++ b/docs/session-handoffs/2026-06-30-reconcile-dev-primary-equality-and-matrix-color-coding.md
@@ -1,0 +1,79 @@
+# Session Handoff — Reconcile dev-primary equality + matrix color-coding
+
+**Date:** 2026-06-30 (work spanned 2026-06-29 evening → 2026-06-30)
+**Machine:** ace-linux-1 (`dev-primary`)
+**Trigger:** "reconcile equality for machine"
+
+## Objective
+
+Reconcile the machine-equality matrix (#2801) for `dev-primary`, which was reading
+`STALE-CHECKOUT` across its entire column.
+
+## What was done
+
+### 1. Diagnosed + fixed the real cause (durable)
+`dev-primary` local `main` had **diverged** from origin: ahead 7 unpushed cron commits
+(`chore(sync): auto-sync` ×6, `chore(gtm)` ×1) + behind 11 merged PRs. The 7 ahead were
+**100% machine-generated churn** (verified: only non-rolling-state file was
+`queue/.watcher-state/git-pull-failures.count`, itself a counter). Origin strictly
+superseded them.
+
+- **Not a push-auth failure** — the cron's "push skipped/failed" was it correctly refusing
+  a non-fast-forward push.
+- **Did NOT rebase** — both sides re-churned ~210 rolling-state files; rebase = conflict storm.
+- **Resolution:** `git reset --hard origin/main` after proving zero human work at risk, with
+  a `backup/pre-reconcile-2026-06-29` safety branch (since deleted; commit `43ecdfeec` in
+  reflog ~14d). Result: ahead 0 / behind 0, clean — and the auto-sync cron's pushes are
+  unblocked going forward (no longer rejected as non-FF).
+- **Proven:** clean-window collection cleared `STALE-CHECKOUT` (35→1 legend-only),
+  `dev-primary` reporting real verdicts at parity with `dev-secondary`.
+
+### 2. Refreshed the two unmasked freshness signals
+Clearing `STALE-CHECKOUT` unmasked two real, fleet-wide signals (identical on dev-secondary):
+- **Session curation** (`CURATED-EXPIRED`) → ran `curate-session-memory.sh` (133 sessions/24h,
+  published). **Fixed.**
+- **Memory freshness** (`MEMORY-EXPIRED`) → ran `bridge-hermes-claude.sh`; refreshed 4 surfaces.
+  **Residual:** `context.md` is genuinely 82.8h stale (stable machine-conventions file,
+  regenerates byte-identical). `memory_freshness` grades 4/5 surfaces by **git-commit age**,
+  so it only clears once those surfaces are committed — and `context.md` won't until its content
+  actually changes. **Not gamed** with a no-op commit. Genuine fleet-wide signal.
+
+### 3. Matrix HTML color-coding (requested) — LANDED
+Group-summary (`tr.grp`) cells forced `background:#1a202c`, overriding the verdict color
+classes, so the rows you scan first read uniformly dark. CSS-only fix in
+`scripts/readiness/build-equality-matrix.py`: label `<th>` stays the dark clickable header;
+summary `<td>` shows its verdict-class color (dark text, bold, subtle inset tint).
+- **PR [#3322](https://github.com/vamseeachanta/workspace-hub/pull/3322) — MERGED** to `origin/main`
+  (`7c21478e5`); matrix already rebuilt with colors on origin (`2f5eb972f`).
+- 79/79 `tests/readiness/test_build_equality_matrix.py` pass. No row structure / cell text
+  changed (verdict-engine HTML contract intact).
+
+## Repo state at exit
+
+- **workspace-hub:** PR #3322 merged on `origin/main`. Local `main` is ahead 3 / behind 3 —
+  **expected auto-sync cron churn**, self-healing; DO NOT manually reset/rebase again (treadmill).
+- **Dirty tree (expected):** regenerated rolling-state from the curation/bridge/collect runs
+  (memory surfaces, dashboards, `.claude/state/*`). The auto-sync cron absorbs + pushes it
+  (now FF-unblocked). Not a concern.
+- **Siblings:** untouched.
+
+## External actions
+
+**None.** No emails/messages sent, no outward-facing actions. A temporary localhost:8765
+viewer server (for in-browser matrix review) was started and **stopped**. Backup branch dropped.
+
+## Next steps / open items (all low-priority, none blocking)
+
+1. **No action needed for the matrix** — it self-greens `dev-primary` from clean state via the
+   now-unblocked auto-sync → equality cron cycle.
+2. **`ace-win-2` codex/hermes `DIVERGES`** in the provider-parity grid — worth verifying whether
+   it's a stale report or a real runtime gap (operator/Windows, no SSH from Linux).
+3. **`ace-win-1` evidence-blind** (whole column `MISSING-EVIDENCE`) — operator-gated Windows
+   collector run.
+4. **`gemini:skills:invoke` EXPECTED-DIVERGENCE** — by design (Gemini CLI no skill dispatch), not a defect.
+
+## Memory captured this session
+
+`feedback_dev_primary_equality_green_is_self_healing` updated with: the diverged-checkout
+reset technique (verify-pure-churn → reset to origin, not rebase), the `memory_freshness`
+git-commit-age gotcha, and the commit-then-collect ordering that breaks the re-collect treadmill.


### PR DESCRIPTION
Session handoff for the dev-primary equality reconcile + matrix group-row color-coding work (companion to merged #3322).

Captures: the diverged-checkout root cause + reset-to-origin fix, the curation/memory-freshness refresh (with the genuine `context.md` residual), the color-coding PR, repo state at exit (local main self-healing via cron — do not manually reset again), no external actions, and low-priority open items (ace-win-2 codex/hermes DIVERGES, ace-win-1 evidence-blind, gemini skill-dispatch by-design).

Docs-only; no code/behavior change.