### PR TITLE
feat(setup): dde-drive NFS mount + canonical drive-reference convention

### DIFF
--- a/docs/standards/canonical-drive-references.md
+++ b/docs/standards/canonical-drive-references.md
@@ -1,0 +1,55 @@
+# Canonical Drive References
+
+> One unique, machine-independent path per shared drive, used consistently
+> across the whole repo ecosystem. Reconciled by
+> `scripts/setup/canonical-drive-links.sh`.
+
+## The rule
+
+Every shared drive has exactly ONE canonical reference: **`/mnt/<drive>`**.
+It resolves on **every** machine in the fleet:
+
+- on the **owner machine** it is the physical disk mount;
+- on **every other machine** it is a symlink to the NFS transport path
+  `/mnt/remote/<owner-host>/<drive>`.
+
+Repos, scripts, configs, docs, and agent prompts reference the canonical
+path only. The transport path (`/mnt/remote/...`) is plumbing — never
+hardcode it in ecosystem code.
+
+## Drive registry
+
+| Drive | Canonical path | Owner host | Physical FS | Transport (on non-owners) | Setup script |
+|-------|----------------|------------|-------------|---------------------------|--------------|
+| ace | `/mnt/ace` | ace-linux-1 | ext4 (7.3 TB) | `/mnt/remote/ace-linux-1/ace` (NFS) | `scripts/setup/nfs-ace-drive.sh` |
+| dde | `/mnt/dde` | ace-linux-2 | NTFS/ntfs3 (2.8 TB) | `/mnt/remote/ace-linux-2/dde` (NFS) | `scripts/setup/nfs-dde-drive.sh` |
+
+**Not shared** (per-machine local disks, never symlinked, no transport):
+`/mnt/local-analysis` — exists independently on each machine with different
+content (workspace/checkout area).
+
+## Transport convention
+
+- NFS mount point: `/mnt/remote/<owner-host>/<drive>` — fstab-managed, options
+  `defaults,nofail,rw,bg,intr,soft,timeo=50` (established by the ace mapping).
+- Exports live in `/etc/exports` on the owner host, scoped to the fleet
+  hostnames (not open subnets).
+- Legacy sshfs automounts at the same paths are retired by the per-drive
+  setup scripts when the NFS mount takes over (sshfs remains acceptable for
+  `local-analysis` cross-machine peeks, which have no canonical alias).
+
+## Adding a new shared drive
+
+1. Mount the disk on its owner at `/mnt/<drive>` (fstab, `nofail`).
+2. Copy `scripts/setup/nfs-dde-drive.sh` → `nfs-<drive>-drive.sh`; set
+   `EXPORT_PATH`, hosts; run `server` mode on the owner, `client` on others.
+3. Add the drive to the `DRIVE_OWNER` registry in
+   `scripts/setup/canonical-drive-links.sh`; run it on every machine.
+4. Add a row to the registry table above.
+
+## Verification
+
+```bash
+sudo bash scripts/setup/canonical-drive-links.sh   # per machine
+bash scripts/setup/nfs-dde-drive.sh verify         # per drive
+```

