### PR TITLE
fix(equality): eliminate collector-artifact false DIVERGES (kanban collation, cron-PATH providers, skills SHA-skew)

### DIFF
--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -200,6 +200,29 @@ def uniform_verdict(dim: str, values: list) -> str:
     return "NO-MAJORITY" if len(tied) > 1 else "DIVERGES"
 
 
+def skills_verdict(pairs: list) -> str:
+    """repo_skill_count is fully determined by the checkout SHA, and machines self-report
+    days apart (weekly Windows cadence vs daily Linux), so clones at DIFFERENT SHAs
+    legitimately count differently — pure checkout skew that graded DIVERGES forever
+    (e.g. 417/416/415 across four boxes). Only a count mismatch at the SAME SHA is real
+    divergence (dirty overlay / partial checkout / broken skill links); cross-SHA
+    mismatches grade EXPECTED-DIFF. Fail-closed: a mismatch involving a report with no
+    checkout_sha cannot be attributed to skew and stays DIVERGES."""
+    real = [(sha, count) for sha, count in pairs if count not in (None, "unknown", "n/a")]
+    if len(real) < 2:
+        return "PENDING"
+    if len({count for _, count in real}) == 1:
+        return "EQUAL"
+    by_sha: dict = {}
+    for sha, count in real:
+        by_sha.setdefault(sha, set()).add(count)
+    if any(len(counts) > 1 for counts in by_sha.values()):
+        return "DIVERGES"
+    if None in by_sha or "" in by_sha:
+        return "DIVERGES"
+    return "EXPECTED-DIFF"
+
+
 # ── session-curation freshness (time-since-last-run, graded at build time) ───
 def freshness_verdict(report: dict, now: datetime | None = None) -> str:
     """Grade the session-curation cell by age of `last_curated_at` vs now.
@@ -333,7 +356,12 @@ def extract_value(dim: str, report: dict):
     if dim == "skills":
         return d.get("skills", {}).get("repo_skill_count")
     if dim == "kanban":
-        return d.get("kanban", {}).get("dispatch_queues")
+        q = d.get("kanban", {}).get("dispatch_queues")
+        # Canonicalize as a sorted membership list: historical evidence was emitted under
+        # locale-dependent collation on Linux vs byte order under Git Bash, so the SAME
+        # queue set arrived as differently-ordered strings and graded DIVERGES. Order is
+        # a collector artifact; membership is the signal.
+        return ",".join(sorted(q.split(","))) if isinstance(q, str) else q
     if dim == "memory":
         return d.get("memory", {}).get("hermes_home")
     if dim == "behavior":
@@ -438,12 +466,15 @@ def verdict_for(dim: str, machine: str, reports: dict, baselines: dict,
         return cold_verdict(dim, rep, baselines.get(machine), probed_repos)
     # Stale peers are EXCLUDED from the uniform value list so a stale report can never
     # manufacture a false EQUAL/DIVERGES/NO-MAJORITY for the fresh machines (A2/BC4).
-    values = [extract_value(dim, reports[m]) for m in roster
-              if roster[m].get("status") == "active"
-              and isinstance(reports.get(m), dict) and "_error" not in reports[m]
-              and isinstance(reports[m].get("dimensions"), dict)
-              and not is_stale(reports[m])]
-    return uniform_verdict(dim, values)
+    fresh = [m for m in roster
+             if roster[m].get("status") == "active"
+             and isinstance(reports.get(m), dict) and "_error" not in reports[m]
+             and isinstance(reports[m].get("dimensions"), dict)
+             and not is_stale(reports[m])]
+    if dim == "skills":
+        return skills_verdict([(reports[m].get("provenance", {}).get("checkout_sha"),
+                                extract_value(dim, reports[m])) for m in fresh])
+    return uniform_verdict(dim, [extract_value(dim, reports[m]) for m in fresh])
 
 
 # ── load + render ────────────────────────────────────────────────────────────

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -125,6 +125,15 @@ else
 fi
 
 # ── 3. HARNESS (reference readiness; gh_auth as ENUM, never the token) ───────
+# Cron carries a minimal PATH that hides user-installed provider CLIs (claude in
+# ~/.npm-global/bin; uv/codex in ~/.local/bin), so an unattended run reported
+# providers as 'absent' that every interactive shell can see — a false NO-MAJORITY
+# in the harness row. Append (not prepend: system binaries keep precedence) the
+# well-known user bin dirs so cron and interactive collections probe the same PATH.
+for _ubin in "${HOME:-}/.npm-global/bin" "${HOME:-}/.local/bin"; do
+  [[ -d "$_ubin" && ":$PATH:" != *":$_ubin:"* ]] && PATH="$PATH:$_ubin"
+done
+export PATH
 readiness_file="harness-readiness-${MACHINE}.yaml"
 [[ -f "${STATE_DIR}/${readiness_file}" ]] || readiness_file="harness-readiness-${HOST}.yaml"
 readiness_overall="missing"
@@ -138,7 +147,10 @@ prov() { have "$1" && echo present || echo absent; }
 skills=$(find "${WS}/.claude/skills" -maxdepth 3 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')
 
 # ── 5. KANBAN ────────────────────────────────────────────────────────────────
-queues=$(find "${WS}/.claude/dispatch" -maxdepth 1 -name '*.yaml' 2>/dev/null | sed 's#.*/##;s#\.yaml$##' | sort | paste -sd',' -)
+# LC_ALL=C: locale collation buried '_leader-state' mid-list while PowerShell sorts
+# ordinal (underscore first) — same queue set diffed as DIVERGES across OSes. Byte
+# order matches the Windows collector's output.
+queues=$(find "${WS}/.claude/dispatch" -maxdepth 1 -name '*.yaml' 2>/dev/null | sed 's#.*/##;s#\.yaml$##' | LC_ALL=C sort | paste -sd',' -)
 : "${queues:=none}"
 
 # ── 6. MEMORY ────────────────────────────────────────────────────────────────

--- a/tests/readiness/test_build_equality_matrix.py
+++ b/tests/readiness/test_build_equality_matrix.py
@@ -746,14 +746,15 @@ def test_matrix_stale_excluded_two_fresh_equal():
 
 def test_matrix_stale_not_in_majority():
     # 2 fresh disagree + 1 stale matching one side → NO-MAJORITY (the stale report must NOT
-    # break the tie by lending its vote to one side) (BC4).
+    # break the tie by lending its vote to one side) (BC4). Vehicle is kanban — skills no
+    # longer majority-votes (SHA-aware: same-SHA mismatch is DIVERGES regardless of ties).
     roster = {"dev-primary": {"status": "active"}, "dev-secondary": {"status": "active"},
               "ace-win-1": {"status": "active"}}
-    reports = {"dev-primary": _report("dev-primary", skills={"repo_skill_count": 407}),
-               "dev-secondary": _report("dev-secondary", skills={"repo_skill_count": 401}),
+    reports = {"dev-primary": _report("dev-primary", kanban={"dispatch_queues": "dev-primary,multi"}),
+               "dev-secondary": _report("dev-secondary", kanban={"dispatch_queues": "dev-primary"}),
                "ace-win-1": _report("ace-win-1", provenance=_prov(dirty=True),
-                                         skills={"repo_skill_count": 407})}
-    assert bem.verdict_for("skills", "dev-primary", reports, {}, roster, TIER1) == "NO-MAJORITY"
+                                         kanban={"dispatch_queues": "dev-primary,multi"})}
+    assert bem.verdict_for("kanban", "dev-primary", reports, {}, roster, TIER1) == "NO-MAJORITY"
 
 
 def test_matrix_fresh_unaffected():
@@ -783,3 +784,61 @@ def test_matrix_stale_renders_in_html(tmp_path, monkeypatch):
     html = next(reports_dir.glob("*-machine-equality-matrix.html")).read_text()
     assert "stale-checkout" in html               # CSS class present (lowercased verdict)
     assert "STALE-CHECKOUT" in html               # visible cell text
+
+
+# ── collector-artifact fixes: SHA-aware skills verdict + order-insensitive kanban ──
+def _two_box(dim: str, val_a, val_b, prov_b: dict | None = None) -> str:
+    roster = {"dev-primary": {"status": "active"}, "dev-secondary": {"status": "active"}}
+    ra, rb = _report("dev-primary"), _report("dev-secondary", provenance=prov_b)
+    ra["dimensions"][dim] = val_a
+    rb["dimensions"][dim] = val_b
+    return bem.verdict_for(dim, "dev-primary", {"dev-primary": ra, "dev-secondary": rb},
+                           {}, roster, TIER1)
+
+
+def test_skills_count_mismatch_across_shas_is_expected_diff():
+    # Evidence collected days apart sits at different SHAs; a count delta there is
+    # checkout skew (the 417/416/415 fleet reading), not divergence.
+    verdict = _two_box("skills", {"repo_skill_count": 417}, {"repo_skill_count": 416},
+                       prov_b={**FRESH_PROV, "checkout_sha": "def5678"})
+    assert verdict == "EXPECTED-DIFF"
+
+
+def test_skills_count_mismatch_same_sha_diverges():
+    # Same SHA, different count = dirty overlay / partial checkout — the real signal.
+    verdict = _two_box("skills", {"repo_skill_count": 417}, {"repo_skill_count": 416})
+    assert verdict == "DIVERGES"
+
+
+def test_skills_equal_counts_across_shas_equal():
+    verdict = _two_box("skills", {"repo_skill_count": 417}, {"repo_skill_count": 417},
+                       prov_b={**FRESH_PROV, "checkout_sha": "def5678"})
+    assert verdict == "EQUAL"
+
+
+def test_skills_mismatch_without_sha_fail_closed_diverges():
+    # A mismatch that includes a report with no checkout_sha cannot be attributed to
+    # checkout skew — fail closed, never silently EXPECTED-DIFF.
+    prov_no_sha = {k: v for k, v in FRESH_PROV.items() if k != "checkout_sha"}
+    verdict = _two_box("skills", {"repo_skill_count": 417}, {"repo_skill_count": 416},
+                       prov_b=prov_no_sha)
+    assert verdict == "DIVERGES"
+
+
+def test_kanban_queue_order_is_ignored():
+    # Locale collation (Linux) vs byte order (Git Bash on Windows) emitted the SAME
+    # queue set as differently-ordered strings; membership, not order, is compared.
+    verdict = _two_box("kanban",
+                       {"dispatch_queues": "dev-primary,home-win,_leader-state"},
+                       {"dispatch_queues": "_leader-state,dev-primary,home-win"},
+                       prov_b={**FRESH_PROV, "checkout_sha": "def5678"})
+    assert verdict == "EQUAL"
+
+
+def test_kanban_membership_difference_still_diverges():
+    roster = {m: {"status": "active"} for m in ("a", "b", "c")}
+    reports = {m: _report(m) for m in roster}
+    reports["a"]["dimensions"]["kanban"] = {"dispatch_queues": "dev-primary,multi"}
+    reports["b"]["dimensions"]["kanban"] = {"dispatch_queues": "dev-primary,multi"}
+    reports["c"]["dimensions"]["kanban"] = {"dispatch_queues": "dev-primary,multi,rogue"}
+    assert bem.verdict_for("kanban", "a", reports, {}, roster, TIER1) == "DIVERGES"

--- a/tests/readiness/test_collect_equality.py
+++ b/tests/readiness/test_collect_equality.py
@@ -598,3 +598,12 @@ def test_collect_origin_ref_age_refreshed_not_frozen(tmp_path):
     out.write_text(re.sub(r"origin_ref_age_h: .*", "origin_ref_age_h: 999", out.read_text()))
     subprocess.run(["bash", str(SCRIPT), "--machine", "dev-primary"], env=env, timeout=60, check=True)
     assert "origin_ref_age_h: 999" not in out.read_text()               # refreshed, not frozen
+
+
+def test_collect_kanban_queue_order_is_byte_sorted(tmp_path):
+    # LC_ALL=C: '_leader-state' sorts FIRST (byte order, matching Git Bash on Windows).
+    # Locale collation buried it mid-list, so the same queue set graded DIVERGES across OSes.
+    ws = _fixture(tmp_path)
+    (ws / ".claude" / "dispatch" / "_leader-state.yaml").write_text("x")
+    d = _run(ws)
+    assert d["dimensions"]["kanban"]["dispatch_queues"] == "_leader-state,dev-primary,multi"


### PR DESCRIPTION
## What

Fixes three **measurement artifacts** that kept the machine-equality matrix red regardless of actual fleet state (found during today's reconcile-equality assessment):

| Artifact | Before | After |
|---|---|---|
| `kanban` locale collation (Linux) vs byte order (Git Bash) | DIVERGES ×3 for the same queue set | EQUAL |
| `harness` providers probed under cron's minimal PATH | `claude: absent` on dev-primary → NO-MAJORITY fleet-wide | `claude: present` on next collection |
| `skills` count compared across checkouts days apart | 417/416/415 checkout skew → DIVERGES forever | EXPECTED-DIFF (cross-SHA); same-SHA mismatch stays DIVERGES |

## How

- `collect-equality.sh`: `LC_ALL=C sort` for dispatch queues (byte order matches the Windows collector); append `~/.npm-global/bin` + `~/.local/bin` to PATH before provider probes (append, not prepend — system binaries keep precedence; `${HOME:-}`-guarded for `set -u`).
- `build-equality-matrix.py`: `extract_value('kanban')` canonicalizes membership (already-committed evidence greens without waiting for every box to re-collect); new `skills_verdict()` — SHA-aware, fail-closed to DIVERGES when a report lacks `checkout_sha`.
- `test_matrix_stale_not_in_majority` (BC4) repointed at `kanban` as its vehicle — `skills` no longer majority-votes.

## Verification

- 388 readiness tests pass (+7 new regression tests).
- Live rebuild against real fleet evidence: kanban DIVERGES×3 → EQUAL, skills DIVERGES×3 → EXPECTED-DIFF (total DIVERGES 27 → 21; the remainder is genuine drift — Windows scheduler/providers/hermes).
- Collector smoke-tested under cron-like `PATH=/usr/bin:/bin`: reports `claude: present` + byte-sorted queues.
- `EXPECTED-DIFF` already in `OK_VERDICTS` + reconcile-ecosystem OK-skip list (no #3263-style drift).

## Pre-existing baseline-red (NOT this PR)

`test_guard_is_invoked_in_target_repo_cwd` fails on clean origin/main: its regex expects `cd "$repo" && python3 "$GUARD"` but `reconcile-ecosystem.sh` now uses `( cd "$repo" && "$PY" "$GUARD" ... )`. Stale contract-test regex; separate one-line fix.