### PR TITLE
feat(ci_health): baseline-vs-regression classifier for PR failures (#3368)

### DIFF
--- a/scripts/ci_health/classify-pr-failures.sh
+++ b/scripts/ci_health/classify-pr-failures.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# classify-pr-failures.sh — wh#3368
+# For a PR's FAILING checks, decide which are pre-existing on the base branch
+# (BASELINE — not this PR's fault) vs newly red (REGRESSION — investigate).
+#
+# Automates the manual investigation that recurs on every merge: "is this red
+# check my PR's fault, or already broken on main?" (this session proved it via
+# a throwaway probe PR — #1343). One command instead.
+#
+# Method: pull the PR's failing check names, then the base branch's latest
+# check-runs (?filter=latest) and legacy statuses; for each PR failure, look up
+# the same name on the base:
+#   base red      -> BASELINE    (also broken on main)
+#   base green    -> REGRESSION  (green on main, red on the PR)
+#   base pending  -> UNKNOWN     (main's run hasn't concluded — can't decide)
+#   base absent   -> NEW         (a check the PR introduces)
+#
+# Limitation (conservative by design): the base state is read from the base
+# branch's *latest* commit only. A path-filtered check that didn't run on that
+# commit shows as NEW/UNKNOWN even if it is chronically red — so the tool may
+# under-claim BASELINE, never over-claim it. It never green-lights a merge it
+# cannot prove is baseline. (A future v2 could walk back N base commits for the
+# last concluded run of each check name.)
+#
+# Usage:
+#   scripts/ci_health/classify-pr-failures.sh <pr#> [--repo <owner/name>] [--base <branch>]
+#
+# Exit codes: 0 = every failing check is BASELINE (safe to merge past, per the
+#             standing "non-required-failing" authorization); 1 = at least one
+#             REGRESSION / NEW / UNKNOWN needs a look; 2 = usage/tooling error.
+# Override the binary for testing: GH_BIN=/path/to/fake-gh.
+
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+PR=""
+REPO=""
+BASE=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --repo=*) REPO="${1#*=}"; shift ;;
+    --repo)   REPO="${2:?--repo requires a value}"; shift 2 ;;
+    --base=*) BASE="${1#*=}"; shift ;;
+    --base)   BASE="${2:?--base requires a value}"; shift 2 ;;
+    -*)       echo "classify-pr-failures: unknown flag: $1" >&2; exit 2 ;;
+    *)        if [[ -z "$PR" ]]; then PR="$1"; else echo "classify-pr-failures: unexpected arg: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PR" ]] || { echo "usage: classify-pr-failures.sh <pr#> [--repo owner/name] [--base branch]" >&2; exit 2; }
+command -v "$GH_BIN" >/dev/null 2>&1 || { echo "classify-pr-failures: '$GH_BIN' not found on PATH" >&2; exit 2; }
+
+declare -a REPO_ARGS=()
+if [[ -n "$REPO" ]]; then REPO_ARGS=(--repo "$REPO"); fi
+
+# Resolve repo (owner/name) for the raw API calls if not supplied.
+if [[ -z "$REPO" ]]; then
+  REPO="$("$GH_BIN" repo view --json nameWithOwner -q .nameWithOwner)" \
+    || { echo "classify-pr-failures: could not resolve repo; pass --repo owner/name" >&2; exit 2; }
+fi
+
+# Base branch: explicit, else the PR's base.
+if [[ -z "$BASE" ]]; then
+  BASE="$("$GH_BIN" pr view "$PR" "${REPO_ARGS[@]}" --json baseRefName -q .baseRefName)" \
+    || { echo "classify-pr-failures: could not read PR #$PR base branch" >&2; exit 2; }
+fi
+
+# PR's failing check names.
+mapfile -t PR_FAILURES < <(
+  "$GH_BIN" pr checks "$PR" "${REPO_ARGS[@]}" --json name,state \
+    -q '.[] | select(.state=="FAILURE" or .state=="ERROR") | .name'
+)
+
+if (( ${#PR_FAILURES[@]} == 0 )); then
+  echo "PR #$PR ($REPO): no failing checks."
+  exit 0
+fi
+
+# Base-branch state per check name. Build an associative map name->red|green|pending.
+declare -A BASE_STATE=()
+
+_red_conclusion() { case "$1" in failure|timed_out|cancelled|action_required|startup_failure|stale) return 0;; *) return 1;; esac; }
+_green_conclusion() { case "$1" in success|neutral|skipped) return 0;; *) return 1;; esac; }
+
+# check-runs (GitHub Actions), latest per name.
+while IFS=$'\t' read -r name status conclusion; do
+  [[ -z "$name" ]] && continue
+  if [[ "$status" != "completed" ]]; then
+    state="pending"
+  elif _red_conclusion "$conclusion"; then
+    state="red"
+  elif _green_conclusion "$conclusion"; then
+    state="green"
+  else
+    state="pending"
+  fi
+  # First (latest) wins; don't overwrite a decided state with a later duplicate.
+  if [[ -z "${BASE_STATE[$name]:-}" ]]; then BASE_STATE["$name"]="$state"; fi
+done < <(
+  "$GH_BIN" api "repos/$REPO/commits/$BASE/check-runs?filter=latest" --paginate \
+    -q '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv' 2>/dev/null || true
+)
+
+# Legacy commit statuses (e.g. some app contexts) — only fill gaps.
+while IFS=$'\t' read -r context cstate; do
+  [[ -z "$context" ]] && continue
+  [[ -n "${BASE_STATE[$context]:-}" ]] && continue
+  case "$cstate" in
+    success) BASE_STATE["$context"]="green" ;;
+    failure|error) BASE_STATE["$context"]="red" ;;
+    *) BASE_STATE["$context"]="pending" ;;
+  esac
+done < <(
+  "$GH_BIN" api "repos/$REPO/commits/$BASE/status" \
+    -q '.statuses[] | [.context, .state] | @tsv' 2>/dev/null || true
+)
+
+echo "PR #$PR ($REPO) failing checks vs base '$BASE':"
+n_baseline=0; n_regression=0; n_new=0; n_unknown=0
+for name in "${PR_FAILURES[@]}"; do
+  case "${BASE_STATE[$name]:-absent}" in
+    red)     label="BASELINE  "; n_baseline=$((n_baseline + 1)) ;;
+    green)   label="REGRESSION"; n_regression=$((n_regression + 1)) ;;
+    pending) label="UNKNOWN   "; n_unknown=$((n_unknown + 1)) ;;
+    *)       label="NEW       "; n_new=$((n_new + 1)) ;;
+  esac
+  printf '  %s  %s\n' "$label" "$name"
+done
+
+echo "Summary: ${n_baseline} baseline, ${n_regression} regression, ${n_new} new, ${n_unknown} unknown"
+if (( n_regression == 0 && n_new == 0 && n_unknown == 0 )); then
+  echo "  → all failures are pre-existing on '$BASE' (baseline-red); safe to merge past per the non-required-failing policy."
+  exit 0
+fi
+echo "  → not all failures are baseline; investigate the regression/new/unknown checks before merging." >&2
+exit 1

