### PR TITLE
chore(skills): regenerate stale skill-index-full.yaml (coherence baseline-red)

### DIFF
--- a/config/agents/skill-index-full.yaml
+++ b/config/agents/skill-index-full.yaml
@@ -650,12 +650,6 @@ skills:
   name: tax-e-filing-research
   when_to_use: '- Preparing to e-file Form 1120 independently - Comparing e-filing service options for cost and features - Need step-by-step filing instructions - Paper filing backup plan ---'
   when_to_use_source: section
-- description: 'Assemble a ready-to-file personal federal tax packet from existing repo artifacts: computation draft, filing checklist, entry guide, and optimization review.'
-  family: business_admin
-  id: business_admin/personal-tax-filing-packet
-  name: personal-tax-filing-packet
-  when_to_use: 'Use when the user wants to prepare or finalize a personal federal tax filing and there is already a workspace/repo with draft tax materials. Common requests: - "let us prepare the filing for personal taxes" - "review my personal tax package" - "what is ready for filing?" - "summarize the return and next steps"'
-  when_to_use_source: trigger
 - description: Assemble and execute a packet-first TaxAct Business filing workflow for C-Corp Form 1120 returns using existing repo artifacts, with strict pre-submit gates and human approval.
   family: business_admin
   id: business_admin/taxact-business-c-corp-filing-packet


### PR DESCRIPTION
Skill-Index Coherence fails on **clean main** — `config/agents/skill-index-full.yaml` lags skills landed since the last regeneration (same class as #3208, previously cleared by #3277 on 06-28; it regrows whenever skills merge without a regen).

One generated file, regenerated via `uv run python scripts/ai/build_skill_index.py`. Merge this **first**, then update-branch + merge #3343 so its coherence check picks up the fresh index.

Longer-term fix candidate (separate issue): make the coherence CI job regenerate-and-diff instead of failing, or add the regen to the merge queue — the manual regen PR is now a recurring chore.