### PR TITLE
feat(#3335): unified drive-index query CLI + registry (epic #3333)

### DIFF
--- a/config/drive-index-registry.yml
+++ b/config/drive-index-registry.yml
@@ -1,0 +1,65 @@
+version: 1
+canonical_aliases:
+  /mnt/remote/ace-linux-2/dde: /mnt/dde
+  /mnt/remote/dev-secondary/dde: /mnt/dde
+defaults:
+  staleness_days: 90
+indexes:
+  - id: ace_knowledge
+    adapter: sqlite_fts
+    path: /mnt/ace/.ace-knowledge/index.db
+    coverage: {drives: [/mnt/ace], subtree: /mnt/ace}
+    domains: [engineering, marine, drilling, cad, standards]
+    freshness: {built_at: "2026-03-26", staleness_days: 120}
+    builder: null
+    adapter_params:
+      fts_table: assets_fts
+      base_table: assets
+      path_column: file_path
+      select_columns: [file_name, file_size, modified_date, engineering_domain]
+  - id: og_standards_inventory
+    adapter: sqlite_fts
+    path: "/mnt/ace/O&G-Standards/_inventory.db"
+    coverage: {drives: [/mnt/ace], subtree: "/mnt/ace/O&G-Standards"}
+    freshness: {built_at: "2025-12-28", staleness_days: 120}
+    builder: null
+    adapter_params:
+      fts_table: documents_fts
+      base_table: documents
+      path_column: file_path
+      select_columns: [filename, organization, doc_type, doc_number, title]
+  - id: cad_readability
+    adapter: tsv
+    path: /mnt/ace/_cad-index/cad-readability-index.tsv
+    coverage: {drives: [/mnt/ace]}
+    domains: [cad, engineering]
+    freshness: {built_at: "2026-06-26", staleness_days: 90}
+    builder: null
+    adapter_params:
+      path_column: path
+      search_columns: [path, name_description, project]
+      passthrough_columns: [format, readability, size, mtime]
+  - id: master_document_index
+    adapter: jsonl
+    path: data/document-index/index.jsonl
+    coverage: {drives: [/mnt/ace, /mnt/dde, /mnt/local-analysis]}
+    freshness:
+      built_at: "2026-04-17"
+      staleness_days: 90
+      note: "Frozen 2026-04-17; dde rows may be lost if rebuilt with stale --force source config before #3334/#3337 remediation."
+    builder: scripts/data/document-index/phase-a-index.py
+    adapter_params:
+      path_field: path
+      search_fields: [path, summary, domain, org, doc_number]
+      sidecar: null
+  - id: dde_literature_catalog
+    adapter: yaml_catalog
+    path: data/document-index/dde-literature-catalog.yaml
+    coverage: {drives: [/mnt/dde]}
+    domains: [literature, standards, engineering]
+    freshness: {built_at: "2026-07-02", staleness_days: 90}
+    builder: null
+    adapter_params:
+      items_key: auto
+      path_fields: [path, source_dir]
+      text_fields: [title, domain, notes]

--- a/scripts/data/drive-index-search/adapters/__init__.py
+++ b/scripts/data/drive-index-search/adapters/__init__.py
@@ -1,0 +1,12 @@
+from adapters.jsonl import JsonlAdapter
+from adapters.sqlite_fts import SqliteFtsAdapter
+from adapters.tsv import TsvAdapter
+from adapters.yaml_catalog import YamlCatalogAdapter
+
+
+ADAPTER_TYPES = {
+    "sqlite_fts": SqliteFtsAdapter,
+    "jsonl": JsonlAdapter,
+    "tsv": TsvAdapter,
+    "yaml_catalog": YamlCatalogAdapter,
+}

--- a/scripts/data/drive-index-search/adapters/base.py
+++ b/scripts/data/drive-index-search/adapters/base.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+import re
+from typing import Any
+
+
+TOKEN_RE = re.compile(r"[A-Za-z0-9_./&+-]+")
+
+
+class AdapterError(Exception):
+    pass
+
+
+@dataclass
+class SearchResult:
+    raw_path: str
+    source_index: str
+    adapter: str
+    raw_score: float
+    rank_basis: str
+    meta: dict[str, Any] = field(default_factory=dict)
+    canonical_path: str | None = None
+    score: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "canonical_path": self.canonical_path or self.raw_path,
+            "raw_path": self.raw_path,
+            "source_index": self.source_index,
+            "adapter": self.adapter,
+            "score": self.score if self.score is not None else self.raw_score,
+            "rank_basis": self.rank_basis,
+            "meta": self.meta,
+        }
+
+
+def tokenize(query: str) -> list[str]:
+    tokens = [token.lower() for token in TOKEN_RE.findall(query)]
+    return [token for token in tokens if token]
+
+
+def field_text(row: dict[str, Any], fields: list[str]) -> str:
+    values = []
+    for field_name in fields:
+        value = row.get(field_name)
+        if value is not None:
+            values.append(str(value))
+    return " ".join(values).lower()
+
+
+def token_score(row: dict[str, Any], tokens: list[str], fields: list[str]) -> tuple[float, int]:
+    if not tokens:
+        return 0.0, 0
+    text = field_text(row, fields)
+    matched = sum(1 for token in tokens if token in text)
+    if matched == 0:
+        return 0.0, 0
+    density = sum(text.count(token) for token in tokens)
+    return matched / len(tokens) + min(math.log1p(density) / 10.0, 0.2), matched
+
+
+def push_top(heap: list[tuple[float, int, SearchResult]], item: tuple[float, int, SearchResult], cap: int) -> None:
+    import heapq
+
+    if len(heap) < cap:
+        heapq.heappush(heap, item)
+    elif item[0] > heap[0][0]:
+        heapq.heapreplace(heap, item)
+
+
+class BaseAdapter:
+    def __init__(self, index):
+        self.index = index
+
+    def search(self, tokens: list[str], limit: int) -> list[SearchResult]:
+        raise NotImplementedError
+
+    def interrupt(self) -> None:
+        return None

