### PR TITLE
feat(enforcement): real gh-auth preflight via gh api user (#3368)

### DIFF
--- a/scripts/enforcement/check-gh-auth.sh
+++ b/scripts/enforcement/check-gh-auth.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# check-gh-auth.sh — wh#3368
+# Verify GitHub auth is REALLY working before a push/PR workflow relies on it.
+#
+# `gh auth status` can report a logged-in ✓ while the stored token is actually
+# invalid — the API then 401s on the first real call. This check hits the API
+# directly (`gh api user`), which is the only reliable signal. Documented
+# incident: memory `ace-linux-2-gh-token-expired` (a whole session's first half
+# lost to a token that `gh auth status` still called good).
+#
+# Usage:
+#   scripts/enforcement/check-gh-auth.sh [--quiet]
+#
+# Exit codes: 0 = authenticated (prints the login unless --quiet);
+#             1 = not authenticated / token invalid;
+#             2 = gh CLI not installed.
+# Override the binary for testing: GH_BIN=/path/to/fake-gh.
+
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+QUIET=0
+case "${1:-}" in
+  --quiet) QUIET=1 ;;
+  "" ) ;;
+  * ) echo "check-gh-auth: unknown flag: $1" >&2; exit 2 ;;
+esac
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+  echo "check-gh-auth: '$GH_BIN' not found on PATH — install the GitHub CLI." >&2
+  exit 2
+fi
+
+# The authoritative probe: an actual authenticated API call. Do NOT trust
+# `gh auth status` — it reads local config and can pass on a dead token.
+if login="$("$GH_BIN" api user -q .login 2>/dev/null)" && [[ -n "$login" ]]; then
+  (( QUIET )) || echo "check-gh-auth: authenticated as $login"
+  exit 0
+fi
+
+echo "check-gh-auth: GitHub auth is NOT working (gh api user failed)." >&2
+echo "  'gh auth status' may still show a stale ✓ — re-authenticate:" >&2
+echo "    gh auth login -h github.com" >&2
+exit 1

--- a/tests/enforcement/test_check_gh_auth.py
+++ b/tests/enforcement/test_check_gh_auth.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/enforcement/check-gh-auth.sh (wh#3368).
+
+The script verifies real GitHub auth via `gh api user` rather than the
+unreliable `gh auth status`. Tests stub the gh binary via the GH_BIN env
+override so they never touch the network or the host's real credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "enforcement" / "check-gh-auth.sh"
+
+
+def _fake_gh(tmp_path: Path, *, login: str | None, exit_code: int = 0) -> Path:
+    """A stub `gh` that emulates `gh api user -q .login`."""
+    body = "#!/usr/bin/env bash\n"
+    if login is not None and exit_code == 0:
+        body += f'printf "%s\\n" "{login}"\nexit 0\n'
+    else:
+        body += f"exit {exit_code}\n"
+    p = tmp_path / "gh"
+    p.write_text(body)
+    p.chmod(0o755)
+    return p
+
+
+def _run(*args: str, gh_bin: str | Path):
+    env = os.environ.copy()
+    env["GH_BIN"] = str(gh_bin)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args], capture_output=True, text=True, env=env
+    )
+
+
+def test_valid_auth_passes_and_prints_login(tmp_path: Path):
+    gh = _fake_gh(tmp_path, login="vamseeachanta")
+    r = _run(gh_bin=gh)
+    assert r.returncode == 0
+    assert "vamseeachanta" in r.stdout
+
+
+def test_quiet_suppresses_login_output(tmp_path: Path):
+    gh = _fake_gh(tmp_path, login="vamseeachanta")
+    r = _run("--quiet", gh_bin=gh)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_invalid_token_fails_with_guidance(tmp_path: Path):
+    # gh present but the API call fails (401) — the stale-status trap.
+    gh = _fake_gh(tmp_path, login=None, exit_code=1)
+    r = _run(gh_bin=gh)
+    assert r.returncode == 1
+    assert "not working" in r.stderr.lower()
+    assert "gh auth login" in r.stderr
+
+
+def test_empty_login_treated_as_failure(tmp_path: Path):
+    gh = _fake_gh(tmp_path, login="")  # exit 0 but empty output
+    r = _run(gh_bin=gh)
+    assert r.returncode == 1
+
+
+def test_missing_gh_binary_is_distinct_exit_code(tmp_path: Path):
+    r = _run(gh_bin=tmp_path / "definitely-not-here")
+    assert r.returncode == 2
+    assert "not found" in r.stderr.lower()
+
+
+def test_unknown_flag_is_usage_error(tmp_path: Path):
+    gh = _fake_gh(tmp_path, login="x")
+    r = _run("--bogus", gh_bin=gh)
+    assert r.returncode == 2


### PR DESCRIPTION
Guard #3 of the friction suite (#3368). `gh auth status` can show a stale ✓ while the token is dead — this probes `gh api user` (the reliable signal), prints the login on success, and points to `gh auth login` on failure. `GH_BIN` override for hermetic tests; 6 tests green; live-verified (`authenticated as vamseeachanta`). Fire it at the top of any push/PR workflow. Refs #3368