### PR TITLE
chore(#801): activate ecosystem data-source auto-suggestion hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -270,6 +270,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${WORKSPACE_HUB:-$(git rev-parse --show-toplevel)}/.claude/hooks/ecosystem-data-nudge.sh\" 2>/dev/null || true",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [


### PR DESCRIPTION
Wires the UserPromptSubmit hook (merged in #3328) into `.claude/settings.json` so it fires. When a prompt enters an engineering domain (riser/mooring/pipeline/...), the hook surfaces one line → the data-source catalog + the domain-database issue — the #801 'stop re-prompting me' behavior, live.

Single-file change: adds `hooks.UserPromptSubmit` → `ecosystem-data-nudge.sh` (stdout+exit0, keyword-gated, once-per-domain-per-session, fail-open, 5s timeout).

**Pipe-tested green:** positive prompt ('riser fatigue') emits the pointer incl. ACE_SHARE-precedent note; negative prompt ('what time is it') silent. Config-protected file → owner merges. After merge, open /hooks once to reload the watcher. Completes PR #3328; epic llm-wiki#799.