--- a/scripts/data/drive-index-search/adapters/jsonl.py
+++ b/scripts/data/drive-index-search/adapters/jsonl.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import heapq
+import json
+
+from adapters.base import AdapterError, BaseAdapter, SearchResult, push_top, token_score
+
+
+OVERSAMPLE = 4
+
+
+class JsonlAdapter(BaseAdapter):
+    def search(self, tokens: list[str], limit: int) -> list[SearchResult]:
+        params = self.index.adapter_params
+        path_field = params["path_field"]
+        search_fields = params.get("search_fields", [path_field])
+        cap = max(limit * OVERSAMPLE, limit, 1)
+        heap: list[tuple[float, int, SearchResult]] = []
+        malformed = 0
+        lowered = tokens
+        try:
+            with open(self.index.path, "r", encoding="utf-8", errors="replace") as handle:
+                for line_no, line in enumerate(handle, start=1):
+                    raw_line = line.lower()
+                    if not any(token in raw_line for token in lowered):
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        malformed += 1
+                        continue
+                    score, matched = token_score(row, tokens, search_fields)
+                    if score == 0:
+                        continue
+                    raw_path = row.get(path_field)
+                    if not raw_path:
+                        continue
+                    meta = {key: value for key, value in row.items() if key != path_field}
+                    meta["matched_tokens"] = matched
+                    meta["total_tokens"] = len(tokens)
+                    meta["malformed_lines"] = malformed
+                    result = SearchResult(
+                        raw_path=str(raw_path),
+                        source_index=self.index.id,
+                        adapter=self.index.adapter,
+                        raw_score=score,
+                        rank_basis="token_match",
+                        meta=meta,
+                    )
+                    push_top(heap, (score, line_no, result), cap)
+        except OSError as exc:
+            raise AdapterError(f"{self.index.id}: jsonl read failed: {exc}") from exc
+
+        return [item[2] for item in sorted(heap, key=lambda item: (-item[0], item[1]))[:limit]]

--- a/scripts/data/drive-index-search/adapters/sqlite_fts.py
+++ b/scripts/data/drive-index-search/adapters/sqlite_fts.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+from adapters.base import AdapterError, BaseAdapter, SearchResult
+
+
+def quote_fts_token(token: str) -> str:
+    return '"' + token.replace('"', '""') + '"'
+
+
+class SqliteFtsAdapter(BaseAdapter):
+    def __init__(self, index):
+        super().__init__(index)
+        self._conn: sqlite3.Connection | None = None
+        self._lock = threading.Lock()
+
+    def interrupt(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.interrupt()
+
+    def search(self, tokens: list[str], limit: int) -> list[SearchResult]:
+        params = self.index.adapter_params
+        fts_table = _identifier(params["fts_table"])
+        base_table = _identifier(params["base_table"])
+        path_column = _identifier(params["path_column"])
+        select_columns = [_identifier(col) for col in params.get("select_columns", [])]
+        match = " OR ".join(quote_fts_token(token) for token in tokens)
+        if not match:
+            return []
+        select_sql = ", ".join([f"base.{path_column} AS raw_path", *[f"base.{col} AS {col}" for col in select_columns]])
+        sql = (
+            f"SELECT {select_sql}, bm25({fts_table}) AS bm25_score "
+            f"FROM {fts_table} JOIN {base_table} base ON base.rowid = {fts_table}.rowid "
+            f"WHERE {fts_table} MATCH ? ORDER BY bm25_score LIMIT ?"
+        )
+        uri = f"file:{self.index.path}?mode=ro"
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            with self._lock:
+                self._conn = conn
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql, (match, limit)).fetchall()
+        except sqlite3.Error as exc:
+            raise AdapterError(f"{self.index.id}: sqlite query failed: {exc}") from exc
+        finally:
+            with self._lock:
+                conn_to_close = self._conn
+                self._conn = None
+            if conn_to_close is not None:
+                conn_to_close.close()
+
+        results = []
+        for row in rows:
+            meta = {key: row[key] for key in row.keys() if key not in {"raw_path", "bm25_score"}}
+            meta["matched_tokens"] = len(tokens)
+            meta["total_tokens"] = len(tokens)
+            results.append(
+                SearchResult(
+                    raw_path=row["raw_path"],
+                    source_index=self.index.id,
+                    adapter=self.index.adapter,
+                    raw_score=float(row["bm25_score"]),
+                    rank_basis="fts_bm25",
+                    meta=meta,
+                )
+            )
+        return results
+
+
+def _identifier(value: str) -> str:
+    if not value.replace("_", "").isalnum():
+        raise AdapterError(f"unsafe sqlite identifier: {value}")
+    return value