--- a/tests/enforcement/test_classify_pr_failures.py
+++ b/tests/enforcement/test_classify_pr_failures.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/ci_health/classify-pr-failures.sh (wh#3368).
+
+Classifies a PR's failing checks as BASELINE (also red on the base branch) vs
+REGRESSION / NEW / UNKNOWN. Tests stub `gh` via GH_BIN with a dispatcher that
+serves per-call fixtures from a temp dir — no network, no real repo state.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci_health" / "classify-pr-failures.sh"
+
+FAKE_GH = r"""#!/usr/bin/env bash
+# Dispatch on the call type; emit the matching fixture file (already in the
+# shape the real `gh ... -q` would produce). Missing fixture -> empty output.
+args="$*"
+d="$FAKE_DIR"
+emit() { [[ -f "$d/$1" ]] && cat "$d/$1" || true; }
+case "$args" in
+  *"pr checks"*)             emit pr_checks ;;
+  *"check-runs"*)            emit check_runs ;;
+  *"commits/"*"/status"*)    emit status ;;
+  *"pr view"*)               emit base ;;
+  *"repo view"*)             emit repo ;;
+  *)                         exit 0 ;;
+esac
+"""
+
+
+def _make_gh(tmp_path: Path, *, pr_checks="", check_runs="", status="", base="main",
+             repo="vamseeachanta/digitalmodel") -> tuple[Path, dict]:
+    d = tmp_path / "fx"
+    d.mkdir()
+    (d / "pr_checks").write_text(pr_checks)
+    (d / "check_runs").write_text(check_runs)
+    (d / "status").write_text(status)
+    (d / "base").write_text(base + "\n")
+    (d / "repo").write_text(repo + "\n")
+    gh = tmp_path / "gh"
+    gh.write_text(FAKE_GH)
+    gh.chmod(0o755)
+    return gh, {"FAKE_DIR": str(d)}
+
+
+def _run(*args, gh_bin, env_extra):
+    env = os.environ.copy()
+    env["GH_BIN"] = str(gh_bin)
+    env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args], capture_output=True, text=True, env=env
+    )
+
+
+def test_all_failures_baseline_passes(tmp_path: Path):
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="Atlas staleness check\nCI harness and compliance tests\n",
+        check_runs=(
+            "Atlas staleness check\tcompleted\tfailure\n"
+            "CI harness and compliance tests\tcompleted\tfailure\n"
+            "tests-subsea\tcompleted\tsuccess\n"
+        ),
+    )
+    r = _run("1343", "--repo", "vamseeachanta/digitalmodel", "--base", "main",
+             gh_bin=gh, env_extra=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "2 baseline, 0 regression" in r.stdout
+    assert "BASELINE" in r.stdout
+
+
+def test_regression_detected_fails(tmp_path: Path):
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="tests-foo\nAtlas staleness check\n",
+        check_runs=(
+            "tests-foo\tcompleted\tsuccess\n"          # green on main -> regression
+            "Atlas staleness check\tcompleted\tfailure\n"
+        ),
+    )
+    r = _run("42", "--repo", "o/r", "--base", "main", gh_bin=gh, env_extra=env)
+    assert r.returncode == 1
+    assert "REGRESSION" in r.stdout
+    assert "1 regression" in r.stdout
+
+
+def test_new_check_absent_on_base_fails(tmp_path: Path):
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="brand-new-check\n",
+        check_runs="tests-subsea\tcompleted\tsuccess\n",  # name not present
+    )
+    r = _run("42", "--repo", "o/r", "--base", "main", gh_bin=gh, env_extra=env)
+    assert r.returncode == 1
+    assert "NEW" in r.stdout
+
+
+def test_pending_on_base_is_unknown(tmp_path: Path):
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="Run Quality Gates\n",
+        check_runs="Run Quality Gates\tin_progress\t\n",  # not concluded
+    )
+    r = _run("42", "--repo", "o/r", "--base", "main", gh_bin=gh, env_extra=env)
+    assert r.returncode == 1
+    assert "UNKNOWN" in r.stdout
+
+
+def test_no_failures_passes(tmp_path: Path):
+    gh, env = _make_gh(tmp_path, pr_checks="")
+    r = _run("42", "--repo", "o/r", "--base", "main", gh_bin=gh, env_extra=env)
+    assert r.returncode == 0
+    assert "no failing checks" in r.stdout
+
+
+def test_legacy_status_context_classifies_baseline(tmp_path: Path):
+    # check-runs empty; the failing context only appears in legacy statuses.
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="security/scan\n",
+        check_runs="",
+        status="security/scan\tfailure\n",
+    )
+    r = _run("42", "--repo", "o/r", "--base", "main", gh_bin=gh, env_extra=env)
+    assert r.returncode == 0
+    assert "BASELINE" in r.stdout
+
+
+def test_base_inferred_from_pr_when_not_passed(tmp_path: Path):
+    gh, env = _make_gh(
+        tmp_path,
+        pr_checks="Atlas staleness check\n",
+        check_runs="Atlas staleness check\tcompleted\tfailure\n",
+        base="develop",
+    )
+    r = _run("42", "--repo", "o/r", gh_bin=gh, env_extra=env)  # no --base
+    assert r.returncode == 0
+    assert "base 'develop'" in r.stdout
+
+
+def test_missing_pr_arg_is_usage_error(tmp_path: Path):
+    gh, env = _make_gh(tmp_path)
+    r = _run("--repo", "o/r", gh_bin=gh, env_extra=env)
+    assert r.returncode == 2


### PR DESCRIPTION
Guard #2 of the friction suite (#3368) — the highest day-to-day payoff.

Automates the merge-time question that recurred all session: **"is this red check my PR's fault, or already broken on `main`?"** This session answered it by hand with a throwaway probe PR (#1343). Now:

```
scripts/ci_health/classify-pr-failures.sh <pr#> [--repo o/n] [--base branch]
```

Pulls the PR's failing checks + the base branch's latest check-runs & statuses, labels each **BASELINE / REGRESSION / NEW / UNKNOWN**, and exits 0 iff every failure is baseline (safe to merge past per the non-required-failing policy), else 1.

**Conservative by design:** reads the base branch's *latest* commit, so a path-filtered check absent there shows `NEW`/`UNKNOWN` rather than being wrongly called baseline — it under-claims baseline, never over-claims, and never green-lights a merge it can't prove. A v2 could walk back N base commits per check name.

`GH_BIN` override for hermetic tests (8 cases, green). **Live-verified**: on dm#1343 it correctly labels `Atlas staleness check` → BASELINE; on wh#3367 it flagged a real pre-existing `skill-index-full.yaml` staleness (see note below).

Refs #3368