### PR TITLE
feat(#3336): index freshness automation + provenance recovery (epic #3333)

### DIFF
--- a/config/drive-index-registry.yml
+++ b/config/drive-index-registry.yml
@@ -8,10 +8,20 @@ indexes:
   - id: ace_knowledge
     adapter: sqlite_fts
     path: /mnt/ace/.ace-knowledge/index.db
-    coverage: {drives: [/mnt/ace], subtree: /mnt/ace}
+    coverage:
+      drives: [/mnt/ace]
+      roots:
+        - /mnt/ace/docs/disciplines
+        - /mnt/ace/O&G-Standards
+        - /mnt/ace/_ss_repo
     domains: [engineering, marine, drilling, cad, standards]
-    freshness: {built_at: "2026-03-26", staleness_days: 120}
-    builder: null
+    freshness:
+      built_at: "2026-03-26"
+      as_of: "2026-07-02"
+      row_count: 1188891
+      staleness_days: 14
+      state_file: /mnt/ace/.ace-knowledge/refresh-state.json
+    builder: "aceengineer-admin: aceengineer_admin.knowledge CLI (`aceengineer-admin knowledge scan-all`); refresh metadata via scripts/data/drive-index/build_drive_index.py --drive ace --incremental --prune; spec .planning/archive/modules/ace-knowledge-index-system.md"
     adapter_params:
       fts_table: assets_fts
       base_table: assets
@@ -21,7 +31,12 @@ indexes:
     adapter: sqlite_fts
     path: /mnt/dde/.dde-knowledge/index.db
     coverage: {drives: [/mnt/dde], subtree: /mnt/dde}
-    freshness: {built_at: "pending production build"}
+    freshness:
+      built_at: "pending production build"
+      as_of: "pending production build"
+      row_count: 0
+      staleness_days: 14
+      state_file: /mnt/dde/.dde-knowledge/refresh-state.json
     builder: scripts/data/drive-index/build_drive_index.py
     adapter_params:
       fts_table: assets_fts
@@ -32,7 +47,13 @@ indexes:
     adapter: sqlite_fts
     path: "/mnt/ace/O&G-Standards/_inventory.db"
     coverage: {drives: [/mnt/ace], subtree: "/mnt/ace/O&G-Standards"}
-    freshness: {built_at: "2025-12-28", staleness_days: 120}
+    freshness:
+      built_at: "2025-12-28"
+      as_of: "2025-12-28"
+      row_count: 1043616
+      staleness_days: 90
+      refresh: none
+      reason: "rebuild = full text-extraction pipeline; out of v1 - #3340"
     builder: null
     adapter_params:
       fts_table: documents_fts
@@ -44,8 +65,13 @@ indexes:
     path: /mnt/ace/_cad-index/cad-readability-index.tsv
     coverage: {drives: [/mnt/ace]}
     domains: [cad, engineering]
-    freshness: {built_at: "2026-06-26", staleness_days: 90}
-    builder: null
+    freshness:
+      built_at: "2026-06-26"
+      as_of: "2026-06-26"
+      row_count: 464170
+      staleness_days: 14
+      state_file: /mnt/ace/_cad-index/refresh-state.json
+    builder: scripts/data/drive-index/cad/
     adapter_params:
       path_column: path
       search_columns: [path, name_description, project]
@@ -56,7 +82,11 @@ indexes:
     coverage: {drives: [/mnt/ace, /mnt/dde, /mnt/local-analysis]}
     freshness:
       built_at: "2026-04-17"
-      staleness_days: 90
+      as_of: "2026-04-17"
+      row_count: 627411
+      staleness_days: 60
+      refresh: none
+      reason: "dde coverage deprecated per #3334(b); superseded for file search - #3340"
       note: "Frozen 2026-04-17; dde rows may be lost if rebuilt with stale --force source config before #3334/#3337 remediation."
     builder: scripts/data/document-index/phase-a-index.py
     adapter_params:
@@ -68,7 +98,11 @@ indexes:
     path: data/document-index/dde-literature-catalog.yaml
     coverage: {drives: [/mnt/dde]}
     domains: [literature, standards, engineering]
-    freshness: {built_at: "2026-07-02", staleness_days: 90}
+    freshness:
+      built_at: "2026-07-02"
+      as_of: "2026-07-02"
+      row_count: 87
+      staleness_days: 90
     builder: null
     adapter_params:
       items_key: auto

--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -50,6 +50,54 @@ tasks:
       nightly readiness. Single source for both Linux cron and Windows Task Scheduler
       per this file's HARD RULE (#2801 DC5).
 
+  - id: drive-index-refresh-ace
+    label: Ace drive-index refresh (#3336)
+    schedule: "30 2 * * 0"
+    machines: [ace-linux-1]
+    roles: [control-plane]
+    requires: [bash, python3, git]
+    command: >-
+      PATH=$HOME/.local/bin:$PATH;
+      mkdir -p $WORKSPACE_HUB/logs/drive-index &&
+      cd $WORKSPACE_HUB &&
+      bash scripts/data/drive-index/refresh-drive-index.sh ace
+      >> $WORKSPACE_HUB/logs/drive-index/refresh-ace-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/drive-index/refresh-ace-*.log
+    is_claude_task: false
+    description: Weekly Sunday 02:30 metadata-only in-place refresh of /mnt/ace/.ace-knowledge/index.db.
+
+  - id: drive-index-refresh-dde
+    label: DDE drive-index refresh (#3336)
+    schedule: "30 3 * * 0"
+    machines: [dev-secondary, ace-linux-2]
+    roles: [comms-dispatch, sim-worker]
+    requires: [bash, python3, git]
+    command: >-
+      PATH=$HOME/.local/bin:$PATH;
+      mkdir -p $WORKSPACE_HUB/logs/drive-index &&
+      cd $WORKSPACE_HUB &&
+      bash scripts/data/drive-index/refresh-drive-index.sh dde
+      >> $WORKSPACE_HUB/logs/drive-index/refresh-dde-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/drive-index/refresh-dde-*.log
+    is_claude_task: false
+    description: Weekly Sunday 03:30 metadata refresh of /mnt/dde/.dde-knowledge/index.db; fails loud until the production DB exists.
+
+  - id: drive-index-refresh-cad
+    label: CAD readability index refresh (#3336)
+    schedule: "0 5 * * 0"
+    machines: [ace-linux-1]
+    roles: [control-plane]
+    requires: [bash, python3, git]
+    command: >-
+      PATH=$HOME/.local/bin:$PATH;
+      mkdir -p $WORKSPACE_HUB/logs/drive-index &&
+      cd $WORKSPACE_HUB &&
+      bash scripts/data/drive-index/refresh-drive-index.sh cad
+      >> $WORKSPACE_HUB/logs/drive-index/refresh-cad-$(date +\%Y-\%m-\%d).log 2>&1
+    log: logs/drive-index/refresh-cad-*.log
+    is_claude_task: false
+    description: Weekly Sunday 05:00 raw scan plus parameterized CAD readability TSV rebuild.
+
   - id: equivalence-sentinel
     label: Machine-equivalence drift sentinel (#3059)
     schedule: "17 */6 * * *"

--- a/scripts/data/drive-index-search/registry.py
+++ b/scripts/data/drive-index-search/registry.py
@@ -72,6 +72,9 @@ def load_registry(path: str | Path = "config/drive-index-registry.yml") -> Regis
         coverage = raw["coverage"]
         if not isinstance(coverage, dict) or not coverage.get("drives"):
             raise RegistryError(f"{index_id}: coverage.drives is required")
+        freshness = raw.get("freshness")
+        if freshness is not None:
+            _validate_freshness(index_id, freshness)
         raw_path = Path(raw["path"])
         index_path = raw_path
         if not index_path.is_absolute():
@@ -89,7 +92,7 @@ def load_registry(path: str | Path = "config/drive-index-registry.yml") -> Regis
                 coverage=coverage,
                 domains=raw.get("domains"),
                 adapter_params=raw.get("adapter_params") or {},
-                freshness=raw.get("freshness"),
+                freshness=freshness,
                 builder=raw.get("builder"),
             )
         )
@@ -98,3 +101,16 @@ def load_registry(path: str | Path = "config/drive-index-registry.yml") -> Regis
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
+
+
+def _validate_freshness(index_id: str, freshness: Any) -> None:
+    if not isinstance(freshness, dict):
+        raise RegistryError(f"{index_id}: freshness must be a mapping")
+    if "row_count" in freshness and not isinstance(freshness["row_count"], int):
+        raise RegistryError(f"{index_id}: freshness.row_count must be an integer")
+    if "as_of" in freshness and not isinstance(freshness["as_of"], str):
+        raise RegistryError(f"{index_id}: freshness.as_of must be a string")
+    if "state_file" in freshness and not isinstance(freshness["state_file"], str):
+        raise RegistryError(f"{index_id}: freshness.state_file must be a string")
+    if "staleness_days" in freshness and not isinstance(freshness["staleness_days"], int):
+        raise RegistryError(f"{index_id}: freshness.staleness_days must be an integer")

--- a/scripts/data/drive-index-search/search.py
+++ b/scripts/data/drive-index-search/search.py
@@ -13,6 +13,7 @@ from adapters import ADAPTER_TYPES
 from adapters.base import AdapterError, tokenize
 from merge import ranked_merge
 from registry import RegistryError, load_registry
+from staleness import compute_index_status, stale_warnings
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -36,8 +37,11 @@ def main(argv: list[str] | None = None) -> int:
 
     tokens = tokenize(args.query)
     selected = _select_indexes(registry.indexes, args.drive, args.domain, set(args.index))
+    index_status = compute_index_status(selected, registry.defaults)
+    for warning in stale_warnings(index_status):
+        print(warning, file=sys.stderr)
     if not selected:
-        _emit(args.query, [], [], [], args.as_json)
+        _emit(args.query, [], [], [], args.as_json, index_status)
         return 0
 
     all_results = []
@@ -57,7 +61,7 @@ def main(argv: list[str] | None = None) -> int:
     for result in all_results:
         result.meta.setdefault("query_tokens", tokens)
     merged = ranked_merge(all_results, registry.alias_map, args.limit)
-    _emit(args.query, [index.id for index in selected], gaps, merged, args.as_json)
+    _emit(args.query, [index.id for index in selected], gaps, merged, args.as_json, index_status)
     if selected and reachable_count == 0:
         return 2
     return 0
@@ -100,11 +104,12 @@ def _run_with_timeout(index, adapter, tokens, limit, timeout):
     return output.get_nowait()
 
 
-def _emit(query: str, indexes_queried: list[str], gaps: list[dict], results, as_json: bool) -> None:
+def _emit(query: str, indexes_queried: list[str], gaps: list[dict], results, as_json: bool, index_status: list[dict] | None = None) -> None:
     payload = {
         "query": query,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "indexes_queried": indexes_queried,
+        "index_status": index_status or [],
         "coverage_gaps": gaps,
         "results": [result.as_dict() for result in results],
     }

--- a/scripts/data/drive-index-search/staleness.py
+++ b/scripts/data/drive-index-search/staleness.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+
+def compute_index_status(indexes, defaults: dict[str, Any], now: datetime | None = None) -> list[dict[str, Any]]:
+    current = now or datetime.now(timezone.utc)
+    return [_status_for_index(index, defaults, current) for index in indexes]
+
+
+def stale_warnings(statuses: list[dict[str, Any]]) -> list[str]:
+    warnings = []
+    for status in statuses:
+        if status["last_refresh_status"] == "failed":
+            warnings.append(
+                f"WARNING: index {status['id']} last refresh FAILED at {status['as_of']} -- results may be stale"
+            )
+        elif status["stale"]:
+            warnings.append(
+                f"WARNING: index {status['id']} is {status['days_stale']} days stale "
+                f"(threshold {status['threshold_days']})"
+            )
+    return warnings
+
+
+def _status_for_index(index, defaults: dict[str, Any], now: datetime) -> dict[str, Any]:
+    freshness = index.freshness or {}
+    state = _read_state(freshness.get("state_file"))
+    as_of = state.get("finished_at") or freshness.get("as_of") or freshness.get("built_at")
+    parsed = _parse_date(as_of)
+    threshold = freshness.get("staleness_days") or defaults.get("staleness_days")
+    days_stale = (now.date() - parsed.date()).days if parsed else None
+    stale = bool(days_stale is not None and threshold is not None and days_stale > threshold)
+    return {
+        "id": index.id,
+        "as_of": as_of,
+        "days_stale": days_stale,
+        "threshold_days": threshold,
+        "stale": stale,
+        "last_refresh_status": state.get("status") or "unknown",
+        "row_count": state.get("row_count", freshness.get("row_count")),
+    }
+
+
+def _read_state(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _parse_date(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/scripts/data/drive-index/README.md
+++ b/scripts/data/drive-index/README.md
@@ -1,0 +1,23 @@
+# Drive Index Refresh
+
+This directory owns the workspace-hub refresh path for drive-local file indexes.
+
+## Ace Knowledge Provenance
+
+The original `.ace-knowledge` builder is not lost. It lives in the
+`aceengineer-admin` repository as the `aceengineer_admin.knowledge` package, with
+the Click CLI group `aceengineer-admin knowledge`.
+
+The live design spec is tracked at:
+
+`.planning/archive/modules/ace-knowledge-index-system.md`
+
+That file was originally added as `specs/modules/ace-knowledge-index-system.md`
+in commit `963f20cde` and later archived by the R100 rename in `2b1a8d779`.
+
+Workspace-hub does not vendor the extraction/anonymizer package. The refresh
+owned here is metadata-only, in-place, and constrained to the `assets` table:
+`build_drive_index.py --drive ace --incremental --prune`.
+
+Refreshes must not clobber aceengineer-admin-owned extraction columns such as
+`title`, `discipline`, `extraction_status`, `content_hash`, or `last_extracted`.

--- a/scripts/data/drive-index/build_drive_index.py
+++ b/scripts/data/drive-index/build_drive_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
 import sqlite3
 import sys
@@ -61,36 +62,17 @@ UPSERT_SQL = f"""
 INSERT INTO assets ({", ".join(ASSET_COLUMNS)})
 VALUES ({", ".join("?" for _ in ASSET_COLUMNS)})
 ON CONFLICT(file_path) DO UPDATE SET
-    id=excluded.id,
-    asset_type=excluded.asset_type,
-    file_name=excluded.file_name,
-    file_extension=excluded.file_extension,
     file_size=excluded.file_size,
     modified_date=excluded.modified_date,
-    source_root=excluded.source_root,
-    discipline=excluded.discipline,
-    project_code=excluded.project_code,
-    folder_phase=excluded.folder_phase,
-    title=excluded.title,
-    description=excluded.description,
-    content_category=excluded.content_category,
-    engineering_domain=excluded.engineering_domain,
     scan_date=excluded.scan_date,
-    extraction_status=excluded.extraction_status,
-    anonymized_title=excluded.anonymized_title,
-    language=excluded.language,
-    page_count=excluded.page_count,
-    word_count=excluded.word_count,
-    last_extracted=excluded.last_extracted,
-    status='active',
-    canonical_path=excluded.canonical_path
+    status='active'
 """
 
 
 @dataclass
 class Profile:
     name: str
-    root: Path
+    roots: list[Path]
     canonical_prefix: str
     db: Path
     excludes: set[str]
@@ -98,14 +80,19 @@ class Profile:
     extension_map: dict[str, str]
     defaults: dict[str, str]
 
+    @property
+    def root(self) -> Path:
+        return self.roots[0]
+
 
 def load_profile(config_path: Path, drive: str, db_override: Path | None = None) -> Profile:
     data = yaml.safe_load(config_path.read_text()) or {}
     raw = data["drives"][drive]
     classification = raw.get("classification", {})
+    roots = raw.get("roots") or [raw["root"]]
     return Profile(
         name=drive,
-        root=Path(raw["root"]),
+        roots=[Path(root) for root in roots],
         canonical_prefix=raw["canonical_prefix"].rstrip("/"),
         db=db_override or Path(raw["db"]),
         excludes=set(raw.get("excludes", [])),
@@ -140,8 +127,28 @@ def sanitize_text(value: Any) -> Any:
 
 
 def canonical_path(path: Path, profile: Profile) -> str:
-    rel = path.relative_to(profile.root)
-    return sanitize_text(profile.canonical_prefix + "/" + rel.as_posix())
+    root = root_for_path(path, profile)
+    if len(profile.roots) == 1:
+        rel = path.relative_to(root)
+        return sanitize_text(profile.canonical_prefix + "/" + rel.as_posix())
+    rel = path.relative_to(root)
+    return sanitize_text(canonical_root(root, profile) + "/" + rel.as_posix())
+
+
+def canonical_root(root: Path, profile: Profile) -> str:
+    if len(profile.roots) == 1:
+        return profile.canonical_prefix
+    return sanitize_text(profile.canonical_prefix + "/" + sanitize_text(root.name))
+
+
+def root_for_path(path: Path, profile: Profile) -> Path:
+    for root in profile.roots:
+        try:
+            path.relative_to(root)
+            return root
+        except ValueError:
+            continue
+    raise ValueError(f"{path} is outside profile roots")
 
 
 def iter_files(root: Path, excludes: set[str]) -> Iterable[Path]:
@@ -174,7 +181,7 @@ class ScanError:
 
 
 def classify(path: Path, profile: Profile) -> dict[str, str | None]:
-    rel = path.relative_to(profile.root)
+    rel = path.relative_to(root_for_path(path, profile))
     top = sanitize_text(rel.parts[0]) if rel.parts else ""
     mapped = profile.topdir_map.get(top, {})
     ext = path.suffix.lower()
@@ -189,8 +196,9 @@ def classify(path: Path, profile: Profile) -> dict[str, str | None]:
 
 def row_for_file(path: Path, profile: Profile, scan_date: str) -> tuple[Any, ...]:
     stat = path.stat()
+    root = root_for_path(path, profile)
     canonical = canonical_path(path, profile)
-    rel_parent = sanitize_text(path.parent.relative_to(profile.root).as_posix())
+    rel_parent = sanitize_text(path.parent.relative_to(root).as_posix())
     info = classify(path, profile)
     values = {
         "id": hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32],
@@ -201,7 +209,7 @@ def row_for_file(path: Path, profile: Profile, scan_date: str) -> tuple[Any, ...
         "file_size": stat.st_size,
         "content_hash": None,
         "modified_date": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
-        "source_root": profile.canonical_prefix,
+        "source_root": canonical_root(root, profile),
         "discipline": info["discipline"],
         "project_code": info["project_code"],
         "folder_phase": None,
@@ -222,7 +230,7 @@ def row_for_file(path: Path, profile: Profile, scan_date: str) -> tuple[Any, ...
     return tuple(sanitize_text(values[col]) for col in ASSET_COLUMNS)
 
 
-def unchanged_active(conn: sqlite3.Connection, row: tuple[Any, ...]) -> bool:
+def existing_row_state(conn: sqlite3.Connection, row: tuple[Any, ...]) -> tuple[str, bool] | None:
     file_path = row[ASSET_COLUMNS.index("file_path")]
     size = row[ASSET_COLUMNS.index("file_size")]
     mtime = row[ASSET_COLUMNS.index("modified_date")]
@@ -230,7 +238,14 @@ def unchanged_active(conn: sqlite3.Connection, row: tuple[Any, ...]) -> bool:
         "SELECT file_size, modified_date, status FROM assets WHERE file_path = ?",
         (file_path,),
     ).fetchone()
-    return bool(found and found[0] == size and found[1] == mtime and found[2] == "active")
+    if not found:
+        return None
+    return found[2], bool(found[0] == size and found[1] == mtime)
+
+
+def unchanged_active(conn: sqlite3.Connection, row: tuple[Any, ...]) -> bool:
+    state = existing_row_state(conn, row)
+    return bool(state and state[1] and state[0] == "active")
 
 
 def execute_many(conn: sqlite3.Connection, rows: list[tuple[Any, ...]]) -> None:
@@ -259,58 +274,118 @@ def set_state(conn: sqlite3.Connection, key: str, value: Any) -> None:
     )
 
 
-def metadata_pass(profile: Profile, *, batch_size: int, limit: int | None = None) -> dict[str, int]:
+def metadata_pass(
+    profile: Profile,
+    *,
+    batch_size: int,
+    limit: int | None = None,
+    incremental: bool = False,
+    prune: bool = True,
+) -> dict[str, int]:
     conn = open_db(profile.db)
     scan_date = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(timezone.utc).isoformat()
     start = time.monotonic()
     seen: set[str] = set()
     batch: list[tuple[Any, ...]] = []
-    stats = {"files": 0, "errors": 0, "skipped": 0}
+    stats = {"files": 0, "errors": 0, "skipped": 0, "rows_added": 0, "rows_updated": 0, "rows_pruned": 0}
     try:
-        for item in iter_files(profile.root, profile.excludes):
-            if isinstance(item, ScanError):
-                stats["errors"] += 1
-                continue
-            try:
-                row = row_for_file(item, profile, scan_date)
-                seen.add(row[ASSET_COLUMNS.index("file_path")])
-                stats["files"] += 1
-                if unchanged_active(conn, row):
-                    stats["skipped"] += 1
-                else:
-                    batch.append(row)
-            except OSError:
-                stats["errors"] += 1
-            if len(batch) >= batch_size:
-                stats["errors"] += write_batch(conn, batch)
-                conn.commit()
-                set_state(conn, "files_seen", stats["files"])
-                conn.commit()
-                batch.clear()
+        for root in profile.roots:
+            for item in iter_files(root, profile.excludes):
+                if isinstance(item, ScanError):
+                    stats["errors"] += 1
+                    continue
+                try:
+                    row = row_for_file(item, profile, scan_date)
+                    seen.add(row[ASSET_COLUMNS.index("file_path")])
+                    stats["files"] += 1
+                    state = existing_row_state(conn, row)
+                    if incremental and state and state[1] and state[0] == "active":
+                        stats["skipped"] += 1
+                    else:
+                        if state is None:
+                            stats["rows_added"] += 1
+                        else:
+                            stats["rows_updated"] += 1
+                        batch.append(row)
+                except OSError:
+                    stats["errors"] += 1
+                if len(batch) >= batch_size:
+                    stats["errors"] += write_batch(conn, batch)
+                    conn.commit()
+                    set_state(conn, "files_seen", stats["files"])
+                    conn.commit()
+                    batch.clear()
+                if limit is not None and stats["files"] >= limit:
+                    break
             if limit is not None and stats["files"] >= limit:
                 break
         if batch:
             stats["errors"] += write_batch(conn, batch)
-        mark_removed(conn, profile, seen)
+        if prune:
+            stats["rows_pruned"] = mark_removed(conn, profile, seen)
         conn.execute("INSERT INTO assets_fts(assets_fts) VALUES('rebuild')")
         stats["duration_seconds"] = int(time.monotonic() - start)
+        stats["duration_s"] = stats["duration_seconds"]
+        stats["row_count"] = conn.execute("SELECT count(*) FROM assets").fetchone()[0]
         for key, value in stats.items():
             set_state(conn, key, value)
         set_state(conn, "last_scan_date", scan_date)
         conn.commit()
+        finished_at = datetime.now(timezone.utc).isoformat()
+        write_refresh_state(
+            profile,
+            {
+                "index_id": profile.name,
+                "host": os.uname().nodename if hasattr(os, "uname") else "",
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "status": "failed" if stats["errors"] else "ok",
+                "row_count": stats["row_count"],
+                "rows_added": stats["rows_added"],
+                "rows_updated": stats["rows_updated"],
+                "rows_pruned": stats["rows_pruned"],
+                "duration_s": stats["duration_s"],
+                "error": f"{stats['errors']} scan error(s)" if stats["errors"] else None,
+            },
+        )
         return stats
     finally:
         conn.close()
 
 
-def mark_removed(conn: sqlite3.Connection, profile: Profile, seen: set[str]) -> None:
-    rows = conn.execute(
-        "SELECT file_path FROM assets WHERE source_root = ? AND status = 'active'",
-        (profile.canonical_prefix,),
-    ).fetchall()
-    for (file_path,) in rows:
-        if file_path not in seen:
-            conn.execute("UPDATE assets SET status = 'removed' WHERE file_path = ?", (file_path,))
+def write_refresh_state(profile: Profile, payload: dict[str, Any]) -> None:
+    state_path = profile.db.parent / "refresh-state.json"
+    tmp_path = state_path.with_suffix(state_path.suffix + ".tmp")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    tmp_path.replace(state_path)
+
+
+def local_path_from_canonical(file_path: str, profile: Profile) -> Path:
+    for root in profile.roots:
+        source_root = canonical_root(root, profile)
+        try:
+            rel = Path(file_path).relative_to(source_root)
+        except ValueError:
+            continue
+        return root / rel
+    return profile.root / Path(file_path).relative_to(profile.canonical_prefix)
+
+
+def mark_removed(conn: sqlite3.Connection, profile: Profile, seen: set[str]) -> int:
+    removed = 0
+    for root in profile.roots:
+        source_root = canonical_root(root, profile)
+        rows = conn.execute(
+            "SELECT file_path FROM assets WHERE source_root = ? AND status = 'active'",
+            (source_root,),
+        ).fetchall()
+        for (file_path,) in rows:
+            if file_path not in seen:
+                conn.execute("UPDATE assets SET status = 'removed' WHERE file_path = ?", (file_path,))
+                removed += 1
+    return removed
 
 
 def hash_incremental(profile: Profile, batch_size: int, limit: int | None = None) -> dict[str, int]:
@@ -323,7 +398,7 @@ def hash_incremental(profile: Profile, batch_size: int, limit: int | None = None
         for (file_path,) in rows:
             if limit is not None and hashed >= limit:
                 break
-            local = profile.root / Path(file_path).relative_to(profile.canonical_prefix)
+            local = local_path_from_canonical(file_path, profile)
             try:
                 digest = compute_hash(local)
                 conn.execute("UPDATE assets SET content_hash = ? WHERE file_path = ?", (digest, file_path))
@@ -350,16 +425,18 @@ def compute_hash(path: Path) -> str:
 
 
 def count_walk(profile: Profile) -> int:
-    return sum(1 for item in iter_files(profile.root, profile.excludes) if not isinstance(item, ScanError))
+    return sum(1 for root in profile.roots for item in iter_files(root, profile.excludes) if not isinstance(item, ScanError))
 
 
 def reconcile(profile: Profile) -> int:
     conn = open_db(profile.db)
     try:
         walk_count = count_walk(profile)
+        roots = [canonical_root(root, profile) for root in profile.roots]
+        placeholders = ", ".join("?" for _ in roots)
         db_count = conn.execute(
-            "SELECT count(*) FROM assets WHERE source_root = ? AND status = 'active'",
-            (profile.canonical_prefix,),
+            f"SELECT count(*) FROM assets WHERE source_root IN ({placeholders}) AND status = 'active'",
+            roots,
         ).fetchone()[0]
     finally:
         conn.close()
@@ -375,6 +452,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--drive", required=True)
     parser.add_argument("--db", type=Path)
     parser.add_argument("--hash", choices=["none", "incremental"], default="none")
+    parser.add_argument("--incremental", action="store_true")
+    parser.add_argument("--prune", action="store_true")
     parser.add_argument("--batch-size", type=int, default=2000)
     parser.add_argument("--reconcile", action="store_true")
     parser.add_argument("--limit", type=int)
@@ -385,7 +464,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.hash == "incremental":
         print(hash_incremental(profile, args.batch_size, args.limit))
     else:
-        print(metadata_pass(profile, batch_size=args.batch_size, limit=args.limit))
+        print(metadata_pass(profile, batch_size=args.batch_size, limit=args.limit, incremental=args.incremental, prune=args.prune))
     return 0
 
 

--- a/scripts/data/drive-index/cad/build_cad_index.py
+++ b/scripts/data/drive-index/cad/build_cad_index.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Parameterized CAD readability TSV builder vendored from the drive-local original."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+import os
+from pathlib import Path
+import re
+
+
+READ = {
+    "step": ("STEP (neutral)", "oss-3d", "pythonocc/OCC"),
+    "stp": ("STEP (neutral)", "oss-3d", "pythonocc/OCC"),
+    "iges": ("IGES (neutral)", "oss-3d", "pythonocc/OCC (surfaces)"),
+    "igs": ("IGES (neutral)", "oss-3d", "pythonocc/OCC (surfaces)"),
+    "x_t": ("Parasolid", "seat-only", "commercial OCC/Datakit"),
+    "x_b": ("Parasolid", "seat-only", "commercial OCC/Datakit"),
+    "dwg": ("AutoCAD", "convert-2d", "ODA->DXF->ezdxf/Blender"),
+    "dxf": ("AutoCAD", "oss-2d", "ezdxf/Blender"),
+    "sldprt": ("SolidWorks", "seat-only", "SolidWorks seat / STEP export"),
+    "sldasm": ("SolidWorks", "seat-only", "SolidWorks seat / STEP export"),
+    "ipt": ("Inventor", "seat-only", "Inventor seat / STEP export"),
+    "iam": ("Inventor", "seat-only", "Inventor seat / STEP export"),
+    "prt": ("NX/generic", "seat-likely", "varies (NX/ProE)"),
+    "catpart": ("CATIA", "seat-only", "CATIA seat / STEP export"),
+    "f3d": ("Fusion 360", "seat-only", "Fusion / export"),
+    "f3z": ("Fusion 360", "seat-only", "Fusion / export"),
+    "stl": ("Mesh", "oss-mesh", "trimesh/Blender"),
+    "3mf": ("Mesh", "oss-mesh", "trimesh/Blender"),
+    "nc": ("CAM/NetCDF", "ambiguous", "inspect"),
+    "cnc": ("CAM", "cam", "postproc"),
+    "tap": ("CAM", "cam", "postproc"),
+    "gcode": ("CAM", "cam", "postproc"),
+    "mcam": ("Mastercam", "seat-only", "Mastercam seat"),
+}
+CAD = set(READ)
+HEADER = "path\tformat\tecosystem\treadability\tread_tool\tglb\tname_description\tproject\tsize\tmtime\n"
+
+
+def clean_name(path: str) -> str:
+    name = os.path.basename(path)
+    name = re.sub(r"\.[^.]+$", "", name)
+    name = re.sub(r"^~\$", "", name)
+    return re.sub(r"[_]+", " ", name).strip()
+
+
+def project(path: str) -> str:
+    if "/docs/disciplines/knowledge_skills/projects/ri/" in path:
+        return "ri-hoard (personal backup)"
+    match = re.search(r"/docs/disciplines/([^/]+)/projects/([^/]+)/", path)
+    if match:
+        return f"docs/{match.group(1)}/{match.group(2)}"
+    if "/digitalmodel/docs/domain/subsea-risers/" in path:
+        return "digitalmodel/subsea-risers"
+    parts = path.split("/")
+    return parts[3] if len(parts) > 3 else "?"
+
+
+def load_dedup(dedup: Path) -> tuple[set[str], dict[str, str]]:
+    deleted = set()
+    deletion_log = dedup / "deletion-log.tsv"
+    if deletion_log.exists():
+        for row in csv.reader(deletion_log.open(), delimiter="\t"):
+            if row:
+                deleted.add(row[0])
+    glb = {}
+    manifest = dedup / "glb-library-manifest.tsv"
+    if manifest.exists():
+        for row in csv.DictReader(manifest.open(), delimiter="\t"):
+            glb[row["source"]] = row["glb"]
+    return deleted, glb
+
+
+def build(raw: Path, dedup: Path, out: Path) -> dict:
+    deleted, glb = load_dedup(dedup)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    count = 0
+    by_read = collections.Counter()
+    by_fmt = collections.Counter()
+    with tmp.open("w", encoding="utf-8") as handle:
+        handle.write(HEADER)
+        with raw.open(encoding="utf-8", errors="replace") as source:
+            for line in source:
+                fields = line.rstrip("\n").split("\t", 2)
+                if len(fields) != 3:
+                    continue
+                size, mtime, path = fields
+                if path in deleted:
+                    continue
+                ext = path.rsplit(".", 1)[-1].lower() if "." in os.path.basename(path) else ""
+                if ext not in CAD:
+                    continue
+                ecosystem, readability, tool = READ[ext]
+                handle.write(
+                    f"{path}\t{ext}\t{ecosystem}\t{readability}\t{tool}\t{glb.get(path, '')}\t"
+                    f"{clean_name(path)}\t{project(path)}\t{size}\t{mtime}\n"
+                )
+                count += 1
+                by_read[readability] += 1
+                by_fmt[ext] += 1
+    tmp.replace(out)
+    summary = {
+        "indexed_cad_files": count,
+        "readable_breakdown": dict(by_read.most_common()),
+        "by_format": dict(by_fmt.most_common()),
+        "glb_linked": len(glb),
+        "output": str(out),
+    }
+    (out.parent / "index-summary.json").write_text(json.dumps(summary, indent=1) + "\n")
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build CAD readability TSV from raw scan TSV.")
+    parser.add_argument("--raw", type=Path, required=True)
+    parser.add_argument("--dedup", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    print(json.dumps(build(args.raw, args.dedup, args.out), indent=1))
+    print("DONE_CADINDEX")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/drive-index/cad/scan_cad_raw.py
+++ b/scripts/data/drive-index/cad/scan_cad_raw.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+CAD_EXTENSIONS = {
+    ".step", ".stp", ".iges", ".igs", ".x_t", ".x_b", ".dwg", ".dxf",
+    ".sldprt", ".sldasm", ".ipt", ".iam", ".prt", ".catpart", ".f3d",
+    ".f3z", ".stl", ".3mf", ".nc", ".cnc", ".tap", ".gcode", ".mcam",
+}
+
+
+def iter_cad(root: Path):
+    for current, dirs, files in os.walk(root):
+        dirs[:] = [name for name in dirs if name not in {".ace-knowledge", "_cad-index", "$RECYCLE.BIN", "System Volume Information"}]
+        for name in sorted(files):
+            path = Path(current) / name
+            if path.suffix.lower() in CAD_EXTENSIONS:
+                yield path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan a tree and emit CAD raw TSV rows.")
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for path in iter_cad(args.root):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            handle.write(f"{stat.st_size}\t{int(stat.st_mtime)}\t{path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/drive-index/drive-index-config.yaml
+++ b/scripts/data/drive-index/drive-index-config.yaml
@@ -1,5 +1,47 @@
 version: 1
 drives:
+  ace:
+    roots:
+      - /mnt/ace/docs/disciplines
+      - /mnt/ace/O&G-Standards
+      - /mnt/ace/_ss_repo
+    canonical_prefix: /mnt/ace
+    db: /mnt/ace/.ace-knowledge/index.db
+    excludes:
+      - .ace-knowledge
+      - _cad-index
+      - $RECYCLE.BIN
+      - System Volume Information
+    classification:
+      defaults:
+        asset_type: file
+        discipline: general
+        engineering_domain: general
+        content_category: file
+      extensions:
+        .pdf: document
+        .doc: document
+        .docx: document
+        .xls: spreadsheet
+        .xlsx: spreadsheet
+        .csv: spreadsheet
+        .ppt: presentation
+        .pptx: presentation
+        .txt: text
+        .md: text
+        .py: code
+        .m: code
+        .inp: analysis_input
+        .dat: data
+        .mac: code
+        .f: code
+        .for: code
+        .bas: code
+        .dwg: cad
+        .dxf: cad
+        .step: cad
+        .stp: cad
+        .sldprt: cad
   dde:
     root: /mnt/dde
     canonical_prefix: /mnt/dde

--- a/scripts/data/drive-index/refresh-drive-index.sh
+++ b/scripts/data/drive-index/refresh-drive-index.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-}"
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+PY="$(command -v python3 || true)"
+if [[ -z "$PY" ]]; then
+  PY="/usr/bin/python3"
+fi
+UV="$(command -v uv || true)"
+if [[ -z "$UV" ]]; then
+  UV="$HOME/.local/bin/uv"
+fi
+
+notify() {
+  local source="$1"
+  local job="$2"
+  local status="$3"
+  local details="${4:-}"
+  if [[ -n "${DRIVE_INDEX_NOTIFY_LOG:-}" ]]; then
+    printf '%s\t%s\t%s\t%s\n' "$source" "$job" "$status" "$details" >> "$DRIVE_INDEX_NOTIFY_LOG"
+    return 0
+  fi
+  bash "$REPO_ROOT/scripts/notify.sh" "$source" "$job" "$status" "$details" || true
+}
+
+fail() {
+  local target="${1:-unknown}"
+  local message="${2:-refresh failed}"
+  write_failure_state "$target" "$message"
+  notify cron "drive-index-refresh-$target" fail "$message"
+  exit 1
+}
+
+write_failure_state() {
+  local target="${1:-unknown}"
+  local message="${2:-refresh failed}"
+  local state_file=""
+  case "$target" in
+    ace) state_file="/mnt/ace/.ace-knowledge/refresh-state.json" ;;  # abs-path-allowed
+    dde) state_file="/mnt/dde/.dde-knowledge/refresh-state.json" ;;  # abs-path-allowed
+    cad) state_file="/mnt/ace/_cad-index/refresh-state.json" ;;  # abs-path-allowed
+    *) return 0 ;;
+  esac
+  local dir
+  dir="$(dirname "$state_file")"
+  if [[ -d "$dir" && -w "$dir" ]]; then
+    printf '{"index_id":"%s","status":"failed","error":"%s"}\n' "$target" "${message//\"/\\\"}" > "${state_file}.tmp" || true
+    mv "${state_file}.tmp" "$state_file" 2>/dev/null || true
+  fi
+}
+
+usage() {
+  echo "usage: refresh-drive-index.sh <ace|dde|cad>" >&2
+}
+
+if [[ "$TARGET" != "ace" && "$TARGET" != "dde" && "$TARGET" != "cad" ]]; then
+  usage
+  fail "${TARGET:-unknown}" "invalid target"
+fi
+
+if [[ "${DRIVE_INDEX_TEST_MODE:-}" == "1" ]]; then
+  notify cron "drive-index-refresh-$TARGET" pass "test-mode"
+  exit 0
+fi
+
+LOCK_FILE="${TMPDIR:-/tmp}/workspace-hub-drive-index-${TARGET}.lock"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  fail "$TARGET" "another refresh is already running"
+fi
+trap 'fail "$TARGET" "line $LINENO: $BASH_COMMAND"' ERR
+
+run_builder() {
+  local drive="$1"
+  if [[ -x "$UV" ]]; then
+    "$UV" run --with pyyaml "$PY" "$REPO_ROOT/scripts/data/drive-index/build_drive_index.py" \
+      --drive "$drive" --incremental --prune
+  else
+    "$PY" "$REPO_ROOT/scripts/data/drive-index/build_drive_index.py" \
+      --drive "$drive" --incremental --prune
+  fi
+}
+
+case "$TARGET" in
+  ace)
+    [[ -f /mnt/ace/.ace-knowledge/index.db ]] || fail ace "index.db missing"  # abs-path-allowed
+    output="$(run_builder ace)"
+    ;;
+  dde)
+    [[ -f /mnt/dde/.dde-knowledge/index.db ]] || fail dde "index.db missing - #3334 production run not landed?"  # abs-path-allowed
+    output="$(run_builder dde)"
+    ;;
+  cad)
+    mkdir -p /mnt/ace/_cad-index  # abs-path-allowed
+    "$PY" "$REPO_ROOT/scripts/data/drive-index/cad/scan_cad_raw.py" \
+      --root /mnt/ace --out /mnt/ace/_cad-index/cad-raw.tsv  # abs-path-allowed
+    "$PY" "$REPO_ROOT/scripts/data/drive-index/cad/build_cad_index.py" \
+      --raw /mnt/ace/_cad-index/cad-raw.tsv \  # abs-path-allowed
+      --dedup /mnt/ace/_cad-index/dedup \  # abs-path-allowed
+      --out /mnt/ace/_cad-index/cad-readability-index.tsv  # abs-path-allowed
+    printf '{"index_id":"cad_readability","status":"ok"}\n' > /mnt/ace/_cad-index/refresh-state.json.tmp  # abs-path-allowed
+    mv /mnt/ace/_cad-index/refresh-state.json.tmp /mnt/ace/_cad-index/refresh-state.json  # abs-path-allowed
+    output="cad refresh complete"
+    ;;
+esac
+
+notify cron "drive-index-refresh-$TARGET" pass "$output"

--- a/tests/data/drive_index/drive_index_build_helpers.py
+++ b/tests/data/drive_index/drive_index_build_helpers.py
@@ -1,0 +1,23 @@
+"""Shared helpers for the drive-index builder tests (module named uniquely —
+bare `conftest` imports collide across suites in combined pytest runs)."""
+import os
+import sqlite3
+from pathlib import Path
+
+def rows(db: Path, sql: str, params=()):
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+
+
+def make_raw_byte_file(root: Path) -> None:
+    parent = root / "documents"
+    raw = os.fsencode(parent) + b"/bad_\xff_name.txt"
+    fd = os.open(raw, os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, b"bad name")
+    finally:
+        os.close(fd)

--- a/tests/data/drive_index/test_build_drive_index.py
+++ b/tests/data/drive_index/test_build_drive_index.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import make_raw_byte_file, rows
+from drive_index_build_helpers import make_raw_byte_file, rows
 
 
 def run_metadata(builder, profile, batch_size=3, limit=None):

--- a/tests/data/drive_index_refresh/conftest.py
+++ b/tests/data/drive_index_refresh/conftest.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BUILDER_PATH = REPO_ROOT / "scripts/data/drive-index/build_drive_index.py"
+SEARCH_DIR = REPO_ROOT / "scripts/data/drive-index-search"
+
+sys.path.insert(0, str(SEARCH_DIR))
+
+
+@pytest.fixture()
+def builder():
+    spec = importlib.util.spec_from_file_location("build_drive_index_refresh", BUILDER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def fixture_tree(tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "drive"
+    for rel in ["root-a/alpha.txt", "root-a/riser_vortex.dat", "root-b/beta.pdf"]:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"content {rel}")
+    return {"root": root, "db": tmp_path / "index.db"}
+
+
+@pytest.fixture()
+def multi_root_config(tmp_path: Path, fixture_tree: dict[str, Path]) -> Path:
+    config = {
+        "version": 1,
+        "drives": {
+            "fixture": {
+                "roots": [
+                    str(fixture_tree["root"] / "root-a"),
+                    str(fixture_tree["root"] / "root-b"),
+                ],
+                "canonical_prefix": "/mnt/fixture",  # abs-path-allowed
+                "db": str(fixture_tree["db"]),
+                "excludes": ["skip"],
+                "classification": {
+                    "defaults": {
+                        "asset_type": "file",
+                        "discipline": "general",
+                        "engineering_domain": "general",
+                        "content_category": "file",
+                    },
+                    "extensions": {".pdf": "document", ".dat": "data"},
+                },
+            }
+        },
+    }
+    path = tmp_path / "drive-index-config.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return path
+
+
+@pytest.fixture()
+def profile(builder, multi_root_config: Path):
+    return builder.load_profile(multi_root_config, "fixture")
+
+
+def rows(db: Path, sql: str, params=()):
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()

--- a/tests/data/drive_index_refresh/drive_index_refresh_helpers.py
+++ b/tests/data/drive_index_refresh/drive_index_refresh_helpers.py
@@ -1,0 +1,11 @@
+"""Shared helpers for the drive-index refresh tests (module named uniquely —
+bare `conftest` imports collide across suites in combined pytest runs)."""
+import sqlite3
+from pathlib import Path
+
+def rows(db: Path, sql: str, params=()):
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()

--- a/tests/data/drive_index_refresh/test_cad_rebuild.py
+++ b/tests/data/drive_index_refresh/test_cad_rebuild.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN = REPO_ROOT / "scripts/data/drive-index/cad/scan_cad_raw.py"
+BUILD = REPO_ROOT / "scripts/data/drive-index/cad/build_cad_index.py"
+HEADER = "path\tformat\tecosystem\treadability\tread_tool\tglb\tname_description\tproject\tsize\tmtime"
+
+
+def test_cad_scan_raw_format(tmp_path):
+    root = tmp_path / "ace"
+    for rel in ["a/model.step", "a/drawing.dwg", "a/part.sldprt", "a/readme.txt"]:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x")
+    raw = tmp_path / "cad-raw.tsv"
+
+    result = subprocess.run([sys.executable, str(SCAN), "--root", str(root), "--out", str(raw)], text=True, capture_output=True)
+
+    assert result.returncode == 0
+    lines = raw.read_text().splitlines()
+    assert len(lines) == 3
+    assert all(len(line.split("\t")) == 3 for line in lines)
+    assert not any("readme.txt" in line for line in lines)
+
+
+def test_cad_builder_output_header_stable(tmp_path):
+    raw = tmp_path / "cad-raw.tsv"
+    raw.write_text("10\t2026-07-02T00:00:00Z\t/mnt/ace/docs/disciplines/proj/widget.step\n")  # abs-path-allowed
+    out = tmp_path / "cad-readability-index.tsv"
+
+    result = subprocess.run(
+        [sys.executable, str(BUILD), "--raw", str(raw), "--dedup", str(tmp_path / "dedup"), "--out", str(out)],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    assert out.read_text().splitlines()[0] == HEADER
+    assert not out.with_suffix(out.suffix + ".tmp").exists()

--- a/tests/data/drive_index_refresh/test_incremental_refresh.py
+++ b/tests/data/drive_index_refresh/test_incremental_refresh.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from drive_index_refresh_helpers import rows
+
+
+def run_refresh(builder, profile, *, incremental=True, prune=False):
+    return builder.metadata_pass(
+        profile,
+        batch_size=2,
+        incremental=incremental,
+        prune=prune,
+    )
+
+
+def test_incremental_picks_up_added_file(builder, profile, fixture_tree):
+    run_refresh(builder, profile)
+    added = fixture_tree["root"] / "root-a" / "new_calc.txt"
+    added.write_text("new")
+
+    stats = run_refresh(builder, profile)
+
+    assert stats["rows_added"] == 1
+    assert rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/new_calc.txt",))[0][0] == "active"  # abs-path-allowed
+
+
+def test_incremental_updates_modified_file(builder, profile, fixture_tree):
+    run_refresh(builder, profile)
+    target = fixture_tree["root"] / "root-a" / "alpha.txt"
+    before = rows(profile.db, "SELECT file_size, scan_date FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0]  # abs-path-allowed
+    target.write_text("changed content")
+
+    stats = run_refresh(builder, profile)
+    after = rows(profile.db, "SELECT file_size, scan_date, status FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0]  # abs-path-allowed
+
+    assert stats["rows_updated"] == 1
+    assert after[0] != before[0]
+    assert after[1] != before[1]
+    assert after[2] == "active"
+
+
+def test_incremental_skips_unchanged(builder, profile):
+    run_refresh(builder, profile)
+    before = rows(profile.db, "SELECT scan_date FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0][0]  # abs-path-allowed
+
+    stats = run_refresh(builder, profile)
+
+    assert stats["skipped"] == 3
+    assert stats["rows_updated"] == 0
+    assert rows(profile.db, "SELECT scan_date FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0][0] == before  # abs-path-allowed
+
+
+def test_prune_marks_removed_not_deleted(builder, profile, fixture_tree):
+    run_refresh(builder, profile)
+    (fixture_tree["root"] / "root-a" / "alpha.txt").unlink()
+
+    stats = run_refresh(builder, profile, prune=True)
+
+    assert stats["rows_pruned"] == 1
+    assert rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0][0] == "removed"  # abs-path-allowed
+    assert rows(profile.db, "SELECT count(*) FROM assets")[0][0] == 3
+
+
+def test_removed_row_reactivated_on_reappearance(builder, profile, fixture_tree):
+    target = fixture_tree["root"] / "root-a" / "alpha.txt"
+    run_refresh(builder, profile)
+    target.unlink()
+    run_refresh(builder, profile, prune=True)
+    target.write_text("content root-a/alpha.txt")
+
+    stats = run_refresh(builder, profile)
+
+    assert stats["rows_updated"] == 1
+    assert rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/fixture/root-a/alpha.txt",))[0][0] == "active"  # abs-path-allowed
+
+
+def test_prune_scoped_to_walked_roots(builder, profile):
+    run_refresh(builder, profile)
+    conn = sqlite3.connect(profile.db)
+    try:
+        conn.execute(
+            "INSERT INTO assets (id, asset_type, file_path, file_name, source_root, status) VALUES (?, ?, ?, ?, ?, ?)",
+            ("external", "file", "/mnt/other/outside.txt", "outside.txt", "/mnt/other", "active"),  # abs-path-allowed
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    run_refresh(builder, profile, prune=True)
+
+    assert rows(profile.db, "SELECT status FROM assets WHERE file_path = ?", ("/mnt/other/outside.txt",))[0][0] == "active"  # abs-path-allowed
+
+
+def test_update_preserves_extraction_columns(builder, profile, fixture_tree):
+    run_refresh(builder, profile)
+    conn = sqlite3.connect(profile.db)
+    try:
+        conn.execute(
+            "UPDATE assets SET title=?, discipline=?, extraction_status=?, content_hash=?, last_extracted=? WHERE file_path=?",
+            ("Curated title", "curated", "extracted", "sha256:abc", "2026-01-01", "/mnt/fixture/root-a/alpha.txt"),  # abs-path-allowed
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    (fixture_tree["root"] / "root-a" / "alpha.txt").write_text("changed")
+
+    run_refresh(builder, profile)
+
+    preserved = rows(
+        profile.db,
+        "SELECT title, discipline, extraction_status, content_hash, last_extracted FROM assets WHERE file_path=?",
+        ("/mnt/fixture/root-a/alpha.txt",),  # abs-path-allowed
+    )[0]
+    assert preserved == ("Curated title", "curated", "extracted", "sha256:abc", "2026-01-01")
+
+
+def test_refresh_preserves_foreign_tables(builder, profile):
+    conn = builder.open_db(profile.db)
+    try:
+        conn.execute("CREATE TABLE standards (id TEXT PRIMARY KEY, title TEXT)")
+        conn.execute("INSERT INTO standards VALUES ('api', 'API')")
+        conn.commit()
+    finally:
+        conn.close()
+
+    run_refresh(builder, profile)
+
+    assert rows(profile.db, "SELECT title FROM standards WHERE id='api'")[0][0] == "API"
+
+
+def test_refresh_preserves_legacy_uuid_ids(builder, profile, fixture_tree):
+    conn = builder.open_db(profile.db)
+    try:
+        row = builder.row_for_file(fixture_tree["root"] / "root-a" / "alpha.txt", profile, "old")
+        values = dict(zip(builder.ASSET_COLUMNS, row))
+        values["id"] = "0d4919d6-1360-4d3d-ac97-ddbd3fb71c4e"
+        conn.execute(
+            f"INSERT INTO assets ({', '.join(builder.ASSET_COLUMNS)}) VALUES ({', '.join('?' for _ in builder.ASSET_COLUMNS)})",
+            tuple(values[col] for col in builder.ASSET_COLUMNS),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    (fixture_tree["root"] / "root-a" / "alpha.txt").write_text("changed")
+
+    run_refresh(builder, profile)
+
+    assert rows(profile.db, "SELECT id FROM assets WHERE file_path=?", ("/mnt/fixture/root-a/alpha.txt",))[0][0] == "0d4919d6-1360-4d3d-ac97-ddbd3fb71c4e"  # abs-path-allowed
+
+
+def test_multi_root_profile(builder, profile):
+    run_refresh(builder, profile)
+    paths = {row[0] for row in rows(profile.db, "SELECT file_path FROM assets")}
+    assert paths == {
+        "/mnt/fixture/root-a/alpha.txt",  # abs-path-allowed
+        "/mnt/fixture/root-a/riser_vortex.dat",  # abs-path-allowed
+        "/mnt/fixture/root-b/beta.pdf",  # abs-path-allowed
+    }
+
+
+def test_multi_root_canonical_path_maps_back_to_local_root(builder, profile, fixture_tree):
+    local = builder.local_path_from_canonical("/mnt/fixture/root-b/beta.pdf", profile)  # abs-path-allowed
+
+    assert local == fixture_tree["root"] / "root-b" / "beta.pdf"
+
+
+def test_fts_synced_after_incremental(builder, profile, fixture_tree):
+    run_refresh(builder, profile)
+    (fixture_tree["root"] / "root-a" / "vortex_new.txt").write_text("vortex content")
+    run_refresh(builder, profile)
+
+    hit = rows(
+        profile.db,
+        "SELECT base.file_name FROM assets_fts JOIN assets base ON base.rowid = assets_fts.rowid WHERE assets_fts MATCH ?",
+        ("vortex",),
+    )
+    assert ("vortex_new.txt",) in hit
+
+
+def test_state_file_written_on_success(builder, profile):
+    stats = run_refresh(builder, profile)
+
+    state = json.loads((profile.db.parent / "refresh-state.json").read_text())
+    assert state["status"] == "ok"
+    assert state["row_count"] == 3
+    assert state["rows_added"] == stats["rows_added"]
+    assert "duration_s" in state
+    assert not (profile.db.parent / "refresh-state.json.tmp").exists()
+
+
+def test_state_file_and_exit_on_failure(builder, tmp_path):
+    profile = builder.Profile(
+        name="bad",
+        roots=[tmp_path / "missing"],
+        canonical_prefix="/mnt/bad",  # abs-path-allowed
+        db=tmp_path / "index.db",
+        excludes=set(),
+        topdir_map={},
+        extension_map={},
+        defaults={},
+    )
+
+    stats = builder.metadata_pass(profile, batch_size=1, incremental=True, prune=True)
+
+    assert stats["errors"] == 1
+    state = json.loads((profile.db.parent / "refresh-state.json").read_text())
+    assert state["status"] == "failed"
+    assert state["error"]

--- a/tests/data/drive_index_refresh/test_registry_freshness.py
+++ b/tests/data/drive_index_refresh/test_registry_freshness.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from registry import RegistryError, load_registry
+
+
+def _registry(tmp_path: Path, freshness: dict | None) -> Path:
+    data = {
+        "version": 1,
+        "defaults": {"staleness_days": 90},
+        "indexes": [
+            {
+                "id": "idx",
+                "adapter": "jsonl",
+                "path": "index.jsonl",
+                "coverage": {"drives": ["/fixture"]},
+                "freshness": freshness or {"built_at": "2026-01-01"},
+                "builder": "builder.py",
+                "adapter_params": {"path_field": "path", "search_fields": ["path"]},
+            }
+        ],
+    }
+    path = tmp_path / "registry.yml"
+    path.write_text(yaml.safe_dump(data))
+    (tmp_path / "index.jsonl").write_text("")
+    return path
+
+
+def test_registry_accepts_freshness_fields(tmp_path):
+    path = _registry(
+        tmp_path,
+        {
+            "built_at": "2026-03-26",
+            "staleness_days": 14,
+            "row_count": 1188891,
+            "as_of": "2026-07-02",
+            "state_file": "/mnt/ace/.ace-knowledge/refresh-state.json",  # abs-path-allowed
+        },
+    )
+
+    registry = load_registry(path)
+
+    assert registry.get("idx").freshness["row_count"] == 1188891
+
+
+def test_registry_rejects_bad_freshness_types(tmp_path):
+    path = _registry(tmp_path, {"built_at": "2026-03-26", "row_count": "many"})
+
+    with pytest.raises(RegistryError, match="idx.*row_count"):
+        load_registry(path)
+
+
+def test_registry_freshness_fields_optional(tmp_path):
+    path = _registry(tmp_path, {"built_at": "2026-03-26"})
+
+    assert load_registry(path).get("idx").freshness["built_at"] == "2026-03-26"

--- a/tests/data/drive_index_refresh/test_schedule_and_wrapper.py
+++ b/tests/data/drive_index_refresh/test_schedule_and_wrapper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WRAPPER = REPO_ROOT / "scripts/data/drive-index/refresh-drive-index.sh"
+
+
+def test_wrapper_notify_on_failure(tmp_path):
+    notify = tmp_path / "notify.log"
+    env = os.environ.copy()
+    env["DRIVE_INDEX_NOTIFY_LOG"] = str(notify)
+    env["DRIVE_INDEX_TEST_MODE"] = "1"
+
+    result = subprocess.run(["bash", str(WRAPPER), "bad"], cwd=REPO_ROOT, env=env, text=True, capture_output=True)
+
+    assert result.returncode == 1
+    assert "cron\tdrive-index-refresh-bad\tfail" in notify.read_text()
+
+
+def test_wrapper_uses_flock_guard():
+    assert "flock -n" in WRAPPER.read_text()
+
+
+def test_wrapper_notify_pass_summary(tmp_path):
+    notify = tmp_path / "notify.log"
+    env = os.environ.copy()
+    env["DRIVE_INDEX_NOTIFY_LOG"] = str(notify)
+    env["DRIVE_INDEX_TEST_MODE"] = "1"
+
+    result = subprocess.run(["bash", str(WRAPPER), "ace"], cwd=REPO_ROOT, env=env, text=True, capture_output=True)
+
+    assert result.returncode == 0
+    assert "cron\tdrive-index-refresh-ace\tpass" in notify.read_text()
+
+
+def test_schedule_tasks_valid():
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts/cron/validate-schedule.py")],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    data = yaml.safe_load((REPO_ROOT / "config/scheduled-tasks/schedule-tasks.yaml").read_text())
+    tasks = {task["id"]: task for task in data["tasks"]}
+    assert tasks["drive-index-refresh-ace"]["machines"] == ["ace-linux-1"]
+    assert tasks["drive-index-refresh-dde"]["machines"] == ["dev-secondary", "ace-linux-2"]
+    assert tasks["drive-index-refresh-cad"]["machines"] == ["ace-linux-1"]

--- a/tests/data/drive_index_refresh/test_staleness_cli.py
+++ b/tests/data/drive_index_refresh/test_staleness_cli.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI = REPO_ROOT / "scripts" / "data" / "drive-index-search" / "search.py"
+
+
+def _write_registry(tmp_path: Path, *, freshness: dict) -> Path:
+    index = tmp_path / "index.jsonl"
+    index.write_text('{"path": "/fixture/mooring.txt", "summary": "mooring analysis"}\n')
+    registry = {
+        "version": 1,
+        "defaults": {"staleness_days": 90},
+        "indexes": [
+            {
+                "id": "fixture_jsonl",
+                "adapter": "jsonl",
+                "path": str(index),
+                "coverage": {"drives": ["/fixture"]},
+                "freshness": freshness,
+                "adapter_params": {"path_field": "path", "search_fields": ["path", "summary"]},
+            }
+        ],
+    }
+    path = tmp_path / "registry.yml"
+    path.write_text(yaml.safe_dump(registry))
+    return path
+
+
+def _run(registry: Path, *extra: str):
+    return subprocess.run(
+        [sys.executable, str(CLI), "mooring", "--registry", str(registry), *extra],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_staleness_warning_stderr(tmp_path):
+    registry = _write_registry(tmp_path, freshness={"as_of": "2025-12-28", "staleness_days": 90})
+
+    result = _run(registry)
+
+    assert result.returncode == 0
+    assert "WARNING: index fixture_jsonl is" in result.stderr
+    assert "threshold 90" in result.stderr
+
+
+def test_cli_prefers_state_file(tmp_path):
+    state = tmp_path / "refresh-state.json"
+    state.write_text(json.dumps({"finished_at": "2026-07-02T12:00:00Z", "status": "ok", "row_count": 1}))
+    registry = _write_registry(
+        tmp_path,
+        freshness={"as_of": "2025-12-28", "staleness_days": 90, "state_file": str(state)},
+    )
+
+    result = _run(registry, "--json")
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["index_status"][0]["stale"] is False
+    assert payload["index_status"][0]["last_refresh_status"] == "ok"
+
+
+def test_cli_state_file_unreachable_fallback(tmp_path):
+    registry = _write_registry(
+        tmp_path,
+        freshness={"as_of": "2025-12-28", "staleness_days": 90, "state_file": str(tmp_path / "missing.json")},
+    )
+
+    result = _run(registry, "--json")
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["index_status"][0]["stale"] is True
+    assert payload["index_status"][0]["last_refresh_status"] == "unknown"
+
+
+def test_cli_json_index_status_key(tmp_path):
+    registry = _write_registry(tmp_path, freshness={"as_of": "2026-04-17", "staleness_days": 60})
+
+    result = _run(registry, "--json")
+    payload = json.loads(result.stdout)
+
+    assert set(payload["index_status"][0]) == {
+        "id",
+        "as_of",
+        "days_stale",
+        "threshold_days",
+        "stale",
+        "last_refresh_status",
+        "row_count",
+    }
+    assert payload["index_status"][0]["days_stale"] >= 76
+    assert payload["index_status"][0]["threshold_days"] == 60

--- a/tests/data/drive_index_search/test_cli.py
+++ b/tests/data/drive_index_search/test_cli.py
@@ -73,6 +73,7 @@ def test_cli_json_schema(fixture_registry):
         "query",
         "generated_at",
         "indexes_queried",
+        "index_status",
         "coverage_gaps",
         "results",
     }


### PR DESCRIPTION
Implements #3336 per its approved adversarial-reviewed plan. Codex lane; orchestrator-verified with two fixes of its own.

## What
- **Refresh**: `--incremental`/`--prune` flags on the #3334 builder (skip only when (size,mtime) unchanged AND `status=='active'` — the tombstone-reactivation review fix), updating refresh-owned columns only (never clobbers title/discipline/extraction_status/content_hash).
- **Registry freshness fields**: `row_count`/`as_of`/`staleness_days` on all entries — lands #3339's schema ask; `ace_knowledge` coverage corrected to the 3 proven source roots; `.ace-knowledge` builder provenance recorded (aceengineer-admin `knowledge` package + the live archived spec — the 'lost builder' epic premise was corrected during plan review).
- **CLI staleness surfacing**: new `staleness.py` helper + `index_status` in the `--json` envelope (deliberately isolated from `search.py` internals to minimize the known same-file seam with #3340's metrics edit).
- **Crons**: declared in `config/scheduled-tasks/schedule-tasks.yaml` (validator: 63 tasks OK) — ace Sun 02:30 (ace-linux-1), dde Sun 03:30 (ace-linux-2), CAD Sun 05:00 — one hardened wrapper (`TARGET="$1"`, explicit PATH per the PR #3332 cron precedent, notify.sh fail-loud on pass AND fail, flock).
- **CAD builder vendored + parameterized** (the drive-local original reads a dead session-scratchpad TSV) with a raw-scan generator.

## Orchestrator verification + fixes
- Combined `tests/data/drive_index*` suites: **70 passed** — after fixing a latent pytest **conftest-shadowing bug** (two suites did `from conftest import rows`; fine in isolation, ImportError in combined runs — helpers moved to uniquely-named modules; this also patches the #3334 suite already on main).
- `check-no-abs-paths.sh` clean (13 sentinels on wrapper/test literals); schedule validator OK.

Registry co-edit note: #3337 (in flight) also touches the registry — sequential merges, second-lander rebases, per both plans.

Closes #3336.