--- a/scripts/data/drive-index-search/adapters/tsv.py
+++ b/scripts/data/drive-index-search/adapters/tsv.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import csv
+
+from adapters.base import AdapterError, BaseAdapter, SearchResult, push_top, token_score
+
+
+OVERSAMPLE = 4
+
+
+class TsvAdapter(BaseAdapter):
+    def search(self, tokens: list[str], limit: int) -> list[SearchResult]:
+        params = self.index.adapter_params
+        path_column = params["path_column"]
+        search_columns = params.get("search_columns", [path_column])
+        passthrough = params.get("passthrough_columns", [])
+        cap = max(limit * OVERSAMPLE, limit, 1)
+        heap = []
+        try:
+            with open(self.index.path, "r", encoding="utf-8", errors="replace", newline="") as handle:
+                reader = csv.DictReader(handle, delimiter="\t")
+                header = reader.fieldnames or []
+                required = {path_column, *search_columns, *passthrough}
+                missing = sorted(required.difference(header))
+                if missing:
+                    raise AdapterError(f"{self.index.id}: missing required column(s): {', '.join(missing)}")
+                for line_no, row in enumerate(reader, start=2):
+                    if not any(token in "\t".join(row.values()).lower() for token in tokens):
+                        continue
+                    score, matched = token_score(row, tokens, search_columns)
+                    if score == 0:
+                        continue
+                    meta = {column: row.get(column) for column in passthrough}
+                    meta["matched_tokens"] = matched
+                    meta["total_tokens"] = len(tokens)
+                    result = SearchResult(
+                        raw_path=row[path_column],
+                        source_index=self.index.id,
+                        adapter=self.index.adapter,
+                        raw_score=score,
+                        rank_basis="token_match",
+                        meta=meta,
+                    )
+                    push_top(heap, (score, line_no, result), cap)
+        except OSError as exc:
+            raise AdapterError(f"{self.index.id}: tsv read failed: {exc}") from exc
+        return [item[2] for item in sorted(heap, key=lambda item: (-item[0], item[1]))[:limit]]

--- a/scripts/data/drive-index-search/adapters/yaml_catalog.py
+++ b/scripts/data/drive-index-search/adapters/yaml_catalog.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import yaml
+
+from adapters.base import AdapterError, BaseAdapter, SearchResult, token_score
+
+
+class YamlCatalogAdapter(BaseAdapter):
+    def search(self, tokens: list[str], limit: int) -> list[SearchResult]:
+        params = self.index.adapter_params
+        path_fields = params.get("path_fields", ["path"])
+        text_fields = params.get("text_fields", [])
+        try:
+            with open(self.index.path, "r", encoding="utf-8") as handle:
+                doc = yaml.safe_load(handle) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            raise AdapterError(f"{self.index.id}: yaml read failed: {exc}") from exc
+
+        rows = []
+        for ordinal, item in enumerate(_items(doc, params.get("items_key", "auto"))):
+            raw_path = next((item.get(field) for field in path_fields if item.get(field)), None)
+            if not raw_path:
+                continue
+            score, matched = token_score(item, tokens, [*path_fields, *text_fields])
+            if score == 0:
+                continue
+            meta = {key: value for key, value in item.items() if key not in path_fields}
+            meta["matched_tokens"] = matched
+            meta["total_tokens"] = len(tokens)
+            rows.append(
+                (
+                    -score,
+                    ordinal,
+                    SearchResult(
+                        raw_path=str(raw_path),
+                        source_index=self.index.id,
+                        adapter=self.index.adapter,
+                        raw_score=score,
+                        rank_basis="token_match",
+                        meta=meta,
+                    ),
+                )
+            )
+        return [row[2] for row in sorted(rows)[:limit]]
+
+
+def _items(value, items_key):
+    if items_key != "auto" and isinstance(value, dict):
+        value = value.get(items_key, [])
+    if isinstance(value, list) and all(isinstance(item, dict) for item in value):
+        yield from value
+        return
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _items(child, "auto")

--- a/scripts/data/drive-index-search/merge.py
+++ b/scripts/data/drive-index-search/merge.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from adapters.base import SearchResult
+from pathnorm import canonicalize_path
+
+
+FILENAME_HIT_BONUS = 0.25
+ALL_TOKENS_BONUS = 0.25
+
+
+def ranked_merge(results: list[SearchResult], alias_map: dict[str, str], limit: int) -> list[SearchResult]:
+    deduped: dict[str, SearchResult] = {}
+    for result in results:
+        result.canonical_path = canonicalize_path(result.raw_path, alias_map)
+        result.score = _normalized_score(result)
+        existing = deduped.get(result.canonical_path)
+        if existing is None:
+            deduped[result.canonical_path] = result
+            continue
+        keep, other = (result, existing) if _sort_key(result) < _sort_key(existing) else (existing, result)
+        also_in = list(keep.meta.get("also_in", []))
+        also_in.append(other.source_index)
+        also_in.extend(other.meta.get("also_in", []))
+        keep.meta["also_in"] = sorted(set(also_in))
+        deduped[result.canonical_path] = keep
+    return sorted(deduped.values(), key=_sort_key)[:limit]
+
+
+def _normalized_score(result: SearchResult) -> float:
+    if result.rank_basis == "fts_bm25":
+        magnitude = max(0.0, -float(result.raw_score))
+        return 1.0 / (1.0 + magnitude)
+    matched = float(result.meta.get("matched_tokens", 0))
+    total = max(float(result.meta.get("total_tokens", 1)), 1.0)
+    score = matched / total
+    path_lower = result.raw_path.rsplit("/", 1)[-1].lower()
+    query_tokens = result.meta.get("query_tokens", [])
+    if any(token in path_lower for token in query_tokens):
+        score += FILENAME_HIT_BONUS
+    if matched >= total:
+        score += ALL_TOKENS_BONUS
+    return max(0.0, min(score, 1.0))
+
+
+def _sort_key(result: SearchResult) -> tuple[float, str, str]:
+    return (-(result.score if result.score is not None else 0.0), result.canonical_path or result.raw_path, result.source_index)

--- a/scripts/data/drive-index-search/pathnorm.py
+++ b/scripts/data/drive-index-search/pathnorm.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def canonicalize_path(path: str, alias_map: dict[str, str]) -> str:
+    for alias, canonical in sorted(alias_map.items(), key=lambda item: len(item[0]), reverse=True):
+        if path == alias:
+            return canonical
+        if path.startswith(alias + "/"):
+            return canonical + path[len(alias) :]
+    return path

