### PR TITLE
fix(scheduled-tasks): licensed-run-alarm uses system python3 (uv is a snap, off cron PATH)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -71,13 +71,13 @@ tasks:
     schedule: "*/15 * * * *"
     machines: [dev-secondary, ace-linux-2]
     roles: [comms-dispatch, sim-worker]
-    requires: [bash, python3, uv, git]
+    requires: [bash, python3, git]
     command: >-
       PATH=$HOME/.local/bin:$PATH;
       . $HOME/.deckhand/licensed-run.env &&
       cd /mnt/local-analysis/deckhand-ops &&
       git pull --ff-only -q ;
-      uv run --with pyyaml python scripts/deckhand/licensed-run-ops.py alarm --no-telegram
+      python3 scripts/deckhand/licensed-run-ops.py alarm --no-telegram
       >> $HOME/.deckhand/licensed-run-alarm.log 2>&1
     log: ~/.deckhand/licensed-run-alarm.log
     is_claude_task: false


### PR DESCRIPTION
Follow-up to [#3395](https://github.com/vamseeachanta/workspace-hub/pull/3395) / deckhand [#527](https://github.com/vamseeachanta/deckhand/issues/527). The first cron tick (18:00) proved the entry installs and fires, but failed with `uv: not found` — on dev-secondary `uv` is a snap (`/snap/bin/uv`) and the entry's PATH prepend only covers `$HOME/.local/bin`. Switch to system `python3` (has pyyaml; the ops script self-inserts its `src/` path), matching the cron recipe in deckhand's `licensed-run-ops.md`. Verified manually with `/usr/bin/python3`: alarm evaluates and trips (exit 4) on the real stranded run. Will install with `setup-cron.sh --replace` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)