--- a/scripts/setup/canonical-drive-links.sh
+++ b/scripts/setup/canonical-drive-links.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# canonical-drive-links.sh — Make shared-drive references unique and
+# consistent across the machine fleet.
+#
+# Convention (docs/standards/canonical-drive-references.md):
+#   Every shared drive has ONE canonical path that resolves on EVERY
+#   machine: <MNT_ROOT>/<drive>. On the owner machine it is the physical
+#   mount; everywhere else it is a symlink to the NFS transport path
+#   <REMOTE_ROOT>/<owner-host>/<drive>. Repos, scripts, and docs must
+#   reference the canonical path only — never the transport path.
+#
+# Idempotent. Run as root on ANY machine in the fleet:
+#   sudo bash scripts/setup/canonical-drive-links.sh
+#
+# The NFS mounts themselves are set up by the per-drive scripts
+# (nfs-ace-drive.sh, nfs-dde-drive.sh); this script only reconciles the
+# canonical symlinks on top of them.
+set -euo pipefail
+
+MNT_ROOT="/mnt"                 # abs-path-allowed
+REMOTE_ROOT="/mnt/remote"       # abs-path-allowed
+
+# Registry: drive -> owner host. Add a line per new shared drive.
+declare -A DRIVE_OWNER=(
+    [ace]="ace-linux-1"
+    [dde]="ace-linux-2"
+)
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: must run as root (sudo)"
+    exit 1
+fi
+
+host="$(hostname -s)"
+status=0
+
+for drive in "${!DRIVE_OWNER[@]}"; do
+    owner="${DRIVE_OWNER[$drive]}"
+    canonical="$MNT_ROOT/$drive"
+    transport="$REMOTE_ROOT/$owner/$drive"
+
+    if [[ "$host" == "$owner" ]]; then
+        # Owner machine: canonical path must be the physical mount.
+        if mountpoint -q "$canonical" 2>/dev/null; then
+            echo "OK    $canonical (physical mount, this machine owns '$drive')"
+        else
+            echo "FAIL  $canonical is not mounted — check the local disk / fstab"
+            status=1
+        fi
+        continue
+    fi
+
+    # Remote machine: canonical path must be a symlink to the transport path.
+    if [[ -L "$canonical" ]]; then
+        if [[ "$(readlink "$canonical")" == "$transport" ]]; then
+            echo "OK    $canonical -> $transport"
+        else
+            ln -sfn "$transport" "$canonical"
+            echo "FIXED $canonical -> $transport (was $(readlink "$canonical" || true))"
+        fi
+    elif mountpoint -q "$canonical" 2>/dev/null; then
+        echo "WARN  $canonical is a real mount but '$drive' is owned by $owner — resolve manually"
+        status=1
+    elif [[ -e "$canonical" ]]; then
+        echo "WARN  $canonical exists and is not a symlink — resolve manually"
+        status=1
+    else
+        ln -s "$transport" "$canonical"
+        echo "LINKED $canonical -> $transport"
+    fi
+
+    # Surface (but don't fail on) a transport path that isn't wired up yet.
+    if [[ ! -d "$transport" ]]; then
+        echo "NOTE  transport $transport does not exist yet — run the NFS setup script for '$drive'"
+    fi
+done
+
+exit "$status"