--- a/scripts/data/drive-index-search/registry.py
+++ b/scripts/data/drive-index-search/registry.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from adapters import ADAPTER_TYPES
+
+
+ALLOWED_TOP_LEVEL = {"version", "canonical_aliases", "defaults", "indexes"}
+
+
+class RegistryError(Exception):
+    pass
+
+
+@dataclass
+class IndexEntry:
+    id: str
+    adapter: str
+    path: Path
+    coverage: dict[str, Any]
+    domains: list[str] | None
+    adapter_params: dict[str, Any]
+    freshness: dict[str, Any] | None = None
+    builder: str | None = None
+
+
+@dataclass
+class Registry:
+    indexes: list[IndexEntry]
+    alias_map: dict[str, str]
+    defaults: dict[str, Any]
+
+    def get(self, index_id: str) -> IndexEntry:
+        for index in self.indexes:
+            if index.id == index_id:
+                return index
+        raise KeyError(index_id)
+
+
+def load_registry(path: str | Path = "config/drive-index-registry.yml") -> Registry:
+    registry_path = Path(path).resolve()
+    repo_root = _repo_root()
+    try:
+        data = yaml.safe_load(registry_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise RegistryError(f"failed to load registry {registry_path}: {exc}") from exc
+    unknown = set(data).difference(ALLOWED_TOP_LEVEL)
+    if unknown:
+        raise RegistryError(f"unknown top-level key(s): {', '.join(sorted(unknown))}")
+    if data.get("version") != 1:
+        raise RegistryError("registry version must be 1")
+    entries = data.get("indexes")
+    if not isinstance(entries, list):
+        raise RegistryError("indexes must be a list")
+    seen = set()
+    indexes = []
+    for raw in entries:
+        index_id = raw.get("id", "<missing>")
+        for key in ("id", "adapter", "path", "coverage", "adapter_params"):
+            if key not in raw:
+                raise RegistryError(f"{index_id}: missing required key {key}")
+        if index_id in seen:
+            raise RegistryError(f"duplicate index id: {index_id}")
+        seen.add(index_id)
+        adapter = raw["adapter"]
+        if adapter not in ADAPTER_TYPES:
+            raise RegistryError(f"{index_id}: unknown adapter {adapter}")
+        coverage = raw["coverage"]
+        if not isinstance(coverage, dict) or not coverage.get("drives"):
+            raise RegistryError(f"{index_id}: coverage.drives is required")
+        raw_path = Path(raw["path"])
+        index_path = raw_path
+        if not index_path.is_absolute():
+            if str(raw_path).startswith("fixtures/") and registry_path.parent.name == "fixtures":
+                index_path = registry_path.parent / Path(*raw_path.parts[1:])
+            elif (registry_path.parent / raw_path).exists():
+                index_path = registry_path.parent / raw_path
+            else:
+                index_path = repo_root / raw_path
+        indexes.append(
+            IndexEntry(
+                id=index_id,
+                adapter=adapter,
+                path=index_path.resolve(),
+                coverage=coverage,
+                domains=raw.get("domains"),
+                adapter_params=raw.get("adapter_params") or {},
+                freshness=raw.get("freshness"),
+                builder=raw.get("builder"),
+            )
+        )
+    return Registry(indexes=indexes, alias_map=data.get("canonical_aliases") or {}, defaults=data.get("defaults") or {})
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]

