### PR TITLE
feat(slim-git-history): content-parity gate so a rewrite can't silently drop merged work

### DIFF
--- a/.claude/skills/devops/slim-git-history/SKILL.md
+++ b/.claude/skills/devops/slim-git-history/SKILL.md
@@ -17,6 +17,12 @@ digitalmodel #1142 pattern). Works per-repo; repeat across repos.
   (client reports, datasets) are often deliberately version-controlled. The
   TRACKED-vs-GONE classification in step 1 exists to prevent this.
 - **Always back up before any rewrite** (mirror clone or `git bundle`).
+- **A blob-strip must leave `HEAD`'s tree byte-identical.** It only removes
+  already-deleted (GONE) blobs, so the *current* tree cannot change. Verify this
+  with the **content-parity gate** (`analyze-repo-bloat.sh --verify-parity`, step 6)
+  BEFORE the force-push — a non-zero exit means the rewrite dropped a live
+  deliverable. This is the guard that would have caught the 2026-06 slim silently
+  dropping digitalmodel #989 (the DNV-OS-F101 module) from `main`.
 - The **non-rewrite wins (step 2) are always safe** — do them regardless, even if
   the rewrite is deferred.
 
@@ -87,9 +93,15 @@ The agent stops here and hands the operator this sequence:
 ```
 git clone --mirror <repo> ../<repo>-backup.git     # 1. backup
 git filter-repo <planned args>                      # 2. rewrite (in a fresh clone)
-git push --force --all && git push --force --tags    # 3. force-push (OPERATOR)
-git gc --prune=now --aggressive                      # 4. reclaim locally
+# 3. CONTENT-PARITY GATE — must print PASS (exit 0) before pushing (#989 guard):
+bash <workspace-hub>/.claude/skills/devops/slim-git-history/scripts/analyze-repo-bloat.sh \
+     --verify-parity ../<repo>-backup.git .
+git push --force --all && git push --force --tags    # 4. force-push (OPERATOR) — only after PASS
+git gc --prune=now --aggressive                      # 5. reclaim locally
 ```
+> If step 3 prints **FAIL**, the rewrite dropped a still-tracked file — **stop, do
+> not push**, and narrow the filter (a `--strip-blobs-bigger-than` threshold that
+> also caught a TRACKED deliverable is the usual cause; switch to `--path`).
 
 ## Step 5 — Coordination (shared-repo hazards)
 
@@ -103,9 +115,18 @@ git gc --prune=now --aggressive                      # 4. reclaim locally
 ## Step 6 — Verify
 
 ```
+# CONTENT PARITY (the load-bearing check — run BEFORE force-push, gates it):
+analyze-repo-bloat.sh --verify-parity ../<repo>-backup.git .   # must print PASS
 du -sh .git              # confirm shrink
 git fsck --full          # integrity
 git clone <remote> /tmp/smoke && cd /tmp/smoke && git log --oneline -1   # fresh-clone smoke test
 ```