--- a/scripts/setup/nfs-dde-drive.sh
+++ b/scripts/setup/nfs-dde-drive.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# nfs-dde-drive.sh — Set up NFS share of the dde drive from ace-linux-2 to ace-linux-1.
+#
+# Mirror of scripts/setup/nfs-ace-drive.sh with the roles inverted:
+# ace-linux-2 owns the dde disk (NTFS, ntfs3) and acts as NFS server;
+# ace-linux-1 is the client.
+#
+# Run as root on the appropriate machine:
+#   ace-linux-2 (server): sudo bash scripts/setup/nfs-dde-drive.sh server
+#   ace-linux-1 (client): sudo bash scripts/setup/nfs-dde-drive.sh client
+#
+# From ace-linux-1 you can drive the server side over ssh:
+#   ssh -t ace-linux-2 "sudo bash -s server" < scripts/setup/nfs-dde-drive.sh
+#
+# What this does:
+#   server: installs nfs-kernel-server, exports the dde drive to ace-linux-1
+#   client: retires the legacy sshfs automount at the same mount point,
+#           mounts ace-linux-2's dde drive over NFS, and creates the
+#           canonical symlink so the ecosystem-wide reference resolves
+#           (see docs/standards/canonical-drive-references.md and
+#           scripts/setup/canonical-drive-links.sh)
+#
+# Prerequisites:
+#   - Both machines on the same LAN
+#   - ace-linux-1 can resolve "ace-linux-2" (via /etc/hosts or DNS)
+set -euo pipefail
+
+MODE="${1:-}"
+EXPORT_PATH="/mnt/dde"                          # abs-path-allowed
+CLIENT_MOUNT="/mnt/remote/ace-linux-2/dde"      # abs-path-allowed
+CANONICAL_LINK="/mnt/dde"                       # abs-path-allowed
+SERVER_HOST="ace-linux-2"
+CLIENT_HOST="ace-linux-1"
+
+usage() {
+    echo "Usage: sudo $0 {server|client|verify}"
+    echo ""
+    echo "  server  — run on $SERVER_HOST: install NFS server, export $EXPORT_PATH"
+    echo "  client  — run on $CLIENT_HOST: retire sshfs, mount $SERVER_HOST:$EXPORT_PATH, link $CANONICAL_LINK"
+    echo "  verify  — run on either: check NFS is working"
+    exit 1
+}
+
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "Error: must run as root (sudo)"
+        exit 1
+    fi
+}
+
+setup_server() {
+    require_root
+    local hostname
+    hostname="$(hostname -s)"
+    if [[ "$hostname" != "$SERVER_HOST" ]]; then
+        echo "Warning: expected hostname '$SERVER_HOST', got '$hostname'"
+        read -rp "Continue anyway? [y/N] " confirm
+        [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+    fi
+
+    if ! mountpoint -q "$EXPORT_PATH"; then
+        echo "Error: $EXPORT_PATH is not a mounted filesystem — check the dde disk"
+        exit 1
+    fi
+
+    echo "==> Installing NFS server..."
+    apt-get update -qq
+    apt-get install -y -qq nfs-kernel-server
+
+    echo "==> Configuring export..."
+    # fsid: explicit id so the NTFS (ntfs3) volume is reliably exportable.
+    local export_line="$EXPORT_PATH    $CLIENT_HOST(rw,sync,no_subtree_check,crossmnt,fsid=101)"
+
+    if grep -qF "$EXPORT_PATH" /etc/exports 2>/dev/null; then
+        echo "Export for $EXPORT_PATH already exists in /etc/exports:"
+        grep "$EXPORT_PATH" /etc/exports
+        echo "Skipping — edit /etc/exports manually if you need to change it."
+    else
+        echo "$export_line" >> /etc/exports
+        echo "Added to /etc/exports: $export_line"
+    fi
+
+    echo "==> Applying exports..."
+    exportfs -ra
+
+    echo "==> Starting NFS server..."
+    systemctl enable --now nfs-kernel-server
+
+    echo "==> Done. Verify with: exportfs -v"
+    exportfs -v
+}
+
+retire_sshfs() {
+    # The dde drive was previously reached via a fuse.sshfs systemd automount
+    # at the same mount point. Comment out its fstab entry and stop its units
+    # so the NFS mount can take over the path.
+    if grep -E "^[^#].*[[:space:]]$CLIENT_MOUNT[[:space:]].*sshfs" /etc/fstab >/dev/null 2>&1; then
+        echo "==> Retiring legacy sshfs entry for $CLIENT_MOUNT..."
+        cp /etc/fstab "/etc/fstab.bak.nfs-dde.$(date +%Y%m%d%H%M%S)"
+        sed -i -E "\|^[^#].*[[:space:]]$CLIENT_MOUNT[[:space:]].*sshfs|s|^|# retired by nfs-dde-drive.sh: |" /etc/fstab
+        echo "Commented out in /etc/fstab (backup written to /etc/fstab.bak.nfs-dde.*)"
+    else
+        echo "==> No active sshfs fstab entry for $CLIENT_MOUNT — nothing to retire."
+    fi
+
+    systemctl daemon-reload
+
+    local automount_unit
+    automount_unit="$(systemd-escape -p --suffix=automount "$CLIENT_MOUNT")"
+    systemctl stop "$automount_unit" 2>/dev/null || true
+
+    if mountpoint -q "$CLIENT_MOUNT" 2>/dev/null; then
+        umount "$CLIENT_MOUNT" 2>/dev/null || umount -l "$CLIENT_MOUNT" || true
+    fi
+}
+
+setup_client() {
+    require_root
+    local hostname
+    hostname="$(hostname -s)"
+    if [[ "$hostname" != "$CLIENT_HOST" ]]; then
+        echo "Warning: expected hostname '$CLIENT_HOST', got '$hostname'"
+        read -rp "Continue anyway? [y/N] " confirm
+        [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+    fi
+
+    echo "==> Installing NFS client..."
+    apt-get update -qq
+    apt-get install -y -qq nfs-common
+
+    retire_sshfs
+
+    echo "==> Creating mount point..."
+    mkdir -p "$CLIENT_MOUNT"
+
+    echo "==> Adding fstab entry..."
+    # Same options as the ace mapping on ace-linux-2 (nfs-ace-drive.sh).
+    local fstab_line="$SERVER_HOST:$EXPORT_PATH  $CLIENT_MOUNT  nfs  defaults,nofail,rw,bg,intr,soft,timeo=50  0  0"
+
+    if grep -E "^[^#]*$SERVER_HOST:$EXPORT_PATH[[:space:]]" /etc/fstab >/dev/null 2>&1; then
+        echo "fstab entry already exists:"
+        grep "$SERVER_HOST:$EXPORT_PATH" /etc/fstab
+        echo "Skipping — edit /etc/fstab manually if you need to change it."
+    else
+        echo "$fstab_line" >> /etc/fstab
+        echo "Added to fstab: $fstab_line"
+    fi
+
+    systemctl daemon-reload
+
+    echo "==> Mounting..."
+    mount "$CLIENT_MOUNT" || {
+        echo "Mount failed. Check that:"
+        echo "  1. $SERVER_HOST is reachable: ping $SERVER_HOST"
+        echo "  2. NFS server is running on $SERVER_HOST: showmount -e $SERVER_HOST"
+        echo "  3. Firewall allows NFS (port 2049)"
+        exit 1
+    }
+
+    echo "==> Creating canonical reference $CANONICAL_LINK -> $CLIENT_MOUNT..."
+    if [[ -L "$CANONICAL_LINK" ]]; then
+        ln -sfn "$CLIENT_MOUNT" "$CANONICAL_LINK"
+    elif [[ -e "$CANONICAL_LINK" ]]; then
+        echo "Warning: $CANONICAL_LINK exists and is not a symlink — leaving it alone."
+        echo "Resolve manually, then run: scripts/setup/canonical-drive-links.sh"
+    else
+        ln -s "$CLIENT_MOUNT" "$CANONICAL_LINK"
+    fi
+
+    echo "==> Done. Verify with: ls $CANONICAL_LINK"
+    ls "$CANONICAL_LINK" | head -10
+}
+
+verify() {
+    echo "==> Checking NFS..."
+    local hostname
+    hostname="$(hostname -s)"
+
+    if [[ "$hostname" == "$SERVER_HOST" ]]; then
+        echo "On server ($SERVER_HOST):"
+        echo "  Exports:"
+        exportfs -v 2>/dev/null || echo "  (exportfs not available — NFS server not installed?)"
+        echo "  NFS service:"
+        systemctl is-active nfs-kernel-server 2>/dev/null || echo "  not running"
+    fi
+
+    if [[ "$hostname" == "$CLIENT_HOST" ]]; then
+        echo "On client ($CLIENT_HOST):"
+        echo "  Mount status:"
+        if mountpoint -q "$CLIENT_MOUNT" 2>/dev/null; then
+            echo "  $CLIENT_MOUNT is mounted"
+            df -h "$CLIENT_MOUNT"
+        else
+            echo "  $CLIENT_MOUNT is NOT mounted"
+            echo "  Try: sudo mount $CLIENT_MOUNT"
+        fi
+        echo "  Canonical reference:"
+        if [[ -L "$CANONICAL_LINK" ]]; then
+            echo "  $CANONICAL_LINK -> $(readlink "$CANONICAL_LINK")"
+        else
+            echo "  $CANONICAL_LINK is NOT a symlink — run scripts/setup/canonical-drive-links.sh"
+        fi
+    fi
+
+    echo "  Showmount (from $hostname):"
+    showmount -e "$SERVER_HOST" 2>/dev/null || echo "  (cannot reach NFS server)"
+}
+
+case "$MODE" in
+    server) setup_server ;;
+    client) setup_client ;;
+    verify) verify ;;
+    *)      usage ;;
+esac


