### PR TITLE
feat(legal): riser-projects provenance deny patterns (dm#1259 gate-prep)

### DIFF
--- a/.legal-deny-list.yaml
+++ b/.legal-deny-list.yaml
@@ -130,3 +130,21 @@ exclusions:
   - "*.dat"
 
 default_severity: "block"
+
+# Riser-projects provenance names (dm#1259 gate-prep, 2026-07-02).
+# SCOPE NOTE: only low-collision compound names go here — famous public-domain
+# field/rig names (which legitimately appear in worldenergydata's regulatory
+# datasets) are enforced instead by digitalmodel's scoped provenance-token
+# tripwire (tests/riser_database/test_provenance_tripwire.py), to avoid
+# reddening wed scans (lesson from dm#1245 review).
+riser_project_provenance:
+  - pattern: "Zohr Deep"
+    case_sensitive: false
+  - pattern: "GEB Deep"
+    case_sensitive: false
+  - pattern: "Rosa 312"
+    case_sensitive: false
+  - pattern: "Piklis"
+    case_sensitive: false
+  - pattern: "Jujak"
+    case_sensitive: false


### PR DESCRIPTION
Gate-prep for the approved dm#1259 plan (v2 D4): adds a `riser_project_provenance` group with 5 low-collision compound name patterns to the private deny list.

**Deliberate deviation from the plan text, flagged for review:** famous public-domain field/rig names and bare project numbers are NOT added globally — they legitimately appear in worldenergydata's public regulatory datasets (BSEE field records, the 2,268-rig fleet CSV), and the fixed-string scanner would permanently redden wed scans (the dm#1245 review's false-positive lesson). Those names are enforced instead by dm's scoped, regex-capable provenance-token tripwire (part of the dm#1259 PR), which auto-extracts tokens from the private registry's source pages and asserts them absent from every public riser-DB artifact.

Note: the same edit is applied to the primary checkout's working tree so in-context gates use it immediately; this PR makes it durable.