### PR TITLE
chore(#3333): stamp dde_knowledge registry from production build

### DIFF
--- a/config/drive-index-registry.yml
+++ b/config/drive-index-registry.yml
@@ -34,9 +34,9 @@ indexes:
     path: /mnt/dde/.dde-knowledge/index.db
     coverage: {drives: [/mnt/dde], subtree: /mnt/dde}
     freshness:
-      built_at: "pending production build"
-      as_of: "pending production build"
-      row_count: 0
+      built_at: "2026-07-02"
+      as_of: "2026-07-03"
+      row_count: 1346317
       staleness_days: 14
       state_file: /mnt/dde/.dde-knowledge/refresh-state.json
     builder: scripts/data/drive-index/build_drive_index.py


### PR DESCRIPTION
Stamps the `dde_knowledge` freshness block in `config/drive-index-registry.yml` now that the production dde index build has completed on ace-linux-2.

## Build result (ace-linux-2, 2026-07-02)
```
{'files': 1346317, 'errors': 0, 'skipped': 0, 'duration_seconds': 3602}
```
`index.db` = 1.48 GB at `/mnt/dde/.dde-knowledge/`.

## Change
| field | was | now |
|---|---|---|
| `built_at` | `pending production build` | `2026-07-02` |
| `as_of` | `pending production build` | `2026-07-03` |
| `row_count` | `0` | `1346317` |

`row_count` verified via `SELECT COUNT(*) FROM assets` on the DB (`mode=ro`).

## End-to-end proof (live, cross-machine)
Ran from **ace-linux-1** through the canonical `/mnt/dde` NFS path against ace-linux-2's index:
```
python3 scripts/data/drive-index-search/search.py "mooring" --index dde_knowledge --json --limit 5
```
Returned 5 real results with canonical `/mnt/dde/...` paths; `index_status` reports `row_count: 1346317`, `days_stale: 0`, `stale: false` — confirming the stamped registry is read correctly.

Final closeout item for epic #3333.