### PR DESCRIPTION
## What

Mounts the **dde drive** (2.8 TB NTFS on ace-linux-2) onto ace-linux-1 the same way the ace drive is mapped on ace-linux-2 (NFS, `nofail,bg,soft`), and establishes the ecosystem-wide **canonical drive reference** convention.

- `scripts/setup/nfs-dde-drive.sh` — mirror of `nfs-ace-drive.sh`, roles inverted. `server` mode (ace-linux-2): installs nfs-kernel-server, exports `/mnt/dde` with `fsid=101` (NTFS/ntfs3 needs a stable fs identity). `client` mode (ace-linux-1): retires the legacy fuse.sshfs automount occupying `/mnt/remote/ace-linux-2/dde` (fstab backup + comment-out, stops the systemd automount unit), mounts NFS, creates the canonical symlink. `verify` mode on either host.
- `scripts/setup/canonical-drive-links.sh` — idempotent, registry-driven: `/mnt/<drive>` resolves on EVERY machine — physical mount on the owner host, symlink to `/mnt/remote/<owner>/<drive>` elsewhere. Also fixes the missing `/mnt/ace` on ace-linux-2.
- `docs/standards/canonical-drive-references.md` — the convention: repos/scripts/prompts reference canonical paths only; transport paths are plumbing.

## Verification
- `bash -n` clean on both scripts; `scripts/enforcement/check-no-abs-paths.sh` passes (sentinels on the 5 intentional literal-path lines).
- `nfs-dde-drive.sh verify` run on ace-linux-1: correctly reports sshfs mount live, NFS server absent, canonical link missing — the exact pre-activation state.
- Activation itself needs sudo on both machines (owner action, commands in the script header).

## Related
Epic #3333 — #3337 (canonical-path normalization across file indexes) consumes this convention.