### PR TITLE
feat(ops): merge-when-CLEAN babysitter script (#3390 item 6)

### DIFF
--- a/.claude/rules/model-routing.md
+++ b/.claude/rules/model-routing.md
@@ -19,7 +19,7 @@
 2. **Review economics:** r1 plan/code reviews go to cheaper lanes (Codex/Sonnet); premium models only for r2+ or T2-scope reviews.
 3. **Start-of-task grounding:** before building, verify the working branch against `origin/main` and the issue/PR state (`gh issue view` / `gh pr list --search`) — see `feedback_check_issue_state_before_implementing_on_detached_head` and `feedback_verify_generated_state_against_origin_not_working_copy`.
 4. **Self-merge:** governed by [`merge-authorization.md`](merge-authorization.md) — default is verify green + hand the human the command; agent-run merges only under an explicit, per-PR, non-sticky authorization (owner-adopted policy, #3390 item 4).
-5. **Automate waiting:** if you catch yourself polling a merge or a slow op in the foreground, switch to a background watcher immediately — don't re-derive this per session.
+5. **Automate waiting:** if you catch yourself polling a merge or a slow op in the foreground, switch to a background watcher immediately — don't re-derive this per session. Canonical merge babysitter (Level 2 per [`patterns.md`](patterns.md)): `scripts/operations/merge-when-clean.sh <pr> [--repo owner/name]` — watch-only by default, prints the merge command on CLEAN; `--merge` only under an explicit per-PR authorization ([`merge-authorization.md`](merge-authorization.md)).
 
 **Do NOT apply when:** the user explicitly names the model/provider for a task — their directive wins.
 

--- a/scripts/operations/merge-when-clean.sh
+++ b/scripts/operations/merge-when-clean.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# merge-when-clean.sh — PR merge babysitter (workspace-hub#3390 item 6)
+#
+# Canonizes the merge-when-CLEAN pattern re-derived by hand in multiple sessions
+# (wed#771 2026-07-04 ruleset race; Spain-chain "quiet-gate" 2026-07-05): on a
+# churning main with strict-up-to-date rulesets, the only reliable CLI merge is
+# to wait for GitHub's own mergeStateStatus==CLEAN — never hand-count checks
+# (a MISSING required check reads as "not pending" = false green) and never
+# update-branch in a loop (cancels queued CI -> livelock). See
+# .claude/rules/model-routing.md corollary 5 and MEMORY
+# feedback_dependabot_merge_no_rebase_trust_clean.
+#
+# DEFAULT IS WATCH-ONLY: it prints the merge command when the PR goes CLEAN.
+# --merge actually merges, and per .claude/rules/merge-authorization.md that
+# flag may only be passed with an explicit, per-PR human authorization
+# (non-sticky: one authorized run never covers the next PR).
+#
+# Usage:
+#   merge-when-clean.sh <pr-number> [--repo owner/name] [--merge]
+#                       [--interval SECONDS] [--timeout MINUTES] [--once]
+#
+# Exit codes: 0 merged or CLEAN reported | 2 conflict (DIRTY, needs human)
+#             3 timed out | 4 PR closed without merge | 5 usage/gh error
+
+set -euo pipefail
+
+PR="" REPO="" DO_MERGE=0 INTERVAL=60 TIMEOUT_MIN=120 ONCE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)     REPO="$2"; shift 2 ;;
+    --merge)    DO_MERGE=1; shift ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --timeout)  TIMEOUT_MIN="$2"; shift 2 ;;
+    --once)     ONCE=1; shift ;;
+    -h|--help)  grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)         echo "unknown flag: $1" >&2; exit 5 ;;
+    *)          PR="$1"; shift ;;
+  esac
+done
+
+[ -n "$PR" ] || { echo "usage: merge-when-clean.sh <pr-number> [--repo owner/name] [--merge] [--interval s] [--timeout min] [--once]" >&2; exit 5; }
+REPO_ARGS=()
+[ -n "$REPO" ] && REPO_ARGS=(--repo "$REPO")
+
+deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+
+while :; do
+  read -r state status <<<"$(gh pr view "$PR" "${REPO_ARGS[@]}" --json state,mergeStateStatus \
+      -q '"\(.state) \(.mergeStateStatus)"')" || { echo "gh pr view failed" >&2; exit 5; }
+  ts=$(date -u +%H:%M:%SZ)
+
+  case "$state" in
+    MERGED) echo "[$ts] PR #$PR already MERGED — nothing to do."; exit 0 ;;
+    CLOSED) echo "[$ts] PR #$PR is CLOSED without merge." >&2; exit 4 ;;
+  esac
+
+  case "$status" in
+    CLEAN)
+      if [ "$DO_MERGE" -eq 1 ]; then
+        echo "[$ts] PR #$PR CLEAN — merging (authorized per-PR, merge-authorization.md)."
+        gh pr merge "$PR" "${REPO_ARGS[@]}" --squash --delete-branch
+        # verify MERGED on the remote — do not trust the exit code alone
+        for _ in 1 2 3 4 5; do
+          sleep 3
+          [ "$(gh pr view "$PR" "${REPO_ARGS[@]}" --json state -q .state)" = "MERGED" ] && {
+            echo "[$(date -u +%H:%M:%SZ)] PR #$PR verified MERGED on remote."; exit 0; }
+        done
+        echo "merge command ran but PR #$PR is not MERGED on remote — investigate." >&2; exit 5
+      else
+        echo "[$ts] PR #$PR is CLEAN. Watch-only mode — run:"
+        echo "  gh pr merge $PR --squash --delete-branch ${REPO:+--repo $REPO}"
+        exit 0
+      fi ;;
+    DIRTY)
+      echo "[$ts] PR #$PR has CONFLICTS (DIRTY) — needs rebase/regeneration by a human or the owning session." >&2
+      exit 2 ;;
+    *)
+      # BLOCKED / BEHIND / UNSTABLE / UNKNOWN: GitHub state is still settling or
+      # main is churning. Do NOT update-branch here — wait for CLEAN.
+      echo "[$ts] PR #$PR state=$state mergeStateStatus=$status — waiting ${INTERVAL}s." ;;
+  esac
+
+  [ "$ONCE" -eq 1 ] && exit 0
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "timed out after ${TIMEOUT_MIN} min (last status: $status)" >&2; exit 3; }
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Closes item 6 of #3390 — canonizes the merge-babysitter pattern that sessions kept re-deriving by hand (wed#771 ruleset race 2026-07-04; Spain-chain quiet-gate 2026-07-05).

`scripts/operations/merge-when-clean.sh <pr> [--repo owner/name] [--merge] [--interval s] [--timeout min] [--once]`

- Trusts only GitHub's `mergeStateStatus==CLEAN` — never hand-counted checks (a MISSING required check reads as false green), never `update-branch` in a loop (cancels queued CI → livelock). Per `feedback_dependabot_merge_no_rebase_trust_clean`.
- **Watch-only by default**: prints the merge command when CLEAN. `--merge` is gated by `.claude/rules/merge-authorization.md` (explicit per-PR authorization) and post-verifies MERGED on the remote.
- Exit codes distinguish merged/CLEAN (0), conflict (2), timeout (3), closed-unmerged (4), usage (5).
- `model-routing.md` corollary 5 now points at it (Level-2 per the enforcement gradient).

Tested live (non-mutating): merged PR → exit 0 'already MERGED'; open BLOCKED and UNKNOWN PRs → wait lines with `--once`; missing arg → exit 5. The CLEAN branch is print-only in watch mode.

Refs #3390