+
+**Why parity is first:** `du`/`fsck`/smoke-test confirm the repo is *smaller* and
+*internally intact* — but a rewrite that silently dropped a merged deliverable
+passes all three (it's smaller, it fsck's clean, it clones). Only the parity gate
+compares the live `HEAD` tree against the pre-rewrite backup and fails when a
+tracked file vanished. A GONE-blob strip must leave the tree byte-identical; any
+diff is a dropped deliverable (the digitalmodel #989 failure mode).
 
 See [scripts/analyze-repo-bloat.sh](scripts/analyze-repo-bloat.sh) for the analysis details.

--- a/.claude/skills/devops/slim-git-history/scripts/analyze-repo-bloat.sh
+++ b/.claude/skills/devops/slim-git-history/scripts/analyze-repo-bloat.sh
@@ -6,6 +6,40 @@
 # Usage: analyze-repo-bloat.sh [repo-path] [top-N]
 # Never writes to the repo. Heavy on large repos (walks all history) — give it time.
 set -euo pipefail
+
+# --------------------------------------------------------------------------- #
+# Post-rewrite content-parity gate (SKILL.md step 6).
+# A GONE-blob strip MUST leave the live HEAD tree byte-identical — it only removes
+# already-deleted historical blobs. If HEAD's tree changed, the rewrite dropped a
+# still-tracked deliverable: the failure mode that silently lost digitalmodel #989
+# (the DNV-OS-F101 module) in the 2026-06 history slim.
+# Run AFTER filter-repo, BEFORE the operator force-pushes; a non-zero exit gates it.
+#   analyze-repo-bloat.sh --verify-parity <pre-rewrite-backup> <post-rewrite-live>
+# --------------------------------------------------------------------------- #
+if [ "${1:-}" = "--verify-parity" ]; then
+  BACKUP="${2:?usage: --verify-parity <pre-rewrite-backup-repo> <post-rewrite-live-repo>}"
+  LIVE="${3:?usage: --verify-parity <pre-rewrite-backup-repo> <post-rewrite-live-repo>}"
+  bt="$(git -C "$BACKUP" rev-parse 'HEAD^{tree}')" \
+    || { echo "cannot read backup HEAD tree: $BACKUP" >&2; exit 2; }
+  lt="$(git -C "$LIVE" rev-parse 'HEAD^{tree}')" \
+    || { echo "cannot read live HEAD tree: $LIVE" >&2; exit 2; }
+  echo "== content-parity gate: pre-rewrite backup vs post-rewrite live =="
+  echo "  backup HEAD tree: $bt"
+  echo "  live   HEAD tree: $lt"
+  if [ "$bt" = "$lt" ]; then
+    echo "  >> PASS: live tree is byte-identical — the strip dropped no tracked"
+    echo "     deliverable. Safe to force-push."
+    exit 0
+  fi
+  echo "  >> FAIL: the rewrite CHANGED the live tree. Paths present in the backup but"
+  echo "     dropped or altered in the rewritten repo (must be EMPTY for a blob-strip):"
+  diff <(git -C "$BACKUP" -c core.quotePath=false ls-tree -r HEAD | sort) \
+       <(git -C "$LIVE" -c core.quotePath=false ls-tree -r HEAD | sort) \
+    | grep '^<' | sed 's/^< /       /' | head -50 || true
+  echo "  >> DO NOT force-push. A GONE-blob strip must leave HEAD's tree unchanged."
+  exit 1
+fi
+
 REPO="${1:-.}"
 TOPN="${2:-30}"
 cd "$REPO"

--- a/config/agents/skill-index-full.yaml
+++ b/config/agents/skill-index-full.yaml
@@ -1378,6 +1378,12 @@ skills:
   name: xlsx
   when_to_use: '- Reading and analyzing Excel data with pandas - Creating formatted spreadsheets programmatically - Building financial models with formulas - Generating reports with charts and graphs - Automating data entry and updates - Converting between Excel and other formats - Batch processing multiple spreadsheets - Creating templates for repeated use'
   when_to_use_source: section
+- description: Surface SPECIFIC FILES on the shared drives (/mnt/ace, /mnt/dde) relevant to the current task — the FILE-level complement to ecosystem-data-sources (domain-catalog level). Extracts query terms from work context, runs the drive-index CLI once, presents ranked canonical paths with freshness caveats. Use for similar-past-work, prior-project, or files/examples/precedent asks; when domain work needs past deliverables (mooring calc → xlsx/py; CAD → dwg/step; standards → PDF inventory).
+  family: data
+  id: data/drive-file-search
+  name: drive-file-search
+  when_to_use: drive-file-search Surface SPECIFIC FILES on the shared drives (/mnt/ace, /mnt/dde) relevant to the current task — the FILE-level complement to ecosystem-data-sources (domain-catalog level). Extracts query terms from work context, runs the drive-index CLI once, presents ranked canonical paths with freshness caveats. Use for similar-past-work, prior-project, or files/examples/precedent asks; when domain work needs past deliverables (mooring calc → xlsx/py; CAD → dwg/step; standards → PDF inventory). data
+  when_to_use_source: backfill
 - description: Proactively surface what DATA the ecosystem already has for an engineering domain — before starting analysis, points to the consolidated data-source catalog, any latent ACE_SHARE project precedent, and the domain-database issue that curates it. Use when work touches an engineering domain (riser, mooring, pipeline, structural/FFS, naval-arch/hydro, metocean, materials, production, geotech, drilling, CAD/sim, or financial/asset), when someone asks 'do we have data for X', 'where do we get X data', 'build the X database', or before implementing a calculation that needs reference data.
   family: data
   id: data/ecosystem-data-sources


### PR DESCRIPTION
## Root cause this closes
The 2026-06 digitalmodel history slim dropped merged PR **#989** (the DNV-OS-F101 module) from `main` — **invisibly**. The rewrite shrank cleanly, passed `git fsck`, and cloned fine, so the skill's Step-6 checks (`du`/`fsck`/smoke-test) all passed. None of them verify that no *tracked deliverable* was lost. (Surfaced during a backup-branch audit; #989 re-landed via digitalmodel#1435.)

## The fix — a content-parity gate
A GONE-blob strip only removes **already-deleted** blobs, so the live `HEAD` tree **must stay byte-identical**. The gate asserts exactly that:

```
analyze-repo-bloat.sh --verify-parity <pre-rewrite-backup> <post-rewrite-live>
```
- Compares `HEAD^{tree}` of the backup mirror vs the rewritten repo.
- **PASS** (identical) → exit 0, safe to force-push.
- **FAIL** (tree changed) → names the dropped/altered paths, exit 1 → **gates the operator force-push**.

Wired into **Step 4** (runs before the force-push) and **Step 6** (as the load-bearing check, with a note on why `du`/`fsck`/smoke-test miss this failure mode), plus a new non-negotiable safety rule.

## Verification
- `bash -n` clean; **shellcheck clean**
- PASS case (identical trees) → exit 0
- FAIL case (dropped `b.txt`) → names it, exit 1
- usage guard (missing args) → exit 1
- default analyzer mode unchanged (no regression)

Non-code change to an operator skill; agent does not force-push or self-merge.