### PR TITLE
feat(brand): CI guard for brand-token drift on report pages (#3402)

### DIFF
--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -67,6 +67,13 @@ jobs:
             echo "No stage prompt drift report produced." >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Check brand token drift (#3402)
+        run: |
+          echo "## Brand-Token Drift Guard (#3402)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          uv run python scripts/enforcement/check-brand-token-drift.py | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
   review-evidence:
     name: Review Evidence Check
     runs-on: ubuntu-latest

--- a/scripts/enforcement/check-brand-token-drift.py
+++ b/scripts/enforcement/check-brand-token-drift.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Brand-token drift guard — workspace-hub#3402 (epic #3401).
+
+The self-contained report pages under docs/reports/*.html are copied verbatim into
+public/ and each carries a *frozen inline copy* of the hub brand tokens. This guard
+fails if a page that DECLARES the brand (defines --brand) diverges from the
+canonical docs/assets/brand.css values — so the purple identity stays consistent
+even though each page inlines its own copy.
+
+Pages that do NOT declare --brand (dark scorecards and other intentional designs)
+are exempt — they are not claiming the hub brand.
+
+Run locally and in CI (see .github/workflows/enforcement-gate.yml):
+    python scripts/enforcement/check-brand-token-drift.py
+Exit 0 = consistent, 1 = drift.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BRAND_CSS = ROOT / "docs" / "assets" / "brand.css"
+REPORTS = ROOT / "docs" / "reports"
+
+TOKEN_RE = re.compile(r"--([a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})")
+
+
+def norm(hexv: str) -> str:
+    """Normalise a hex colour for comparison (#fff -> #ffffff, lowercased)."""
+    h = hexv.strip().lower()
+    if re.fullmatch(r"#[0-9a-f]{3}", h):
+        h = "#" + "".join(c * 2 for c in h[1:])
+    return h
+
+
+def root_tokens(text: str) -> dict[str, str]:
+    """Extract the first :root{} custom-property map from CSS/HTML text."""
+    m = re.search(r":root\s*\{([^}]*)\}", text, re.DOTALL)
+    if not m:
+        return {}
+    return {name: norm(val) for name, val in TOKEN_RE.findall(m.group(1))}
+
+
+def find_violations(canon: dict[str, str], pages: dict[str, dict[str, str]]):
+    """pages: {label: token_map}. A page is checked only if it declares --brand;
+    every canonical token it also defines must match. Returns [(label, name, got, want)]."""
+    out = []
+    for label, toks in pages.items():
+        if "brand" not in toks:  # not a brand page -> exempt
+            continue
+        for name, val in toks.items():
+            if name in canon and val != canon[name]:
+                out.append((label, name, val, canon[name]))
+    return out
+
+
+def main() -> int:
+    if not BRAND_CSS.exists():
+        print(f"brand guard: {BRAND_CSS} missing", file=sys.stderr)
+        return 1
+    canon = root_tokens(BRAND_CSS.read_text(encoding="utf-8"))
+    pages = {
+        str(p.relative_to(ROOT)): root_tokens(p.read_text(encoding="utf-8", errors="ignore"))
+        for p in sorted(REPORTS.glob("*.html"))
+    }
+    checked = [lbl for lbl, t in pages.items() if "brand" in t]
+    violations = find_violations(canon, pages)
+    if violations:
+        print("BRAND-TOKEN DRIFT — report pages that declare --brand must match "
+              "docs/assets/brand.css:\n")
+        for label, name, got, want in violations:
+            print(f"  ✗ {label}: --{name} = {got} (brand.css: {want})")
+        print("\nFix the page's :root to the canonical values, or update "
+              "docs/assets/brand.css if the brand deliberately changed.")
+        return 1
+    print(f"brand guard OK — {len(checked)} brand-declaring report page(s) match "
+          f"docs/assets/brand.css ({len(canon)} tokens)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/enforcement/test_check_brand_drift.py
+++ b/tests/enforcement/test_check_brand_drift.py
@@ -1,0 +1,52 @@
+"""Tests for the brand-token drift guard (workspace-hub#3402).
+
+Verifies: hex normalisation, :root parsing, the declare-brand-then-must-match rule
+(with non-brand pages exempt), and that the real docs/reports tree is consistent.
+"""
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts" / "enforcement" / "check-brand-token-drift.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("brand_drift_guard", GUARD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+G = _load()
+CANON = {"fg": "#1a2230", "brand": "#5b3fd6", "card": "#ffffff"}
+
+
+def test_norm_expands_and_lowercases():
+    assert G.norm("#FFF") == "#ffffff"
+    assert G.norm("#5b3FD6") == "#5b3fd6"
+
+
+def test_root_tokens_parses_first_root():
+    toks = G.root_tokens(":root{--fg:#1a2230;--brand:#5b3fd6;--card:#fff}")
+    assert toks == {"fg": "#1a2230", "brand": "#5b3fd6", "card": "#ffffff"}
+
+
+def test_matching_brand_page_has_no_violation():
+    pages = {"ok.html": {"brand": "#5b3fd6", "fg": "#1a2230", "ok": "#1f9d55"}}
+    assert G.find_violations(CANON, pages) == []
+
+
+def test_drifted_brand_page_is_flagged():
+    pages = {"bad.html": {"brand": "#7000ff", "fg": "#1a2230"}}
+    v = G.find_violations(CANON, pages)
+    assert v and v[0][0] == "bad.html" and v[0][1] == "brand"
+
+
+def test_non_brand_page_is_exempt():
+    # a dark scorecard with its own scheme and NO --brand is not checked
+    pages = {"dark.html": {"bg": "#0f1117", "fg": "#e6edf3"}}
+    assert G.find_violations(CANON, pages) == []
+
+
+def test_real_reports_tree_is_consistent():
+    assert G.main() == 0


### PR DESCRIPTION
Final slice of the workspace-hub brand plan (#3402, status:plan-approved).

**Context (why a guard, not a migration):** wh's `docs/reports/*.html` are self-contained pages copied verbatim into `public/`, each carrying a *frozen inline copy* of the hub brand tokens. They already match `docs/assets/brand.css` today — restructuring them to link an external sheet would break their by-design self-containment. So instead of migrating, this **locks in the consistency**.

- `scripts/enforcement/check-brand-token-drift.py` — fails if a report page that **declares the brand** (`--brand`) diverges from canonical `docs/assets/brand.css`. Pages without `--brand` (dark scorecards, other intentional designs) are **exempt**.
- Wired into **enforcement-gate.yml**.
- **TDD** `tests/enforcement/test_check_brand_drift.py` (6 tests: norm, parse, match, drift-flagged, non-brand-exempt, real-tree-consistent) — pass. Guard passes on the real tree (4 brand pages match, 6 tokens). ruff-clean.

Note: test filename dropped `_token` to clear the repo's `*_token*` secret-file gitignore.

Completes #3402's guard slice. Ready for review/merge — not auto-merged.