### PR TITLE
feat(equality): always-committed matrix — divergence-proof publish to origin/main (#3342)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -33,19 +33,22 @@ tasks:
     schedule: "30 4 * * 1"
     machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2]
     roles: [control-plane, comms-dispatch, sim-worker]
-    requires: [bash, python3, uv]
+    requires: [bash, python3, uv, git]
     command: >-
       PATH=$HOME/.local/bin:$PATH;
       cd $WORKSPACE_HUB &&
-      bash scripts/readiness/collect-equality.sh &&
-      uv run --no-project --with pyyaml python scripts/readiness/build-equality-matrix.py
+      bash scripts/readiness/equality-matrix-cron.sh
       >> $WORKSPACE_HUB/logs/quality/equality-$(date +\%Y-\%m-\%d).log 2>&1
     log: logs/quality/equality-*.log
     is_claude_task: false
     description: >-
-      Per-machine weekly (Mon 04:30) cold-dimension self-report + matrix rebuild,
-      commit-on-change (no churn). Hot dims referenced from nightly readiness. Single
-      source for both Linux cron and Windows Task Scheduler per this file's HARD RULE (#2801 DC5).
+      Per-machine weekly (Mon 04:30) cold-dimension self-report + matrix rebuild +
+      publish to origin/main (equality-matrix-cron.sh: collect + build + fail-loud
+      notify per #2972, then publish-equality.sh — sparse-worktree, newer-evidence-only —
+      so evidence reaches origin even when the interactive checkout is diverged; the
+      old repo-sync delegation went dark exactly then). Hot dims referenced from
+      nightly readiness. Single source for both Linux cron and Windows Task Scheduler
+      per this file's HARD RULE (#2801 DC5).
 
   - id: equivalence-sentinel
     label: Machine-equivalence drift sentinel (#3059)
@@ -98,16 +101,19 @@ tasks:
     command: >-
       PATH=$HOME/.local/bin:$PATH;
       cd $WORKSPACE_HUB &&
-      bash scripts/readiness/collect-equality.sh &&
-      uv run --no-project --with pyyaml python scripts/readiness/build-equality-matrix.py
+      bash scripts/readiness/equality-matrix-cron.sh
       >> $WORKSPACE_HUB/logs/quality/equality-refresh-$(date +\%Y-\%m-\%d).log 2>&1
     log: logs/quality/equality-refresh-*.log
     is_claude_task: false
     description: >-
-      Daily rebuild of the equality matrix on the control-plane box, INDEPENDENT of the
-      session-curation cron, so a DEAD curation cron still ages its freshness cell past
-      green (orange >12h, red >24h). Without this daily rebuild the weekly equality-report
-      (#2801) would freeze the last-green render and the dead-man's-switch would never fire.
+      Daily rebuild + publish of the equality matrix on the control-plane box
+      (equality-matrix-cron.sh: collect + build + publish-equality.sh), INDEPENDENT of
+      the session-curation cron, so a DEAD curation cron still ages its freshness cell
+      past green (orange >12h, red >24h). Without this daily rebuild the weekly
+      equality-report (#2801) would freeze the last-green render and the
+      dead-man's-switch would never fire. Publishing to origin/main here also keeps the
+      COMMITTED render fresh daily — the fleet compares against origin, not any one
+      box's working tree.
 
   # Linux-only (v1); Windows Task Scheduler parity deferred per epic #3058.
   - id: harness-install-doctor

--- a/scripts/readiness/equality-matrix-cron.sh
+++ b/scripts/readiness/equality-matrix-cron.sh
@@ -23,5 +23,11 @@ fail() {
 
 bash "$REPO_ROOT/scripts/readiness/collect-equality.sh" || fail "collect-equality.sh failed"
 uv run --script "$REPO_ROOT/scripts/readiness/build-equality-matrix.py" || fail "build-equality-matrix.py failed (deps/build)"
-bash "$REPO_ROOT/scripts/notify.sh" cron equality-matrix pass "matrix rebuilt" || true
+# Publish evidence + render to origin/main via a sparse worktree. The matrix only
+# compares machines equally when every box's evidence reaches origin; the old
+# delegation to repo-sync went dark whenever the interactive checkout diverged
+# (non-FF pile-up) or the sync cron died.
+bash "$REPO_ROOT/scripts/readiness/publish-equality.sh" --rebuild \
+  || fail "publish-equality.sh failed (evidence not on origin)"
+bash "$REPO_ROOT/scripts/notify.sh" cron equality-matrix pass "matrix rebuilt + published" || true
 echo "equality-matrix-cron OK"

--- a/scripts/readiness/publish-equality.sh
+++ b/scripts/readiness/publish-equality.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# publish-equality.sh — commit THIS machine's equality artifacts to origin/main via a
+# disposable SPARSE worktree, independent of the interactive checkout's state.
+#
+# WHY: the matrix only compares machines equally when every machine's evidence reaches
+# origin/main. The scheduled Linux path (equality-matrix-cron.sh) used to only BUILD and
+# delegate the commit+push to the repo-sync cron — a chain that breaks exactly when the
+# fleet most needs comparable evidence: a diverged interactive checkout piles up non-FF
+# commits, a dead sync cron publishes nothing, and the machine goes dark on the matrix.
+#
+# HOW: fetch origin/main → temp worktree with a sparse checkout of ONLY the artifact
+# paths (.claude/state, docs/reports, scripts/readiness — seconds, not a 22k-file
+# checkout) → copy in any LOCAL equality yaml whose generated_at is NEWER than origin's
+# copy (never clobbers a peer's fresher evidence) → optionally rebuild the matrix INSIDE
+# the worktree so the committed render reflects the union of freshest evidence →
+# scoped commit → push (fast-forward by construction; one retry on a push race).
+# The main checkout's HEAD/index/rebase state is never touched.
+#
+# Usage: publish-equality.sh [--rebuild] [--dry-run] [--repo <path>] [--remote <name>]
+#                            [--branch <name>]
+#   --rebuild   re-render the matrix HTML inside the worktree (control-plane crons)
+#   --dry-run   stage + commit in the worktree, print the plan, do NOT push
+#   --repo      repo whose artifacts + git dir to use (default: this script's checkout)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+REMOTE="origin"; BRANCH="main"; REBUILD=0; DRY_RUN=0
+for ((i=1; i<=$#; i++)); do
+  case "${!i}" in
+    --rebuild) REBUILD=1;;
+    --dry-run) DRY_RUN=1;;
+    --repo)   j=$((i+1)); REPO_ROOT="${!j:-}";;
+    --remote) j=$((i+1)); REMOTE="${!j:-origin}";;
+    --branch) j=$((i+1)); BRANCH="${!j:-main}";;
+  esac
+done
+[[ -n "$REPO_ROOT" && -d "$REPO_ROOT" ]] || { echo "publish-equality: no repo root" >&2; exit 1; }
+
+HOST="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+say()  { echo "publish-equality: $*"; }
+fail() {
+  bash "$REPO_ROOT/scripts/notify.sh" cron equality-publish fail "$1" 2>/dev/null || true
+  echo "publish-equality FAIL: $1" >&2
+  exit 1
+}
+
+# One publish per host at a time (a 6h curation refresh racing the daily rebuild).
+LOCK="${TMPDIR:-/tmp}/publish-equality-${HOST}.lock"
+exec 9>"$LOCK" || fail "cannot open lock $LOCK"
+flock -n 9 || { say "another publish in flight; skipping"; exit 0; }
+
+WT=""
+cleanup() {
+  [[ -n "$WT" ]] && git -C "$REPO_ROOT" worktree remove --force "$WT" >/dev/null 2>&1
+  git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+# generated_at of an equality yaml ("" when absent/garbled) — ISO stamps compare lexically.
+gen_at() { awk -F'"' '/^generated_at:/{print $2; exit}' "$1" 2>/dev/null; }
+
+attempt() {
+  cleanup; WT=""
+  timeout 120 git -C "$REPO_ROOT" fetch "$REMOTE" "$BRANCH" --quiet || return 1
+
+  WT="$(mktemp -d "${TMPDIR:-/tmp}/publish-equality-wt.XXXXXX")" || return 1
+  rmdir "$WT"    # git worktree add wants to create the leaf itself
+  git -C "$REPO_ROOT" worktree add --no-checkout --detach "$WT" "$REMOTE/$BRANCH" >/dev/null 2>&1 || return 1
+  git -C "$WT" sparse-checkout set --no-cone '/.claude/state' '/docs/reports' '/scripts/readiness' \
+    >/dev/null 2>&1 || return 1
+  git -C "$WT" checkout --quiet --detach "$REMOTE/$BRANCH" || return 1
+  mkdir -p "$WT/.claude/state" "$WT/docs/reports"
+
+  # 1. Evidence: copy in each LOCAL equality yaml strictly newer than origin's copy.
+  local f base local_gen origin_gen
+  for f in "$REPO_ROOT"/.claude/state/equality-*.yaml; do
+    [[ -f "$f" ]] || continue
+    base="$(basename "$f")"
+    local_gen="$(gen_at "$f")"
+    [[ -n "$local_gen" ]] || continue                      # unstamped evidence is not publishable
+    origin_gen="$(gen_at "$WT/.claude/state/$base")"
+    if [[ "$local_gen" > "${origin_gen:-}" ]]; then
+      cp "$f" "$WT/.claude/state/$base" || return 1
+      say "evidence: $base ($local_gen > ${origin_gen:-none})"
+    fi
+  done
+
+  # 2. Render (control-plane): rebuild from the worktree's union-of-freshest evidence.
+  if [[ "$REBUILD" == 1 ]]; then
+    if command -v uv >/dev/null 2>&1; then
+      (cd "$WT" && uv run --script scripts/readiness/build-equality-matrix.py) >/dev/null \
+        || return 1
+    else
+      (cd "$WT" && python3 scripts/readiness/build-equality-matrix.py) >/dev/null || return 1
+    fi
+  fi
+
+  # 3. Scoped stage + allowlist guard: ONLY equality artifacts may ever be committed here.
+  git -C "$WT" add -A -- '.claude/state' 'docs/reports' || return 1
+  local staged
+  staged="$(git -C "$WT" diff --cached --name-only)"
+  if [[ -z "$staged" ]]; then
+    say "nothing newer than $REMOTE/$BRANCH; no commit needed"
+    PUBLISHED="noop"
+    return 0
+  fi
+  while IFS= read -r p; do
+    case "$p" in
+      .claude/state/equality-*.yaml) ;;
+      docs/reports/*machine-equality-matrix.html) ;;
+      *) say "unexpected staged path '$p' — refusing to publish"; return 1;;
+    esac
+  done <<< "$staged"
+
+  git -C "$WT" commit --quiet -m "chore(equality): publish equality artifacts from ${HOST}" \
+    || return 1
+  if [[ "$DRY_RUN" == 1 ]]; then
+    say "dry-run — would push:"
+    git -C "$WT" show --stat --oneline HEAD | sed 's/^/  /'
+    PUBLISHED="dry-run"
+    return 0
+  fi
+  timeout 300 git -C "$WT" push "$REMOTE" HEAD:"$BRANCH" || return 1
+  PUBLISHED="pushed"
+  return 0
+}
+
+PUBLISHED=""
+if ! attempt; then
+  say "first attempt failed (push race or transient); retrying once"
+  attempt || fail "could not publish equality artifacts to $REMOTE/$BRANCH from ${HOST}"
+fi
+say "done (${PUBLISHED})"

--- a/scripts/readiness/refresh-equality-matrix.sh
+++ b/scripts/readiness/refresh-equality-matrix.sh
@@ -52,27 +52,15 @@ fi
 bash "$REPO_ROOT/scripts/readiness/equality-matrix-cron.sh" "${cron_args[@]}" \
   || { echo "equality-matrix-cron.sh failed" >&2; exit 1; }
 
-# ------ 3/3  commit + push the equality artifacts (manual on-demand only) ----------------
-step "3/3  Commit + push equality artifacts"
-today="$(date +%F)"
-artifacts=(
-  "docs/reports/${today}-machine-equality-matrix.html"
-  "docs/reports/machine-equality-matrix.html"
-)
-# Stage the matrix HTML + any changed per-machine state yaml (scoped; no blanket add).
-git add -- "${artifacts[@]}" 2>/dev/null || true
-while IFS= read -r f; do
-  [[ -n "$f" ]] && git add -- "$f"
-done < <(git status --porcelain -- '.claude/state/equality-*.yaml' | awk '{print $2}')
-
-if git diff --cached --quiet; then
-  echo "No equality changes to commit (canonical payload unchanged)."
-else
-  host="$(hostname | tr '[:upper:]' '[:lower:]')"
-  git commit -m "chore: equality report from ${host}" || { echo "commit failed" >&2; exit 1; }
-  git push origin main || { echo "push failed; left local commit for repo-sync retry" >&2; exit 1; }
-  echo "Pushed equality artifacts; GitHub Pages will redeploy."
-fi
+# ------ 3/3  publish ---------------------------------------------------------------------
+step "3/3  Publish"
+# Publishing now lives INSIDE equality-matrix-cron.sh (publish-equality.sh: sparse
+# worktree, newer-evidence-only, render rebuilt from the union of freshest evidence),
+# so manual and scheduled runs share one commit+push path and a machine with a stale
+# view can never clobber a peer's fresher state. Nothing further to do here — the
+# inline `git commit && git push origin main` this step used to carry failed outright
+# whenever local main had diverged, which is exactly when publishing matters most.
+echo "Publish handled by equality-matrix-cron.sh (publish-equality.sh); nothing to do."
 
 # ------ verify --------------------------------------------------------------------------
 step "Provenance + commit"

--- a/tests/readiness/test_build_equality_matrix.py
+++ b/tests/readiness/test_build_equality_matrix.py
@@ -608,16 +608,24 @@ def test_harness_config_real_roster_and_baselines():
 
 def test_wiring_single_source_schedule():
     # DC5: the schedule lives in the ONE canonical source (schedule-tasks.yaml), weekly,
-    # all 4 active machines, invoking both collector and matrix builder, with a Windows render path.
+    # all 4 active machines, with a Windows render path. The command routes through the
+    # fail-loud wrapper (#2972), which must carry collector + builder + publisher — so
+    # the collect/build/publish chain stays single-sourced one hop deeper.
     tasks = yaml.safe_load(
         (REPO_ROOT / "config" / "scheduled-tasks" / "schedule-tasks.yaml").read_text())["tasks"]
     eq = next(t for t in tasks if t["id"] == "equality-report")
     assert eq["schedule"].split()[-1] == "1"            # weekly, Monday
-    assert "collect-equality.sh" in eq["command"]
-    assert "build-equality-matrix.py" in eq["command"]
+    assert "equality-matrix-cron.sh" in eq["command"]
+    wrapper = (REPO_ROOT / "scripts" / "readiness" / "equality-matrix-cron.sh").read_text()
+    assert "collect-equality.sh" in wrapper
+    assert "build-equality-matrix.py" in wrapper
+    assert "publish-equality.sh" in wrapper
     for m in ("dev-primary", "dev-secondary", "ace-win-1", "ace-win-2"):
         assert m in eq["machines"]
     assert (REPO_ROOT / "scripts" / "windows" / "equality-report.ps1").exists()
+    # The daily dead-man's-switch rebuild routes through the SAME wrapper.
+    refresh = next(t for t in tasks if t["id"] == "equality-matrix-refresh")
+    assert "equality-matrix-cron.sh" in refresh["command"]
 
 
 def test_verdict_behavior_is_uniform_not_expected_diff():

--- a/tests/readiness/test_publish_equality.py
+++ b/tests/readiness/test_publish_equality.py
@@ -1,0 +1,188 @@
+"""TDD tests for publish-equality.sh — the sparse-worktree equality publisher.
+
+Contract: equality artifacts ALWAYS reach origin/main so the matrix compares every
+machine equally — independent of the interactive checkout's state (dirty, diverged,
+mid-rebase). Only evidence strictly NEWER than origin's copy is published (a machine
+with a stale view can never clobber a peer's fresher state), staged paths are
+allowlist-guarded, and the temp worktree is always cleaned up.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "readiness" / "publish-equality.sh"
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@example.com",
+    "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@example.com",
+}
+
+
+def _git(*args: str, cwd: Path) -> str:
+    res = subprocess.run(["git", *args], cwd=cwd, env=GIT_ENV,
+                         capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0, f"git {' '.join(args)}: {res.stderr}"
+    return res.stdout
+
+
+def _yaml(machine: str, stamp: str) -> str:
+    return f'generated_at: "{stamp}"\nmachine: "{machine}"\n'
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    """Bare origin + working clone. Origin main seeds: self evidence (old stamp),
+    peer evidence (fresh stamp), empty docs/reports, empty scripts/readiness."""
+    origin = tmp_path / "origin.git"
+    _git("init", "--bare", "-b", "main", str(origin), cwd=tmp_path)
+    seed = tmp_path / "seed"
+    _git("clone", str(origin), str(seed), cwd=tmp_path)
+    (seed / ".claude" / "state").mkdir(parents=True)
+    (seed / "docs" / "reports").mkdir(parents=True)
+    (seed / "scripts" / "readiness").mkdir(parents=True)
+    (seed / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-06-01T00:00:00"))
+    (seed / ".claude" / "state" / "equality-peer.yaml").write_text(
+        _yaml("peer", "2026-06-20T00:00:00"))
+    (seed / "docs" / "reports" / ".gitkeep").write_text("")
+    (seed / "scripts" / "readiness" / ".gitkeep").write_text("")
+    _git("add", "-A", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+
+    clone = tmp_path / "clone"
+    _git("clone", str(origin), str(clone), cwd=tmp_path)
+    return origin, clone
+
+
+def _run(clone: Path, *args: str, expect_rc: int = 0) -> subprocess.CompletedProcess:
+    res = subprocess.run(["bash", str(SCRIPT), "--repo", str(clone), *args],
+                         env=GIT_ENV, capture_output=True, text=True, timeout=120)
+    assert res.returncode == expect_rc, f"rc={res.returncode}\n{res.stdout}\n{res.stderr}"
+    return res
+
+
+def _origin_file(origin: Path, path: str) -> str:
+    res = subprocess.run(["git", "show", f"main:{path}"], cwd=origin, env=GIT_ENV,
+                         capture_output=True, text=True, timeout=60)
+    return res.stdout if res.returncode == 0 else ""
+
+
+def test_publishes_newer_local_evidence(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    _run(clone)
+    assert "2026-07-01T12:00:00" in _origin_file(
+        origin, ".claude/state/equality-dev-primary.yaml")
+
+
+def test_does_not_clobber_fresher_origin_evidence(tmp_path):
+    # Local copy of the PEER's evidence is older than origin's — must never regress it.
+    origin, clone = _fixture(tmp_path)
+    (clone / ".claude" / "state" / "equality-peer.yaml").write_text(
+        _yaml("peer", "2026-06-10T00:00:00"))
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))       # something newer, so a commit happens
+    _run(clone)
+    assert "2026-06-20T00:00:00" in _origin_file(origin, ".claude/state/equality-peer.yaml")
+
+
+def test_noop_when_nothing_newer(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    before = _git("rev-parse", "main", cwd=origin).strip()
+    res = _run(clone)
+    assert "no commit needed" in res.stdout
+    assert _git("rev-parse", "main", cwd=origin).strip() == before
+
+
+def test_publishes_even_when_local_checkout_diverged_and_dirty(tmp_path):
+    # The core value: a diverged + dirty interactive checkout must not block publishing.
+    origin, clone = _fixture(tmp_path)
+    seed = tmp_path / "seed"
+    (seed / "docs" / "reports" / "advance.txt").write_text("x")
+    _git("add", "-A", cwd=seed); _git("commit", "-m", "advance", cwd=seed)
+    _git("push", "origin", "main", cwd=seed)               # origin moves ahead of clone
+    (clone / "local.txt").write_text("local")
+    _git("add", "local.txt", cwd=clone)
+    _git("commit", "-m", "local-divergence", cwd=clone)    # clone moves ahead of origin
+    (clone / "dirty.txt").write_text("dirty")              # …and is dirty on top
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    _run(clone)
+    assert "2026-07-01T12:00:00" in _origin_file(
+        origin, ".claude/state/equality-dev-primary.yaml")
+    # the clone's own divergence/dirt is untouched
+    assert (clone / "dirty.txt").exists()
+    assert "local-divergence" in _git("log", "-1", "--format=%s", cwd=clone)
+
+
+STUB_BUILDER = """\
+from pathlib import Path
+root = Path(__file__).resolve().parents[2]
+(root / "docs" / "reports" / "machine-equality-matrix.html").write_text("<html>stub</html>")
+"""
+
+
+def test_rebuild_renders_matrix_inside_worktree(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    seed = tmp_path / "seed"
+    _git("pull", "origin", "main", cwd=seed)
+    (seed / "scripts" / "readiness" / "build-equality-matrix.py").write_text(STUB_BUILDER)
+    _git("add", "-A", cwd=seed); _git("commit", "-m", "stub builder", cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    _run(clone, "--rebuild")
+    assert "stub" in _origin_file(origin, "docs/reports/machine-equality-matrix.html")
+
+
+def test_refuses_unexpected_staged_paths(tmp_path):
+    # A builder that writes outside the artifact allowlist must abort the publish.
+    origin, clone = _fixture(tmp_path)
+    seed = tmp_path / "seed"
+    _git("pull", "origin", "main", cwd=seed)
+    (seed / "scripts" / "readiness" / "build-equality-matrix.py").write_text(
+        STUB_BUILDER.replace("machine-equality-matrix.html", "evil.txt"))
+    _git("add", "-A", cwd=seed); _git("commit", "-m", "evil builder", cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+    before = _git("rev-parse", "main", cwd=origin).strip()
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    _run(clone, "--rebuild", expect_rc=1)
+    assert _git("rev-parse", "main", cwd=origin).strip() == before
+
+
+def test_dry_run_pushes_nothing(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    before = _git("rev-parse", "main", cwd=origin).strip()
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    res = _run(clone, "--dry-run")
+    assert "would push" in res.stdout
+    assert _git("rev-parse", "main", cwd=origin).strip() == before
+
+
+def test_worktree_always_cleaned_up(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        _yaml("dev-primary", "2026-07-01T12:00:00"))
+    _run(clone)
+    wts = _git("worktree", "list", "--porcelain", cwd=clone)
+    assert wts.count("worktree ") == 1        # only the main checkout remains
+
+
+def test_unstamped_local_evidence_is_not_published(tmp_path):
+    origin, clone = _fixture(tmp_path)
+    (clone / ".claude" / "state" / "equality-dev-primary.yaml").write_text(
+        "machine: dev-primary\n")             # no generated_at ⇒ not publishable
+    res = _run(clone)
+    assert "no commit needed" in res.stdout
+    assert "2026-06-01T00:00:00" in _origin_file(
+        origin, ".claude/state/equality-dev-primary.yaml")


### PR DESCRIPTION
Closes #3342.

## What

Guarantees the equality matrix + every machine's evidence ALWAYS reach origin/main — the fleet compares against origin, not any one box's working tree.

## Why (2026-07-01 reconcile-assessment findings)

The scheduled Linux path only built the matrix and delegated commit+push to repo-sync, which went dark exactly when comparability mattered: dev-primary's diverged checkout piled up non-FF commits, dev-secondary's crons died, dated renders froze at 2026-06-28, and origin held fresher peer evidence than the control-plane box could see.

## How

**New `scripts/readiness/publish-equality.sh`** — the divergence-proof publisher:
- Disposable **sparse worktree** off freshly-fetched origin/main (`.claude/state` + `docs/reports` + `scripts/readiness` only — seconds, not a 22k-file checkout); never touches the interactive checkout's HEAD/index/rebase state.
- Copies in only evidence whose `generated_at` is **strictly newer** than origin's copy — a machine with a stale view can never clobber a peer's fresher state.
- `--rebuild` re-renders the matrix **inside the worktree** from the union of freshest evidence, so the committed render always compares all machines fairly.
- Staged-path **allowlist guard** (only `equality-*.yaml` + `*machine-equality-matrix.html` may ever be committed), FF push with one race retry, per-host flock, always-cleaned worktree, fail-loud notify.

**Wiring:** `equality-matrix-cron.sh` publishes after building; `refresh-equality-matrix.sh` step 3/3 delegates (its inline `git push origin main` failed whenever local main diverged); `schedule-tasks.yaml` routes both equality tasks through the wrapper (closes the #2972 yaml drift).

## Verification

- **9 new tests** (`test_publish_equality.py`): newer-evidence-only, no-clobber-fresher-peer, publish-from-diverged+dirty-checkout, rebuild-in-worktree, allowlist refusal aborts, dry-run pushes nothing, worktree cleanup, unstamped evidence skipped.
- Full readiness suite: **406 passed**, 1 skipped, 1 pre-existing baseline-red (`test_guard_is_invoked_in_target_repo_cwd`, stale regex vs `reconcile-ecosystem.sh` — unrelated, noted in #3332 too).
- **Live dry-run against the real repo (currently mid-rebase!)**: stages today's dated render + alias cleanly, correctly skips evidence not newer than origin.
- Enforcement: my files clean under check-no-abs-paths + legal-sanity (both exit 1 on pre-existing baseline entries only).

## Operator follow-ups (in #3342, not this PR)

1. **Re-run `scripts/cron/setup-cron.sh --apply` on dev-primary** — installed crontab predates 2026-06-26; the catalog selects `equality-matrix-refresh` but it was never installed. After this PR merges, re-running also picks up the new wrapper commands.
2. dev-secondary cron pipeline silent since 06-30 — on-box check.
3. Windows Task Scheduler rollout: #2815/#2998.