### PR TITLE
fix(kanban): skip unresolvable repos in reconcile instead of crashing (#3380)

### DIFF
--- a/scripts/kanban/reconcile.py
+++ b/scripts/kanban/reconcile.py
@@ -49,6 +49,7 @@ class ReconcileResult:
     changed_files: list[Path]
     oversized: list[tuple[str, int]] = field(default_factory=list)
     count_drift: list[tuple[str, int, int]] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -434,6 +435,17 @@ def unified_diff(before: dict[Path, str], after: dict[Path, str], root: Path) ->
     return "".join(chunks)
 
 
+def _is_unresolvable_repo_error(exc: Exception) -> bool:
+    """True only for the 'repo renamed/removed/no access' fetch failure.
+
+    Scoped narrowly to the GraphQL "Could not resolve to a Repository" message
+    so that transient failures (rate limit, network, auth) are NOT swallowed —
+    those must still raise and fail the reconcile rather than silently drop a
+    repo's board. See #3380.
+    """
+    return "could not resolve to a repository" in str(exc).lower()
+
+
 def build_live_cards(
     repos: list[str],
     issue_fetcher: Callable[[str], list[dict]],
@@ -443,10 +455,26 @@ def build_live_cards(
     existing_counts: dict[str, int],
     allow_empty_repos: set[str],
     allow_shrink_repos: set[str],
-) -> dict[str, tuple[Path, dict]]:
+) -> tuple[dict[str, tuple[Path, dict]], list[str]]:
     live = {}
+    skipped: list[str] = []
     for repo in repos:
-        issues = issue_fetcher(repo)
+        try:
+            issues = issue_fetcher(repo)
+        except RuntimeError as exc:
+            if _is_unresolvable_repo_error(exc):
+                # Repo was renamed/removed (or the token lost access). Skip it and
+                # leave its board untouched — do NOT let one dead repo wedge the
+                # whole reconcile. It is excluded from the active-rebuild set by
+                # the caller so its existing cards are preserved verbatim. #3380
+                print(
+                    f"WARNING: skipping {repo}: repository not resolvable "
+                    "(renamed/removed/no access)",
+                    file=sys.stderr,
+                )
+                skipped.append(repo)
+                continue
+            raise
         existing_count = existing_counts.get(repo, 0)
         if len(issues) < existing_count:
             if not issues and repo in allow_empty_repos:
@@ -470,7 +498,7 @@ def build_live_cards(
             card = card_for_issue(repo, issue, existing.get(key))
             board = target_board(repo, card["gh_labels"], repo_boards, domain_boards)
             live[key] = (board, card)
-    return live
+    return live, skipped
 
 
 def rebuild_boards(
@@ -525,7 +553,7 @@ def reconcile_kanban(
     board_data = {path: load_yaml(path) for path in files}
     before = {path: path.read_text(encoding="utf-8") for path in files}
     existing = existing_cards(board_data, files)
-    live = build_live_cards(
+    live, skipped = build_live_cards(
         repos,
         issue_fetcher,
         repo_boards,
@@ -535,7 +563,12 @@ def reconcile_kanban(
         allow_empty_repos or set(),
         allow_shrink_repos or set(),
     )
-    rebuilt = rebuild_boards(board_data, files, set(repos), live)
+    # A skipped (unresolvable) repo must be EXCLUDED from the active-rebuild set,
+    # otherwise rebuild_boards would drop its existing github_issue cards (they are
+    # absent from `live`) and silently empty its board. Excluding it preserves the
+    # board verbatim. #3380
+    active_for_rebuild = set(repos) - set(skipped)
+    rebuilt = rebuild_boards(board_data, files, active_for_rebuild, live)
     after = {}
     for path in files:
         after[path] = before[path] if rebuilt[path] == board_data[path] else dump_yaml(rebuilt[path])
@@ -550,6 +583,7 @@ def reconcile_kanban(
         changed_files=changed_files,
         oversized=board_size_report(rebuilt, limit=size_limit),
         count_drift=card_count_drift(rebuilt, entries),
+        skipped=skipped,
     )
 
 
@@ -615,6 +649,15 @@ def main(argv: list[str] | None = None) -> int:
         print("kanban reconcile: no changes")
     if args.dry_run:
         print("DRY-RUN: no files written")
+
+    # Surface unresolvable repos that were skipped (renamed/removed/no access).
+    # Informational — the run still succeeds for every resolvable repo. #3380
+    if result.skipped:
+        print(
+            f"\nNOTE: skipped {len(result.skipped)} unresolvable repo(s): "
+            f"{', '.join(result.skipped)}",
+            file=sys.stderr,
+        )
 
     # On-demand card_count recompute (writes manifest.yaml; skipped in dry-run).
     counts_fixed = False

--- a/tests/test_kanban_reconcile.py
+++ b/tests/test_kanban_reconcile.py
@@ -671,3 +671,139 @@ def test_workflow_contract_keeps_phase_2_cron_active_and_push_retry_bounded():
     assert "non-fast-forward" in run
     assert "fetch first" in run
     assert "git pull --rebase" not in run
+
+
+# --- #3380: an unresolvable repo (renamed/removed) must be skipped, not crash ---
+
+UNRESOLVABLE_MSG = (
+    "gh api graphql failed for vamseeachanta/gone-repo (cursor=None): "
+    "GraphQL: Could not resolve to a Repository with the name "
+    "'vamseeachanta/gone-repo'. (repository)"
+)
+
+
+def seed_two_repo_kanban(root: Path) -> Path:
+    """Manifest with two repo-tier boards — one resolvable, one renamed away."""
+    kanban = root / ".claude/memory/kanban"
+    write_yaml(
+        kanban / "manifest.yaml",
+        {
+            "manifest": {
+                "boards": [
+                    {
+                        "slug": "repo-workspace-hub",
+                        "tier": "repo",
+                        "repo": "vamseeachanta/workspace-hub",
+                        "file": "boards/repo-workspace-hub.yaml",
+                    },
+                    {
+                        "slug": "repo-gone",
+                        "tier": "repo",
+                        "repo": "vamseeachanta/gone-repo",
+                        "file": "boards/repo-gone.yaml",
+                    },
+                ]
+            }
+        },
+    )
+    write_yaml(
+        kanban / "boards/repo-workspace-hub.yaml",
+        {
+            "board": {
+                "slug": "repo-workspace-hub",
+                "tier": "repo",
+                "repo": "vamseeachanta/workspace-hub",
+            },
+            "cards": [],
+        },
+    )
+    write_yaml(
+        kanban / "boards/repo-gone.yaml",
+        {
+            "board": {
+                "slug": "repo-gone",
+                "tier": "repo",
+                "repo": "vamseeachanta/gone-repo",
+            },
+            "cards": [
+                {
+                    "idempotency_key": "gh:vamseeachanta/gone-repo#1",
+                    "title": "card on unresolvable repo must survive the skip",
+                    "source": "github_issue",
+                    "source_url": "https://github.com/vamseeachanta/gone-repo/issues/1",
+                    "gh_state": "open",
+                    "gh_labels": [],
+                    "initial_status": "triage",
+                    "priority": 0,
+                }
+            ],
+        },
+    )
+    return kanban
+
+
+def test_reconcile_skips_unresolvable_repo_and_leaves_board_untouched(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    reconcile = load_reconcile()
+    kanban = seed_two_repo_kanban(tmp_path)
+    gone_board = kanban / "boards/repo-gone.yaml"
+    before = gone_board.read_bytes()
+
+    def fetcher(repo: str) -> list[dict]:
+        if repo == "vamseeachanta/gone-repo":
+            raise RuntimeError(UNRESOLVABLE_MSG)
+        return [issue(2802, "fresh issue")]
+
+    result = reconcile.reconcile_kanban(kanban, issue_fetcher=fetcher, dry_run=False)
+
+    assert result.skipped == ["vamseeachanta/gone-repo"]
+    err = capsys.readouterr().err
+    assert "WARNING: skipping vamseeachanta/gone-repo" in err
+    assert "not resolvable" in err
+    # the skipped repo's board is untouched — its cards survive
+    assert gone_board.read_bytes() == before
+    # the resolvable repo still reconciled
+    keys = [
+        card["idempotency_key"]
+        for card in read_yaml(kanban / "boards/repo-workspace-hub.yaml")["cards"]
+    ]
+    assert keys == ["gh:vamseeachanta/workspace-hub#2802"]
+
+
+def test_reconcile_other_fetch_errors_still_raise(tmp_path: Path):
+    # Only the resolve-failure class is skippable; rate limit / network / auth
+    # errors must still fail the reconcile (no silent partial state).
+    reconcile = load_reconcile()
+    kanban = seed_two_repo_kanban(tmp_path)
+
+    def fetcher(repo: str) -> list[dict]:
+        if repo == "vamseeachanta/gone-repo":
+            raise RuntimeError(
+                "gh api graphql failed for vamseeachanta/gone-repo "
+                "(cursor=None): API rate limit exceeded"
+            )
+        return [issue(2802, "fresh issue")]
+
+    with pytest.raises(RuntimeError, match="rate limit"):
+        reconcile.reconcile_kanban(kanban, issue_fetcher=fetcher, dry_run=True)
+
+
+def test_main_exits_zero_and_prints_skip_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    reconcile = load_reconcile()
+    kanban = seed_two_repo_kanban(tmp_path)
+
+    def fake_fetch(repo: str, *, page_size: int = 100, runner=None) -> list[dict]:
+        if repo == "vamseeachanta/gone-repo":
+            raise RuntimeError(UNRESOLVABLE_MSG)
+        return [issue(2802, "fresh issue")]
+
+    monkeypatch.setattr(reconcile, "fetch_repo_issues", fake_fetch)
+
+    rc = reconcile.main(["--kanban-root", str(kanban)])
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "skipped 1 unresolvable repo(s): vamseeachanta/gone-repo" in err


### PR DESCRIPTION
Closes #3380.

## Root cause
Kanban Reconcile failed 5 consecutive scheduled runs (28701912703 and prior). `scripts/kanban/reconcile.py` raised an unhandled `RuntimeError` when `gh api graphql` could not resolve one manifest repo ("Could not resolve to a Repository") — a repo that was renamed/removed (or the token lost access). Because the error aborted the whole batch, **no** repo's board reconciled and issue↔board state silently drifted the entire time the workflow was red.

## Fix (runtime resilience)
A `Could not resolve to a Repository` fetch failure now **skips that one repo** with a stderr warning and continues. Critically, the skipped repo is excluded from the active-rebuild set, so `rebuild_boards` preserves its existing board cards **verbatim** instead of dropping them as stale. Every other error class (rate limit, network, auth, malformed pagination) **still raises** — no silent partial state. `main()` prints a skip summary and exits 0 when the resolvable repos reconciled.

## TDD
3 new tests in `tests/test_kanban_reconcile.py`:
- skip + board preserved byte-for-byte + resolvable repo still reconciles
- non-resolve errors (rate limit) still raise
- `main()` exits 0 and prints the skip summary

Full file: **24 passed**.

## Scope note (deliberate)
The offending manifest entry is **left in place**. Its board holds real cards, so removing the entry would re-trigger the `validate_unmanifested_boards` guard (a second crash), and the repo slug **cannot be corrected in this public repo** without surfacing a private client identifier. The runtime skip neutralizes the crash regardless of the entry's presence. Whether to retire that entry / relocate its board to a private kanban surface is a data + privacy decision for the owner, not an autonomous CI fix — flagged on #3380.

Do not squash-merge until CI is green on the PR.
