### PR TITLE
feat(#3339): drive-file nudge UserPromptSubmit hook + map (epic #3333)

### DIFF
--- a/.claude/hooks/drive-file-map.json
+++ b/.claude/hooks/drive-file-map.json
@@ -1,0 +1,64 @@
+{
+  "_note": "Hand-curated config for drive-file-nudge.sh (#3339, epic #3333). NOT generated — unlike ecosystem-domain-map.json (which gen_domain_pointers.py owns). Engineering-domain keywords are deliberately NOT duplicated here: the hook reads them from ecosystem-domain-map.json at runtime (Tier 2 degrades off if that map is absent).",
+  "tier1_intent_phrases": [
+    "similar past work",
+    "search the drives",
+    "prior project files",
+    "like we did before",
+    "we did before",
+    "previous project",
+    "past project",
+    "have we done this before"
+  ],
+  "tier2_intent_phrases": [
+    "do we have",
+    "reuse",
+    "precedent",
+    "similar work"
+  ],
+  "artifact_nouns": [
+    "drawing",
+    "drawings",
+    "report",
+    "reports",
+    "spec",
+    "specs",
+    "template",
+    "example",
+    "model",
+    "models",
+    "calc",
+    "calcs",
+    "deck",
+    "dataset",
+    "document",
+    "documents",
+    "file",
+    "files"
+  ],
+  "data_ask_exclusions": [
+    "do we have data",
+    "data for",
+    "data on"
+  ],
+  "software_context_exclusions": [
+    "ci pipeline",
+    "build pipeline",
+    "data pipeline",
+    "deployment pipeline"
+  ],
+  "coverage_fallback": {
+    "ace": "~1.2M",
+    "dde": "~0.5M",
+    "as_of": "2026-07-02"
+  },
+  "skill_ref": "drive-file-search (#3338)",
+  "precomputed": {
+    "_note": "Authoring-time ERE-escaped alternation joins of the lists above (plan D4/F3: zero runtime joins). Keep in sync with the lists — test_map_precomputed_consistency pins list<->join equality.",
+    "tier1_re": "similar past work|search the drives|prior project files|like we did before|we did before|previous project|past project|have we done this before",
+    "tier2_re": "do we have|reuse|precedent|similar work",
+    "artifact_re": "drawing|drawings|report|reports|spec|specs|template|example|model|models|calc|calcs|deck|dataset|document|documents|file|files",
+    "data_ask_re": "do we have data|data for|data on",
+    "software_context_exclusions_re": "ci pipeline|build pipeline|data pipeline|deployment pipeline"
+  }
+}

--- a/.claude/hooks/drive-file-nudge.sh
+++ b/.claude/hooks/drive-file-nudge.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# drive-file-nudge.sh — UserPromptSubmit hook (#3339, epic #3333)
+# Sibling of ecosystem-data-nudge.sh (the "#801 pattern": same contract,
+# different matching engine). When a prompt shows file-seeking intent
+# (Tier 1: strong multiword phrases) or an engineering-domain + artifact
+# co-occurrence (Tier 2), emit ONE context line pointing at the
+# drive-file-search skill (#3338) with the dated drive-index coverage fact,
+# so prior project files get surfaced before the session rebuilds from
+# scratch.
+#
+# Contract (identical to ecosystem-data-nudge.sh): hook JSON on stdin
+# (.prompt / .session_id), ONE line on stdout, exit 0 ALWAYS, fail-open
+# (no jq / no map -> silent exit 0). Fires at most ONCE per session:
+# state key claude-<sid>-drivefile in ${DRIVE_NUDGE_STATE_DIR:-/tmp}.
+#
+# Latency (plan D4/F3, budget <50 ms): SINGLE-PASS matcher — exactly ONE jq
+# spawn per prompt: stdin parse + config read ride the same invocation
+# (drive-file-map.json + ecosystem-domain-map.json via --slurpfile; the
+# alternation strings are precomputed in the map at authoring time). The
+# alternation passes themselves run as bash builtin [[ =~ ]] ERE matches
+# (zero extra process spawns — the same regexes the plan's grep passes would
+# use, hardened for loaded hosts). Total per prompt: bash + 1 jq.
+# Deliberately NOT #801's per-domain/per-keyword grep loop (measured
+# 270-460 ms there — over budget; do not copy it back in).
+#
+# Trigger tiers (plan D2, adversarial review F2/F5/F7):
+#   Tier 1 fires alone: strong multiword file-seeking phrases only.
+#   Tier 2 requires eco-domain keyword co-occurrence (domains reused at
+#     runtime from ecosystem-domain-map.json; Tier 2 degrades OFF if that
+#     map is absent) AND (demoted intent phrase OR artifact noun), with
+#     software compounds ("ci pipeline", ...) discounted from domain hits.
+#   DATA-shaped asks (do we have data|data for|data on) are carved out of
+#     BOTH tiers and left to #801's DATA-level nudge (plan D7).
+set -uo pipefail
+
+WS="${WORKSPACE_HUB:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)}"
+MAP="${WS}/.claude/hooks/drive-file-map.json"
+ECO="${WS}/.claude/hooks/ecosystem-domain-map.json"   # optional: Tier 2 only
+
+# Fail-open: no jq or no map -> silently do nothing.
+command -v jq >/dev/null 2>&1 || exit 0
+[[ -f "$MAP" ]] || exit 0
+
+INPUT=""
+IFS= read -r -d '' INPUT || true   # builtin stdin slurp (no cat spawn)
+
+# THE single jq spawn (plan D4/F3): parses stdin (sanitized session id +
+# lower-cased prompt with control chars -- incl. newlines -- flattened to
+# spaces, so the line-based splitting below is safe) AND emits all config in
+# the same invocation: precomputed alternation strings from MAP
+# (authoring-time joins; list fallback kept for robustness) plus the eco-map
+# domain-keyword alternation ($eco is [] when that map is absent ->
+# DOMAIN_RE empty -> Tier 2 degrades off). Malformed or empty stdin -> jq
+# emits nothing -> exit 0 (and no state file is written).
+ECO_ARGS=(--argjson eco '[]')
+[[ -f "$ECO" ]] && ECO_ARGS=(--slurpfile eco "$ECO")
+CFG="$(printf '%s' "$INPUT" | jq -r --slurpfile m "$MAP" "${ECO_ARGS[@]}" '
+    def esc: gsub("(?<c>[.\\[\\\\*^$()+?{|])"; "\\" + .c);
+    $m[0] as $map |
+    ((.session_id // "nosession") | tostring | gsub("[^a-zA-Z0-9._-]"; "-")),
+    ((.prompt // "") | tostring | ascii_downcase | gsub("[[:cntrl:]]"; " ")),
+    ($map.precomputed.tier1_re // (($map.tier1_intent_phrases // []) | map(esc) | join("|"))),
+    ($map.precomputed.tier2_re // (($map.tier2_intent_phrases // []) | map(esc) | join("|"))),
+    ($map.precomputed.artifact_re // (($map.artifact_nouns // []) | map(esc) | join("|"))),
+    ($map.precomputed.data_ask_re // (($map.data_ask_exclusions // []) | map(esc) | join("|"))),
+    ($map.precomputed.software_context_exclusions_re // (($map.software_context_exclusions // []) | map(esc) | join("|"))),
+    ([$eco[0].domains[]?.keywords[]?] | unique | map(esc) | join("|")),
+    ($map.coverage_fallback.ace // "?"),
+    ($map.coverage_fallback.dde // "?"),
+    ($map.coverage_fallback.as_of // "unknown"),
+    ($map.skill_ref // "drive-file-search (#3338)")
+  ' 2>/dev/null)" || true
+[[ -n "$CFG" ]] || exit 0
+mapfile -t C <<< "$CFG"
+(( ${#C[@]} >= 12 )) || exit 0
+SID="${C[0]}"; PROMPT_LC="${C[1]}"
+TIER1_RE="${C[2]}"; TIER2_RE="${C[3]}"; ARTIFACT_RE="${C[4]}"
+DATA_ASK_RE="${C[5]}"; SW_EXCL_RE="${C[6]}"; DOMAIN_RE="${C[7]}"
+ACE="${C[8]}"; DDE="${C[9]}"; AS_OF="${C[10]}"; SKILL_REF="${C[11]}"
+[[ -n "$PROMPT_LC" ]] || exit 0
+[[ -n "$SID" ]] || SID="nosession"
+
+# Once per session: a single builtin stat -- every prompt after the first
+# fire exits here (post-fire cost stays bash + 1 jq, like any other prompt).
+STATE_DIR="${DRIVE_NUDGE_STATE_DIR:-/tmp}"
+STATE="${STATE_DIR}/claude-${SID}-drivefile"
+[[ -f "$STATE" ]] && exit 0
+
+B='(^|[^a-z0-9])'
+E='([^a-z0-9]|$)'
+
+# All alternation matches below are bash builtin [[ =~ ]] ERE (prompt and
+# patterns are already lower-cased) — zero process spawns on the match path.
+
+# DATA-ask carve-out (plan D7): DATA-shaped asks are excluded from BOTH tiers
+# and route to #801's DATA-level nudge only.
+RE="${B}(${DATA_ASK_RE})${E}"
+if [[ -n "$DATA_ASK_RE" ]] && [[ "$PROMPT_LC" =~ $RE ]]; then
+    exit 0
+fi
+
+FIRE=0
+RE="${B}(${TIER1_RE})${E}"
+if [[ -n "$TIER1_RE" ]] && [[ "$PROMPT_LC" =~ $RE ]]; then
+    # Tier 1: strong multiword file-seeking phrase fires alone.
+    FIRE=1
+elif [[ -n "$DOMAIN_RE" ]]; then
+    # Tier 2: eco-domain keyword AND (demoted intent phrase OR artifact noun).
+    # Domain hits inside software compounds are discounted first (plan D2/F7:
+    # "ci pipeline" etc. must not count as a pipeline-domain hit).
+    PROMPT_DOM="$PROMPT_LC"
+    if [[ -n "$SW_EXCL_RE" ]]; then
+        RE="(${SW_EXCL_RE})"
+        n=0
+        while (( n < 20 )) && [[ "$PROMPT_DOM" =~ $RE ]]; do
+            PROMPT_DOM="${PROMPT_DOM/"${BASH_REMATCH[0]}"/ }"
+            n=$(( n + 1 ))
+        done
+    fi
+    T2A="${TIER2_RE}"
+    [[ -n "$TIER2_RE" && -n "$ARTIFACT_RE" ]] && T2A="${TIER2_RE}|${ARTIFACT_RE}"
+    [[ -z "$TIER2_RE" ]] && T2A="${ARTIFACT_RE}"
+    DRE="${B}(${DOMAIN_RE})${E}"
+    TRE="${B}(${T2A})${E}"
+    if [[ -n "$T2A" ]] && [[ "$PROMPT_DOM" =~ $DRE ]] && [[ "$PROMPT_LC" =~ $TRE ]]; then
+        FIRE=1
+    fi
+fi
+[[ "$FIRE" == "1" ]] || exit 0
+
+# Coverage fact comes ONLY from the dated map fallback in v1 (plan D3/F1 —
+# the #3335 registry schema carries no row counts). as_of date + dde
+# staleness softener are REQUIRED content (plan F6).
+echo "[drive-file] This prompt suggests prior work may exist on the shared drives (${ACE} /mnt/ace + ${DDE} /mnt/dde files indexed as of ${AS_OF} - dde coverage may be stale, see #3334). Invoke the ${SKILL_REF} skill (.claude/skills/data/drive-file-search) to surface related files before building from scratch." # abs-path-allowed
+# Record the once-per-session state via builtin redirect (no touch spawn on
+# the common path); fall back to mkdir -p for a not-yet-created state dir.
+{ : > "$STATE"; } 2>/dev/null \
+    || { mkdir -p "$STATE_DIR" && : > "$STATE"; } 2>/dev/null \
+    || true
+exit 0

--- a/tests/hooks/test_drive_file_nudge_3339.py
+++ b/tests/hooks/test_drive_file_nudge_3339.py
@@ -1,0 +1,426 @@
+"""Tests for #3339: drive-file nudge UserPromptSubmit hook (epic #3333).
+
+Mirrors the #801 hook harness (tests/data_sources/test_ecosystem_data_sources_801.py):
+subprocess invocation of the bash hook + WORKSPACE_HUB / DRIVE_NUDGE_STATE_DIR
+tmp-dir isolation, session ids derived from tmp_path so /tmp state never collides.
+
+Run: python3 -m pytest tests/hooks/test_drive_file_nudge_3339.py -v
+"""
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import time
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+IMPL = os.path.dirname(os.path.dirname(HERE))
+HOOK = os.path.join(IMPL, ".claude", "hooks", "drive-file-nudge.sh")
+MAP = os.path.join(IMPL, ".claude", "hooks", "drive-file-map.json")
+ECO_HOOK = os.path.join(IMPL, ".claude", "hooks", "ecosystem-data-nudge.sh")
+SETTINGS = os.path.join(IMPL, ".claude", "settings.json")
+SKILL_MD = os.path.join(
+    IMPL, ".claude", "skills", "data", "drive-file-search", "SKILL.md"
+)
+
+# Small fixture eco-map (shape matches the generated ecosystem-domain-map.json;
+# repo_home/has_ace_share_precedent kept so the #801 hook can run against it in
+# the dual-emission test). "pipeline" and "anchor" are real eco-map keywords —
+# kept here to exercise the software-compound discount and the documented
+# Tier-2 collision class.
+FAKE_ECO = {
+    "_note": "test fixture",
+    "domains": {
+        "mooring": {
+            "keywords": ["mooring", "anchor", "catenary"],
+            "repo_home": "digitalmodel",
+            "has_ace_share_precedent": True,
+        },
+        "metocean": {
+            "keywords": ["metocean"],
+            "repo_home": "worldenergydata",
+            "has_ace_share_precedent": False,
+        },
+        "pipeline-subsea": {
+            "keywords": ["pipeline", "flowline"],
+            "repo_home": "digitalmodel",
+            "has_ace_share_precedent": False,
+        },
+    },
+}
+
+TIER1_PROMPT = "set up a fatigue analysis like we did before"  # issue acceptance prompt
+TIER2_PROMPT = "pull together the mooring analysis report"
+
+
+def _run_hook(prompt, session_id, ws, hook=None):
+    env = dict(os.environ)
+    env["WORKSPACE_HUB"] = ws
+    # Isolate once-per-session state inside this test's unique tmp dir.
+    env["DRIVE_NUDGE_STATE_DIR"] = ws
+    env["ECOSYSTEM_NUDGE_STATE_DIR"] = ws  # for the dual-emission #801 run
+    payload = json.dumps({"prompt": prompt, "session_id": session_id})
+    return subprocess.run(
+        ["bash", hook or HOOK],
+        input=payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+@pytest.fixture()
+def ws(tmp_path):
+    """A fake workspace-hub root with hook + real map + fixture eco-map."""
+    hooks = tmp_path / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    shutil.copy(HOOK, hooks / "drive-file-nudge.sh")
+    shutil.copy(MAP, hooks / "drive-file-map.json")
+    (hooks / "ecosystem-domain-map.json").write_text(json.dumps(FAKE_ECO))
+    return str(tmp_path)
+
+
+def _sid(ws, suffix=""):
+    # Unique per test invocation (tmp_path basename), same trick as the #801 suite.
+    return "test-" + os.path.basename(str(ws).rstrip("/")) + suffix
+
+
+# ── Positive firing ──────────────────────────────────────────────────────
+
+
+def test_fires_on_intent_phrase(ws):
+    """Tier 1: the issue's acceptance prompt fires alone."""
+    p = _run_hook(TIER1_PROMPT, _sid(ws), ws)
+    assert p.returncode == 0
+    assert "[drive-file]" in p.stdout
+    assert "drive-file-search" in p.stdout
+    assert p.stdout.strip().count("\n") == 0  # exactly ONE line
+
+
+def test_fires_on_domain_plus_artifact(ws):
+    """Tier 2: eco-domain keyword + artifact noun co-occurrence fires."""
+    p = _run_hook(TIER2_PROMPT, _sid(ws), ws)
+    assert p.returncode == 0
+    assert "[drive-file]" in p.stdout
+
+
+# ── Negative / silent paths ──────────────────────────────────────────────
+
+
+def test_silent_on_domain_only(ws):
+    """Tier 2 needs BOTH halves — a bare domain mention stays silent."""
+    p = _run_hook("run a mooring analysis", _sid(ws), ws)
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_silent_on_artifact_only(ws):
+    """Bare artifact nouns never fire alone (false-positive guard)."""
+    p = _run_hook("write a report on the meeting", _sid(ws), ws)
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_silent_on_irrelevant_prompt(ws):
+    for i, prompt in enumerate(["what time is it", "refactor this python function please"]):
+        p = _run_hook(prompt, _sid(ws, f"-s{i}"), ws)
+        assert p.returncode == 0
+        assert p.stdout.strip() == ""
+
+
+def test_silent_on_demoted_intent_phrases(ws):
+    """REQUIRED negatives (review F2): the three demonstrated false-positive
+    prompts stay silent under the revised tiers (demoted intent phrases need
+    domain co-occurrence; 'ci pipeline' is discounted as a software compound)."""
+    prompts = [
+        "do we have unit tests for this module",
+        "reuse this helper function in the CI pipeline",
+        "this sets a bad precedent for the API design",
+    ]
+    for i, prompt in enumerate(prompts):
+        p = _run_hook(prompt, _sid(ws, f"-d{i}"), ws)
+        assert p.returncode == 0
+        assert p.stdout.strip() == "", f"false positive on: {prompt!r}"
+
+
+def test_data_ask_routes_to_801_only(ws):
+    """D7 carve-out: DATA-shaped asks never fire this hook — #801's DATA-level
+    nudge owns them (would otherwise be Tier 2: 'do we have' + 'metocean')."""
+    p = _run_hook("do we have data for metocean", _sid(ws), ws)
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_word_boundary_no_false_fire(ws):
+    """(^|[^a-z0-9])…([^a-z0-9]|$) boundaries: substrings only — 'reporting'
+    is not 'report', 'precedented' is not 'precedent' (domain kw 'pipeline'
+    matches but neither Tier-2 half does)."""
+    p = _run_hook("the reporting pipeline is precedented", _sid(ws), ws)
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+# ── Coexistence with #801 (plan D7) ──────────────────────────────────────
+
+
+def test_dual_emission_with_801_accepted(ws):
+    """Dual emission is the ACCEPTED, asserted design: the mooring-report
+    prompt fires this hook (FILE level) AND #801 (DATA level), one line each."""
+    eco_hook_copy = os.path.join(ws, ".claude", "hooks", "ecosystem-data-nudge.sh")
+    shutil.copy(ECO_HOOK, eco_hook_copy)
+    sid = _sid(ws)
+    p_drive = _run_hook(TIER2_PROMPT, sid, ws)
+    p_eco = _run_hook(TIER2_PROMPT, sid, ws, hook=eco_hook_copy)
+    assert "[drive-file]" in p_drive.stdout
+    assert p_drive.stdout.strip().count("\n") == 0
+    assert "[ecosystem-data]" in p_eco.stdout
+    assert p_eco.stdout.strip().count("\n") == 0
+
+
+def test_known_limitation_collision_probe(ws):
+    """Documents the ACCEPTED Tier-2 collision class (review F7): eco-map
+    keyword 'anchor' x artifact noun 'template' — a software prompt that DOES
+    fire. Accepted: once-per-session bounds the cost at one line; tuning the
+    exclusion lists is a config-only change."""
+    p = _run_hook("fix the anchor tag in the template", _sid(ws), ws)
+    assert p.returncode == 0
+    assert "[drive-file]" in p.stdout  # expected (accepted) false positive
+
+
+# ── Once-per-session state ───────────────────────────────────────────────
+
+
+def test_once_per_session(ws):
+    sid = _sid(ws)
+    a = _run_hook(TIER1_PROMPT, sid, ws)
+    assert "[drive-file]" in a.stdout
+    # second prompt is itself a Tier-1 phrase — still suppressed
+    b = _run_hook("search the drives for mooring examples", sid, ws)
+    assert b.returncode == 0
+    assert b.stdout.strip() == ""
+    assert os.path.exists(os.path.join(ws, f"claude-{sid}-drivefile"))
+
+
+def test_new_session_fires_again(ws):
+    a = _run_hook(TIER1_PROMPT, _sid(ws, "-a"), ws)
+    b = _run_hook(TIER1_PROMPT, _sid(ws, "-b"), ws)
+    assert "[drive-file]" in a.stdout
+    assert "[drive-file]" in b.stdout
+
+
+# ── Fail-open ────────────────────────────────────────────────────────────
+
+
+def test_failopen_without_map(tmp_path):
+    hooks = tmp_path / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    shutil.copy(HOOK, hooks / "drive-file-nudge.sh")
+    (hooks / "ecosystem-domain-map.json").write_text(json.dumps(FAKE_ECO))
+    # no drive-file-map.json present
+    p = _run_hook(TIER1_PROMPT, "test-" + tmp_path.name, str(tmp_path))
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_failopen_without_eco_map(tmp_path):
+    """Tier 2 silently degrades to off without the eco map; Tier 1 survives."""
+    hooks = tmp_path / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    shutil.copy(HOOK, hooks / "drive-file-nudge.sh")
+    shutil.copy(MAP, hooks / "drive-file-map.json")
+    # no ecosystem-domain-map.json present
+    ws_dir = str(tmp_path)
+    p2 = _run_hook(TIER2_PROMPT, "test-" + tmp_path.name + "-t2", ws_dir)
+    assert p2.returncode == 0
+    assert p2.stdout.strip() == ""  # Tier 2 off
+    p1 = _run_hook(TIER1_PROMPT, "test-" + tmp_path.name + "-t1", ws_dir)
+    assert p1.returncode == 0
+    assert "[drive-file]" in p1.stdout  # Tier 1 still works
+
+
+def test_failopen_without_jq(ws):
+    """No-jq guard (review F8): the stub PATH dir explicitly provides symlinks
+    to bash, cat, grep, sed, touch, mkdir — everything the hook spawns EXCEPT
+    jq (grep/sed are not coreutils, so they are linked explicitly)."""
+    stub = os.path.join(ws, "stubbin")
+    os.mkdir(stub)
+    for tool in ("bash", "cat", "grep", "sed", "touch", "mkdir"):
+        real = shutil.which(tool)
+        assert real, f"host is missing {tool}"
+        os.symlink(real, os.path.join(stub, tool))
+    assert shutil.which("jq", path=stub) is None  # stub really has no jq
+    env = dict(os.environ)
+    env["WORKSPACE_HUB"] = ws
+    env["DRIVE_NUDGE_STATE_DIR"] = ws
+    env["PATH"] = stub
+    payload = json.dumps({"prompt": TIER1_PROMPT, "session_id": _sid(ws, "-nojq")})
+    p = subprocess.run(
+        [os.path.join(stub, "bash"), HOOK],
+        input=payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_malformed_stdin(ws):
+    for i, bad in enumerate(["not json", "", "{"]):
+        env = dict(os.environ)
+        env["WORKSPACE_HUB"] = ws
+        env["DRIVE_NUDGE_STATE_DIR"] = ws
+        p = subprocess.run(
+            ["bash", HOOK],
+            input=bad,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert p.returncode == 0, f"non-zero exit on stdin {bad!r}"
+        assert p.stdout.strip() == ""
+    # no state file was written for any malformed invocation
+    leftovers = [f for f in os.listdir(ws) if f.endswith("-drivefile")]
+    assert leftovers == []
+
+
+# ── Content / config ─────────────────────────────────────────────────────
+
+
+def test_coverage_fallback_dated(ws):
+    """The coverage line comes ONLY from the dated map fallback (review F1) and
+    MUST carry the as_of date + the dde staleness softener (review F6)."""
+    with open(MAP) as f:
+        cov = json.load(f)["coverage_fallback"]
+    p = _run_hook(TIER1_PROMPT, _sid(ws), ws)
+    out = p.stdout
+    assert cov["ace"] in out
+    assert cov["dde"] in out
+    assert cov["as_of"] in out
+    assert "stale" in out  # dde staleness softener ...
+    assert "#3334" in out  # ... referencing the dde refresh issue
+
+
+def test_map_precomputed_consistency():
+    """The authoring-time precomputed alternation strings (plan D4/F3) must
+    equal the ERE-escaped joins of their source lists — pins against drift."""
+    specials = set(".[\\*^$()+?{|")
+
+    def ere_escape(s):
+        return "".join("\\" + c if c in specials else c for c in s)
+
+    with open(MAP) as f:
+        m = json.load(f)
+    pre = m["precomputed"]
+    pairs = [
+        ("tier1_intent_phrases", "tier1_re"),
+        ("tier2_intent_phrases", "tier2_re"),
+        ("artifact_nouns", "artifact_re"),
+        ("data_ask_exclusions", "data_ask_re"),
+        ("software_context_exclusions", "software_context_exclusions_re"),
+    ]
+    for list_key, re_key in pairs:
+        expected = "|".join(ere_escape(x) for x in m[list_key])
+        assert pre[re_key] == expected, f"{re_key} drifted from {list_key}"
+
+
+# ── Latency budget ───────────────────────────────────────────────────────
+
+
+def test_latency_budget(ws):
+    """<50 ms acceptance (review F3: enforce median-of-5 AND min-of-5; budget
+    overridable via DRIVE_NUDGE_LATENCY_BUDGET_MS for slow CI). A host load
+    spike can distort one batch (plan Risks: wall-clock flake under load), so
+    up to 3 batches of 5 are attempted; the assertion holds if ANY batch has
+    both min-of-5 and median-of-5 under budget."""
+    budget_s = float(os.environ.get("DRIVE_NUDGE_LATENCY_BUDGET_MS", "50")) / 1000.0
+    batches = []
+    for attempt in range(3):
+        times = []
+        for i in range(5):
+            t0 = time.perf_counter()
+            p = _run_hook(TIER1_PROMPT, _sid(ws, f"-lat{attempt}{i}"), ws)
+            times.append(time.perf_counter() - t0)
+            assert p.returncode == 0
+            assert "[drive-file]" in p.stdout  # fresh sid each run: match path
+        lo, med = min(times), statistics.median(times)
+        batches.append((lo, med))
+        if lo < budget_s and med < budget_s:
+            return
+    detail = "; ".join(
+        f"batch{i}: min {lo * 1000:.1f} ms / median {med * 1000:.1f} ms"
+        for i, (lo, med) in enumerate(batches)
+    )
+    raise AssertionError(
+        f"no batch met the {budget_s * 1000:.0f} ms budget on min-of-5 AND "
+        f"median-of-5 ({detail})"
+    )
+
+
+# ── Wiring + cross-artifact alignment (skip-guarded) ─────────────────────
+
+
+def _wiring_present():
+    try:
+        with open(SETTINGS) as f:
+            settings = json.load(f)
+    except (OSError, ValueError):
+        return False
+    for entry in settings.get("hooks", {}).get("UserPromptSubmit", []):
+        for h in entry.get("hooks", []):
+            if "drive-file-nudge.sh" in h.get("command", ""):
+                return True
+    return False
+
+
+@pytest.mark.skipif(
+    not _wiring_present(),
+    reason="settings.json wiring is owner-merged (#3330 precedent); "
+    "skip until the UserPromptSubmit entry lands",
+)
+def test_settings_wiring():
+    """Wiring test (pattern: tests/hooks/test_state_size_settings_wiring.py):
+    passes on the branch that carries the owner-merged settings.json entry."""
+    assert _wiring_present()
+
+
+def _skill_triggers():
+    """Parse the `triggers:` list from #3338's SKILL.md frontmatter (tolerant)."""
+    try:
+        with open(SKILL_MD) as f:
+            text = f.read()
+    except OSError:
+        return None
+    m = re.search(r"^---\s*$(.*?)^---\s*$", text, re.S | re.M)
+    block = m.group(1) if m else text
+    tm = re.search(r"^triggers:\s*$((?:\n\s+-\s+.*)+)", block, re.M)
+    if not tm:
+        return None
+    return [
+        re.sub(r"^\s+-\s+", "", line).strip().strip("\"'")
+        for line in tm.group(1).strip("\n").splitlines()
+    ]
+
+
+@pytest.mark.skipif(
+    not os.path.exists(SKILL_MD),
+    reason="cross-artifact alignment (review F5): skip until #3338's "
+    ".claude/skills/data/drive-file-search/SKILL.md lands",
+)
+def test_hook_skill_trigger_alignment(ws):
+    """Every canonical skill trigger fires this hook's Tier-1 matcher; the
+    DATA-level phrasing routes to neither (it stays with #801)."""
+    triggers = _skill_triggers()
+    if not triggers:
+        pytest.skip("SKILL.md present but no parseable triggers: list")
+    for i, trig in enumerate(triggers):
+        p = _run_hook(trig, _sid(ws, f"-al{i}"), ws)
+        assert "[drive-file]" in p.stdout, f"skill trigger did not fire hook: {trig!r}"
+    p = _run_hook("do we have data for metocean", _sid(ws, "-al-data"), ws)
+    assert p.stdout.strip() == ""


### PR DESCRIPTION
Implements #3339 per its approved adversarial-reviewed plan (`docs/plans/2026-07-02-issue-3339-drive-file-nudge-hook.md`). Claude-agent lane; orchestrator-verified including live behavioral probes.

## What
- `.claude/hooks/drive-file-nudge.sh` — sibling to `ecosystem-data-nudge.sh` (untouched): JSON stdin → at most ONE nudge line naming the `drive-file-search` skill + dated coverage ("~1.2M ace + ~0.5M dde as of 2026-07-02, dde may be stale — see #3334"); once-per-session; fail-open on missing jq/map; Tier 1 = strong multiword phrases only, Tier 2 = demoted phrases requiring engineering-domain co-occurrence, DATA-ask carve-out routes "do we have data for…" to the existing DATA-level nudge.
- `.claude/hooks/drive-file-map.json` — externalized tiers/nouns/exclusions/coverage-fallback + precomputed alternation strings.
- `tests/hooks/test_drive_file_nudge_3339.py` — 21 tests: **19 pass, 2 skip-guarded** (settings wiring until owner merge; skill-trigger alignment until #3338 lands — that same test exists on #3338's branch and un-skips when both merge).

## Performance (the point of this design)
Exactly **one jq spawn per prompt** + bash-builtin ERE matching (the plan's own D4/F3 escalation — the drafted ≤4-grep version measured 23–74 ms under load, so the agent implemented the stronger option): **median-of-5 ≈ 26 ms, min ≈ 15 ms** subprocess wall vs the 50 ms budget — ~15× faster than the existing hook's 270–460 ms (that fix is filed separately as #3349, and this hook is the reference implementation for it).

## Verified (orchestrator-run)
- 19/21 re-confirmed; live probes: Tier-1 prompt fires (with `WORKSPACE_HUB` pointing at a tree containing the map), the three demonstrated false-positive prompts stay silent, DATA-ask stays silent. Fail-open confirmed live: with `WORKSPACE_HUB` pointing at a tree lacking the map, silent exit 0.
- `tests/hooks/` regression: 49 passed, 2 skipped; pre-existing `test_pre_push.py` failures unchanged from HEAD.

## Owner wiring step (config-protected, NOT in this PR — #3330 precedent)
Append to `hooks.UserPromptSubmit[]` in `.claude/settings.json` after merge:
```json
{ "hooks": [ { "type": "command",
    "command": "bash \"${WORKSPACE_HUB:-$(git rev-parse --show-toplevel)}/.claude/hooks/drive-file-nudge.sh\" 2>/dev/null || true",
    "timeout": 5 } ] }
```

Closes #3339.