### PR TITLE
feat(#3338): drive-file-search skill — context-aware related-file surfacing (epic #3333)

### DIFF
--- a/.claude/skills/data/drive-file-search/SKILL.md
+++ b/.claude/skills/data/drive-file-search/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: drive-file-search
+description: "Surface SPECIFIC FILES on the shared drives (/mnt/ace, /mnt/dde) relevant
+  to the current task — the FILE-level complement to ecosystem-data-sources (domain-catalog
+  level). Extracts query terms from work context, runs the drive-index CLI once,
+  presents ranked canonical paths with freshness caveats. Use for similar-past-work,
+  prior-project, or files/examples/precedent asks; when domain work needs past deliverables
+  (mooring calc → xlsx/py; CAD → dwg/step; standards → PDF inventory)."
+version: 1.0.0
+category: data
+related_skills:
+- ecosystem-data-sources
+triggers:
+- similar past work
+- do we have files for
+- do we have examples of
+- do we have precedent for
+- search the drives
+- prior project
+- past project files
+- have we done this before
+type: reference
+freedom: high
+---
+
+# Drive File Search — context-aware related-file surfacing
+
+FILE-level asks only; domain-catalog asks belong to `ecosystem-data-sources`.
+
+## Procedure
+
+1. **Extract context** (full detail + worked walkthrough:
+   `references/context-extraction.md`). Fail-soft signals: repo name; issue title/labels;
+   engineering domain via keywords read live from `.claude/hooks/ecosystem-domain-map.json`
+   (generated — never hand-copy its keywords here); artifact-type hints
+   (calcs → xlsx/py/csv; CAD → dwg/ipt/step; standards → pdf; simulation → dat/sim/yml/owr).
+
+2. **Build the query** — 2–5 deduped terms (matched domain keyword + 1–3 issue-title
+   words). Pass `--domain <d>` only if `<d>` appears in a `domains:` list in
+   `config/drive-index-registry.yml`; else fold the domain word into the terms
+   (unknown `--domain` = empty selection, exit 0).
+
+3. **Run the ONE command** (read-only):
+
+   `uv run python scripts/data/drive-index-search/search.py "<terms>" [--domain <d>] --json --limit 20`
+
+   (`python3` works when uv is broken.)
+
+4. **Branch on exit code**:
+   - `0` — parse the JSON envelope on stdout (covers partial AND empty results — always
+     check `coverage_gaps`).
+   - `2` — registry error OR zero reachable indexes: name the down indexes/drives,
+     point to `scripts/setup/canonical-drive-links.sh` (PR #3341 if absent), offer
+     `ecosystem-data-sources` as fallback.
+   - CLI missing — cite issue #3335, fall back to `ecosystem-data-sources`; never
+     run ad-hoc drive crawls (bounded reads only).
+
+5. **Present top 10**. Required per result: `canonical_path`, `source_index`, `score`,
+   `rank_basis` (`meta.*` optional; `raw_path` never shown). Show the canonical
+   `/mnt/...` path; why relevant: matched terms, `rank_basis`, extension-vs-hint
+   (reorder within equal-score groups only); source index + freshness caveat from the
+   registry's `freshness/built_at` ("freshness unknown" if absent). Quote each
+   `coverage_gaps` `reason` VERBATIM (opaque free text — never pattern-match or
+   paraphrase); name the excluded drive. Offer exactly three next actions: open one
+   listed file (bounded read); record chosen paths under "Documents consulted" in the
+   plan's Resource Intelligence section; refine terms, re-run once.
+
+## Guardrails (never violate)
+
+- **Read-only**: never write to `/mnt/ace` or `/mnt/dde`; the CLI opens indexes read-only.
+- **De-identification** (public repo): drive paths embed client names/project codes.
+  Before quoting a surfaced path into an issue, plan, PR, or commit, scan for client
+  tokens; if found, describe as metadata only ("a past <domain> deliverable on
+  /mnt/ace") or redact. In-session display is fine; persisting into public artifacts
+  is the gated act. De-id stays on lane:claude.
+- **Unreachable drive is normal** (dde often unmounted): present partial results plus
+  the coverage_gaps caveat; never mount, never sudo.
+
+**Related**: `ecosystem-data-sources` (DATA/domain-catalog level).

--- a/.claude/skills/data/drive-file-search/references/context-extraction.md
+++ b/.claude/skills/data/drive-file-search/references/context-extraction.md
@@ -1,0 +1,135 @@
+# Context extraction — full procedure (drive-file-search Step 1–2 detail)
+
+Everything below is executable by any runtime (Claude, Codex, Gemini) with only
+`bash`, `git`, `gh`, and `python`. Every signal is **fail-soft**: if a command
+errors or a file is absent, drop that signal and continue with the rest.
+
+## Step 1 — Extract work context
+
+### (a) Repo + issue
+
+```bash
+repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")   # "" if not a git repo
+# only if an issue number N is already known in-session:
+gh issue view N --json title,labels
+```
+
+- `terms_issue` = significant words of the issue title: strip stopwords
+  (the/a/of/for/and/...), strip numbers-only tokens.
+- Note labels that hint at a domain or category (`cat:*`, domain words).
+
+### (b) Engineering domain — reuse the generated map, never a hand-copied list
+
+Read `.claude/hooks/ecosystem-domain-map.json` (generated from
+`llm-wiki/data/domain-database-index.yml`; 12 domains, each with `keywords[]`).
+Pick the **first domain whose `keywords[]` match** the task description or issue
+title — word-boundary, case-insensitive (the same matching posture as
+`.claude/hooks/ecosystem-data-nudge.sh`). Record the domain id and the specific
+keyword(s) that matched. Do not copy keyword lists into any other file; read the
+map live so the skill never drifts from the generated source.
+
+### (c) Artifact-type hints — task type → file-type expectation
+
+| Task type | Expected extensions |
+|---|---|
+| calcs / analysis | xlsx, py, csv |
+| CAD / geometry | dwg, ipt, step, sldprt, iges |
+| standards / code question | pdf |
+| simulation | dat, sim, yml, owr |
+
+Hints are **presentation garnish only**: they boost hint-matching extensions
+within equal-score groups at display time (Step 5 of SKILL.md); they never change
+the query and never re-rank across different scores.
+
+Return: `(repo, terms_issue, domain, matched_keywords, hints)`.
+
+## Step 2 — Assemble the query (2–5 terms, ONE CLI call)
+
+```
+terms = dedupe(top matched domain keyword(s) + 1–3 significant issue-title words)
+```
+
+`--domain` vocabulary guard: map ids (`mooring`, `riser`, ...) are NOT guaranteed
+to be registry `domains:` values (the live registry uses `engineering`, `marine`,
+`drilling`, `cad`, `standards`, `literature`). Only pass `--domain <d>` if `<d>`
+appears in a `domains:` list in `config/drive-index-registry.yml`. Otherwise
+**fold the domain word into the query terms — the safe default**: an entry with
+`domains:` absent matches ALL queries, and an unknown `--domain` yields an empty
+selection with exit 0 (silent-empty, not an error). A grep-level check of the
+registry can false-positive on comments or other keys, so the guard is
+best-effort; prefer folding whenever in doubt.
+
+## Worked mock walkthrough (dry-runnable without the live drives)
+
+**Context:** working in `digitalmodel` on a mooring fatigue calc; the in-session
+issue title is "Mooring line fatigue screening".
+
+1. **Extract** — (a) `repo = digitalmodel`; issue title terms → `line`, `fatigue`,
+   `screening` (stopwords dropped). (b) The map's `mooring` domain matches on
+   keywords `mooring` and `mooring line`. (c) Task type = calc → hints
+   `xlsx, py, csv`.
+2. **Assemble** — `mooring` is not a `domains:` value in the live registry
+   (`engineering, marine, drilling, cad, standards, literature`), so fold it in.
+   Terms: `"mooring line fatigue screening"`. No `--domain` flag.
+3. **Run the ONE command:**
+
+   ```bash
+   uv run python scripts/data/drive-index-search/search.py \
+     "mooring line fatigue screening" --json --limit 20
+   ```
+
+4. **Parse** — for this dry run, treat `references/mock-envelope.json` as the
+   stdout envelope (exit 0). It contains 5 results across 2 source indexes and
+   one `coverage_gaps` entry (`dde_literature_catalog`, reason `unreachable` —
+   opaque free text, quoted verbatim, never interpreted).
+5. **Present** (top 5 shown; scores are all distinct, so artifact-type hints
+   reorder nothing here — they would only reorder within an equal-score group):
+
+   ```
+   Related files on the shared drives for "mooring line fatigue screening":
+
+   1. /mnt/ace/projects/example-fpso/mooring/line-fatigue-screening.xlsx
+      why: matched mooring/line/fatigue/screening; rank_basis fts_bm25 (score 0.94);
+      .xlsx matches the calc hint
+      source: ace_knowledge — built 2026-03-26 (may lag recent drive changes)
+
+   2. /mnt/ace/projects/example-fpso/mooring/fatigue-postprocess.py
+      why: matched mooring/line/fatigue/screening; rank_basis fts_bm25 (score 0.87);
+      .py matches the calc hint
+      source: ace_knowledge — built 2026-03-26
+
+   3. /mnt/dde/literature/fatigue/chain-fatigue-review.pdf
+      why: matched mooring/fatigue/screening; rank_basis token_match (score 0.75)
+      source: master_document_index — frozen 2026-04-17; dde results may be stale
+
+   4. /mnt/ace/projects/example-semisub/mooring/line-tension-summary.csv
+      why: matched mooring/line; rank_basis token_match (score 0.62);
+      .csv matches the calc hint
+      source: master_document_index — frozen 2026-04-17
+
+   5. /mnt/ace/standards/example-org/offshore-mooring-design-practice.pdf
+      why: matched mooring/line; rank_basis token_match (score 0.58)
+      source: master_document_index — frozen 2026-04-17
+
+   NOT searched: index dde_literature_catalog ("unreachable") — results exclude the
+   dde literature catalog; to restore: scripts/setup/canonical-drive-links.sh (PR #3341).
+
+   Next actions:
+   1. open/read one of the listed files (bounded read of that file only)
+   2. record chosen paths as "Documents consulted" in the active plan's
+      Resource Intelligence section
+   3. refine terms and re-run once
+   ```
+
+Presentation notes demonstrated above:
+
+- `canonical_path` is always shown (`/mnt/<drive>/...`); `raw_path` (e.g. the
+  `/mnt/remote/...` alias on result 3) is never shown — it exists in the envelope
+  only for de-identification checks and dedup.
+- Freshness caveats come from the registry entry's `freshness/built_at`; if an
+  entry has no freshness metadata, say "freshness unknown" — never invent a date.
+- The `coverage_gaps` `reason` ("unreachable") is quoted verbatim as opaque free
+  text — no enum exists, so never pattern-match or paraphrase it.
+- Before quoting any of these paths into a public artifact (issue/plan/PR/commit),
+  apply the De-identification guardrail in SKILL.md — the mock paths here are
+  fictional and already de-identified.

--- a/.claude/skills/data/drive-file-search/references/mock-envelope.json
+++ b/.claude/skills/data/drive-file-search/references/mock-envelope.json
@@ -1,0 +1,94 @@
+{
+  "query": "mooring line fatigue screening",
+  "generated_at": "2026-07-02T12:00:00+00:00",
+  "indexes_queried": [
+    "ace_knowledge",
+    "master_document_index",
+    "dde_literature_catalog"
+  ],
+  "coverage_gaps": [
+    {
+      "id": "dde_literature_catalog",
+      "path": "data/document-index/dde-literature-catalog.yaml",
+      "reason": "unreachable"
+    }
+  ],
+  "results": [
+    {
+      "canonical_path": "/mnt/ace/projects/example-fpso/mooring/line-fatigue-screening.xlsx",
+      "raw_path": "/mnt/ace/projects/example-fpso/mooring/line-fatigue-screening.xlsx",
+      "source_index": "ace_knowledge",
+      "adapter": "sqlite_fts",
+      "score": 0.94,
+      "rank_basis": "fts_bm25",
+      "meta": {
+        "file_name": "line-fatigue-screening.xlsx",
+        "file_size": 412688,
+        "modified_date": "2024-11-18",
+        "engineering_domain": "mooring",
+        "query_tokens": ["mooring", "line", "fatigue", "screening"]
+      }
+    },
+    {
+      "canonical_path": "/mnt/ace/projects/example-fpso/mooring/fatigue-postprocess.py",
+      "raw_path": "/mnt/ace/projects/example-fpso/mooring/fatigue-postprocess.py",
+      "source_index": "ace_knowledge",
+      "adapter": "sqlite_fts",
+      "score": 0.87,
+      "rank_basis": "fts_bm25",
+      "meta": {
+        "file_name": "fatigue-postprocess.py",
+        "file_size": 18240,
+        "modified_date": "2024-11-20",
+        "engineering_domain": "mooring",
+        "query_tokens": ["mooring", "line", "fatigue", "screening"]
+      }
+    },
+    {
+      "canonical_path": "/mnt/dde/literature/fatigue/chain-fatigue-review.pdf",
+      "raw_path": "/mnt/remote/ace-linux-2/dde/literature/fatigue/chain-fatigue-review.pdf",
+      "source_index": "master_document_index",
+      "adapter": "jsonl",
+      "score": 0.75,
+      "rank_basis": "token_match",
+      "meta": {
+        "domain": "mooring",
+        "summary": "review of chain fatigue screening methods",
+        "matched_tokens": 3,
+        "total_tokens": 4,
+        "query_tokens": ["mooring", "line", "fatigue", "screening"]
+      }
+    },
+    {
+      "canonical_path": "/mnt/ace/projects/example-semisub/mooring/line-tension-summary.csv",
+      "raw_path": "/mnt/ace/projects/example-semisub/mooring/line-tension-summary.csv",
+      "source_index": "master_document_index",
+      "adapter": "jsonl",
+      "score": 0.62,
+      "rank_basis": "token_match",
+      "meta": {
+        "domain": "mooring",
+        "summary": "mooring line tension summary table",
+        "matched_tokens": 2,
+        "total_tokens": 4,
+        "query_tokens": ["mooring", "line", "fatigue", "screening"]
+      }
+    },
+    {
+      "canonical_path": "/mnt/ace/standards/example-org/offshore-mooring-design-practice.pdf",
+      "raw_path": "/mnt/ace/standards/example-org/offshore-mooring-design-practice.pdf",
+      "source_index": "master_document_index",
+      "adapter": "jsonl",
+      "score": 0.58,
+      "rank_basis": "token_match",
+      "meta": {
+        "domain": "mooring",
+        "org": "example-org",
+        "summary": "recommended practice for offshore mooring design",
+        "matched_tokens": 2,
+        "total_tokens": 4,
+        "query_tokens": ["mooring", "line", "fatigue", "screening"]
+      }
+    }
+  ]
+}

--- a/tests/skills/test_drive_file_search_skill.py
+++ b/tests/skills/test_drive_file_search_skill.py
@@ -1,0 +1,238 @@
+"""Tests for drive-file-search skill (#3338, epic #3333).
+
+Validates (per docs/plans/2026-07-02-issue-3338-drive-file-search-skill.md):
+- SKILL.md frontmatter contract (name, category, type, related_skills, triggers)
+- Trigger disjointness vs ecosystem-data-sources (FILE-level vs DATA-level routing)
+- Body contract anchors (the one CLI command, --json, exit-2 branch, coverage_gaps,
+  canonical-drive-links.sh, de-identification + read-only guardrails)
+- Size within the audit-word-count.py thresholds (<=200 lines AND <=500 words)
+- Domain map consumed (literal path present), not copied (map keywords absent)
+- Mock envelope conforms to the #3335 CLI --json schema
+- Post-#3335 scripted smoke against the fixture registry (skip-guarded)
+- Hook<->skill trigger alignment with #3339 (skip-guarded until its map lands)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "data" / "drive-file-search"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+CONTEXT_DOC = SKILL_DIR / "references" / "context-extraction.md"
+MOCK_ENVELOPE = SKILL_DIR / "references" / "mock-envelope.json"
+ECOSYSTEM_SKILL = (
+    REPO_ROOT / ".claude" / "skills" / "data" / "ecosystem-data-sources" / "SKILL.md"
+)
+CLI = REPO_ROOT / "scripts" / "data" / "drive-index-search" / "search.py"
+FIXTURE_REGISTRY = (
+    REPO_ROOT / "tests" / "data" / "drive_index_search" / "fixtures" / "test-registry.yml"
+)
+HOOK_MAP = REPO_ROOT / ".claude" / "hooks" / "drive-file-map.json"  # lands with #3339
+
+# Audit thresholds from scripts/skills/audit-word-count.py::classify
+# (>200 lines -> WARNING, >500 words -> OVER_BUDGET); pinned per plan review F1.
+MAX_LINES = 200
+MAX_WORDS = 500
+
+# Single source of truth for the #3335 --json envelope schema
+# (scripts/data/drive-index-search/search.py::_emit + adapters/base.py::as_dict).
+ENVELOPE_TOP_KEYS = {"query", "generated_at", "indexes_queried", "coverage_gaps", "results"}
+RESULT_KEYS = {"canonical_path", "raw_path", "source_index", "adapter", "score", "rank_basis", "meta"}
+GAP_KEYS = {"id", "path", "reason"}
+
+CANONICAL_TRIGGERS = ["similar past work", "search the drives", "prior project"]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _split(path: Path) -> tuple[dict, str]:
+    """Return (frontmatter mapping, body text) of a SKILL.md."""
+    text = _read(path)
+    parts = text.split("---", maxsplit=2)
+    assert len(parts) >= 3, f"{path}: frontmatter not properly delimited"
+    data = yaml.safe_load(parts[1])
+    assert isinstance(data, dict), f"{path}: frontmatter must be a YAML mapping"
+    return data, parts[2]
+
+
+def _assert_envelope_schema(envelope: dict, require_mnt_paths: bool) -> None:
+    """Shared schema assertions for the mock fixture AND the live-CLI smoke."""
+    assert set(envelope.keys()) == ENVELOPE_TOP_KEYS, (
+        f"envelope top-level keys {sorted(envelope)} != {sorted(ENVELOPE_TOP_KEYS)}"
+    )
+    assert isinstance(envelope["query"], str)
+    assert isinstance(envelope["generated_at"], str)
+    assert isinstance(envelope["indexes_queried"], list)
+    for gap in envelope["coverage_gaps"]:
+        assert set(gap.keys()) == GAP_KEYS, f"gap keys {sorted(gap)} != {sorted(GAP_KEYS)}"
+        # reason is OPAQUE FREE TEXT (no enum in #3335) — assert type only, never value
+        assert isinstance(gap["reason"], str) and gap["reason"].strip()
+    for result in envelope["results"]:
+        assert set(result.keys()) == RESULT_KEYS, (
+            f"result keys {sorted(result)} != {sorted(RESULT_KEYS)}"
+        )
+        assert isinstance(result["score"], (int, float))
+        assert isinstance(result["meta"], dict)
+        if require_mnt_paths:
+            assert result["canonical_path"].startswith("/mnt/"), result["canonical_path"]
+            assert not result["canonical_path"].startswith("/mnt/remote/"), (
+                f"canonical_path must not use the /mnt/remote alias: {result['canonical_path']}"
+            )
+
+
+class TestSkillStructure:
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file(), f"Missing {SKILL_MD}"
+
+    def test_reference_files_exist(self):
+        assert CONTEXT_DOC.is_file(), f"Missing {CONTEXT_DOC}"
+        assert MOCK_ENVELOPE.is_file(), f"Missing {MOCK_ENVELOPE}"
+
+    def test_frontmatter_contract(self):
+        data, _ = _split(SKILL_MD)
+        assert data["name"] == "drive-file-search"
+        assert isinstance(data["description"], str) and data["description"].strip()
+        assert data["category"] == "data"
+        assert data["type"] == "reference"
+        assert data["freedom"] == "high"
+        assert "ecosystem-data-sources" in data["related_skills"]
+        triggers = [t.lower() for t in data["triggers"]]
+        for phrase in CANONICAL_TRIGGERS:
+            assert phrase in triggers, f"missing canonical trigger: {phrase!r}"
+        assert any(t.startswith("do we have") and t.endswith("for") for t in triggers), (
+            "missing a 'do we have ... for' trigger phrasing"
+        )
+
+    def test_skill_size_within_audit_limits(self):
+        text = _read(SKILL_MD)
+        lines = len(text.splitlines())
+        words = len(text.split())
+        assert lines <= MAX_LINES, f"SKILL.md is {lines} lines (audit WARNING > {MAX_LINES})"
+        assert words <= MAX_WORDS, f"SKILL.md is {words} words (audit OVER_BUDGET > {MAX_WORDS})"
+
+
+class TestTriggerRouting:
+    def test_triggers_disjoint_from_ecosystem_data_sources(self):
+        data, _ = _split(SKILL_MD)
+        eco, _ = _split(ECOSYSTEM_SKILL)
+        mine = {t.lower().strip() for t in data["triggers"]}
+        theirs = {t.lower().strip() for t in eco["triggers"]}
+        overlap = mine & theirs
+        assert not overlap, f"FILE-level vs DATA-level triggers must be disjoint: {overlap}"
+
+    @pytest.mark.skipif(
+        not HOOK_MAP.exists(), reason="#3339 drive-file-map.json not landed yet"
+    )
+    def test_hook_skill_trigger_alignment(self):
+        """Every canonical skill trigger fires the #3339 hook matcher; DATA-level
+        phrasings route to neither this FILE-level skill nor the hook."""
+        data, _ = _split(SKILL_MD)
+        hook_text = _read(HOOK_MAP).lower()
+        for phrase in CANONICAL_TRIGGERS:
+            assert phrase in hook_text, f"hook map missing canonical trigger: {phrase!r}"
+        triggers = {t.lower().strip() for t in data["triggers"]}
+        assert "do we have data for" not in triggers, "DATA-level phrasing leaked into skill"
+        assert "do we have data for" not in hook_text, "DATA-level phrasing leaked into hook"
+
+
+class TestBodyContract:
+    def test_body_contains_contract_anchors(self):
+        _, body = _split(SKILL_MD)
+        for anchor in (
+            "scripts/data/drive-index-search/search.py",
+            "--json",
+            "coverage_gaps",
+            "canonical-drive-links.sh",
+        ):
+            assert anchor in body, f"SKILL.md body missing anchor: {anchor!r}"
+        assert "`2`" in body and "exit code" in body.lower(), (
+            "SKILL.md body must document the exit-2 branch"
+        )
+        lower = body.lower()
+        assert "de-identification" in lower, "missing De-identification guardrail"
+        assert "read-only" in lower, "missing read-only guardrail"
+
+    def test_domain_map_consumed_not_copied(self):
+        _, body = _split(SKILL_MD)
+        assert "ecosystem-domain-map.json" in body, (
+            "SKILL.md must reference the generated domain map by its literal path"
+        )
+        text = _read(SKILL_MD).lower()
+        for keyword in ("station-keeping", "catenary"):
+            assert keyword not in text, (
+                f"map keyword {keyword!r} hand-copied into SKILL.md — read the map live instead"
+            )
+
+
+class TestMockEnvelope:
+    def test_mock_envelope_schema(self):
+        envelope = json.loads(_read(MOCK_ENVELOPE))
+        _assert_envelope_schema(envelope, require_mnt_paths=True)
+        results = envelope["results"]
+        assert len(results) >= 5, "mock must carry at least 5 results"
+        assert len({r["source_index"] for r in results}) >= 2, "need >= 2 source indexes"
+        bases = {r["rank_basis"] for r in results}
+        assert {"fts_bm25", "token_match"} <= bases, f"need mixed rank_basis, got {bases}"
+        gaps = envelope["coverage_gaps"]
+        assert any("dde" in gap["id"] for gap in gaps), "need a dde coverage_gaps entry"
+
+    def test_walkthrough_uses_mock_envelope(self):
+        text = _read(CONTEXT_DOC)
+        assert "mock-envelope.json" in text
+        assert "scripts/data/drive-index-search/search.py" in text
+
+
+@pytest.mark.skipif(not CLI.exists(), reason="#3335 CLI not merged yet")
+class TestScriptedSmoke:
+    """Post-#3335 smoke — runs the REAL merged CLI against its own fixtures only."""
+
+    def test_scripted_smoke_fixture_registry(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(CLI),
+                "riser",
+                "--registry",
+                str(FIXTURE_REGISTRY),
+                "--json",
+                "--limit",
+                "5",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=120,
+        )
+        assert proc.returncode == 0, f"exit {proc.returncode}: {proc.stderr}"
+        envelope = json.loads(proc.stdout)
+        _assert_envelope_schema(envelope, require_mnt_paths=False)
+        assert envelope["query"] == "riser"
+        assert envelope["results"], "fixture registry should yield results for 'riser'"
+
+    def test_scripted_smoke_exit2_branch(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(CLI),
+                "riser",
+                "--registry",
+                str(REPO_ROOT / "tests" / "data" / "no-such-registry.yml"),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=120,
+        )
+        assert proc.returncode == 2, (
+            f"registry error must exit 2 (got {proc.returncode}): {proc.stderr}"
+        )


### PR DESCRIPTION
Implements #3338 per its approved adversarial-reviewed plan (`docs/plans/2026-07-02-issue-3338-drive-file-search-skill.md`). Claude-agent lane; orchestrator-verified.

## What
- `.claude/skills/data/drive-file-search/SKILL.md` — 79 lines / 498 words (inside the audit's ≤200/≤500 thresholds, pinned by test). FILE-level complement to `ecosystem-data-sources` (DATA-level); triggers fully disjoint (tested). Documents the one CLI command, the `--json` envelope, exit-2 handling (→ `canonical-drive-links.sh`), `coverage_gaps` treated as opaque text, read-only + de-identification guardrails.
- `references/context-extraction.md` — the context-extraction procedure (repo/issue → domain via `ecosystem-domain-map.json` → artifact-type hints) with the `--domain` fold-into-query-terms safe default, plus a worked mock walkthrough.
- `references/mock-envelope.json` — verified against the REAL merged CLI's emission code, not the plan prose.
- `tests/skills/test_drive_file_search_skill.py` — 12 structural tests; **11 pass, 1 correctly skip-guarded** (`test_hook_skill_trigger_alignment` waits for #3339's `drive-file-map.json`; it un-skips automatically once that lands).

## Verification (orchestrator-run)
- 11 passed / 1 skipped re-confirmed; `validate_skills_frontmatter.py` clean; size re-measured 79/498.
- Real-CLI smoke against the merged #3335 fixture registry: exit 0 with valid envelope; nonexistent registry → exit 2. Both pinned as tests (not skipped — #3335 is merged).
- Regression: full `tests/skills/` failures identical to origin/main baseline (27F/5E pre-existing, e.g. dark_intelligence) — this change adds only passes.

Closes #3338.