### PR TITLE
feat(#3334): dde drive index builder + registry entry + JSONL deprecation (epic #3333)

### DIFF
--- a/config/drive-index-registry.yml
+++ b/config/drive-index-registry.yml
@@ -17,6 +17,17 @@ indexes:
       base_table: assets
       path_column: file_path
       select_columns: [file_name, file_size, modified_date, engineering_domain]
+  - id: dde_knowledge
+    adapter: sqlite_fts
+    path: /mnt/dde/.dde-knowledge/index.db
+    coverage: {drives: [/mnt/dde], subtree: /mnt/dde}
+    freshness: {built_at: "pending production build"}
+    builder: scripts/data/drive-index/build_drive_index.py
+    adapter_params:
+      fts_table: assets_fts
+      base_table: assets
+      path_column: file_path
+      select_columns: [file_name, file_size, modified_date, engineering_domain]
   - id: og_standards_inventory
     adapter: sqlite_fts
     path: "/mnt/ace/O&G-Standards/_inventory.db"

--- a/scripts/data/document-index/config.yaml
+++ b/scripts/data/document-index/config.yaml
@@ -30,7 +30,10 @@ sources:
                  .py, .m, .inp, .dat, .mac, .f, .for, .bas]
 
   dde_project:
-    enabled: true
+    # WARNING: dde rows in index.jsonl survive RESUME runs only — a --force rebuild
+    # merges from {} + enabled sources and DROPS all 495,487 dde rows.
+    # Superseded 2026-07 by /mnt/dde/.dde-knowledge/index.db (#3334)
+    enabled: false
     paths:
       - /mnt/remote/dev-secondary/dde/documents
       - /mnt/remote/dev-secondary/dde/0000 O&G

