### PR TITLE
refactor(brand): extract tracked docs/assets/brand.css as single source (#3402)

### DIFF
--- a/docs/assets/brand.css
+++ b/docs/assets/brand.css
@@ -1,0 +1,21 @@
+:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6}
+*{box-sizing:border-box}
+body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
+header.site,footer.site{padding:14px 22px;background:var(--card);border-bottom:1px solid var(--line);display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+footer.site{border-top:1px solid var(--line);border-bottom:0;color:var(--muted);font-size:14px;margin-top:48px}
+.home{color:var(--brand);font-weight:700;text-decoration:none}
+nav a{color:var(--muted);text-decoration:none;font-size:14px}
+nav a:hover{color:var(--brand)}
+main{max-width:900px;margin:0 auto;padding:28px 22px}
+h1{font-size:28px}
+.content h2{margin-top:1.5em;border-bottom:1px solid var(--line);padding-bottom:.2em}
+.tw{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:14px;background:var(--card)}
+th,td{border:1px solid var(--line);padding:6px 10px;text-align:left}
+th{background:#f0f3f7}
+pre{background:#0f1722;color:#cfe3ff;padding:14px;border-radius:8px;overflow-x:auto;font-size:13px}
+code{background:#eef1f5;padding:1px 5px;border-radius:4px}
+a{color:var(--brand)}
+hr{border:0;border-top:1px solid var(--line);margin:1.4em 0}
+:where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--brand);outline-offset:2px;border-radius:3px}
+.sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -120,28 +120,7 @@ def md_to_html(md: str) -> str:
     return "\n".join(out)
 
 
-STYLE = """:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#5b3fd6}
-*{box-sizing:border-box}
-body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
-header.site,footer.site{padding:14px 22px;background:var(--card);border-bottom:1px solid var(--line);display:flex;gap:14px;flex-wrap:wrap;align-items:center}
-footer.site{border-top:1px solid var(--line);border-bottom:0;color:var(--muted);font-size:14px;margin-top:48px}
-.home{color:var(--brand);font-weight:700;text-decoration:none}
-nav a{color:var(--muted);text-decoration:none;font-size:14px}
-nav a:hover{color:var(--brand)}
-main{max-width:900px;margin:0 auto;padding:28px 22px}
-h1{font-size:28px}
-.content h2{margin-top:1.5em;border-bottom:1px solid var(--line);padding-bottom:.2em}
-.tw{overflow-x:auto}
-table{border-collapse:collapse;width:100%;font-size:14px;background:var(--card)}
-th,td{border:1px solid var(--line);padding:6px 10px;text-align:left}
-th{background:#f0f3f7}
-pre{background:#0f1722;color:#cfe3ff;padding:14px;border-radius:8px;overflow-x:auto;font-size:13px}
-code{background:#eef1f5;padding:1px 5px;border-radius:4px}
-a{color:var(--brand)}
-hr{border:0;border-top:1px solid var(--line);margin:1.4em 0}
-:where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--brand);outline-offset:2px;border-radius:3px}
-.sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
-"""
+STYLE = (ROOT / "docs" / "assets" / "brand.css").read_text(encoding="utf-8")
 
 
 # Per-session review pages (#3298) publish from an enumerated manifest, never a

--- a/tests/test_build_pages_brand.py
+++ b/tests/test_build_pages_brand.py
@@ -1,0 +1,36 @@
+"""Tracked brand.css as the single source for the Pages builder (wh#3401 / #3402).
+
+The generator must READ its stylesheet from the tracked docs/assets/brand.css
+(not an embedded Python string), so non-generated pages can link the same file
+and the brand lives in one editable place. Purple identity + a11y baseline kept.
+"""
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BRAND = ROOT / "docs" / "assets" / "brand.css"
+
+
+def _style() -> str:
+    spec = importlib.util.spec_from_file_location(
+        "build_pages_brand", ROOT / "scripts" / "build_pages.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.STYLE
+
+
+def test_brand_css_is_tracked_and_present():
+    assert BRAND.exists(), "docs/assets/brand.css must exist as the tracked source"
+
+
+def test_generator_reads_the_tracked_brand_css():
+    # single source: the generator's STYLE is exactly the tracked file's content
+    assert _style() == BRAND.read_text(encoding="utf-8")
+
+
+def test_brand_css_keeps_identity_and_a11y():
+    css = BRAND.read_text(encoding="utf-8")
+    assert "--brand:#5b3fd6" in css  # wh stays purple
+    assert ":focus-visible" in css  # a11y baseline retained
+    assert ".sr-only" in css


### PR DESCRIPTION
Follow-up slice of the workspace-hub brand plan (#3402, status:plan-approved).

Moves the Pages builder's stylesheet out of an embedded Python string (`STYLE = """…"""`) into a **tracked `docs/assets/brand.css`** that the generator reads. Now the brand lives in one editable file — which the non-generated source pages (`docs/reports/*.html`, `docs/gtm/*.html`) can also `<link>` in the next slice. wh stays **purple** (#5b3fd6); a11y baseline retained.

- **Byte-identical output**: generated `public/assets/style.css` == `docs/assets/brand.css` (verified by diff).
- **TDD**: `test_build_pages_brand.py` (brand.css tracked + present, generator reads it, purple + a11y kept) — passes; existing build_pages tests pass (9 total, no regression); ruff-clean.
- `public/` untouched (gitignored + CI-regenerated).

Built via a git worktree off origin/main (main clone still dirty/behind — untouched). Unblocks slice #2 (migrate the non-generated source pages onto this css).

Ready for review/merge — not auto-merged.