### PR TITLE
feat(enforcement): byte-size guard for auto-memory MEMORY.md index (#3366)

### DIFF
--- a/scripts/enforcement/check-memory-index-size.sh
+++ b/scripts/enforcement/check-memory-index-size.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# check-memory-index-size.sh — wh#3366
+# Guard the Claude Code auto-memory INDEX (MEMORY.md) against the harness's
+# BYTE-size load cap. The harness loads MEMORY.md into context up to ~24.4KB
+# and SILENTLY DROPS everything past that — long-tail memories stop being
+# recalled with no error. The existing scripts/memory/compact-memory.py
+# triggers on LINE count (MEMORY_MD_LIMIT=180), which a small number of very
+# long lines sails past while the byte size blows the load cap. This check
+# closes that gap: it measures bytes, not lines.
+#
+# Usage:
+#   scripts/enforcement/check-memory-index-size.sh [--warn-kib=<N>] [--hard-kib=<N>] [<file>...]
+#
+# With no positional args, scans the auto-memory indices at
+#   ~/.claude/projects/*/memory/MEMORY.md
+# (per-project, machine-local; not repo-tracked). With positional args,
+# checks exactly those files (used by tests).
+#
+# Thresholds (KiB, defaults chosen from the harness reminders):
+#   --warn-kib  17   over the compaction target — compact soon (exit 0 + warn)
+#   --hard-kib  24   at/over the load cap — content is being DROPPED (exit 1)
+#
+# Exit codes: 0 = ok or warn-only; 1 = one or more indices at/over the hard cap.
+# Bypass: ALLOW_MEMORY_INDEX_OVERSIZE=1 (logs to stderr).
+
+set -euo pipefail
+
+WARN_KIB=17
+HARD_KIB=24
+declare -a POSITIONAL=()
+
+while (( $# > 0 )); do
+  case "$1" in
+    --warn-kib=*) WARN_KIB="${1#*=}"; shift ;;
+    --warn-kib)   WARN_KIB="${2:?--warn-kib requires a value}"; shift 2 ;;
+    --hard-kib=*) HARD_KIB="${1#*=}"; shift ;;
+    --hard-kib)   HARD_KIB="${2:?--hard-kib requires a value}"; shift 2 ;;
+    --)           shift; POSITIONAL+=("$@"); break ;;
+    -*)           echo "check-memory-index-size: unknown flag: $1" >&2; exit 2 ;;
+    *)            POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+warn_bytes=$(( WARN_KIB * 1024 ))
+hard_bytes=$(( HARD_KIB * 1024 ))
+
+declare -a TARGETS=()
+if (( ${#POSITIONAL[@]} == 0 )); then
+  # Glob may not expand; guard with nullglob.
+  shopt -s nullglob
+  for f in "$HOME"/.claude/projects/*/memory/MEMORY.md; do
+    TARGETS+=("$f")
+  done
+  shopt -u nullglob
+  if (( ${#TARGETS[@]} == 0 )); then
+    # No auto-memory indices on this machine — nothing to guard.
+    exit 0
+  fi
+else
+  for arg in "${POSITIONAL[@]}"; do
+    [[ -f "$arg" ]] || { echo "check-memory-index-size: not a file: $arg" >&2; exit 2; }
+    TARGETS+=("$arg")
+  done
+fi
+
+file_bytes() {
+  # Portable byte count (Linux `stat -c`, BSD/macOS `stat -f`, wc fallback).
+  stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || wc -c < "$1"
+}
+
+declare -a OVER_HARD=()
+declare -a OVER_WARN=()
+for f in "${TARGETS[@]}"; do
+  bytes="$(file_bytes "$f")"
+  kib=$(( bytes / 1024 ))
+  if (( bytes >= hard_bytes )); then
+    OVER_HARD+=("$f")
+    printf '%s: %d KiB (>= %d KiB load cap — content is being DROPPED on load)\n' "$f" "$kib" "$HARD_KIB" >&2
+  elif (( bytes >= warn_bytes )); then
+    OVER_WARN+=("$f")
+    printf '%s: %d KiB (>= %d KiB target — compact soon)\n' "$f" "$kib" "$WARN_KIB" >&2
+  fi
+done
+
+if (( ${#OVER_WARN[@]} > 0 && ${#OVER_HARD[@]} == 0 )); then
+  echo "check-memory-index-size: ${#OVER_WARN[@]} index(es) over the ${WARN_KIB} KiB target (still loading in full)." >&2
+  echo "  Compact via scripts/memory/compact-memory.py or trim MEMORY.md hooks." >&2
+fi
+
+if (( ${#OVER_HARD[@]} > 0 )); then
+  if [[ "${ALLOW_MEMORY_INDEX_OVERSIZE:-0}" == "1" ]]; then
+    echo "check-memory-index-size: ${#OVER_HARD[@]} oversize index(es); ALLOW_MEMORY_INDEX_OVERSIZE=1 bypass in effect" >&2
+    exit 0
+  fi
+  echo "" >&2
+  echo "check-memory-index-size: ${#OVER_HARD[@]} auto-memory index(es) at/over the ${HARD_KIB} KiB load cap." >&2
+  echo "  Everything past the cap is silently dropped from recall. Compact to under ${WARN_KIB} KiB:" >&2
+  echo "  keep one line per entry, move detail into the topic file, drop/merge stale entries (detail survives in the topic .md files)." >&2
+  echo "  One-shot bypass (logged): ALLOW_MEMORY_INDEX_OVERSIZE=1 ..." >&2
+  exit 1
+fi
+exit 0

--- a/tests/enforcement/test_check_memory_index_size.py
+++ b/tests/enforcement/test_check_memory_index_size.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/enforcement/check-memory-index-size.sh (wh#3366).
+
+Guards the Claude Code auto-memory index (MEMORY.md) against the harness's
+BYTE-size load cap — the gap that let the index silently grow to 52KB and
+drop its long tail from recall while compact-memory.py's LINE-based limit
+(180) never fired.
+
+Fixture strategy: each test writes a MEMORY.md of a controlled byte size to
+tmp_path and invokes the script in positional-args mode (which bypasses the
+~/.claude auto-detect), so tests are hermetic and independent of host state.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "enforcement" / "check-memory-index-size.sh"
+
+
+def _write_index(path: Path, kib: float) -> Path:
+    """Write a MEMORY.md of approximately `kib` KiB using whole index lines."""
+    line = "- [Topic](topic-file.md) — a representative one-line index hook entry\n"
+    target = int(kib * 1024)
+    body = ""
+    while len(body.encode()) < target:
+        body += line
+    path.write_text(body)
+    return path
+
+
+def _run(*args: str, env_extra: dict | None = None):
+    import os
+
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_under_target_passes_quietly(tmp_path: Path):
+    idx = _write_index(tmp_path / "MEMORY.md", kib=10)
+    r = _run(str(idx))
+    assert r.returncode == 0
+    assert r.stderr.strip() == ""
+
+
+def test_over_target_under_cap_warns_but_passes(tmp_path: Path):
+    idx = _write_index(tmp_path / "MEMORY.md", kib=20)  # >17 target, <24 cap
+    r = _run(str(idx))
+    assert r.returncode == 0, r.stderr
+    assert "target" in r.stderr.lower()
+
+
+def test_at_or_over_hard_cap_fails(tmp_path: Path):
+    idx = _write_index(tmp_path / "MEMORY.md", kib=30)  # >= 24 cap
+    r = _run(str(idx))
+    assert r.returncode == 1
+    assert "load cap" in r.stderr.lower()
+    assert "dropped" in r.stderr.lower()
+
+
+def test_bypass_env_downgrades_hard_failure(tmp_path: Path):
+    idx = _write_index(tmp_path / "MEMORY.md", kib=30)
+    r = _run(str(idx), env_extra={"ALLOW_MEMORY_INDEX_OVERSIZE": "1"})
+    assert r.returncode == 0
+    assert "bypass" in r.stderr.lower()
+
+
+def test_custom_thresholds_respected(tmp_path: Path):
+    idx = _write_index(tmp_path / "MEMORY.md", kib=12)
+    # Lower the hard cap below the file size -> should now fail.
+    r = _run("--hard-kib=10", str(idx))
+    assert r.returncode == 1
+
+
+def test_missing_positional_file_is_usage_error(tmp_path: Path):
+    r = _run(str(tmp_path / "does-not-exist.md"))
+    assert r.returncode == 2
+
+
+def test_multiple_indices_one_over_cap_fails(tmp_path: Path):
+    ok = _write_index(tmp_path / "a-MEMORY.md", kib=8)
+    bad = _write_index(tmp_path / "b-MEMORY.md", kib=28)
+    r = _run(str(ok), str(bad))
+    assert r.returncode == 1
+    assert "b-MEMORY.md" in r.stderr
+    assert "a-MEMORY.md" not in r.stderr
+
+
+def test_no_positional_args_never_errors_on_absent_indices(tmp_path: Path):
+    # With no args it scans ~/.claude/projects/*/memory/MEMORY.md; whatever the
+    # host state, the script must not crash (exit 0 or 1, never a bash error).
+    r = _run()
+    assert r.returncode in (0, 1)


### PR DESCRIPTION
Closes the gap that let the auto-memory index silently truncate this week.

**Root cause:** the harness loads `MEMORY.md` up to a ~24.4KB **byte** cap and drops the rest from recall with no error. `scripts/memory/compact-memory.py` triggers on **line count** (`MEMORY_MD_LIMIT=180`) — a handful of very long lines pass that while the byte size blows the load cap (observed 146 lines / 52KB, long tail invisible).

**This PR** adds `scripts/enforcement/check-memory-index-size.sh` (Level-2 per the enforcement gradient):
- Measures **bytes**, not lines.
- Warns at 17 KiB (compaction target), fails at 24 KiB (load cap).
- `ALLOW_MEMORY_INDEX_OVERSIZE=1` bypass; positional-args mode for hermetic tests.
- Scans `~/.claude/projects/*/memory/MEMORY.md` by default; no-op when none present.
- 8 tests (`tests/enforcement/test_check_memory_index_size.py`), all green.

**Follow-ups (noted in #3366):** wire into a session-start / periodic check (the file changes outside git, so pre-commit isn't the firing point), and teach `compact-memory.py` to also rewrite the `MEMORY.md` index by bytes (its rewrite is currently `# not yet implemented`).

Refs #3366