--- a/scripts/data/drive-index/build_drive_index.py
+++ b/scripts/data/drive-index/build_drive_index.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Drive-local SQLite FTS5 index builder."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = SCRIPT_DIR / "drive-index-config.yaml"
+HASH_CHUNK_SIZE = 65536
+
+ASSET_COLUMNS = (
+    "id asset_type file_path file_name file_extension file_size content_hash "
+    "modified_date source_root discipline project_code folder_phase title description "
+    "content_category engineering_domain scan_date extraction_status anonymized_title "
+    "language page_count word_count last_extracted status canonical_path"
+).split()
+
+CREATE_ASSETS_SQL = """
+CREATE TABLE IF NOT EXISTS assets (
+    id TEXT PRIMARY KEY,
+    asset_type TEXT NOT NULL,
+    file_path TEXT UNIQUE NOT NULL,
+    file_name TEXT NOT NULL,
+    file_extension TEXT,
+    file_size INTEGER DEFAULT 0,
+    content_hash TEXT,
+    modified_date TEXT,
+    source_root TEXT,
+    discipline TEXT,
+    project_code TEXT,
+    folder_phase TEXT,
+    title TEXT,
+    description TEXT,
+    content_category TEXT,
+    engineering_domain TEXT,
+    scan_date TEXT,
+    extraction_status TEXT DEFAULT 'pending',
+    anonymized_title TEXT,
+    language TEXT DEFAULT 'en',
+    page_count INTEGER,
+    word_count INTEGER,
+    last_extracted TEXT,
+    status TEXT DEFAULT 'active',
+    canonical_path TEXT
+)
+"""
+
+UPSERT_SQL = f"""
+INSERT INTO assets ({", ".join(ASSET_COLUMNS)})
+VALUES ({", ".join("?" for _ in ASSET_COLUMNS)})
+ON CONFLICT(file_path) DO UPDATE SET
+    id=excluded.id,
+    asset_type=excluded.asset_type,
+    file_name=excluded.file_name,
+    file_extension=excluded.file_extension,
+    file_size=excluded.file_size,
+    modified_date=excluded.modified_date,
+    source_root=excluded.source_root,
+    discipline=excluded.discipline,
+    project_code=excluded.project_code,
+    folder_phase=excluded.folder_phase,
+    title=excluded.title,
+    description=excluded.description,
+    content_category=excluded.content_category,
+    engineering_domain=excluded.engineering_domain,
+    scan_date=excluded.scan_date,
+    extraction_status=excluded.extraction_status,
+    anonymized_title=excluded.anonymized_title,
+    language=excluded.language,
+    page_count=excluded.page_count,
+    word_count=excluded.word_count,
+    last_extracted=excluded.last_extracted,
+    status='active',
+    canonical_path=excluded.canonical_path
+"""
+
+
+@dataclass
+class Profile:
+    name: str
+    root: Path
+    canonical_prefix: str
+    db: Path
+    excludes: set[str]
+    topdir_map: dict[str, dict[str, str]]
+    extension_map: dict[str, str]
+    defaults: dict[str, str]
+
+
+def load_profile(config_path: Path, drive: str, db_override: Path | None = None) -> Profile:
+    data = yaml.safe_load(config_path.read_text()) or {}
+    raw = data["drives"][drive]
+    classification = raw.get("classification", {})
+    return Profile(
+        name=drive,
+        root=Path(raw["root"]),
+        canonical_prefix=raw["canonical_prefix"].rstrip("/"),
+        db=db_override or Path(raw["db"]),
+        excludes=set(raw.get("excludes", [])),
+        topdir_map=classification.get("topdirs", {}) or {},
+        extension_map={k.lower(): v for k, v in (classification.get("extensions", {}) or {}).items()},
+        defaults=classification.get("defaults", {}) or {},
+    )
+
+
+def open_db(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(CREATE_ASSETS_SQL)
+    conn.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS assets_fts USING fts5("
+        "title, description, anonymized_title, content=assets, content_rowid=rowid)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS scan_state ("
+        "key TEXT PRIMARY KEY, value TEXT, updated_at TEXT NOT NULL)"
+    )
+    conn.commit()
+    return conn
+
+
+def sanitize_text(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.encode("utf-8", "backslashreplace").decode("utf-8")
+    return value
+
+
+def canonical_path(path: Path, profile: Profile) -> str:
+    rel = path.relative_to(profile.root)
+    return sanitize_text(profile.canonical_prefix + "/" + rel.as_posix())
+
+
+def iter_files(root: Path, excludes: set[str]) -> Iterable[Path]:
+    def walk(current: Path) -> Iterable[Path]:
+        try:
+            entries = sorted(os.scandir(current), key=lambda e: sanitize_text(e.name))
+        except OSError as exc:
+            yield ScanError(current, exc)  # type: ignore[misc]
+            return
+        for entry in entries:
+            name = sanitize_text(entry.name)
+            try:
+                if entry.is_symlink():
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    if name not in excludes:
+                        yield from walk(Path(entry.path))
+                elif entry.is_file(follow_symlinks=False):
+                    yield Path(entry.path)
+            except OSError as exc:
+                yield ScanError(Path(entry.path), exc)  # type: ignore[misc]
+
+    yield from walk(root)
+
+
+@dataclass
+class ScanError:
+    path: Path
+    error: OSError
+
+
+def classify(path: Path, profile: Profile) -> dict[str, str | None]:
+    rel = path.relative_to(profile.root)
+    top = sanitize_text(rel.parts[0]) if rel.parts else ""
+    mapped = profile.topdir_map.get(top, {})
+    ext = path.suffix.lower()
+    return {
+        "asset_type": profile.extension_map.get(ext, profile.defaults.get("asset_type", "file")),
+        "discipline": mapped.get("discipline", profile.defaults.get("discipline")),
+        "engineering_domain": mapped.get("engineering_domain", profile.defaults.get("engineering_domain")),
+        "project_code": mapped.get("project_code", profile.defaults.get("project_code")),
+        "content_category": mapped.get("content_category", profile.defaults.get("content_category")),
+    }
+
+
+def row_for_file(path: Path, profile: Profile, scan_date: str) -> tuple[Any, ...]:
+    stat = path.stat()
+    canonical = canonical_path(path, profile)
+    rel_parent = sanitize_text(path.parent.relative_to(profile.root).as_posix())
+    info = classify(path, profile)
+    values = {
+        "id": hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32],
+        "asset_type": info["asset_type"],
+        "file_path": canonical,
+        "file_name": sanitize_text(path.name),
+        "file_extension": sanitize_text(path.suffix.lower() or None),
+        "file_size": stat.st_size,
+        "content_hash": None,
+        "modified_date": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+        "source_root": profile.canonical_prefix,
+        "discipline": info["discipline"],
+        "project_code": info["project_code"],
+        "folder_phase": None,
+        "title": sanitize_text(path.stem),
+        "description": rel_parent if rel_parent != "." else profile.canonical_prefix,
+        "content_category": info["content_category"],
+        "engineering_domain": info["engineering_domain"],
+        "scan_date": scan_date,
+        "extraction_status": "pending",
+        "anonymized_title": None,
+        "language": "en",
+        "page_count": None,
+        "word_count": None,
+        "last_extracted": None,
+        "status": "active",
+        "canonical_path": canonical,
+    }
+    return tuple(sanitize_text(values[col]) for col in ASSET_COLUMNS)
+
+
+def unchanged_active(conn: sqlite3.Connection, row: tuple[Any, ...]) -> bool:
+    file_path = row[ASSET_COLUMNS.index("file_path")]
+    size = row[ASSET_COLUMNS.index("file_size")]
+    mtime = row[ASSET_COLUMNS.index("modified_date")]
+    found = conn.execute(
+        "SELECT file_size, modified_date, status FROM assets WHERE file_path = ?",
+        (file_path,),
+    ).fetchone()
+    return bool(found and found[0] == size and found[1] == mtime and found[2] == "active")
+
+
+def execute_many(conn: sqlite3.Connection, rows: list[tuple[Any, ...]]) -> None:
+    conn.executemany(UPSERT_SQL, rows)
+
+
+def write_batch(conn: sqlite3.Connection, rows: list[tuple[Any, ...]]) -> int:
+    try:
+        execute_many(conn, rows)
+        return 0
+    except sqlite3.Error:
+        errors = 0
+        for row in rows:
+            try:
+                conn.execute(UPSERT_SQL, row)
+            except sqlite3.Error:
+                errors += 1
+        return errors
+
+
+def set_state(conn: sqlite3.Connection, key: str, value: Any) -> None:
+    conn.execute(
+        "INSERT INTO scan_state(key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at",
+        (key, str(value), datetime.now(timezone.utc).isoformat()),
+    )
+
+
+def metadata_pass(profile: Profile, *, batch_size: int, limit: int | None = None) -> dict[str, int]:
+    conn = open_db(profile.db)
+    scan_date = datetime.now(timezone.utc).isoformat()
+    start = time.monotonic()
+    seen: set[str] = set()
+    batch: list[tuple[Any, ...]] = []
+    stats = {"files": 0, "errors": 0, "skipped": 0}
+    try:
+        for item in iter_files(profile.root, profile.excludes):
+            if isinstance(item, ScanError):
+                stats["errors"] += 1
+                continue
+            try:
+                row = row_for_file(item, profile, scan_date)
+                seen.add(row[ASSET_COLUMNS.index("file_path")])
+                stats["files"] += 1
+                if unchanged_active(conn, row):
+                    stats["skipped"] += 1
+                else:
+                    batch.append(row)
+            except OSError:
+                stats["errors"] += 1
+            if len(batch) >= batch_size:
+                stats["errors"] += write_batch(conn, batch)
+                conn.commit()
+                set_state(conn, "files_seen", stats["files"])
+                conn.commit()
+                batch.clear()
+            if limit is not None and stats["files"] >= limit:
+                break
+        if batch:
+            stats["errors"] += write_batch(conn, batch)
+        mark_removed(conn, profile, seen)
+        conn.execute("INSERT INTO assets_fts(assets_fts) VALUES('rebuild')")
+        stats["duration_seconds"] = int(time.monotonic() - start)
+        for key, value in stats.items():
+            set_state(conn, key, value)
+        set_state(conn, "last_scan_date", scan_date)
+        conn.commit()
+        return stats
+    finally:
+        conn.close()
+
+
+def mark_removed(conn: sqlite3.Connection, profile: Profile, seen: set[str]) -> None:
+    rows = conn.execute(
+        "SELECT file_path FROM assets WHERE source_root = ? AND status = 'active'",
+        (profile.canonical_prefix,),
+    ).fetchall()
+    for (file_path,) in rows:
+        if file_path not in seen:
+            conn.execute("UPDATE assets SET status = 'removed' WHERE file_path = ?", (file_path,))
+
+
+def hash_incremental(profile: Profile, batch_size: int, limit: int | None = None) -> dict[str, int]:
+    conn = open_db(profile.db)
+    rows = conn.execute(
+        "SELECT file_path FROM assets WHERE content_hash IS NULL AND status = 'active' ORDER BY file_size ASC"
+    ).fetchall()
+    hashed = errors = 0
+    try:
+        for (file_path,) in rows:
+            if limit is not None and hashed >= limit:
+                break
+            local = profile.root / Path(file_path).relative_to(profile.canonical_prefix)
+            try:
+                digest = compute_hash(local)
+                conn.execute("UPDATE assets SET content_hash = ? WHERE file_path = ?", (digest, file_path))
+                hashed += 1
+            except OSError:
+                errors += 1
+            if hashed and hashed % batch_size == 0:
+                conn.commit()
+        conn.execute("INSERT INTO assets_fts(assets_fts) VALUES('rebuild')")
+        set_state(conn, "hash_files", hashed)
+        set_state(conn, "hash_errors", errors)
+        conn.commit()
+        return {"hashed": hashed, "errors": errors}
+    finally:
+        conn.close()
+
+
+def compute_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(HASH_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def count_walk(profile: Profile) -> int:
+    return sum(1 for item in iter_files(profile.root, profile.excludes) if not isinstance(item, ScanError))
+
+
+def reconcile(profile: Profile) -> int:
+    conn = open_db(profile.db)
+    try:
+        walk_count = count_walk(profile)
+        db_count = conn.execute(
+            "SELECT count(*) FROM assets WHERE source_root = ? AND status = 'active'",
+            (profile.canonical_prefix,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    delta = db_count - walk_count
+    print(f"walk_count={walk_count} db_count={db_count} delta={delta}")
+    tolerance = walk_count * 0.001
+    return 0 if abs(delta) <= tolerance else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a drive-local SQLite FTS index")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--drive", required=True)
+    parser.add_argument("--db", type=Path)
+    parser.add_argument("--hash", choices=["none", "incremental"], default="none")
+    parser.add_argument("--batch-size", type=int, default=2000)
+    parser.add_argument("--reconcile", action="store_true")
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args(argv)
+    profile = load_profile(args.config, args.drive, args.db)
+    if args.reconcile:
+        return reconcile(profile)
+    if args.hash == "incremental":
+        print(hash_incremental(profile, args.batch_size, args.limit))
+    else:
+        print(metadata_pass(profile, batch_size=args.batch_size, limit=args.limit))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/data/drive-index/drive-index-config.yaml
+++ b/scripts/data/drive-index/drive-index-config.yaml
@@ -1,0 +1,74 @@
+version: 1
+drives:
+  dde:
+    root: /mnt/dde
+    canonical_prefix: /mnt/dde
+    db: /mnt/dde/.dde-knowledge/index.db
+    excludes:
+      - $RECYCLE.BIN
+      - System Volume Information
+      - .dde-knowledge
+    classification:
+      defaults:
+        asset_type: file
+        discipline: general
+        engineering_domain: general
+        content_category: file
+      topdirs:
+        0000 O&G:
+          discipline: engineering
+          engineering_domain: oil_and_gas
+          content_category: standards
+        ABSG:
+          discipline: engineering
+          engineering_domain: marine
+          content_category: project
+        Literature:
+          discipline: research
+          engineering_domain: literature
+          content_category: literature
+        Orcaflex:
+          discipline: engineering
+          engineering_domain: offshore_analysis
+          content_category: simulation
+        documents:
+          discipline: documents
+          engineering_domain: general
+          content_category: documents
+        dropbox_contents:
+          discipline: documents
+          engineering_domain: general
+          content_category: documents
+        g-drive:
+          discipline: documents
+          engineering_domain: general
+          content_category: documents
+        o-drive:
+          discipline: documents
+          engineering_domain: general
+          content_category: documents
+        Temp - Oil&Gas:
+          discipline: engineering
+          engineering_domain: oil_and_gas
+          content_category: temp
+      extensions:
+        .pdf: document
+        .doc: document
+        .docx: document
+        .xls: spreadsheet
+        .xlsx: spreadsheet
+        .csv: spreadsheet
+        .ppt: presentation
+        .pptx: presentation
+        .txt: text
+        .md: text
+        .py: code
+        .m: code
+        .inp: analysis_input
+        .dat: data
+        .mac: code
+        .f: code
+        .for: code
+        .bas: code
+        .dwg: cad
+        .dxf: cad

--- a/tests/data/drive_index/conftest.py
+++ b/tests/data/drive_index/conftest.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BUILDER_PATH = REPO_ROOT / "scripts/data/drive-index/build_drive_index.py"
+
+
+@pytest.fixture()
+def builder():
+    spec = importlib.util.spec_from_file_location("build_drive_index", BUILDER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def fixture_tree(tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "dde"
+    files = [
+        "documents/readme.txt",
+        "documents/zero.dat",
+        "documents/riser_fatigue_report.pdf",
+        "Orcaflex/model run/sim.dat",
+        "ABSG/design calc.xlsx",
+        "Literature/paper one.pdf",
+        "g-drive/project & notes.docx",
+        "o-drive/unicode_cafe.txt",
+        "Temp - Oil&Gas/input.inp",
+    ]
+    for rel in files:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"" if "zero" in rel else f"content {rel}".encode())
+    for rel in ["$RECYCLE.BIN/decoy.txt", "System Volume Information/secret.txt"]:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("skip")
+    (root / "documents/link").symlink_to(root / "ABSG", target_is_directory=True)
+    return {"root": root, "db": tmp_path / "index.db"}
+
+
+@pytest.fixture()
+def config_path(tmp_path: Path, fixture_tree: dict[str, Path]) -> Path:
+    config = {
+        "version": 1,
+        "drives": {
+            "dde": {
+                "root": str(fixture_tree["root"]),
+                "canonical_prefix": "/mnt/dde",  # abs-path-allowed
+                "db": str(fixture_tree["db"]),
+                "excludes": ["$RECYCLE.BIN", "System Volume Information", ".dde-knowledge"],
+                "classification": {
+                    "defaults": {
+                        "asset_type": "file",
+                        "discipline": "general",
+                        "engineering_domain": "general",
+                        "content_category": "file",
+                    },
+                    "topdirs": {
+                        "Orcaflex": {
+                            "discipline": "engineering",
+                            "engineering_domain": "offshore_analysis",
+                            "content_category": "simulation",
+                        },
+                        "ABSG": {
+                            "discipline": "engineering",
+                            "engineering_domain": "marine",
+                            "content_category": "project",
+                        },
+                    },
+                    "extensions": {".pdf": "document", ".xlsx": "spreadsheet", ".dat": "data"},
+                },
+            }
+        },
+    }
+    path = tmp_path / "drive-index-config.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return path
+
+
+@pytest.fixture()
+def profile(builder, config_path: Path):
+    return builder.load_profile(config_path, "dde")
+
+
+def rows(db: Path, sql: str, params=()):
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+
+def make_raw_byte_file(root: Path) -> None:
+    parent = root / "documents"
+    raw = os.fsencode(parent) + b"/bad_\xff_name.txt"
+    fd = os.open(raw, os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, b"bad name")
+    finally:
+        os.close(fd)

--- a/tests/data/drive_index/test_build_drive_index.py
+++ b/tests/data/drive_index/test_build_drive_index.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from conftest import make_raw_byte_file, rows
+
+
+def run_metadata(builder, profile, batch_size=3, limit=None):
+    return builder.metadata_pass(profile, batch_size=batch_size, limit=limit)
+
+
+def test_schema_matches_ace_columns(builder, profile):
+    conn = builder.open_db(profile.db)
+    try:
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(assets)")]
+        assert columns == builder.ASSET_COLUMNS
+        fts_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'assets_fts'"
+        ).fetchone()[0]
+        assert "content='assets'" in fts_sql or "content=assets" in fts_sql
+    finally:
+        conn.close()
+
+
+def test_index_row_count_matches_fixture(builder, profile):
+    run_metadata(builder, profile)
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE status = 'active'")[0][0] == 9
+
+
+def test_excludes_recycle_bin_and_svi(builder, profile):
+    run_metadata(builder, profile)
+    paths = [row[0] for row in rows(profile.db, "SELECT file_path FROM assets")]
+    assert not any("$RECYCLE.BIN" in path for path in paths)
+    assert not any("System Volume Information" in path for path in paths)
+
+
+def test_canonical_path_prefix(builder, profile, fixture_tree):
+    run_metadata(builder, profile)
+    records = rows(profile.db, "SELECT file_path, canonical_path FROM assets")
+    assert all(path.startswith("/mnt/dde/") for row in records for path in row)  # abs-path-allowed
+    assert all(str(fixture_tree["root"]) not in path for row in records for path in row)
+
+
+def test_fts_query_hits(builder, profile):
+    run_metadata(builder, profile)
+    conn = sqlite3.connect(profile.db)
+    try:
+        hit = conn.execute(
+            "SELECT base.file_name FROM assets_fts "
+            "JOIN assets base ON base.rowid = assets_fts.rowid "
+            "WHERE assets_fts MATCH ?",
+            ("riser fatigue",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert hit == ("riser_fatigue_report.pdf",)
+
+
+def test_idempotent_rerun(builder, profile):
+    run_metadata(builder, profile)
+    before = rows(profile.db, "SELECT id, file_path FROM assets ORDER BY file_path")
+    run_metadata(builder, profile)
+    after = rows(profile.db, "SELECT id, file_path FROM assets ORDER BY file_path")
+    assert after == before
+    path = "/mnt/dde/documents/riser_fatigue_report.pdf"  # abs-path-allowed
+    expected = hashlib.sha256(path.encode()).hexdigest()[:32]
+    assert dict(after)[expected] == path
+
+
+def test_resume_after_interrupt_rewalks_from_start(builder, profile):
+    run_metadata(builder, profile, batch_size=3, limit=3)
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE status = 'active'")[0][0] == 3
+    run_metadata(builder, profile, batch_size=3)
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE status = 'active'")[0][0] == 9
+    assert rows(profile.db, "SELECT value FROM scan_state WHERE key = 'files'")[0][0] == "9"
+
+
+def test_hash_stage_separate_and_incremental(builder, profile):
+    run_metadata(builder, profile)
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE content_hash IS NULL")[0][0] == 9
+    partial = builder.hash_incremental(profile, batch_size=2, limit=4)
+    assert partial["hashed"] == 4
+    complete = builder.hash_incremental(profile, batch_size=2)
+    assert complete["hashed"] == 5
+    missing = rows(profile.db, "SELECT count(*) FROM assets WHERE content_hash IS NULL")[0][0]
+    assert missing == 0
+
+
+def test_unreadable_file_does_not_abort(builder, profile, monkeypatch):
+    original = builder.row_for_file
+
+    def fail_once(path, active_profile, scan_date):
+        if path.name == "readme.txt":
+            raise OSError("simulated unreadable file")
+        return original(path, active_profile, scan_date)
+
+    monkeypatch.setattr(builder, "row_for_file", fail_once)
+    stats = run_metadata(builder, profile)
+    assert stats["errors"] == 1
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE status = 'active'")[0][0] == 8
+
+
+def test_symlink_skipped(builder, profile):
+    run_metadata(builder, profile)
+    assert rows(profile.db, "SELECT count(*) FROM assets WHERE file_path LIKE '%/link/%'")[0][0] == 0
+
+
+def test_reconcile_mode(builder, profile):
+    run_metadata(builder, profile)
+    assert builder.reconcile(profile) == 0
+    conn = sqlite3.connect(profile.db)
+    try:
+        conn.execute("DELETE FROM assets WHERE file_name = 'readme.txt'")
+        conn.commit()
+    finally:
+        conn.close()
+    assert builder.reconcile(profile) != 0
+
+
+def test_removed_row_reactivated_on_reappearance(builder, profile, fixture_tree):
+    target = fixture_tree["root"] / "documents/readme.txt"
+    run_metadata(builder, profile)
+    target.unlink()
+    run_metadata(builder, profile)
+    status = rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/dde/documents/readme.txt",))[0][0]  # abs-path-allowed
+    assert status == "removed"
+    target.write_text("back")
+    run_metadata(builder, profile)
+    status = rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/dde/documents/readme.txt",))[0][0]  # abs-path-allowed
+    assert status == "active"
+
+
+def test_surrogate_filename_batch_fallback(builder, profile, fixture_tree, monkeypatch):
+    make_raw_byte_file(fixture_tree["root"])
+    calls = {"count": 0}
+    original = builder.execute_many
+
+    def fail_first_batch(conn, batch):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.ProgrammingError("simulated batch poison")
+        return original(conn, batch)
+
+    monkeypatch.setattr(builder, "execute_many", fail_first_batch)
+    stats = run_metadata(builder, profile, batch_size=20)
+    assert stats["errors"] == 0
+    paths = [row[0] for row in rows(profile.db, "SELECT file_path FROM assets")]
+    assert any("bad_\\udcff_name.txt" in path for path in paths)
+    assert all("\udcff" not in path for path in paths)
+
+
+def test_classification_map_applied(builder, profile):
+    run_metadata(builder, profile)
+    row = rows(
+        profile.db,
+        "SELECT discipline, engineering_domain, asset_type FROM assets WHERE file_path = ?",
+        ("/mnt/dde/Orcaflex/model run/sim.dat",),  # abs-path-allowed
+    )[0]
+    assert row == ("engineering", "offshore_analysis", "data")

--- a/tests/data/drive_index/test_document_index_deprecation.py
+++ b/tests/data/drive_index/test_document_index_deprecation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PHASE_A = REPO_ROOT / "scripts/data/document-index/phase-a-index.py"
+CONFIG = REPO_ROOT / "scripts/data/document-index/config.yaml"
+
+
+def test_config_dde_source_disabled():
+    cfg = yaml.safe_load(CONFIG.read_text())
+    assert cfg["sources"]["dde_project"]["enabled"] is False
+    assert "DROPS all 495,487 dde rows" in CONFIG.read_text()
+    assert "/mnt/dde/.dde-knowledge/index.db" in CONFIG.read_text()  # abs-path-allowed
+
+
+def test_force_rebuild_retention_semantics(tmp_path: Path):
+    index = tmp_path / "index.jsonl"
+    index.write_text(
+        json.dumps({"path": "/mnt/dde/documents/legacy.pdf", "source": "dde_project"}) + "\n"  # abs-path-allowed
+    )
+    cfg = {
+        "output": {"index_path": str(index)},
+        "sources": {"dde_project": {"enabled": False, "paths": []}},
+        "exclude_patterns": [],
+        "cad_extensions": [],
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    subprocess.run([sys.executable, str(PHASE_A), "--config", str(cfg_path)], check=True)
+    resume_rows = [json.loads(line) for line in index.read_text().splitlines()]
+    assert [row["path"] for row in resume_rows] == ["/mnt/dde/documents/legacy.pdf"]  # abs-path-allowed
+
+    index.write_text(
+        json.dumps({"path": "/mnt/dde/documents/legacy.pdf", "source": "dde_project"}) + "\n"  # abs-path-allowed
+    )
+    subprocess.run([sys.executable, str(PHASE_A), "--config", str(cfg_path), "--force"], check=True)
+    assert index.read_text().strip() == ""


### PR DESCRIPTION
Implements #3334 per its approved adversarial-reviewed plan (`docs/plans/2026-07-02-issue-3334-dde-drive-index.md`). Authored by `codex exec --full-auto` (lane:codex); independently verified and enforcement-fixed by the orchestrating session.

## What
- `scripts/data/drive-index/build_drive_index.py` — drive-agnostic SQLite FTS5 index builder (`--drive dde` profile): schema copied verbatim from the live `.ace-knowledge` index; resume-safe by re-walking with idempotent upserts (the skip-shortcut was rejected in plan review); **tombstone reactivation** (a removed file that reappears is revived even if unchanged — review finding); surrogate/undecodable NTFS filename handling via per-row batch fallback; $RECYCLE.BIN excluded; content hashing deferred to a separate `--hash incremental` stage; `--reconcile` count check.
- `drive-index-config.yaml` — externalized profiles/excludes/classification maps (YAML-config repo rule).
- Registry: `dde_knowledge` entry added to `config/drive-index-registry.yml` (#3335 handshake — CLI picks it up with zero code change once the DB exists).
- `document-index/config.yaml`: `dde_project` → `enabled: false` with the **loud retention warning** (dde rows survive resume runs only; a `--force` rebuild drops all 495,487 — the plan-review MAJOR finding, now documented at the point of danger and pinned by `test_force_rebuild_retention_semantics`).

## Verification (orchestrator-run)
- 16/16 new tests pass; combined with the existing `tests/data/document-index/` suite: **172 passed, 1 xfailed (pre-existing)** — the config edit regresses nothing.
- `check-no-abs-paths.sh` passes (sentinels on 10 test-data literals).
- Codex's targeted legal scan over new files: clean.

## After merge (operational, not in this PR)
First production build runs ON ace-linux-2 (local ntfs3 disk): sync the repo checkout there, `mkdir -p /mnt/dde/.dde-knowledge`, run the builder under nohup per the plan's runbook, then stamp `freshness.built_at` + `row_count` in the registry (#3336 territory).

Closes #3334.