### PR TITLE
fix(#3339): align hook Tier-1 phrases with the skill's canonical triggers

### DIFF
--- a/.claude/hooks/drive-file-map.json
+++ b/.claude/hooks/drive-file-map.json
@@ -8,7 +8,12 @@
     "we did before",
     "previous project",
     "past project",
-    "have we done this before"
+    "have we done this before",
+    "do we have files for",
+    "do we have examples of",
+    "do we have precedent for",
+    "prior project",
+    "past project files"
   ],
   "tier2_intent_phrases": [
     "do we have",
@@ -55,7 +60,7 @@
   "skill_ref": "drive-file-search (#3338)",
   "precomputed": {
     "_note": "Authoring-time ERE-escaped alternation joins of the lists above (plan D4/F3: zero runtime joins). Keep in sync with the lists — test_map_precomputed_consistency pins list<->join equality.",
-    "tier1_re": "similar past work|search the drives|prior project files|like we did before|we did before|previous project|past project|have we done this before",
+    "tier1_re": "similar past work|search the drives|prior project files|like we did before|we did before|previous project|past project|have we done this before|do we have files for|do we have examples of|do we have precedent for|prior project|past project files",
     "tier2_re": "do we have|reuse|precedent|similar work",
     "artifact_re": "drawing|drawings|report|reports|spec|specs|template|example|model|models|calc|calcs|deck|dataset|document|documents|file|files",
     "data_ask_re": "do we have data|data for|data on",

--- a/tests/hooks/test_drive_file_nudge_3339.py
+++ b/tests/hooks/test_drive_file_nudge_3339.py
@@ -399,11 +399,11 @@ def _skill_triggers():
         return None
     m = re.search(r"^---\s*$(.*?)^---\s*$", text, re.S | re.M)
     block = m.group(1) if m else text
-    tm = re.search(r"^triggers:\s*$((?:\n\s+-\s+.*)+)", block, re.M)
+    tm = re.search(r"^triggers:\s*$((?:\n\s*-\s+.*)+)", block, re.M)
     if not tm:
         return None
     return [
-        re.sub(r"^\s+-\s+", "", line).strip().strip("\"'")
+        re.sub(r"^\s*-\s+", "", line).strip().strip("\"'")
         for line in tm.group(1).strip("\n").splitlines()
     ]
 


### PR DESCRIPTION
The twin cross-artifact alignment test (skip-guarded on both #3355 and #3356) un-skipped once both merged — and immediately caught real drift, exactly its purpose:

1. **Parser defect**: the test's frontmatter parser required indented YAML list items; the skill's column-0 `- trigger` lines never parsed, so the test silently skipped instead of running.
2. **Genuine misalignment**: five of the skill's 8 canonical triggers did not fire the hook — `do we have files for`, `do we have examples of`, `do we have precedent for`, `prior project`, `past project files`. Review F2 had demoted bare `do we have` to Tier 2 (correct — it false-positives on dev prompts), but the skill's specific 4–5-word forms are unambiguous and belong in Tier 1 per review F5's own reconciliation rule.

Fix: parser accepts column-0 list items; the five phrases added to `tier1_intent_phrases` with `tier1_re` regenerated in lockstep (the precomputed-consistency drift guard passes).

Verified: both suites → **32 passed, 1 skipped** (settings wiring — owner-gated); the three demonstrated false-positive prompts and the DATA-ask carve-out remain silent.