--- a/scripts/data/drive-index-search/search.py
+++ b/scripts/data/drive-index-search/search.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+import queue
+import sys
+import threading
+
+from adapters import ADAPTER_TYPES
+from adapters.base import AdapterError, tokenize
+from merge import ranked_merge
+from registry import RegistryError, load_registry
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Search registered drive indexes.")
+    parser.add_argument("query")
+    parser.add_argument("--domain")
+    parser.add_argument("--drive")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--registry", default="config/drive-index-registry.yml")
+    parser.add_argument("--index", action="append", default=[])
+    parser.add_argument("--timeout-per-index", type=float, default=60.0)
+    args = parser.parse_args(argv)
+
+    try:
+        registry = load_registry(args.registry)
+    except RegistryError as exc:
+        print(f"registry error: {exc}", file=sys.stderr)
+        _emit(args.query, [], [], [], args.as_json)
+        return 2
+
+    tokens = tokenize(args.query)
+    selected = _select_indexes(registry.indexes, args.drive, args.domain, set(args.index))
+    if not selected:
+        _emit(args.query, [], [], [], args.as_json)
+        return 0
+
+    all_results = []
+    gaps = []
+    reachable_count = 0
+    for index in selected:
+        adapter = ADAPTER_TYPES[index.adapter](index)
+        status, payload = _run_with_timeout(index, adapter, tokens, args.limit, args.timeout_per_index)
+        if status == "ok":
+            reachable_count += 1
+            all_results.extend(payload)
+        else:
+            gap = {"id": index.id, "path": str(index.path), "reason": payload}
+            gaps.append(gap)
+            print(f"warning: index {index.id} {payload} at {index.path} -- skipping", file=sys.stderr)
+
+    for result in all_results:
+        result.meta.setdefault("query_tokens", tokens)
+    merged = ranked_merge(all_results, registry.alias_map, args.limit)
+    _emit(args.query, [index.id for index in selected], gaps, merged, args.as_json)
+    if selected and reachable_count == 0:
+        return 2
+    return 0
+
+
+def _select_indexes(indexes, drive: str | None, domain: str | None, index_ids: set[str]):
+    selected = []
+    for index in indexes:
+        if index_ids and index.id not in index_ids:
+            continue
+        if drive and drive not in index.coverage.get("drives", []):
+            continue
+        if domain and index.domains is not None and domain not in index.domains:
+            continue
+        selected.append(index)
+    return selected
+
+
+def _run_with_timeout(index, adapter, tokens, limit, timeout):
+    output = queue.Queue(maxsize=1)
+
+    def worker():
+        try:
+            if not os.path.exists(index.path):
+                output.put(("gap", "unreachable"))
+                return
+            output.put(("ok", adapter.search(tokens, limit)))
+        except AdapterError as exc:
+            output.put(("gap", str(exc)))
+        except Exception as exc:
+            output.put(("gap", f"unexpected error: {exc}"))
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        adapter.interrupt()
+        thread.join(0.2)
+        return "gap", "timeout"
+    return output.get_nowait()
+
+
+def _emit(query: str, indexes_queried: list[str], gaps: list[dict], results, as_json: bool) -> None:
+    payload = {
+        "query": query,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "indexes_queried": indexes_queried,
+        "coverage_gaps": gaps,
+        "results": [result.as_dict() for result in results],
+    }
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for result in payload["results"]:
+        print(f"{result['score']:.3f}\t{result['source_index']}\t{result['canonical_path']}")
+    for gap in gaps:
+        print(f"gap\t{gap['id']}\t{gap['reason']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/data/drive_index_search/conftest.py
+++ b/tests/data/drive_index_search/conftest.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_DIR = REPO_ROOT / "scripts" / "data" / "drive-index-search"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+sys.path.insert(0, str(PACKAGE_DIR))
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def fixture_registry(fixtures_dir: Path) -> Path:
+    return fixtures_dir / "test-registry.yml"
+
+
+@pytest.fixture(autouse=True)
+def forbid_live_mount_tests(monkeypatch):
+    real_exists = os.path.exists
+
+    def guarded_exists(path):
+        text = os.fspath(path)
+        if text.startswith(("/mnt/ace", "/mnt/dde")):  # abs-path-allowed
+            raise AssertionError(f"test attempted to touch live mount: {text}")
+        return real_exists(path)
+
+    monkeypatch.setattr(os.path, "exists", guarded_exists)

--- a/tests/data/drive_index_search/fixtures/build_fixtures.py
+++ b/tests/data/drive_index_search/fixtures/build_fixtures.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import sqlite3
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def build_sqlite(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE assets (
+            file_path TEXT NOT NULL,
+            file_name TEXT,
+            file_size INTEGER,
+            modified_date TEXT,
+            engineering_domain TEXT
+        );
+        CREATE VIRTUAL TABLE assets_fts
+        USING fts5(title, description, content='assets', content_rowid='rowid');
+        """
+    )
+    rows = [
+        ("/fixture/ace/mooring-fatigue.pdf", "mooring-fatigue.pdf", 100, "2026-01-01", "marine", "mooring fatigue", "mooring fatigue design note"),
+        ("/fixture/ace/mooring-only.pdf", "mooring-only.pdf", 90, "2026-01-02", "marine", "mooring", "line layout"),
+        ("/fixture/ace/fatigue-only.pdf", "fatigue-only.pdf", 80, "2026-01-03", "marine", "fatigue", "detail check"),
+        ("/fixture/ace/riser-note.pdf", "riser-note.pdf", 70, "2026-01-04", "marine", "riser", "unrelated"),
+    ]
+    for file_path, file_name, size, modified, domain, title, description in rows:
+        cur = conn.execute(
+            "INSERT INTO assets(file_path, file_name, file_size, modified_date, engineering_domain) VALUES (?, ?, ?, ?, ?)",
+            (file_path, file_name, size, modified, domain),
+        )
+        conn.execute(
+            "INSERT INTO assets_fts(rowid, title, description) VALUES (?, ?, ?)",
+            (cur.lastrowid, title, description),
+        )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    build_sqlite(ROOT / "fixture.db")

--- a/tests/data/drive_index_search/fixtures/fixture-catalog.yaml
+++ b/tests/data/drive_index_search/fixtures/fixture-catalog.yaml
@@ -1,0 +1,10 @@
+catalog:
+  items:
+    - title: Installation Guide
+      domain: literature
+      notes: mooring installation guide
+      path: /legacy/dde/literature/install-guide.pdf
+    - title: Fatigue Memo
+      domain: literature
+      notes: fatigue memo
+      source_dir: /legacy/dde/literature/fatigue

--- a/tests/data/drive_index_search/fixtures/fixture.jsonl
+++ b/tests/data/drive_index_search/fixtures/fixture.jsonl
@@ -1,0 +1,7 @@
+{"path": "/fixture/ace/riser-design.pdf", "summary": "riser riser riser design", "domain": "marine", "org": "A"}
+{"path": "/fixture/ace/riser-analysis.pdf", "summary": "riser analysis", "domain": "marine", "org": "B"}
+not-json malformed-survivor
+{"path": "/fixture/ace/riser-notes.pdf", "summary": "field riser notes", "domain": "marine", "org": "C"}
+{"path": "/fixture/ace/hidden.pdf", "summary": "nothing scored", "unscored": "riser"}
+{"path": "/fixture/ace/malformed-survivor.pdf", "summary": "malformed-survivor", "domain": "qa", "org": "D"}
+{"path": "/legacy/dde/mooring-from-jsonl.pdf", "summary": "mooring", "domain": "marine", "org": "DDE"}

--- a/tests/data/drive_index_search/fixtures/fixture.tsv
+++ b/tests/data/drive_index_search/fixtures/fixture.tsv
@@ -1,0 +1,4 @@
+path	format	ecosystem	readability	read_tool	glb	name_description	project	size	mtime
+/fixture/ace/cad-mooring.dwg	dwg	ace	high	cad		clearly readable mooring assembly	alpha	123	2026-01-01
+/fixture/ace/cad-riser.dwg	dwg	ace	medium	cad		riser stack	beta	456	2026-01-02
+/fixture/ace/cad-empty.dwg	dwg	ace	low	cad		nothing	gamma	789	2026-01-03

--- a/tests/data/drive_index_search/fixtures/test-registry.yml
+++ b/tests/data/drive_index_search/fixtures/test-registry.yml
@@ -1,0 +1,49 @@
+version: 1
+canonical_aliases:
+  /legacy/dde: /canonical/dde
+defaults:
+  staleness_days: 30
+indexes:
+  - id: fixture_sqlite
+    adapter: sqlite_fts
+    path: fixtures/fixture.db
+    coverage: {drives: [/fixture/ace], subtree: /fixture/ace}
+    domains: [marine, engineering]
+    adapter_params:
+      fts_table: assets_fts
+      base_table: assets
+      path_column: file_path
+      select_columns: [file_name, file_size, modified_date, engineering_domain]
+  - id: fixture_jsonl
+    adapter: jsonl
+    path: fixtures/fixture.jsonl
+    coverage: {drives: [/fixture/ace, /canonical/dde]}
+    domains: [marine]
+    adapter_params:
+      path_field: path
+      search_fields: [path, summary, domain, org]
+      sidecar: null
+  - id: fixture_tsv
+    adapter: tsv
+    path: fixtures/fixture.tsv
+    coverage: {drives: [/fixture/ace]}
+    adapter_params:
+      path_column: path
+      search_columns: [path, name_description, project]
+      passthrough_columns: [format, readability, size, mtime]
+  - id: fixture_yaml
+    adapter: yaml_catalog
+    path: fixtures/fixture-catalog.yaml
+    coverage: {drives: [/canonical/dde]}
+    adapter_params:
+      items_key: auto
+      path_fields: [path, source_dir]
+      text_fields: [title, domain, notes]
+  - id: fixture_missing
+    adapter: jsonl
+    path: fixtures/does-not-exist.jsonl
+    coverage: {drives: [/canonical/dde]}
+    adapter_params:
+      path_field: path
+      search_fields: [path, summary]
+      sidecar: null

--- a/tests/data/drive_index_search/test_adapters.py
+++ b/tests/data/drive_index_search/test_adapters.py
@@ -1,0 +1,103 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from adapters.base import AdapterError, tokenize
+from adapters.jsonl import JsonlAdapter
+from adapters.sqlite_fts import SqliteFtsAdapter
+from adapters.tsv import TsvAdapter
+from adapters.yaml_catalog import YamlCatalogAdapter
+from registry import load_registry
+
+
+def _index(registry_path, index_id):
+    return load_registry(registry_path).get(index_id)
+
+
+def test_sqlite_fts_adapter_bm25_rank(fixture_registry):
+    adapter = SqliteFtsAdapter(_index(fixture_registry, "fixture_sqlite"))
+
+    rows = adapter.search(tokenize("mooring"), limit=5)
+
+    assert len(rows) >= 2
+    assert rows[0].rank_basis == "fts_bm25"
+    assert rows[0].raw_path.endswith("mooring-fatigue.pdf")
+
+
+def test_sqlite_fts_multi_token_or_semantics(fixture_registry):
+    adapter = SqliteFtsAdapter(_index(fixture_registry, "fixture_sqlite"))
+
+    paths = [row.raw_path for row in adapter.search(tokenize("mooring fatigue"), limit=10)]
+
+    assert any(path.endswith("mooring-only.pdf") for path in paths)
+    assert any(path.endswith("fatigue-only.pdf") for path in paths)
+
+
+def test_sqlite_fts_query_token_quoting(fixture_registry):
+    adapter = SqliteFtsAdapter(_index(fixture_registry, "fixture_sqlite"))
+
+    rows = adapter.search(tokenize('mooring" OR x near('), limit=5)
+
+    assert rows
+
+
+def test_sqlite_fts_readonly(fixture_registry):
+    index = _index(fixture_registry, "fixture_sqlite")
+    adapter = SqliteFtsAdapter(index)
+
+    adapter.search(tokenize("mooring"), limit=1)
+
+    with pytest.raises(sqlite3.OperationalError):
+        sqlite3.connect(f"file:{index.path}?mode=ro", uri=True).execute(
+            "CREATE TABLE should_fail(x)"
+        )
+
+
+def test_jsonl_adapter_streaming_topk(fixture_registry):
+    adapter = JsonlAdapter(_index(fixture_registry, "fixture_jsonl"))
+
+    rows = adapter.search(tokenize("riser"), limit=3)
+
+    assert len(rows) == 3
+    assert rows[0].raw_path.endswith("riser-design.pdf")
+    assert all(row.rank_basis == "token_match" for row in rows)
+
+
+def test_jsonl_adapter_skips_malformed_line(fixture_registry):
+    adapter = JsonlAdapter(_index(fixture_registry, "fixture_jsonl"))
+
+    rows = adapter.search(tokenize("malformed-survivor"), limit=5)
+
+    assert len(rows) == 1
+    assert rows[0].meta["malformed_lines"] == 1
+
+
+def test_tsv_adapter_columns(fixture_registry):
+    adapter = TsvAdapter(_index(fixture_registry, "fixture_tsv"))
+
+    rows = adapter.search(tokenize("readable mooring"), limit=5)
+
+    assert rows[0].raw_path.endswith("cad-mooring.dwg")
+    assert rows[0].meta["format"] == "dwg"
+    assert rows[0].meta["readability"] == "high"
+    assert rows[0].meta["mtime"] == "2026-01-01"
+
+
+def test_tsv_adapter_rejects_bad_header(fixture_registry, tmp_path):
+    bad = tmp_path / "bad.tsv"
+    bad.write_text("name_description\tformat\nmooring\tdwg\n")
+    index = _index(fixture_registry, "fixture_tsv")
+    index.path = bad
+
+    with pytest.raises(AdapterError, match="missing required column"):
+        TsvAdapter(index).search(tokenize("mooring"), limit=5)
+
+
+def test_yaml_catalog_adapter(fixture_registry):
+    adapter = YamlCatalogAdapter(_index(fixture_registry, "fixture_yaml"))
+
+    rows = adapter.search(tokenize("installation guide"), limit=5)
+
+    assert rows[0].raw_path == "/legacy/dde/literature/install-guide.pdf"
+    assert rows[0].meta["title"] == "Installation Guide"

--- a/tests/data/drive_index_search/test_cli.py
+++ b/tests/data/drive_index_search/test_cli.py
@@ -1,0 +1,123 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI = REPO_ROOT / "scripts" / "data" / "drive-index-search" / "search.py"
+
+
+def _run(args):
+    return subprocess.run(
+        [sys.executable, str(CLI), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_unreachable_index_degrades(fixture_registry):
+    result = _run(["mooring", "--registry", str(fixture_registry), "--json", "--limit", "5"])
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert "unreachable" in result.stderr
+    assert any(gap["id"] == "fixture_missing" for gap in payload["coverage_gaps"])
+    assert payload["results"]
+
+
+def test_all_indexes_unreachable_exit_code(fixture_registry):
+    result = _run(
+        [
+            "mooring",
+            "--registry",
+            str(fixture_registry),
+            "--json",
+            "--index",
+            "fixture_missing",
+        ]
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 2
+    assert payload["results"] == []
+    assert payload["coverage_gaps"][0]["reason"] == "unreachable"
+
+
+def test_cli_domain_drive_fastpath(fixture_registry):
+    result = _run(
+        [
+            "installation",
+            "--registry",
+            str(fixture_registry),
+            "--json",
+            "--drive",
+            "/canonical/dde",
+        ]
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["indexes_queried"] == ["fixture_jsonl", "fixture_yaml", "fixture_missing"]
+    assert any(row["source_index"] == "fixture_yaml" for row in payload["results"])
+
+
+def test_cli_json_schema(fixture_registry):
+    result = _run(["mooring", "--registry", str(fixture_registry), "--json", "--limit", "3"])
+
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "query",
+        "generated_at",
+        "indexes_queried",
+        "coverage_gaps",
+        "results",
+    }
+    assert {
+        "canonical_path",
+        "raw_path",
+        "source_index",
+        "adapter",
+        "score",
+        "rank_basis",
+        "meta",
+    }.issubset(payload["results"][0])
+
+
+def test_cli_limit_respected(fixture_registry):
+    result = _run(["mooring", "--registry", str(fixture_registry), "--json", "--limit", "2"])
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert len(payload["results"]) == 2
+
+
+def test_empty_selection_returns_zero(fixture_registry):
+    result = _run(
+        [
+            "mooring",
+            "--registry",
+            str(fixture_registry),
+            "--json",
+            "--drive",
+            "/uncovered",
+        ]
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["indexes_queried"] == []
+    assert payload["coverage_gaps"] == []
+
+
+def test_registry_error_exit_code(fixture_registry, tmp_path):
+    bad = tmp_path / "bad.yml"
+    bad.write_text(Path(fixture_registry).read_text().replace("adapter: jsonl", "adapter: nope", 1))
+
+    result = _run(["mooring", "--registry", str(bad), "--json"])
+
+    assert result.returncode == 2
+    assert "nope" in result.stderr

--- a/tests/data/drive_index_search/test_merge_and_normalize.py
+++ b/tests/data/drive_index_search/test_merge_and_normalize.py
@@ -1,0 +1,90 @@
+import random
+
+from adapters.base import SearchResult
+from merge import ranked_merge
+from pathnorm import canonicalize_path
+
+
+def _row(path, source, basis="token_match", raw_score=1.0, matched=1, total=1):
+    return SearchResult(
+        raw_path=path,
+        source_index=source,
+        adapter="fixture",
+        raw_score=raw_score,
+        rank_basis=basis,
+        meta={"matched_tokens": matched, "total_tokens": total},
+    )
+
+
+def test_ranked_merge_deterministic():
+    rows = [
+        _row("/canonical/dde/b.pdf", "b"),
+        _row("/canonical/dde/a.pdf", "a"),
+        _row("/canonical/dde/c.pdf", "a"),
+    ]
+    outputs = []
+
+    for _ in range(10):
+        shuffled = rows[:]
+        random.shuffle(shuffled)
+        outputs.append([row.as_dict() for row in ranked_merge(shuffled, {}, limit=10)])
+
+    assert all(output == outputs[0] for output in outputs)
+
+
+def test_ranked_merge_dedupes_canonical_path():
+    rows = [
+        _row("/legacy/dde/same.pdf", "jsonl"),
+        _row("/canonical/dde/same.pdf", "sqlite"),
+    ]
+
+    merged = ranked_merge(rows, {"/legacy/dde": "/canonical/dde"}, limit=10)
+
+    assert len(merged) == 1
+    assert merged[0].canonical_path == "/canonical/dde/same.pdf"
+    assert merged[0].meta["also_in"] == ["sqlite"]
+
+
+def test_merge_normalizes_scores_per_index():
+    rows = [
+        _row("/a/all-tokens.pdf", "jsonl", matched=2, total=2),
+        _row("/b/singleton.pdf", "sqlite", basis="fts_bm25", raw_score=12.0),
+    ]
+
+    merged = ranked_merge(rows, {}, limit=10)
+
+    assert all(0.0 <= row.score <= 1.0 for row in merged)
+    assert merged[0].canonical_path == "/a/all-tokens.pdf"
+
+
+def test_normalize_dev_secondary_alias():
+    assert (
+        canonicalize_path(
+            "/mnt/remote/dev-secondary/dde/Literature/x.pdf",  # abs-path-allowed
+            {"/mnt/remote/dev-secondary/dde": "/mnt/dde"},  # abs-path-allowed
+        )
+        == "/mnt/dde/Literature/x.pdf"  # abs-path-allowed
+    )
+
+
+def test_normalize_ace_linux2_alias():
+    assert (
+        canonicalize_path(
+            "/mnt/remote/ace-linux-2/dde/documents/y.xlsx",  # abs-path-allowed
+            {"/mnt/remote/ace-linux-2/dde": "/mnt/dde"},  # abs-path-allowed
+        )
+        == "/mnt/dde/documents/y.xlsx"  # abs-path-allowed
+    )
+
+
+def test_normalize_longest_prefix_and_noop():
+    aliases = {
+        "/mnt/remote/ace-linux-2/dde": "/mnt/dde",  # abs-path-allowed
+    }
+
+    assert canonicalize_path("/mnt/ace/docs/a.pdf", aliases) == "/mnt/ace/docs/a.pdf"  # abs-path-allowed
+    assert (
+        canonicalize_path("/mnt/remote/ace-linux-2/dde-extra/z", aliases)  # abs-path-allowed
+        == "/mnt/remote/ace-linux-2/dde-extra/z"  # abs-path-allowed
+    )
+    assert canonicalize_path("/mnt/remote/ace-linux-2/dde/z", aliases) == "/mnt/dde/z"  # abs-path-allowed

--- a/tests/data/drive_index_search/test_registry.py
+++ b/tests/data/drive_index_search/test_registry.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+
+from registry import RegistryError, load_registry
+
+
+def test_registry_parses_valid_yaml(fixture_registry):
+    registry = load_registry(fixture_registry)
+
+    assert len(registry.indexes) == 5
+    assert registry.alias_map["/legacy/dde"] == "/canonical/dde"
+    assert {index.id for index in registry.indexes} == {
+        "fixture_sqlite",
+        "fixture_jsonl",
+        "fixture_tsv",
+        "fixture_yaml",
+        "fixture_missing",
+    }
+
+
+def test_registry_rejects_unknown_adapter(fixture_registry, tmp_path):
+    text = Path(fixture_registry).read_text()
+    bad = tmp_path / "bad.yml"
+    bad.write_text(text.replace("adapter: jsonl", "adapter: parquet", 1))
+
+    with pytest.raises(RegistryError, match="fixture_jsonl.*parquet"):
+        load_registry(bad)
+
+
+def test_registry_rejects_duplicate_ids(fixture_registry, tmp_path):
+    text = Path(fixture_registry).read_text()
+    bad = tmp_path / "bad.yml"
+    bad.write_text(text.replace("id: fixture_jsonl", "id: fixture_sqlite", 1))
+
+    with pytest.raises(RegistryError, match="duplicate.*fixture_sqlite"):
+        load_registry(bad)
+
+
+def test_registry_rejects_missing_required_key(fixture_registry, tmp_path):
+    text = Path(fixture_registry).read_text()
+    bad = tmp_path / "bad.yml"
+    bad.write_text(text.replace("    path: fixtures/fixture.tsv\n", "", 1))
+
+    with pytest.raises(RegistryError, match="fixture_tsv.*path"):
+        load_registry(bad)
+
+
+def test_registry_resolves_relative_paths(fixture_registry):
+    registry = load_registry(fixture_registry)
+    jsonl = registry.get("fixture_jsonl")
+
+    assert jsonl.path.is_absolute()
+    assert jsonl.path.name == "fixture.jsonl"


### PR DESCRIPTION
Implements #3335 per its approved, adversarial-reviewed plan (`docs/plans/2026-07-02-issue-3335-drive-index-query-cli.md`). **First `lane:codex` implementation of the epic** — authored by `codex exec --full-auto` against the plan as binding contract; independently verified, live-smoked, and enforcement-fixed by the orchestrating Claude session.

## What
- `config/drive-index-registry.yml` — Layer 0 single source of truth: 5 index entries (ace_knowledge, og_standards_inventory, cad_readability, master_document_index, dde_literature_catalog) + `canonical_aliases` map (both stale dde alias forms → `/mnt/dde`).
- `scripts/data/drive-index-search/` — `search.py` CLI (pinned `--json` envelope: query/generated_at/indexes_queried/coverage_gaps/results; exit 0 incl. partial, exit 2 registry-error only), `registry.py`, `pathnorm.py`, `merge.py` (absolute token-fraction base + fixed bm25 squash — per-index min-max rejected in plan review), adapters for sqlite_fts / jsonl / tsv / yaml_catalog. SQLite opened read-only (`mode=ro`); JSONL adapter streams with raw-line prefilter + capped heap; multi-token FTS uses quoted-token OR (implicit-AND returns 0 rows on the real data); per-index timeout via worker thread + `Connection.interrupt()`.
- `tests/data/drive_index_search/` — **27 tests, all passing** (`python3 -m pytest`; uv cache is broken on this box), fixtures <29 KB, never touch live DBs.

## Verification (orchestrator-run, not agent-claimed)
- Independent test run: 27/27 in 0.86 s.
- Live smoke `"mooring fatigue" --limit 5 --json`: all 5 indexes queried, ~11 s warm (first-ever run pays a cold-cache read of the 6.84 GB standards DB + 154 MB TSV — subsequent runs are seconds), absent master JSONL correctly degrades to a `coverage_gaps` entry with exit 0, canonical + raw paths both emitted.
- `check-no-abs-paths.sh` passes (sentinels on 12 test-data alias literals — they ARE the normalization test subjects).

## Unblocks
#3338 (skill consumes the `--json` contract), #3334 (registry handshake), #3336 (staleness fields), #3337 (`pathnorm.py` shared helper).

Closes #3335.