### PR TITLE
feat(brand): a11y baseline in Pages builder stylesheet (#3402)

### DIFF
--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -139,6 +139,8 @@ pre{background:#0f1722;color:#cfe3ff;padding:14px;border-radius:8px;overflow-x:a
 code{background:#eef1f5;padding:1px 5px;border-radius:4px}
 a{color:var(--brand)}
 hr{border:0;border-top:1px solid var(--line);margin:1.4em 0}
+:where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--brand);outline-offset:2px;border-radius:3px}
+.sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 """
 
 

--- a/tests/test_build_pages_a11y.py
+++ b/tests/test_build_pages_a11y.py
@@ -1,0 +1,32 @@
+"""Accessibility baseline in the Pages builder stylesheet (wh#3401 / #3402).
+
+The shared STYLE emitted into public/assets/style.css by scripts/build_pages.py
+must carry a consistent keyboard-focus indicator and an .sr-only helper, so every
+generated hub page is keyboard-accessible from one source. Purple brand kept.
+"""
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _style() -> str:
+    spec = importlib.util.spec_from_file_location(
+        "build_pages_a11y", ROOT / "scripts" / "build_pages.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.STYLE
+
+
+def test_style_has_focus_visible():
+    assert ":focus-visible" in _style()
+
+
+def test_style_has_sr_only():
+    assert ".sr-only" in _style()
+
+
+def test_style_keeps_purple_brand():
+    # per-repo identity: wh stays purple, not recoloured to another repo's brand
+    assert "--brand:#5b3fd6" in _style()


### PR DESCRIPTION
First increment of the workspace-hub brand rollout (child of #3401; plan #3402, status:plan-approved).

wh keeps its **own purple identity** (#5b3fd6) — this does NOT recolour it. It adds the shared **a11y baseline** at the single source for generated hub pages: the `STYLE` constant in `scripts/build_pages.py`.
- **focus-visible + `.sr-only`** added to STYLE → every generated page (index/portfolio/skills) gets a consistent keyboard-focus ring from one place.
- **No `public/` committed** — it's gitignored + CI-regenerated; the next Pages build emits the updated stylesheet.
- Logo already routes home (`<a class=home href=index.html>`), so no logo change needed here.
- **TDD**: `tests/test_build_pages_a11y.py` (focus-visible, sr-only, purple retained) — passes.

**Lint:** new test is ruff-clean; my edit adds **0** ruff errors (21 pre-existing in build_pages.py on origin/main, unchanged — wh CI runs ruff best-effort/non-blocking anyway).

Done via a git worktree off origin/main (the main clone was 58 commits behind with 30 dirty machine-state files — untouched).

Follow-ups for #3402: extract a tracked wh-brand.css from STYLE + migrate the `docs/reports/*.html` / `docs/gtm/*.html` source pages + CI guard.

Ready for review/merge — **not** auto-merged (per merge-authorization).