### PR TITLE
docs(plans): reviewed plans for record-schema contract chain #3428-#3432

### DIFF
--- a/docs/plans/2026-07-11-issue-3428-deterministic-run-identity-contract.md
+++ b/docs/plans/2026-07-11-issue-3428-deterministic-run-identity-contract.md
@@ -1,0 +1,327 @@
+# Plan for [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428): Deterministic Run Identity and Algorithm Version Contract
+
+> **Status:** adversarial-reviewed (r1 BLOCK remediated; ready for user review)
+> **Complexity:** T2
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3428
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3428-{claude,codex,gemini}.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` — `ResultEnvelope` supplies
+  `input_hash` (**volatile-key-pruned**: `VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}`),
+  a location-independent content `result_hash`, `code_version()` → `{package_version, git_sha}`
+  (`git_sha` is a **best-effort** `git rev-parse HEAD` that returns `None` off a checkout and does
+  **not** prove a clean tree), and `reproducible` (`None` unless an opt-in double run runs). **These
+  are execution evidence, not identity** — `input_hash` under-specifies (prunes real inputs) and
+  `git_sha` cannot certify a clean commit. The identity contract re-derives strict identity and
+  references these only as evidence.
+- `digitalmodel/docs/registry/workflows.yaml` (`schema_version: 2`) carries a per-row **integer**
+  `version` plus `status`/`latest`. This is an execution routing reference, **not** a semantic
+  algorithm version; the contract maps it explicitly, never infers one from the other.
+- `digitalmodel/src/digitalmodel/workflow_api/provenance.py` — `stamp_provenance` delegates to
+  `assetutilities…make_provenance`, parameterized by `package_name`; `data_as_of` is optional and,
+  for `worldenergydata`, is currently a run timestamp rather than a pinned snapshot.
+- **Gap:** no `algorithm_id` / `algorithm_version_id` / `run_id` definition, no explicit
+  canonicalization + digest algorithm, no clean-tree eligibility check, and no cross-machine
+  determinism proof exist anywhere.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Parent run-dataset contract (identity decisions) | binding, extended here | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (in **draft PR #3452**, not yet on `main`) |
+| Data/execution/report boundaries | reusable | `docs/architecture/execution-manifest.schema.yaml` |
+| Issue lifecycle + approval | binding | `AGENTS.md`, `docs/plans/README.md` |
+| Legal/abs-path scans | binding | `scripts/legal/legal-sanity-scan.sh`, `scripts/enforcement/check-no-abs-paths.sh` |
+
+No engineering-calculation standard applies to this identity contract.
+
+### Documents consulted
+
+- Issue [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428): distinguishes stable
+  `algorithm_id` from immutable `algorithm_version_id`; binds version identity to semver + full clean
+  commit + input/output schema versions + environment digest; binds run identity to canonical replay
+  inputs + seed + execution parameters; exact reruns resolve to the same `run_id`; output-digest
+  mismatch is a reproducibility defect, never a new revision or overwrite; terminal success/failure
+  without retry/attempt identities.
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427) plan (read at
+  `01054d8d`): locks `algorithm_version_id` = f(semver, clean commit, schema versions, env digest);
+  `run_id` = f(version, canonical input set, seed, exec params), excluding outputs; byte identity vs
+  a versioned semantic equality digest; ResultEnvelope-as-evidence crosswalk.
+- Sibling publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) plan
+  (this session): consumes this identity contract; its `RunProjection.identity` block is the first
+  consumer, so the executable reference implementation should be importable by
+  `assetutilities.workflow_api.publication`.
+- Dependents [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429) (artifact),
+  [#3430](https://github.com/vamseeachanta/workspace-hub/issues/3430) (input),
+  [#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431) (output/report),
+  [#3432](https://github.com/vamseeachanta/workspace-hub/issues/3432) (metric) all bind their records
+  to `run_id` / `algorithm_version_id`; this contract is their root and is blocked by none.
+- Concrete producers: dm workflow registry (integer versions) and dm [#1528](https://github.com/vamseeachanta/digitalmodel/issues/1528)
+  (OpenFOAM ESI v2312 pinned toolchain, case/manifest hashes) — a real test of the `environment_digest`
+  binding for a solver-backed algorithm.
+
+### Gaps identified
+
+- No normative record schema separates stable `algorithm_id` from immutable `algorithm_version_id`
+  and `run_id`, or enumerates their exact hash inputs.
+- No explicit, deterministic canonicalization + digest algorithm with valid/invalid fixtures.
+- No clean-tree / pinned-schema / explicit-seed eligibility check that fails closed.
+- No cross-machine determinism proof, and no crosswalk stating the registry integer version and the
+  ResultEnvelope hashes are references/evidence, never identity aliases.
+
+### Evidence (verified 2026-07-11)
+
+```text
+DRAFT PR #3452  feat: define algorithm run ledger for Hugging Face datasets (parent #3427 contract; not on main)
+404 @main       docs/architecture/algorithm-run-dataset-contract.yaml
+EXISTS          assetutilities …/workflow_api/envelope.py (input_hash pruned; git_sha best-effort; reproducible None)
+EXISTS          digitalmodel docs/registry/workflows.yaml (schema_version 2; integer version)
+#3428           OPEN status:needs-plan lane:claude — Blocked by: none
+```
+
+Distinct sources: issue #3428; parent #3427 plan; sibling #3433 plan; four dependent children;
+ResultEnvelope implementation; dm registry; dm #1528 producer — more than the required three.
+
+---
+
+## Deliverable
+
+A normative, machine-validated **deterministic run identity contract**: the record shapes for
+`algorithm_id`, `algorithm_version_id`, and `run_id`; an explicit, deterministic canonicalization +
+SHA-256 digest algorithm; a fail-closed public-eligibility check; valid/invalid fixtures; a
+cross-machine determinism proof; and decision-manual identity/collision/mismatch examples. A reference
+implementation proves determinism; the contract does not build the uploader or any dataset.
+
+---
+
+## Design
+
+### Identifiers
+
+```text
+algorithm_id            stable, human-meaningful: "<source_repo>:<workflow_id>"  (e.g. "digitalmodel:cathodic-protection")
+                        stable across versions; NOT a digest.
+
+algorithm_version_id    IMMUTABLE digest = sha256(canonical_json({
+                          canonicalization_version,     # pinned scheme id (see above)
+                          algorithm_id, semantic_version, source_repo,
+                          source_commit,            # full 40-hex, verified CLEAN tree
+                          input_schema_version, output_schema_version,
+                          environment_digest }))
+                        The dm registry INTEGER `version` maps explicitly to `semantic_version`
+                        via the descriptor; it is never inferred or aliased.
+
+run_id                  IMMUTABLE digest = sha256(canonical_json({
+                          canonicalization_version,
+                          algorithm_version_id,
+                          canonical_input_set_digest,   # OPAQUE injected value, OWNED + computed by #3430
+                          seed,                         # explicit; sentinel "deterministic:no-seed" if none
+                          execution_parameters }))      # run-CONTROL knobs only (see boundary below)
+                        EXCLUDES outputs. Exact reruns resolve to the same run_id.
+                        #3428 assembles run_id from an OPAQUE `canonical_input_set_digest` it does not
+                        compute (dependency-injected; #3428 tests use a stand-in); #3430 owns that
+                        digest's field membership + canonicalization.
+
+execution_parameters vs parameter_set (boundary, resolves the #3430 seam):
+                        execution_parameters = run-CONTROL knobs that steer computation without being
+                          replay DATA — tolerances, iteration/step caps, solver flags, seed-adjacent
+                          controls. They live in run_id directly.
+                        parameter_set (a #3430 Input kind) = replay DATA authored for the run (sweep
+                          values, physical parameters). They flow through canonical_input_set_digest.
+                        A parameter is assigned to EXACTLY ONE side by the algorithm descriptor; the
+                          same parameter can never be double-counted (one run → one run_id).
+
+environment_digest      sha256(canonical_json({ interpreter, interpreter_version, lockfile_hash,
+                          toolchain_pins }))  # toolchain_pins e.g. {"openfoam":"ESI-v2312"} for dm#1528;
+                        only determinism-relevant fields; declared, not sniffed.
+
+repository_identity     { source_repo, owning_dataset }   # one dataset per repo (#3427)
+```
+
+### Canonicalization + digest (pinned, explicit, deterministic)
+
+The canonicalization algorithm is **pinned exactly** (an under-specified scheme would let the
+identity root diverge on equivalent inputs or collide on different ones — disqualifying for the
+contract every other record binds to):
+
+- **Structure:** RFC 8785 JSON Canonicalization Scheme (JCS) — UTF-8, object keys sorted by UTF-16
+  code-unit order, no insignificant whitespace, arrays in declared order.
+- **Strings:** Unicode **NFC** normalization before hashing (so `NFC`/`NFD` spellings collapse).
+- **Numbers:** parsed and normalized via `decimal.Decimal` in a fixed context and serialized with
+  `Decimal.normalize()` — **no float round-trip** (avoids `0.1+0.2` drift); `1e3`==`1000`,
+  `5.0`==`5.00`==`5`. Any value carrying a physical unit MUST be an explicit `{value, unit}` pair
+  with the `unit` string drawn from a pinned unit vocabulary (`m` and `meter` normalize to one
+  token); a bare units-bearing numeric is **rejected**, never silently hashed.
+- **Null/NA:** explicit `null` / `"NA"` (never omitted so presence is unambiguous).
+- **Digest:** SHA-256 hex over the canonical bytes.
+- **Scheme version:** a `canonicalization_version` string is a field of every identity digest input
+  (below), so a future rule change mints new identities deterministically and old ones remain
+  reproducible under their recorded scheme.
+
+This exact scheme is the single canonicalizer reused by #3430 (`canonical_input_set_digest`), #3429
+(structured-object artifacts), and #3431 (`output_equality_digest`) — none forks a second scheme.
+
+### Fail-closed public eligibility
+
+Any of the following fails the public-eligibility check (no identity is minted for publication):
+dirty/uncommitted working tree; unknown, shallow, or unresolved `source_commit`; unpinned input or
+output schema version; missing/partial `environment_digest`; an implicit (unrecorded) seed; a
+registry integer version with no explicit semantic-version mapping.
+
+### Determinism, change-sensitivity, exact rerun, terminal status
+
+- **Determinism:** same canonical version + inputs → identical `run_id` on any machine (identity is
+  derived from the verified clean commit + declared env pins + canonical inputs, never from the
+  volatile `ResultEnvelope.input_hash` or best-effort `git_sha`).
+- **Change-sensitivity:** any change to code (commit), input/output schema, environment, input, seed,
+  or a declared execution parameter yields a different `algorithm_version_id` and/or `run_id`.
+- **Exact rerun:** resolves to the same `run_id`; output equality is checked against a **separate,
+  versioned `output_equality_digest`** that #3431 OWNS and computes. #3428 owns only the *comparison
+  policy* — mismatch is a reproducibility defect that fails closed and cannot mutate or overwrite the
+  existing run — and injects the output digest as an opaque value (its own tests use a stub); #3431
+  fills the computation. run_id excludes outputs, so this is a policy reference, not a cycle.
+- **Terminal status:** `succeeded | reproducible_failure` are the two **terminal, ledger-bearing**
+  statuses; a `reproducible_failure` requires a passed reproducibility verification (a failure whose
+  normalized signature repeats). A flaky/transient failure that has NOT been shown reproducible is
+  **`indeterminate_failure`** — a **non-terminal, non-public state that mints no ledger identity** and
+  cannot enter the dataset. All three carry no retry/attempt identity: a re-execution of the same
+  canonical inputs is the same `run_id`, never a new attempt.
+
+### Crosswalk (evidence, never identity)
+
+`ResultEnvelope.input_hash` and `code_version.git_sha` are retained as *execution evidence*; the
+registry integer `version` is an *execution reference*. None is aliased into strict identity.
+
+---
+
+## Pseudocode
+
+```text
+require semantic_version, source_repo, clean source_commit (verify tree clean), input/output schema versions, environment_digest
+algorithm_version_id = sha256(canonical_json(version components))
+inject canonical_input_set_digest (OPAQUE, computed by #3430), explicit seed (or no-seed sentinel), canonical execution_parameters (run-control only)
+run_id = sha256(canonical_json(canonicalization_version, algorithm_version_id, input_set_digest, seed, exec_params))   # NO outputs
+fail closed if: dirty tree | unknown/shallow commit | unpinned schema | missing env digest | implicit seed | unmapped registry version
+on exact rerun: recompute run_id -> must match; compare INJECTED #3431 output_equality_digest -> mismatch => reject, no mutation
+terminal status in {succeeded, reproducible_failure}; indeterminate_failure = non-terminal, mints NO identity; never an attempt identity
+canonicalization pinned (JCS + decimal.normalize + NFC + canonicalization_version); envelope input_hash/git_sha + registry integer version = evidence only
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Update (in/atop **PR #3452**) | `docs/architecture/algorithm-run-dataset-contract.yaml` | add the normative identity record schema + hash-input enumeration as a strictly additive, non-overlapping section |
+| Create | `assetutilities/src/assetutilities/workflow_api/identity.py` (**DECIDED** home — inherits #3433's owner-confirmed `assetutilities.workflow_api` placement) | pinned canonicalization + digest; clean-tree/eligibility checks; importable by #3433 |
+| Create | `assetutilities/tests/workflow_api/test_identity.py` + `fixtures/identity/{valid,invalid}/…` | valid/invalid + cross-machine determinism fixtures |
+| Update (in **PR #3452**) | `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` | identity examples + collision/mismatch behavior section |
+| Extend | `tests/architecture/test_algorithm_run_dataset_contract.py` (the parity test #3452 already ships) | add identity-section parity assertions rather than a second competing parity test |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, workflow registry, dataset, or credential is modified. All five
+sibling contracts (#3428–#3432) edit `algorithm-run-dataset-contract.yaml` + the decision manual as
+**strictly additive, non-overlapping sections**; they land atop PR #3452 in dependency order (or via
+one integration PR) so no sibling clobbers another's section (per the "N additive lanes sharing a
+file → one integration PR" rule).
+
+---
+
+## TDD Test List
+
+| Test | Verifies | Expected |
+|---|---|---|
+| `test_algorithm_version_id_binds_all_components` | version digest covers semver + clean commit + input/output schema + env digest | omit any component → different id |
+| `test_run_id_binds_inputs_seed_params_excludes_outputs` | run digest covers version + input-set + seed + exec params, not outputs | output change keeps `run_id` |
+| `test_canonicalization_equivalent_values_same_digest` | JCS key order / whitespace; `1e3`==`1000`, `5.0`==`5.00`, NFC==NFD; missing unit tag rejected | equal digests; unit-less numeric rejected |
+| `test_different_inputs_never_collide` | two genuinely different canonical inputs (incl. a near-collision pair `1.0000000001` vs `1.0`) → different digests | no collision |
+| `test_canonicalization_version_in_digests_and_pins_scheme` | `canonicalization_version` is a digest input; a scheme change yields new ids, old ids reproducible | version bound; deterministic |
+| `test_algorithm_id_stable_across_versions_and_not_a_digest` | `algorithm_id` unchanged across version bumps; never a digest of version fields | stable, non-digest |
+| `test_repository_identity_binds_repo_and_dataset` | `{source_repo, owning_dataset}` binds correctly | binding enforced |
+| `test_dirty_or_unpinned_or_implicit_seed_fails_closed` | dirty tree, unknown/shallow commit, unpinned schema, missing env digest, implicit seed all fail | each rejected |
+| `test_same_canonical_inputs_same_run_id_cross_machine` | determinism across simulated machine A/B (different cwd, env noise) | identical `run_id` |
+| `test_any_component_change_changes_identity` | code/schema/env/input/seed/param change → different id | id differs per change |
+| `test_execution_parameter_and_parameter_set_not_double_counted` | a param assigned to exactly one of execution_parameters vs #3430 parameter_set; same run → one `run_id` | no double-count |
+| `test_run_id_uses_opaque_injected_input_set_digest` | #3428 assembles run_id from a stand-in `canonical_input_set_digest` (computed by #3430) | opaque injection; no #3430 dependency at #3428 build |
+| `test_exact_rerun_output_mismatch_fails_closed_no_mutation` | injected (stub) `#3431` output digest differs → reject, no overwrite | prior record intact |
+| `test_terminal_statuses_have_no_attempt_identity` | succeeded + reproducible_failure carry `run_id`; indeterminate_failure mints NO identity; no attempt id | no attempt/retry identity |
+| `test_registry_integer_version_not_aliased_to_semantic` | integer version maps explicitly, never inferred | unmapped version rejected; no implicit inference |
+| `test_envelope_hashes_are_evidence_not_identity` | `input_hash`/`git_sha` never enter identity digests | identity independent of envelope hashes |
+| `test_decision_manual_matches_identity_contract` | manual identity section ↔ contract YAML parity | structure + examples agree |
+
+Tests are written first and fail before implementation exists.
+
+---
+
+## Acceptance Criteria
+
+- [ ] The contract defines `algorithm_id`, `algorithm_version_id`, `run_id`, repository identity,
+      source revision, schema versions, environment digest, seed, and execution-parameter bindings.
+- [ ] Canonicalization and digest algorithms are explicit, deterministic, and covered by valid/invalid
+      fixtures.
+- [ ] Dirty, uncommitted, unknown-revision, or schema-unpinned executions fail public eligibility.
+- [ ] The same canonical version and inputs produce the same `run_id` across repeated executions and
+      machines.
+- [ ] Changes to code, schema, environment, input, seed, or declared execution parameters produce a
+      different identity.
+- [ ] Exact rerun output mismatches fail closed and cannot mutate the existing run.
+- [ ] Successful and failed terminal statuses are represented without introducing retry/attempt
+      identities.
+- [ ] The decision manual documents identity examples and collision/mismatch behavior.
+- [ ] Tests are written first; the suite, legal scan (`--diff-only`), and `check-no-abs-paths.sh` pass.
+
+---
+
+## Sequencing & Gate
+
+No **sibling** contract blocks #3428 — but its implementation is **stacked on parent PR #3452**: the
+`algorithm-run-dataset-contract.yaml` and decision-manual it edits, and the parity test it extends,
+exist ONLY in #3452 (both 404 on `main`), so a branch cut from `main` cannot take the parity test
+red→green. #3428 therefore branches from (or co-merges with) #3452, coordinating the identity schema
+as an additive section and never forking the closed-schema behavior. The "Blocked by: none" on the
+issue refers to sibling contracts; the #3452 stack dependency is an implementation-ordering fact.
+Requires its own reviewed plan and explicit user approval (HITL contract work). Dependents #3429–#3432
+consume this contract; #3433 consumes its reference implementation.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Result |
+|---|---|---|---|
+| r1 | Claude (adversarial) | **BLOCK → remediated** | 2 MAJOR: (1) under-specified numeric/unit canonicalization could diverge on equivalent inputs / collide on different — **fixed**: pinned RFC 8785 JCS + `decimal.Decimal.normalize()` (no float round-trip) + NFC + `canonicalization_version`; (2) "Blocked by none" false for implementation (parity test depends on unmerged PR #3452) — **fixed**: declared stacked-on-#3452. MINORs fixed: `algorithm_id`/repo-identity/collision tests; opaque-injected input/output digests; `indeterminate_failure` terminal state; `execution_parameters`↔`parameter_set` boundary; parity test folded into #3452's existing test. |
+
+No unavailable provider counts as approval; any depth reduction is disclosed for owner acceptance.
+A confirming verification pass before implementation is recommended (single-provider adversarial round).
+
+---
+
+## Risks and Open Questions
+
+- **Environment-digest scope risk:** over-broad env fields make identity brittle (every machine
+  differs); too-narrow misses real determinism inputs (solver build). Mitigation: env digest is a
+  *declared* allowlist of determinism-relevant pins (interpreter, lockfile hash, toolchain), not a
+  sniffed host fingerprint; dm #1528's OpenFOAM pin is the worked example.
+- **Parent-contract coupling risk:** the contract YAML + decision manual are in draft PR #3452, and
+  all five sibling contracts edit them. Mitigation: strictly additive non-overlapping sections; #3428
+  stacks on #3452; siblings land in dependency order or via one integration PR; fail closed on drift.
+- **Reference-implementation home — DECIDED:** `assetutilities.workflow_api.identity`, inheriting
+  #3433's owner-confirmed `assetutilities.workflow_api` placement so the publication module imports one
+  implementation. (No longer an open question.)
+
+---
+
+## Complexity: T2
+
+A normative contract slice with a small deterministic reference implementation + fixtures. Not T3:
+single-domain, no external platform, no cross-system transaction — but it is the identity root every
+other record contract binds to, so its determinism and fail-closed proofs are load-bearing.

--- a/docs/plans/2026-07-11-issue-3429-content-addressed-artifact-residency-contract.md
+++ b/docs/plans/2026-07-11-issue-3429-content-addressed-artifact-residency-contract.md
@@ -1,0 +1,398 @@
+# Plan for [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429): Content-Addressed Artifact and Hugging Face Residency Contract
+
+> **Status:** adversarial-reviewed (r1 BLOCK remediated; ready for user review)
+> **Complexity:** T2
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3429
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3429-{claude,codex,gemini}.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` — the substrate for this contract.
+  `result_hash(payload)` already computes a **location-independent content hash** for `kind: files`
+  payloads: the canonical form is `sorted((basename, sha256))` per output file, so a changed output
+  byte flips a per-file `sha256` and the aggregate hash, while the **absolute directory is discarded**
+  (only `basename` survives). `_sha256_hexdigest` hashes UTF-8 bytes; the module already standardizes
+  on SHA-256 hex. `input_hash` prunes `VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}`
+  *because those keys "carry absolute paths"* — direct evidence the ecosystem already treats absolute
+  paths as unsafe-to-hash / unsafe-to-publish. **These are execution EVIDENCE, not artifact identity:**
+  `result_hash` aggregates a *set* of files under a role-blind digest, whereas this contract needs a
+  **per-artifact** identity (one digest per immutable byte-object) so Input and Output records can each
+  reference the same object. The artifact contract re-uses the per-file `sha256` as the object digest
+  and references `result_hash` only as evidence.
+- `digitalmodel/…/workflow_api/provenance.py` (`stamp_provenance` → `make_provenance`) stamps
+  `input_hash`/`result_hash` into the envelope; no per-artifact record, media type, native format,
+  compression, schema reference, or residency-eligibility field exists anywhere.
+- **Gap:** no `Artifact` record separating **artifact identity** (immutable bytes) from **artifact role**
+  (Input vs Output, which lives on the *referencing* record); no residency-eligibility policy; no
+  integrity-from-bytes revalidation that ignores the manifest; no storage-locator safety check.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Sibling identity contract (canonical_json + SHA-256 conventions) | binding, consumed | `#3428` plan (`docs/plans/2026-07-11-issue-3428-deterministic-run-identity-contract.md`) |
+| Parent run-dataset contract (residency, dedup, exclusions) | binding, extended here | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (in **draft PR #3452**, not on `main`) |
+| Publication object-store consumer (`objects/<sha256[:2]>/<sha256>`, re-hash reader) | binding, consumes this | `#3433` plan |
+| Legal / per-input license scan | binding | `scripts/legal/legal-sanity-scan.sh`, `.legal-deny-list.yaml` |
+| No-absolute-paths / path-leak enforcement | binding | `scripts/enforcement/check-no-abs-paths.sh` |
+
+No engineering-calculation standard applies to this artifact-identity contract.
+
+### Documents consulted
+
+- Issue [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429) (verified `2026-07-11`,
+  title *"standard: content-addressed artifact and Hugging Face residency contract"*, OPEN,
+  `status:needs-plan`, `lane:claude`, **Blocked by #3428**): an Artifact represents immutable physical
+  bytes or an immutable structured object *independently of its role*; artifacts are addressed by digest
+  and deduplicated within the per-repo dataset; carry format, media type, size, schema, integrity,
+  provenance, residency; transient logs/caches/large regenerable dumps stay excluded; integrity
+  revalidated from dataset bytes without trusting manifest assertions. Acceptance criteria copied
+  verbatim below.
+- Sibling identity contract [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428) plan:
+  defines `canonical_json` (UTF-8, lexicographically sorted keys, no insignificant whitespace,
+  normalized numbers with explicit unit tags, explicit `null`/`"NA"`), digests are **SHA-256 hex**, and
+  the load-bearing rule that ResultEnvelope hashes are **evidence, never identity**. This artifact
+  contract **reuses that exact canonicalization/digest convention** so a structured-object artifact
+  digest is byte-identical to what #3428 would compute, and treats `result_hash`/`input_hash` as
+  evidence only.
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427) (verified `2026-07-11`,
+  OPEN, `status:plan-approved`): locks one HF dataset per source repo; HF stores replay-critical public
+  inputs + curated native outputs; artifacts addressed by digest, **deduplicated within the dataset**;
+  transient logs/caches/large regenerable dumps **excluded**. This contract is the digest + residency +
+  exclusion mechanism that realizes those locks.
+- Publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) plan: its dataset
+  carries a content-addressed object store `objects/<sha256[:2]>/<sha256>`, dedups identical bytes to one
+  object, and its **reader re-hashes object bytes to revalidate integrity WITHOUT trusting the row's
+  asserted digest**. This contract makes that byte-revalidation *normative* and supplies the Artifact
+  record #3433 serializes (`artifacts[] -> sha256, size, media type, native format, schema ref,
+  residency policy`).
+- Substrate implementation `assetutilities/…/workflow_api/envelope.py` (fetched `2026-07-11`):
+  `result_hash` `kind: files` canonical form `sorted((basename, sha256))` — a working
+  location-independent per-file content hash this contract elevates to a first-class per-artifact digest.
+
+### Gaps identified
+
+- No `Artifact` record fixes stable artifact identity (SHA-256 of immutable bytes / canonical form of an
+  immutable structured object) with `digest`, `size_bytes`, `media_type`, `native_format`, `compression`,
+  `schema_ref`, `storage_locator`.
+- No rule that **role lives on the referencing record**, so identical bytes referenced as an Input in one
+  run and an Output in another collapse to **one identity**, not two role-tagged copies.
+- No residency-eligibility function admitting only replay-critical public inputs + curated native outputs,
+  and failing restricted / ambiguous-license / client-specific / path-leaking / non-redistributable bytes.
+- No explicit artifact-role **exclusion** policy for transient logs / caches / large regenerable dumps.
+- No integrity-from-bytes revalidation, and no storage-locator safety check rejecting local absolute paths
+  and path leakage.
+
+### Evidence (verified 2026-07-11)
+
+```text
+#3429            OPEN  status:needs-plan lane:claude  "standard: content-addressed artifact and Hugging Face residency contract"  Blocked by #3428
+#3428            OPEN  status:needs-plan lane:claude   (identity contract; canonical_json + SHA-256; hashes=evidence)  — this plan's blocker
+#3427            OPEN  status:plan-approved            (parent; one dataset/repo, dedup, exclusions)
+DRAFT PR #3452   OPEN  feat: define algorithm run ledger for HF datasets  — parent contract YAML NOT on main
+EXISTS           assetutilities …/workflow_api/envelope.py  result_hash kind:files = sorted((basename, sha256)) [location-independent]; VOLATILE_TOP_KEYS pruned "carry absolute paths"
+EXISTS @main     scripts/legal/legal-sanity-scan.sh, scripts/enforcement/check-no-abs-paths.sh
+```
+
+Distinct sources: issue #3429; sibling #3428 plan; parent #3427; publication #3433 plan; ResultEnvelope
+`result_hash` implementation; legal + abs-path scanners — more than the required three.
+
+---
+
+## Deliverable
+
+A normative, machine-validated **content-addressed Artifact contract**: the `Artifact` record shape
+(digest, size, media type, native format, compression, schema reference, storage locator); the identity
+rule that identical bytes → one artifact regardless of how many runs or roles reference it (role lives on
+the referencing Input/Output record, never on the artifact); a fail-closed **residency-eligibility**
+function (replay-critical public inputs + curated native outputs are HF-eligible; restricted /
+ambiguous-license / client-specific / path-leaking / non-redistributable **fail**); an explicit
+**artifact-role exclusion** policy (transient logs / caches / large regenerable dumps); a normative
+**integrity-from-bytes** revalidation (re-hash dataset bytes, ignore manifest assertions); a
+storage-locator safety check (reject local absolute paths and path leakage); valid/invalid fixtures; and
+decision-manual lifecycle / deduplication / retention text. A reference implementation proves the digest
+and residency checks; this contract does **not** build the uploader, dataset, or any HF write.
+
+---
+
+## Design
+
+### Artifact identity
+
+```text
+Artifact                       # immutable bytes OR immutable structured object; ROLE-FREE; BYTE-INTRINSIC ONLY
+  digest            IMMUTABLE identity = sha256(STORED bytes)                 # physical byte payload
+                    OR         = sha256(canonical_json(structured_object))    # structured objects ONLY, #3428 form
+                    SHA-256 hex, exactly the #3428 digest convention. THIS IS THE ARTIFACT IDENTITY.
+  size_bytes        exact STORED byte length (of the addressed bytes as they physically reside)
+  media_type        IANA media type (e.g. "application/parquet", "text/csv")
+  native_format     domain-native format tag (e.g. "csv", "parquet", "openfoam-case", "json")
+  compression       explicit codec or "none"; PURELY DESCRIPTIVE metadata — NEVER triggers a decode-before-hash
+  schema_ref        pinned schema id+version the artifact validates against (null only if schemaless-by-policy)
+  storage_locator   dataset-relative object path "objects/<digest[:2]>/<digest>"  (NEVER an absolute/local path)
+  license_evidence_ref   pointer to redistribution-license evidence (decision inputs, not raw creds)
+                    # NOTE: NO residency.class / eligible on the artifact — residency is role-derived and lives
+                    #       on the referencing Input(#3430)/Output(#3431) record (see "Residency eligibility")
+```
+
+**Digest inputs, restated:** for a physical-byte artifact the digest is `sha256` over the **EXACT immutable
+STORED bytes** — the very bytes #3433's object store re-hashes — and `size_bytes` is the stored byte length;
+`canonical_json` canonicalization (#3428's UTF-8, sorted keys, normalized numbers with unit tags, explicit
+null/NA) is reserved **only** for structured-object artifacts. `size_bytes`, `media_type`, `native_format`,
+`compression`, `schema_ref`, `storage_locator` are **descriptive metadata about the identity — never inputs
+to it** (two byte-identical CSVs with different filenames are one artifact). `compression` is descriptive
+only and **never** causes a decode-before-hash: the stored bytes are hashed as they physically reside.
+
+### Identity is role-free; role lives on the reference
+
+```text
+Run A: inputs[]  -> InputRef{  role:"boundary_condition", artifact_digest: D }   # #3430 record
+Run B: outputs[] -> OutputRef{ role:"curated_result",     artifact_digest: D }   # #3431 record
+                              ^ SAME digest D => ONE Artifact in objects/<D[:2]>/<D>
+```
+
+Identical bytes resolve to a single artifact identity even across multiple runs and multiple roles. An
+Input record and an Output record reference the same artifact by `digest` with **no duplication and no
+role ambiguity**, because the **role is a property of the referencing record, not of the artifact**. The
+object store is deduplicated within the dataset: `objects/<digest[:2]>/<digest>` holds one copy;
+N references share it.
+
+### Residency eligibility (fail-closed) — computed at projection time, not stamped on the artifact
+
+Eligibility is **not** a field on the role-free Artifact record. It is computed at projection time as
+**(byte-intrinsic license) × (per-reference role)**, where the role comes from the referencing
+Input(#3430)/Output(#3431) record. The `class` (replay_critical_input / curated_native_output / excluded)
+and the resulting `eligible` boolean therefore live on the referencing record (or are derived on the fly),
+so identical bytes used as a replay_input in one run and a curated_output in another remain **ONE artifact
+record** with two differently-classed references (reconciled with Risk #3 below).
+
+```text
+eligible_for_public_HF(artifact, referencing_role) := TRUE  iff
+                                                  class(referencing_role) ∈ {replay_critical_input, curated_native_output}
+                                              AND artifact.license_evidence_ref proves redistributable
+                                              AND artifact.storage_locator is SAFE (no absolute/local path, no leak)
+                                              AND not client-specific / restricted / ambiguous-license
+                                              AND referencing_role is NOT an excluded role (below)
+```
+
+Any of the following **FAILS** public projection (no HF residency; fail closed):
+restricted / non-redistributable bytes; ambiguous or missing license evidence; client-specific data;
+a `storage_locator` that leaks a path (absolute local path, home dir, UNC/drive, `..` traversal); or a
+role in the exclusion set. A dataset-level license **cannot** grant redistribution rights absent from the
+artifact's own `license_evidence` (mirrors #3433 Gate A per-input license rule).
+
+### Explicit artifact-role exclusion policy
+
+```text
+EXCLUDED_ARTIFACT_ROLES = { transient_log, cache, scratch, large_regenerable_dump }
+```
+
+Artifacts whose role is transient logs, caches, or large regenerable dumps are **excluded by explicit
+policy** from the dataset regardless of digest (they are regenerable and non-replay-critical). Exclusion is
+asserted as `class = excluded` **on the referencing Input/Output record** (not on the role-free artifact)
+with a reason; it is not silent omission. Note: this role-tag exclusion of "large regenerable dumps" has
+**no size backstop** — there is no byte-count threshold here; the large/regenerable determination defers to
+role assignment on the #3430/#3431 referencing record.
+
+### Integrity revalidated from bytes (normative, manifest-untrusted)
+
+```text
+revalidate(object_bytes, asserted_digest):
+    computed = sha256(object_bytes)          # or sha256(canonical_json(...)) for structured objects
+    if computed != object_path_digest:  FAIL (tamper / corruption)     # path IS the digest -> self-verifying
+    # the manifest row's asserted digest is NEVER trusted as the source of truth:
+    if asserted_digest present and asserted_digest != computed:  FAIL (manifest lies)
+    return computed                          # bytes are authoritative
+```
+
+A reader recomputes the SHA-256 of the object's actual bytes and compares it against the **digest embedded
+in the object path** (`objects/<digest[:2]>/<digest>`), which makes each object **self-verifying** and
+makes #3433's "re-hash without trusting the manifest" behavior normative. Tampered bytes → digest mismatch
+→ FAIL. A manifest whose asserted digest disagrees with the bytes is rejected; the bytes win.
+
+### Storage-locator safety
+
+`storage_locator` MUST be the dataset-relative content-addressed path `objects/<digest[:2]>/<digest>`.
+**Normative locator/digest consistency rule:** `storage_locator == "objects/" + digest[:2] + "/" + digest`
+EXACTLY — the shard prefix is the first two hex chars of the record's own `digest` and the trailing segment
+is the full `digest`; any deviation (mismatched shard, truncated/foreign digest, extra path segments) is
+rejected. Also rejected: any absolute path (`/…`, `C:\…`, `\\host\…`), home-relative (`~`), `..` traversal,
+or embedded machine/user state. This reuses the `check-no-abs-paths.sh` intent already encoded in
+envelope.py's `result_hash` (which keeps only `basename`, discarding the absolute directory).
+
+### Crosswalk (evidence, never identity)
+
+`ResultEnvelope.result_hash` (role-blind set-of-files aggregate) and `input_hash` are retained as
+**execution evidence** referenced by run/output records; neither is the artifact identity. The per-file
+`sha256` inside `result_hash`'s canonical form is the value elevated to a per-artifact `digest`.
+
+---
+
+## Pseudocode
+
+```text
+build_artifact(payload):
+    if payload.kind == "bytes":       digest = sha256(payload.stored_bytes)             # hash the EXACT stored bytes
+    elif payload.kind == "object":    digest = sha256(canonical_json(payload.object))   # structured objects ONLY, #3428
+    size_bytes  = len(payload.stored_bytes)            # stored byte length; compression NEVER decodes before hashing
+    locator     = f"objects/{digest[:2]}/{digest}"
+    assert locator == "objects/" + digest[:2] + "/" + digest   # exact locator/digest consistency -> else FAIL CLOSED
+    assert locator_is_safe(locator)                    # no abs/local path, no leak -> else FAIL CLOSED
+    record = Artifact(digest, size_bytes, media_type, native_format, compression, schema_ref, locator, license_evidence_ref)
+    return record   # BYTE-INTRINSIC ONLY; NO residency/role field. Role + class are set by the referencing Input/Output record
+
+# residency is computed at PROJECTION time from (byte-intrinsic license) x (per-reference role) — NOT stored on the artifact
+classify(artifact, referencing_role) -> residency:
+    if referencing_role in EXCLUDED_ARTIFACT_ROLES:      return {class: excluded, eligible: False, reason}
+    if not redistributable(artifact.license_evidence_ref): return {eligible: False, reason: "restricted/ambiguous/non-redistributable"}
+    if client_specific(referencing_role) or leaks_path(artifact.storage_locator): return {eligible: False, reason}
+    if class(referencing_role) in {replay_critical_input, curated_native_output}: return {eligible: True}
+    return {eligible: False, reason: "unclassified -> fail closed"}
+
+dedup_into_dataset(records):
+    for r in records:  store objects/<r.digest[:2]>/<r.digest> ONCE   # identical digest -> single object, N refs
+
+revalidate_from_bytes(object):                          # reader side; manifest NOT trusted
+    computed = sha256(object.bytes)  # or canonical_json for structured
+    FAIL if computed != digest_in_path(object) OR (manifest.asserted_digest and manifest.asserted_digest != computed)
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Update | `docs/architecture/algorithm-run-dataset-contract.yaml` (**404 on `main`; exists only in parent PR #3452** — this change STACKS ON #3452 as a strictly-additive, non-overlapping section) | add the normative `Artifact` record schema + residency/exclusion policy + integrity-from-bytes rule |
+| Create | `assetutilities/src/assetutilities/workflow_api/artifact.py` (**DECIDED reference-impl home** — inherits #3433's owner-confirmed `assetutilities.workflow_api` placement; imported by #3433's publication module) | per-artifact digest (stored bytes, or `canonical_json` for structured objects), residency classifier, locator-safety check, byte-revalidation |
+| Create | `assetutilities/tests/workflow_api/test_artifact.py` + `fixtures/artifact/{valid,invalid}/…` | valid/invalid + tampered-byte / hash-mismatch / **dedicated forbidden-residency** / unsupported-schema / unsafe-locator / locator-digest-mismatch fixtures |
+| Update | `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` (**404 on `main`; exists only in PR #3452** — additive, non-overlapping section) | artifact lifecycle, deduplication, and retention behavior section |
+| Create | `tests/architecture/test_artifact_contract_parity.py` | assert the decision-manual artifact section matches the contract YAML |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, workflow registry, dataset, or credential is modified. The
+`canonical_json`/SHA-256 helper is **imported from #3428's DECIDED home `assetutilities.workflow_api.identity`**,
+not re-implemented. Both files edited here (the contract YAML and the decision-manual) live only in parent
+PR #3452, so this and the four sibling contracts (#3428/#3430/#3431/#3433) each land as **strictly-additive,
+non-overlapping sections** stacked on #3452 — merged in dependency order or folded into one integration PR.
+
+---
+
+## TDD Test List
+
+| Test | Verifies (acceptance criterion) | Expected |
+|---|---|---|
+| `test_artifact_identity_fields_present` | AC1: digest, size, media type, native format, compression, schema ref, storage locator all defined | record rejected if any identity field missing |
+| `test_bytes_and_structured_digest_use_3428_convention` | AC1: digest = `sha256(bytes)` / `sha256(canonical_json(object))`, SHA-256 hex, matches #3428 | digest byte-identical to #3428 canonicalization |
+| `test_metadata_not_in_identity` | AC1/AC2: media type / filename / compression are metadata, not digest inputs | two byte-identical files, different names → same digest |
+| `test_identical_bytes_one_identity_across_runs_and_roles` | AC2: identical bytes → one identity across multiple runs/roles | single object id; no duplicate |
+| `test_input_and_output_reference_same_artifact_no_role_ambiguity` | AC3: Input + Output records reference same digest; role on the ref, not the artifact | one artifact; two role-tagged refs; artifact role-free |
+| `test_replay_input_and_curated_output_are_hf_eligible` | AC4: replay-critical public input + curated native output eligible | `residency.eligible == True` |
+| `test_restricted_ambiguous_client_pathleak_nonredist_fail` | AC5: restricted / ambiguous-license / client-specific / path-leaking / non-redistributable fail | each `eligible == False`, fail closed |
+| `test_dataset_license_cannot_grant_missing_input_rights` | AC5: dataset-level license cannot override a non-redistributable artifact | still fails |
+| `test_excluded_roles_never_reside` | AC6: transient logs / caches / large regenerable dumps excluded by explicit role policy | `class == excluded`, not silently omitted |
+| `test_integrity_revalidated_from_bytes_ignores_manifest` | AC7: reader re-hashes bytes, ignores manifest assertion | manifest-asserted digest ignored; bytes authoritative |
+| `test_tampered_bytes_fail_hash_mismatch` | AC8 (tampered bytes / hash mismatch): flipped byte → digest ≠ path digest | FAIL |
+| `test_manifest_asserts_wrong_digest_rejected` | AC7/AC8 (hash mismatch): manifest digest ≠ computed | FAIL (bytes win) |
+| `test_unsupported_schema_ref_rejected` | AC8 (unsupported schema): unknown/unpinned `schema_ref` | rejected, fail closed |
+| `test_unsafe_storage_locator_rejected` | AC8 (unsafe locator): absolute/home/UNC/`..`/non-`objects/` path | rejected |
+| `test_storage_locator_matches_record_digest` | AC8 (locator/digest consistency): `storage_locator == "objects/" + digest[:2] + "/" + digest` EXACTLY; mismatched shard or foreign/truncated digest | rejected |
+| `test_forbidden_residency_fixture_rejected` | AC8 (forbidden residency): dedicated invalid fixture asserting a forbidden residency projection (separate from the AC5 test) | rejected, fail closed |
+| `test_valid_fixtures_admit` | AC8: valid fixtures round-trip and admit | pass |
+| `test_decision_manual_matches_artifact_contract` | AC9: manual lifecycle/dedup/retention ↔ contract YAML parity | structure + examples agree |
+
+Tests are written first and fail before implementation exists.
+
+---
+
+## Acceptance Criteria
+
+Verbatim from issue #3429:
+
+- [ ] The Artifact contract defines stable artifact identity, SHA-256 digest, byte size, media type, native format, compression, schema reference, and storage locator.
+- [ ] Identical bytes resolve to one artifact identity even when referenced by multiple runs or roles.
+- [ ] Input and Output records can reference the same artifact without duplication or role ambiguity.
+- [ ] Replay-critical public inputs and curated native outputs are eligible for repository-specific Hugging Face storage.
+- [ ] Restricted, ambiguous-license, client-specific, path-leaking, or non-redistributable artifacts fail public projection.
+- [ ] Transient logs, caches, and large regenerable dumps are excluded by explicit artifact-role policy.
+- [ ] Artifact integrity can be revalidated from dataset bytes without trusting manifest assertions.
+- [ ] Valid/invalid fixtures cover tampered bytes, hash mismatch, forbidden residency, unsupported schema, and unsafe locator values.
+- [ ] The decision manual documents artifact lifecycle, deduplication, and retention behavior.
+
+Added process criteria:
+
+- [ ] TDD tests are written first and fail before implementation; the full suite, the legal scan (`--diff-only`), and `check-no-abs-paths.sh` pass on changed files.
+- [ ] The legal/per-input-license scan and the absolute-path/path-leak scan run over every fixture and the contract, and pass.
+
+---
+
+## Sequencing & Gate
+
+**Blocked by #3428** (this contract reuses #3428's `canonical_json` + SHA-256 digest convention and its
+"hashes are evidence, never identity" rule; #3428's reference implementation is imported, not duplicated).
+Extends the parent contract structure, which is in **draft PR #3452, not yet on `main`** — the contract
+YAML and decision-manual are **404 on `main` and exist only in #3452**, so implementation here is **STACKED
+ON parent PR #3452** and must not fork the closed-schema behavior. All five sibling contracts
+(#3428/#3430/#3431/#3433 + this) edit that YAML + decision-manual as **strictly-additive, non-overlapping
+sections**, landing in dependency order (blocker #3428 first) or folded into one integration PR. Requires
+its own reviewed plan and explicit user approval (HITL contract work; parent #3427 approval does not
+authorize it). The publication child #3433 consumes this contract (its object store + integrity re-reader);
+implementation here lands before #3433 code.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Findings | Result |
+|---|---|---|---|---|
+| r1 | Claude | BLOCK | 2 MAJOR — (1) digest hashed decoded/canonical bytes instead of the STORED bytes #3433 re-hashes (breaks self-verifying re-hash + byte-exact replay); (2) role-derived `residency.class`/`eligible` stamped on the role-free Artifact record (violates one-identity-across-roles). Plus MINORs — locator/digest exact-consistency rule missing; no dedicated forbidden-residency fixture; `canonical_json` import home / reference-impl home / #3452 stacking left as open questions. | All remediated: physical artifacts hash exact stored bytes (`canonical_json` reserved for structured objects); byte-intrinsic-only Artifact record with residency computed at projection time on the referencing record; normative locator==digest rule + `test_storage_locator_matches_record_digest`; dedicated forbidden-residency fixture/test; homes decided (`assetutilities.workflow_api.artifact` / `.identity`); stacked additively on PR #3452. |
+
+No unavailable provider counts as approval; any depth reduction is disclosed for owner acceptance.
+
+---
+
+## Risks and Open Questions
+
+- **Structured-object canonicalization coupling:** an artifact that is an immutable structured object must
+  hash via #3428's exact `canonical_json`, or a structured artifact digest will diverge from what the
+  identity contract computes. Mitigation: import the single #3428 helper; fail closed on version drift;
+  a fixture asserts byte-identical digests across the two modules.
+- **Compression is descriptive, digest is over stored bytes (DECIDED — not an owner preference):** the
+  digest of a physical-byte artifact is `sha256` of the **EXACT immutable STORED bytes** — the same bytes
+  #3433's object store re-hashes to self-verify. A decode-before-hash rule was a **correctness bug**: it
+  would break the self-verifying re-hash and byte-exact replay, and it created a spurious lossy-codec
+  ambiguity. `compression` is purely descriptive metadata and never triggers a decode. This resolves the
+  former "compression vs identity" open question — it is no longer an owner decision; decided = hash stored
+  bytes, and the lossy-codec ambiguity disappears. `canonical_json` canonicalization applies only to
+  structured-object artifacts.
+- **Residency-class must not be stamped on the role-free artifact (reconciled with the Design):**
+  `class` (replay_critical_input / curated_native_output / excluded) and the `eligible` boolean are
+  role-derived and therefore live on the referencing Input (#3430) / Output (#3431) record, or are computed
+  at projection time as (byte-intrinsic license) × (per-reference role) — never on the Artifact record.
+  This is what keeps identical bytes used as a replay_input in one run and a curated_output in another as
+  **ONE artifact record** with two differently-classed references. Mitigation: the classifier takes the
+  referencing role as input; an unclassified reference fails closed.
+- **Parent-contract coupling / stacking risk:** both files this plan edits (the contract YAML and the
+  decision-manual) are **404 on `main` and exist only in parent PR #3452**. Mitigation: this change stacks
+  on #3452 as a **strictly-additive, non-overlapping section**; the five sibling contracts
+  (#3428/#3430/#3431/#3433 + this) land in dependency order or via one integration PR; fail closed on schema
+  drift. The reference-impl home is DECIDED (`assetutilities.workflow_api.artifact`), no longer an open
+  question.
+
+---
+
+## Complexity: T2
+
+A normative contract slice with a small deterministic reference implementation + fixtures, in a single
+domain, no external platform write, no cross-system transaction. Not T1: it is a load-bearing shared
+contract that both Input (#3430) and Output (#3431) records and the publication object store (#3433) bind
+to, and its fail-closed residency + integrity-from-bytes proofs gate what reaches a public Hugging Face
+surface. Not T3: it neither publishes nor orchestrates a multi-stage promotion — it defines the artifact
+record those systems consume.

--- a/docs/plans/2026-07-11-issue-3430-replayable-public-input-snapshot-contract.md
+++ b/docs/plans/2026-07-11-issue-3430-replayable-public-input-snapshot-contract.md
@@ -1,0 +1,419 @@
+# Plan for [#3430](https://github.com/vamseeachanta/workspace-hub/issues/3430): Replayable Public Input and Source Snapshot Contract
+
+> **Status:** adversarial-reviewed (r1 BLOCK remediated; ready for user review)
+> **Complexity:** T2
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3430
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3430-{claude,codex,gemini}.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` — `input_hash(cfg)` computes a
+  SHA-256 over the caller cfg with **volatile top-level keys pruned**
+  (`VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}`, line 35) because those carry absolute
+  paths / machine state. This is **execution evidence, not a replay input set**: it prunes real
+  replay-critical inputs, has no per-input structure (role, schema version, redistribution evidence),
+  and cannot distinguish a parameter from a dataset snapshot. `make_provenance(...)` (line 81) records
+  a single flat `data_as_of` string (line 92) and no snapshot identity, selection, or license. The
+  input contract re-derives a **structured, per-input** replay set and references `input_hash` only as
+  evidence, never as the canonical input-set identity.
+- `worldenergydata/src/worldenergydata/workflow_api/runner.py:238` calls
+  `make_provenance(ihash, package_name=PACKAGE_NAME, data_as_of=utc_now_iso())` — i.e. `data_as_of` is
+  stamped as a **run wall-clock timestamp** (`utc_now_iso()`), *not* a pinned source-data snapshot. A
+  dataset-backed run therefore records *when the code ran*, not *which version of the source data it
+  read*, with no selection/query/filter and no redistribution evidence. **This is the substrate gap
+  this contract closes: such an input must FAIL public admission.**
+- `digitalmodel/docs/registry/workflows.yaml` (`schema_version: 2`) and the dm runner supply the
+  landed execution path whose configs become parameter/configuration inputs here; they are consumed,
+  not modified.
+- **Gap:** no normative Input record separating input *kinds*, no per-input schema-version + canonical
+  representation + digest + role + required-for-replay binding, no dataset snapshot-identity /
+  selection / redistribution-evidence fields, and no fail-closed admission rule anywhere.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Deterministic run identity contract (`canonical_json`, SHA-256, `canonical_input_set_digest`) | binding, consumed | `#3428` plan (this session) |
+| Content-addressed artifact + HF residency contract (artifact identity by digest) | binding, consumed | `#3429` (OPEN) |
+| Parent run-dataset contract (strict public input policy) | binding, extended here | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (in **draft PR #3452**, not on `main`) |
+| Publication projection + egress Gate A (per-input license admission) | binding, downstream consumer | `#3433` plan (this session) |
+| Legal / abs-path scans | binding | `scripts/legal/legal-sanity-scan.sh`, `scripts/enforcement/check-no-abs-paths.sh` |
+| Issue lifecycle + approval | binding | `AGENTS.md`, `docs/plans/README.md` |
+
+No engineering-calculation standard applies to this input-record contract.
+
+### Documents consulted
+
+- Issue [#3430](https://github.com/vamseeachanta/workspace-hub/issues/3430): distinguishes parameter
+  sets, configuration documents, dataset snapshots, public external resources, upstream runs, and
+  artifact references; every replay-critical input binds schema version + canonical representation +
+  digest + role + required-for-replay; dataset/API inputs additionally record source authority, public
+  locator, data-as-of/retrieval time, exact selection/query/filter, snapshot identity, and
+  redistribution evidence; canonically-equivalent JSON/YAML yields identical input-set identity;
+  missing/mutable-unpinned/restricted/ambiguous-license/private/client-specific/unretrievable inputs
+  fail public eligibility; admitted runs reconstruct the complete replay set with no local absolute
+  paths or undocumented machine state. Acceptance criteria copied verbatim below.
+- Sibling identity contract [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428) plan
+  (read this session): defines `canonical_json` (UTF-8, sorted keys, normalized numbers with explicit
+  unit tags, explicit `null`/`NA`) and SHA-256 digests, and binds `run_id` to a
+  `canonical_input_set_digest` **owned by this contract (#3430)** — so this contract's canonicalization
+  *is* the thing that makes `run_id` deterministic. This plan reuses #3428's `canonical_json`/digest
+  verbatim and does not fork it.
+- Sibling artifact contract [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429)
+  (OPEN — verified title "standard: content-addressed artifact and Hugging Face residency contract"):
+  inputs may **reference** content-addressed artifacts by digest; this contract references artifact
+  identity, it does not redefine it.
+- Publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) plan (read this
+  session): its egress **Gate A** does per-input license/redistribution admission and fails closed on
+  restricted/pointer-only/unlicensed/unpinned/unhashed/incomplete inputs, and its
+  `test_dataset_backed_data_as_of_run_timestamp_fails` asserts the worldenergydata `data_as_of`
+  substrate gap is rejected. This contract **defines** those admission rules; the reference impl is
+  importable by #3433.
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427) plan: public publication
+  requires every replay-critical input to be redistributable, versioned or snapshot-pinned,
+  content-hashed, schema-valid, and included in the per-repo HF dataset or publicly retrievable;
+  pointer-only restricted inputs do NOT qualify a run for public publication.
+- **worldenergydata `data_as_of` gap** (verified in code, see Evidence): the concrete failing example
+  that motivates the dataset/API snapshot fields.
+
+### Gaps identified
+
+- No normative Input record enumerates the six input kinds or binds each replay-critical input to
+  schema version + canonical representation + digest + role + required-for-replay.
+- No dataset/API input records source authority, public locator, data-as-of/retrieval time, exact
+  selection/query/filter, snapshot identity, and redistribution evidence — `data_as_of` is a run
+  timestamp today.
+- No canonical **input-set** digest that (a) equals #3428's `canonical_json`/SHA-256 and (b) makes
+  canonically-equivalent JSON/YAML/config produce identical input-set identity.
+- No fail-closed admission rule enumerating the disqualifiers, and no valid/invalid fixtures covering
+  ordering, numeric canonicalization, missing units, unstable locators, incomplete snapshots,
+  forbidden pointer-only, and `data_as_of`-is-run-timestamp.
+
+### Evidence (verified 2026-07-11)
+
+```text
+EXISTS  assetutilities …/workflow_api/envelope.py
+        input_hash() prunes VOLATILE_TOP_KEYS={"Analysis","default","cfg_array"} (line 35); evidence, not input set
+        make_provenance(..., data_as_of=None) flat string; no snapshot/selection/license (lines 81-92)
+CONFIRM worldenergydata …/workflow_api/runner.py:238  data_as_of=utc_now_iso()  -> RUN TIMESTAMP, not snapshot  (the gap)
+404 @main  docs/architecture/algorithm-run-dataset-contract.yaml   (parent contract in DRAFT PR #3452, not on main)
+#3430    OPEN status:needs-plan lane:claude — Blocked by #3428, #3429
+#3428    OPEN (identity; owns canonical_json/digest; run_id binds THIS contract's canonical_input_set_digest)
+#3429    OPEN "content-addressed artifact and Hugging Face residency contract" (artifact identity referenced here)
+#3433    plan-approved — egress Gate A consumes this contract's admission rules
+```
+
+Distinct sources: issue #3430; parent #3427 plan; sibling #3428 identity plan; sibling #3429 artifact
+issue; publication child #3433 plan; the `envelope.py` `input_hash`/`make_provenance` implementation;
+the worldenergydata runner `data_as_of` gap — more than the required three.
+
+---
+
+## Deliverable
+
+A normative, machine-validated **replayable public input + source snapshot contract**: the Input
+record shapes for all six input kinds; a per-input binding of schema version + canonical
+representation + digest + role + required-for-replay; the additional dataset/API snapshot fields
+(source authority, public locator, data-as-of/retrieval time, exact selection/query/filter, snapshot
+identity, redistribution evidence); the **`canonical_input_set_digest`** that #3428's `run_id`
+consumes; a fail-closed public-admission rule; valid/invalid fixtures; and decision-manual admission +
+canonicalization examples. A reference implementation proves canonical-equivalence and admission; the
+contract does not build the uploader, the report, or any dataset.
+
+---
+
+## Design
+
+### Input kinds (closed enumeration)
+
+```text
+parameter_set          canonical scalar/struct parameters authored for the run (e.g. VIV sweep params) — replay DATA (sweep values, physical parameters); flows through canonical_input_set_digest. DISTINCT from #3428 execution_parameters (run-control knobs); see boundary rule below
+configuration_document a config file/document driving the run (dm workflows.yaml row, YAML/JSON cfg)
+dataset_snapshot       an IMMUTABLE pinned slice of a source dataset (BSEE, public registries) — snapshot fields REQUIRED; API-backed inputs (data fetched from a live API) are classified HERE, not as a separate kind, so the six kinds stay a CLOSED enumeration and the snapshot-field trigger is well-defined
+public_external_resource a stable public resource fetched by URL/DOI (spec, standard table, public file)
+upstream_run_reference reference to an already-public upstream run_id in a per-repo HF dataset
+artifact_reference     reference to a content-addressed artifact by digest (identity owned by #3429)
+```
+
+### Per-input binding (every replay-critical input)
+
+```text
+Input
+  input_id            stable within the run: "<role>:<slug>"
+  kind                one of the six kinds above
+  role                semantic role in replay (e.g. "sweep_params", "mesh", "source_dataset")
+  required_for_replay bool — if true, its absence/failure fails public admission
+  schema_version      pinned schema id+version validating this input's canonical representation
+  canonical_repr      canonical_json bytes (#3428) OR, for large payloads, an artifact_reference digest (#3429)
+  digest              sha256 over canonical_repr (or the referenced artifact/object digest)   # #3428 algorithm
+  license             { spdx | declared_terms, redistribution: allowed|restricted|unknown }   # admission input
+```
+
+### `dataset_snapshot` inputs (incl. API-backed) — additional REQUIRED fields (close the `data_as_of` gap)
+
+API-backed inputs are `dataset_snapshot` inputs (see closed enumeration); there is no separate `api`
+kind. Every `dataset_snapshot` input additionally REQUIRES:
+
+```text
+dataset_snapshot input additionally REQUIRES:
+  source_authority    who is authoritative for the data (e.g. "BSEE", "EIA")
+  public_locator      STABLE public locator (versioned URL / DOI / dataset revision) — moving/`latest` refs REJECTED
+  data_as_of          the SOURCE-DATA snapshot instant/version the slice reflects  (NOT the run wall-clock time)
+  retrieval_time      when the slice was retrieved (distinct from data_as_of; both recorded)
+  selection           EXACT selection/query/filter that produced the slice (canonicalized: sorted keys, normalized)
+  snapshot_identity   content digest of the retrieved slice bytes (pins the immutable snapshot)
+  redistribution_evidence  license/terms proving the slice may be publicly redistributed
+```
+
+**Admission rule (fail-closed):** the OPERATIVE predicate is **absence of a verifiable pinned
+snapshot** — defined as (`snapshot_identity` byte-digest of the retrieved slice ∧ a versioned
+`public_locator`). A `dataset_snapshot` input that lacks either — or that lacks `selection` or
+`redistribution_evidence` — **FAILS admission**. The `data_as_of == retrieval_time` timestamp
+comparison is a **SYMPTOM, not the rule** (a timestamp is spoofable — an input can carry
+`data_as_of != retrieval_time` yet still have no pinned snapshot). The worldenergydata
+`data_as_of=utc_now_iso()` input is rejected because it has **no `snapshot_identity` and no versioned
+`public_locator`** (the missing pinned snapshot), not merely because its timestamp equals the run time.
+This is exactly the worldenergydata substrate gap.
+
+### `parameter_set` vs `execution_parameters` boundary (cross-plan seam with #3428)
+
+Adopt the boundary rule now defined in **#3428**: `execution_parameters` = run-**CONTROL** knobs
+(tolerances, iteration/step caps, solver flags, seed-adjacent controls) that enter `run_id` **directly**
+(via #3428, not through this contract); `parameter_set` (a #3430 Input kind) = replay **DATA** (sweep
+values, physical parameters) that flow through `canonical_input_set_digest`. A given parameter is
+assigned to **EXACTLY ONE** side by the **algorithm descriptor** — it is never double-counted (never
+both a #3428 `execution_parameter` and a #3430 `parameter_set` member). This is a strict partition:
+the descriptor is the single source of truth for the assignment. Cross-reference **#3428** for the
+`execution_parameters` half of the seam.
+
+### `canonical_input_set_digest` (owned here; consumed by #3428's `run_id`)
+
+The digest is computed over the **identity-bearing dataset subset only** — the fields that establish
+*which immutable snapshot* the input is — and EXCLUDES fetch-volatile fields:
+
+```text
+identity-bearing dataset subset (enters digest):
+  { source_authority, public_locator, data_as_of (source snapshot version), selection, snapshot_identity }
+
+EXPLICITLY EXCLUDED from the digest (recorded on the record, but MUST NOT affect identity):
+  retrieval_time            # wall-clock of the fetch — varies per re-fetch of the SAME immutable snapshot
+  redistribution_evidence   # license/terms provenance — not part of what the snapshot IS
+
+canonical_input_set_digest = sha256(canonical_json(
+    sorted-by-input_id list of { input_id, kind, role, required_for_replay,
+                                 schema_version, digest,
+                                 [identity-bearing dataset subset above for dataset kinds] }))
+```
+
+Including `retrieval_time` or `redistribution_evidence` in the digest would make **re-fetching the same
+immutable snapshot produce a new `run_id`**, breaking **#3428** determinism — so both are excluded by
+rule. Uses #3428's `canonical_json` verbatim (UTF-8, sorted keys, normalized numbers with explicit unit
+tags, explicit `null`/`NA`, declared array order). Therefore **canonically-equivalent JSON/YAML/config
+values (key order, whitespace, `1.0` vs `1`) produce an identical `canonical_input_set_digest`** — the
+property that makes `run_id` deterministic. A units-bearing numeric input without its unit tag is
+**rejected**, not silently hashed (parity with #3428).
+
+### Fail-closed public admission (the rules #3433 Gate A enforces)
+
+An input fails public eligibility (no run is publicly admitted) if it is:
+missing / not retrievable; mutable-unpinned (moving/`latest` locator, no snapshot identity);
+restricted, ambiguous-license, or unknown-license redistribution; private / client-specific;
+pointer-only to a restricted source (a pointer without a redistributable, hashed, retrievable payload);
+schema-invalid; missing a required unit tag; or (dataset/API) `data_as_of` is a run timestamp. A
+**dataset-level** license never grants rights absent from a specific input's source.
+
+### Complete replay reconstruction (no local state)
+
+An admitted run's complete replay input set reconstructs from the Input records alone — with **no local
+absolute paths and no undocumented machine state** (enforced by `check-no-abs-paths.sh` + the canonical
+representation excluding host fields).
+
+**Replay-critical input BYTES must be MATERIALIZED** — either as an HF-resident content object
+(per **#3429**, artifact identity by digest) or embedded in the record's `canonical_repr`. A stable
+public locator is **PROVENANCE, not the reconstruction source**: a locator-only input can rot (404) or
+silently mutate, in which case the digest can only **verify** a re-fetch, it cannot **rebuild** the
+input. Therefore a `required_for_replay` input is admitted only when its replay bytes are materialized
+(HF-resident object or embedded `canonical_repr`); the stable locator is recorded alongside as
+provenance. Aligns with **#3429** (HF-resident artifacts).
+
+### Report rendering (#3431 consumer)
+
+The rolling HTML report (#3431) renders, from these records only: a **concise input summary**
+(counts by kind, required-for-replay count, dataset snapshots + their `data_as_of`) and a **complete
+input inventory** (every Input record with role, digest, locator/snapshot, license). No new data is
+introduced at report time.
+
+### Crosswalk (evidence, never identity)
+
+`ResultEnvelope.input_hash` (volatile-key-pruned) is retained as *execution evidence*; it is never
+the `canonical_input_set_digest` and never enters `run_id`.
+
+---
+
+## Pseudocode
+
+```text
+for each declared input:
+    require kind in {parameter_set, configuration_document, dataset_snapshot,
+                     public_external_resource, upstream_run_reference, artifact_reference}
+    require role, required_for_replay, schema_version
+    canonical_repr = canonical_json(value)            # #3428; large payload -> artifact_reference (#3429)
+    validate against schema_version                    # fail closed if invalid
+    reject if numeric input carries units but no unit tag
+    digest = sha256(canonical_repr) OR referenced artifact/object digest
+    # parameter vs execution_parameter partition: descriptor assigns EXACTLY ONE side; never both (#3428)
+    assert param not in both #3428 execution_parameters and #3430 parameter_set
+    if required_for_replay:
+        require replay bytes MATERIALIZED (HF-resident object #3429 OR embedded canonical_repr);
+                locator-only is provenance, NOT a reconstruction source -> reject if bytes not materialized
+    if kind == dataset_snapshot:   # incl. API-backed; no separate `api` kind
+        require source_authority, public_locator (versioned, not moving/`latest`),
+                data_as_of (SOURCE snapshot version), retrieval_time,
+                selection (canonicalized), snapshot_identity (slice byte-digest), redistribution_evidence
+        # OPERATIVE predicate: absence of a verifiable pinned snapshot
+        FAIL CLOSED if NOT (snapshot_identity byte-digest AND versioned public_locator)
+        # data_as_of == retrieval_time is a SYMPTOM (spoofable), not the rule
+    admission: FAIL if missing | mutable-unpinned | restricted | ambiguous/unknown license |
+               private | client-specific | pointer-only-restricted | schema-invalid | unretrievable
+# digest EXCLUDES fetch-volatile retrieval_time + redistribution_evidence (else re-fetch breaks #3428 run_id)
+canonical_input_set_digest = sha256(canonical_json(sorted input records
+        with dataset identity subset = {source_authority, public_locator, data_as_of, selection, snapshot_identity}))   # -> #3428 run_id
+assert reconstructable with NO local absolute paths / undocumented machine state
+envelope input_hash recorded as evidence only (never the input-set identity)
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Update | `docs/architecture/algorithm-run-dataset-contract.yaml` (STACKED ON parent PR #3452 — the YAML + decision manual 404 on `main`, exist only in #3452) | add the normative Input record schema, six kinds, dataset snapshot fields, `canonical_input_set_digest`, admission rules — as a STRICTLY ADDITIVE, NON-OVERLAPPING section (all five sibling contracts edit this one YAML; land in dependency order or via one integration PR) |
+| Create | `assetutilities/src/assetutilities/workflow_api/inputs.py` (reference-impl home DECIDED — inherits #3433's owner-confirmed `assetutilities.workflow_api` placement) | build/validate Input records; compute `canonical_input_set_digest` via #3428 `canonical_json`; fail-closed admission; importable by #3433 |
+| Create | `assetutilities/tests/workflow_api/test_inputs.py` + `fixtures/inputs/{valid,invalid}/…` | valid/invalid + canonical-equivalence + admission fixtures |
+| Update | `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` (in PR #3452) | input admission + canonicalization examples |
+| Create | `tests/architecture/test_input_contract_parity.py` | assert the decision-manual input section matches the contract YAML |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, workflow registry, runner, dataset, or credential is modified.
+The `assetutilities` and `worldenergydata` runners are consumed/described, not edited under this issue.
+
+---
+
+## TDD Test List
+
+| Test | Verifies (acceptance criterion) | Expected |
+|---|---|---|
+| `test_input_kinds_are_the_closed_six` | AC1: parameter/config/dataset/public-resource/upstream-run/artifact distinguished | unknown kind rejected; six accepted |
+| `test_every_replay_input_binds_schema_repr_digest_role_flag` | AC2: schema version + canonical repr + digest + role + required-for-replay bound | omit any binding → rejected |
+| `test_dataset_input_records_snapshot_selection_license` | AC3: source authority, public locator, data-as-of/retrieval, selection, snapshot identity, redistribution evidence | missing any dataset field → rejected |
+| `test_data_as_of_run_timestamp_fails_admission` | AC3/AC5: `data_as_of == run timestamp` (wed substrate gap) rejected via MISSING pinned snapshot (no `snapshot_identity`/versioned locator), not the timestamp symptom | rejected (must be pinned source snapshot) |
+| `test_refetch_same_snapshot_yields_same_run_id` | AC4/MAJOR-1: re-fetch same immutable snapshot with a DIFFERENT `retrieval_time` (and different `redistribution_evidence` provenance) → identical `run_id` (digest excludes fetch-volatile fields) | identical `run_id` |
+| `test_ambiguous_or_unknown_license_fails_admission` | AC5/MAJOR-2: license-ambiguous AND license-absent inputs both rejected (fail-closed) | each rejected |
+| `test_parameter_not_double_counted_across_contracts` | MAJOR-3: a param assigned by the algorithm descriptor to EXACTLY ONE side — never both a #3428 `execution_parameter` and a #3430 `parameter_set` member | double-counted param rejected |
+| `test_schema_invalid_input_fails_closed` | AC5/MINOR: a present-but-schema-failing input rejected (distinct from missing-binding cases) | rejected |
+| `test_canonical_equivalent_json_yaml_same_input_set_identity` | AC4: key order / whitespace equivalence → identical `canonical_input_set_digest` | equal digests |
+| `test_numeric_canonicalization_and_missing_unit_rejected` | AC4/AC7: `1.0`==`1`; units-bearing numeric without unit tag rejected | equal digest; unit-less numeric rejected |
+| `test_input_ordering_does_not_change_identity` | AC4/AC7: input records sorted by `input_id` before hashing | reordered inputs → same digest |
+| `test_missing_mutable_restricted_private_clientspecific_unretrievable_fail` | AC5: each disqualifier fails public eligibility | each rejected |
+| `test_unstable_locator_fails` | AC5/AC7: moving/`latest` locator (no snapshot identity) rejected | rejected |
+| `test_incomplete_snapshot_fails` | AC7: dataset input missing snapshot identity/selection | rejected |
+| `test_pointer_only_restricted_input_forbidden` | AC5/AC7: pointer to restricted source, no redistributable hashed payload | rejected |
+| `test_reconstruct_replay_set_has_no_abs_paths_or_machine_state` | AC6: complete replay set reconstructs; no local absolute paths / undocumented machine state | reconstructs; abs-path/host field → fail |
+| `test_input_set_digest_feeds_run_id_deterministically` | AC4: digest equals #3428 `canonical_json`/SHA-256 and is what `run_id` binds | identical digest across machines |
+| `test_report_renders_summary_and_full_inventory_from_records` | AC8: concise summary + complete inventory rendered from records only | both render; no new data introduced |
+| `test_decision_manual_matches_input_contract` | AC9: manual admission/canonicalization examples ↔ contract YAML parity | structure + examples agree |
+| `test_valid_and_invalid_fixtures_cover_all_named_cases` | AC7: ordering, numeric canon, missing units, unstable locators, incomplete snapshots, forbidden pointer-only | fixtures present and each asserted |
+| `test_envelope_input_hash_is_evidence_not_input_set_identity` | crosswalk: `input_hash` never the `canonical_input_set_digest` | identity independent of `input_hash` |
+
+Tests are written first and fail before implementation exists.
+
+---
+
+## Acceptance Criteria
+
+Verbatim from issue #3430:
+
+- [ ] The Input contract distinguishes parameter sets, configuration documents, dataset snapshots, public external resources, upstream runs, and artifact references.
+- [ ] Every replay-critical input binds to a schema version, canonical representation, digest, role, and required-for-replay flag.
+- [ ] Dataset and API inputs record source authority, public locator, data-as-of or retrieval time, exact selection/query/filter, snapshot identity, and redistribution evidence.
+- [ ] Canonically equivalent JSON/YAML/configuration values produce identical input-set identities.
+- [ ] Any missing, mutable-unpinned, restricted, ambiguous-license, private, client-specific, or unretrievable replay input fails public eligibility.
+- [ ] Every admitted run can reconstruct its complete replay input set without local absolute paths or undocumented machine state.
+- [ ] Valid/invalid fixtures cover ordering, numeric canonicalization, missing units, unstable locators, incomplete snapshots, and forbidden pointer-only cases.
+- [ ] The rolling HTML report can render a concise input summary and complete input inventory from these records.
+- [ ] The decision manual documents input admission and canonicalization examples.
+
+Plus process gates:
+
+- [ ] Tests are written first; the suite, the legal scan (`scripts/legal/legal-sanity-scan.sh --diff-only`), and `scripts/enforcement/check-no-abs-paths.sh` pass on changed files.
+- [ ] Per-input license/redistribution admission fails closed on restricted / ambiguous / unknown / pointer-only inputs (the rules #3433 egress Gate A enforces).
+
+---
+
+## Sequencing & Gate
+
+**Blocked by #3428** (owns `canonical_json` + SHA-256 + the `canonical_input_set_digest` this contract
+computes, and the `execution_parameters` half of the parameter boundary) **and #3429** (owns artifact
+identity that `artifact_reference` inputs cite). Implementation is **STACKED ON parent PR #3452**: the
+contract YAML (`algorithm-run-dataset-contract.yaml`) and the decision manual **404 on `main`** and
+exist only in #3452, so this work branches from #3452, not `main`. All **five sibling contracts** edit
+that one YAML; each adds a **STRICTLY ADDITIVE, NON-OVERLAPPING** section, and they land **in dependency
+order or via a single integration PR** to avoid overlapping edits. This plan coordinates the Input
+schema with #3452 and must not fork the closed-schema behavior. Downstream, #3433's egress Gate A and
+#3431's report consume this contract; the reference implementation is importable by #3433. Requires its
+own reviewed plan and **explicit user approval (HITL contract work)** — parent #3427 approval does not
+authorize it.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Result |
+|---|---|---|---|
+| r1 | Claude | BLOCK | 3 MAJOR (digest field membership excludes fetch-volatile `retrieval_time`/`redistribution_evidence`; ambiguous/unknown-license admission test; `parameter_set`↔`execution_parameters` boundary + no-double-count) + MINORs (data_as_of admission teeth = missing pinned snapshot; API-backed = `dataset_snapshot`; schema-invalid fail-closed; replay-byte materialization) — **all remediated** |
+
+No unavailable provider counts as approval; any depth reduction is disclosed for owner acceptance.
+
+---
+
+## Risks and Open Questions
+
+- **`data_as_of` semantic-overload risk:** the field currently means "run time" in the wed runner;
+  reusing the name for a *source snapshot* invites confusion. Mitigation: the contract records
+  `data_as_of` (source snapshot version) **and** `retrieval_time` (fetch instant) as *distinct*
+  fields, and admission fails closed when they are indistinguishable — the run timestamp is never a
+  valid snapshot.
+- **Selection-canonicalization risk:** an "exact selection/query/filter" can be expressed many
+  equivalent ways (SQL vs param dict, key order). Mitigation: `selection` is canonicalized with the
+  same #3428 `canonical_json` so equivalent queries yield one identity; free-form query strings that
+  cannot be canonicalized are rejected as ambiguous.
+- **Pointer-vs-payload boundary risk:** an `upstream_run_reference` / `artifact_reference` is a pointer
+  by design, yet the contract forbids pointer-only restricted inputs. Mitigation: a reference is
+  admissible **only** when its target is itself publicly retrievable and hashed (already-public HF run
+  / content-addressed object per #3429); a pointer to a restricted or private source fails.
+- **Parent-contract coupling / stacked-PR risk:** the contract YAML and decision manual exist only in
+  **draft PR #3452** (404 on `main`); this work is STACKED ON #3452. All five sibling contracts edit
+  that one YAML. Mitigation: each contributes a **strictly additive, non-overlapping** section; land in
+  dependency order or fold into **one integration PR**; branch from #3452 (not `main`); coordinate the
+  Input schema with #3452 and fail closed on schema drift.
+- **Reference-implementation home — DECIDED:** `assetutilities.workflow_api.inputs` (inherits #3433's
+  owner-confirmed `assetutilities.workflow_api` placement; #3433's publication module and #3431's report
+  import one implementation, matching #3428's `identity.py` sibling). No longer an open question.
+
+---
+
+## Complexity: T2
+
+A normative contract slice with a small deterministic reference implementation + fixtures. Not T3:
+single-domain, no external platform commit, no cross-system transaction — but it owns the
+`canonical_input_set_digest` that makes `run_id` deterministic and defines the fail-closed admission
+rules #3433's egress Gate A enforces, so its canonicalization and admission proofs are load-bearing
+for every downstream public publication.

--- a/docs/plans/2026-07-11-issue-3431-curated-output-rolling-report-contract.md
+++ b/docs/plans/2026-07-11-issue-3431-curated-output-rolling-report-contract.md
@@ -1,0 +1,510 @@
+# Plan for [#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431): Curated Output and Rolling Algorithm Report Contract
+
+> **Status:** adversarial-reviewed (r1 BLOCK remediated; ready for user review)
+> **Complexity:** T2
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3431
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3431-{claude,codex,gemini}.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` — `ResultEnvelope` exposes a
+  location-independent content `result_hash` for `kind: files` (a hash of curated output *bytes*),
+  `code_version()`, a volatile-key-pruned `input_hash`, and `reproducible` (`None` unless an opt-in
+  double run runs). `result_hash` is the closest existing surface to an output digest, but it is
+  **execution evidence, not a published contract**: it hashes whatever the run emitted, carries no
+  role/native-schema/units/validation metadata, has no declared canonicalizer, and does not fail
+  closed on volatile content. This contract re-derives a **versioned `output_equality_digest`** and
+  treats `result_hash` as evidence only, never an alias.
+- `digitalmodel/src/digitalmodel/workflow_api/{runner,provenance,golden}.py` — the runner emits
+  output files and `stamp_provenance` assembles provenance; the golden harness compares runs against
+  goldens. These produce **native domain outputs** (e.g. tabular results, plots, solver artifacts)
+  with no normative Output *record* separating curated primary results from transient scratch, and no
+  standard report. dm [#1528](https://github.com/vamseeachanta/digitalmodel/issues/1528) (coupled
+  sloshing CFD) is a concrete producer whose per-run manifest lists synchronized time-history traces,
+  a report hash, and output files — a real test of non-flattening native-schema output handling.
+- `worldenergydata/src/worldenergydata/workflow_api/runner.py` — consumes the same envelope; a
+  dataset-backed algorithm whose outputs must reference pinned inputs (per #3430) and whose report
+  must pin exact HF revisions.
+- `docs/architecture/execution-manifest.schema.yaml` (on `main`) and
+  `docs/architecture/report-evidence-bundle.schema.yaml` (on `main`, per #3433 standards table) —
+  the report-evidence-bundle schema is the **reuse-and-extend** base for the rolling report's
+  evidence sections; this contract extends it with the mandatory Inputs/Outputs structure, the
+  failed-run health section, and the exact-revision pin, rather than inventing a parallel bundle.
+- **Gap:** no normative Output record (role / native schema / media type / shape / units / convention
+  / validation state / review state / artifact refs), no curated-vs-excluded taxonomy, no non-overlapping
+  success/failure output requirements, no stable normalized failure signature, no versioned
+  `output_equality_digest`, and no one-per-algorithm rolling HTML report contract exist anywhere.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Parent run-dataset contract (output/report decisions, exclusions) | binding, extended here | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (in **draft PR #3452**, not yet on `main`) |
+| Sibling identity contract (run_id, output_equality_digest ownership boundary) | binding, consumed | `#3428` plan (this session) |
+| Sibling artifact contract (content-addressed artifact refs) | binding, referenced | `#3429` (outputs reference artifacts by digest; do not redefine) |
+| Report evidence bundle | reusable, extended | `docs/architecture/report-evidence-bundle.schema.yaml` |
+| Data/execution/report boundaries | reusable | `docs/architecture/execution-manifest.schema.yaml` |
+| Issue lifecycle + approval | binding | `AGENTS.md`, `docs/plans/README.md` |
+| Legal/abs-path scans + HTML safety | binding | `scripts/legal/legal-sanity-scan.sh`, `scripts/enforcement/check-no-abs-paths.sh` |
+
+No engineering-calculation standard governs the output/report *contract* itself; producing algorithms
+retain their own calculation-citation obligations for the values they emit.
+
+### Documents consulted
+
+- Issue [#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431) (read live 2026-07-11):
+  Output contract fields (role, native schema, media type, shape/row count, units, coordinate/sign
+  convention, validation state, review state, artifact references); curated vs excluded taxonomy;
+  non-overlapping success/failure output requirements; stable normalized diagnostic signature;
+  exact-rerun output-digest match with fail-closed no-overwrite; one rolling HTML report per algorithm
+  with mandatory Inputs + Outputs and only-applicable optional sections; latest + historical runs,
+  failed-run separation, exact-HF-revision links; git history preserves report evolution while
+  immutable run records remain the data authority; valid/invalid fixtures; decision manual documents
+  the rules. Blocked by #3428 and #3429.
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427) plan: machine-readable
+  outputs preserve native domain schema and reference content-addressed artifacts without flattening
+  engineering meaning; ONE rolling report per algorithm; byte identity vs a **versioned semantic
+  equality digest**; failed runs appear in health analysis but never contribute metrics/insights/
+  decisions; report compares immutable historical runs pinned to exact HF revisions; no per-run HTML.
+- Sibling identity contract [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428) plan
+  (this session): `run_id` **excludes** outputs; the exact-rerun check compares a **separate,
+  versioned `output_equality_digest` that THIS contract (#3431) owns and defines**; a mismatch is a
+  reproducibility defect that fails closed and cannot mutate/overwrite the prior record. This is the
+  boundary the two contracts share: #3428 mints identity; #3431 defines the output digest #3428
+  compares.
+- Publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) plan (this
+  session): the CRITICAL consumer. The rolling report is **drafted at state 3** (unpinned); egress
+  **Gate B** scans the draft; **Gate D** re-scans the FINAL pinned report before the source-repo
+  commit; the report is finalized only after pinning the EXACT verified HF revision; a moving/`main`
+  reference must FAIL. The Publication acceptance **ledger** lives in the SOURCE REPO
+  (`reports/<algorithm>/publications.jsonl`), NOT in the HF dataset; the report renders eligibility
+  from that ledger. This contract's report structure must be consistent with all of the above.
+- Artifact contract [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429): outputs
+  reference content-addressed artifacts by SHA-256 digest + residency policy — **referenced, not
+  redefined** here.
+- Report-evidence base: `docs/architecture/report-evidence-bundle.schema.yaml` — the evidence-section
+  vocabulary this report extends.
+
+### Gaps identified
+
+- No normative Output record enumerates role, native schema, media type, shape/row count, units,
+  coordinate/sign convention, validation state, review state, and artifact references in one shape.
+- No taxonomy distinguishes curated primary results / supporting validation evidence / selected
+  reports / decision-support outputs from EXCLUDED transient outputs.
+- No explicit non-overlapping success-vs-failure output requirement, and no stable normalized failure
+  signature that excludes volatile timestamps/path noise.
+- No versioned `output_equality_digest` (raw-byte default; declared semantic canonicalizer as the
+  only exception; undeclared canonicalizer fails closed).
+- No one-per-algorithm rolling HTML report contract (mandatory Inputs/Outputs, only-applicable
+  optional sections, latest + historical + failed-run separation, exact-HF-revision pins, git-history
+  evolution, safe HTML).
+
+### Evidence (verified 2026-07-11)
+
+```text
+#3431           OPEN status:needs-plan lane:claude — Blocked by: #3428, #3429 (verified live via gh)
+#3428 / #3429   OPEN status:needs-plan (identity + artifact contracts this plan consumes)
+DRAFT PR #3452  feat: define algorithm run ledger … (parent #3427 contract; NOT on main)
+404 @main       docs/architecture/algorithm-run-dataset-contract.yaml
+EXISTS @main    docs/architecture/report-evidence-bundle.schema.yaml (report evidence base)
+EXISTS @main    docs/architecture/execution-manifest.schema.yaml
+EXISTS          assetutilities …/workflow_api/envelope.py (result_hash = output-byte hash; evidence only)
+EXISTS          digitalmodel …/workflow_api/{runner,provenance,golden}.py (native outputs; no report)
+#3433           plan-approved consumer: report drafted@3 (Gate B) → pinned@6 (Gate D) → ledger in source repo
+```
+
+Distinct sources: issue #3431; parent #3427 plan; sibling #3428 plan; consumer #3433 plan; artifact
+#3429; the report-evidence-bundle schema; ResultEnvelope `result_hash`; dm #1528 producer — more than
+the required three.
+
+---
+
+## Deliverable
+
+A normative, machine-validated **curated Output record and rolling algorithm report contract**: the
+Output record shape (role, native schema, media type, shape/row count, units, coordinate/sign
+convention, validation state, review state, artifact references); the curated-vs-excluded output
+taxonomy; explicit non-overlapping success/failure output requirements; a stable normalized failure
+diagnostic signature; the **versioned `output_equality_digest`** (raw-byte default, declared semantic
+canonicalizer as the sole exception, undeclared canonicalizer fails closed); and the one-per-algorithm
+rolling HTML report contract (mandatory Inputs + Outputs, only-applicable optional sections, latest +
+historical + separated failed runs, exact-HF-revision pins, git-history evolution, safe HTML). A
+reference implementation + valid/invalid fixtures prove the rules; the decision manual documents the
+output-selection and report-section rules. **This plan builds nothing** — it defines the contract, its
+tests, and its fixtures; code lands only after review and explicit approval, and after #3428/#3429 and
+the parent contract land on `main`.
+
+---
+
+## Design
+
+### 1. Output record (curated, native, artifact-referencing)
+
+One record per curated output; native domain schema preserved, engineering meaning never flattened.
+
+```text
+OutputRecord
+  role                  curated_primary_result | supporting_validation_evidence |
+                        selected_report | decision_support        # taxonomy §2; EXCLUDED transients omitted, never recorded
+  native_schema         { schema_id, schema_version }             # domain-native shape; NOT flattened to a generic blob
+  media_type            e.g. application/parquet, application/json, image/svg+xml, application/pdf
+  shape                 { rows, cols } | { dims:[...] } | null     # row count / tensor shape where applicable
+  units                 per-field unit tags (declared allowlist); a units-bearing field WITHOUT a unit tag FAILS
+  convention            coordinate/sign/frame convention WHERE APPLICABLE (e.g. "z-down, tension +"); null when N/A
+  validation_state      passed | failed | not_applicable          # against the output's declared schema/domain checks
+  review_state          machine_only | human_reviewed | not_required
+  artifact_refs[]       -> #3429 content-addressed artifact by { sha256, media_type, residency }  # REFERENCE, not redefine
+  digest_contribution   included (DEFAULT) | excluded              # feeds output_equality_digest (§4)
+                        # DEFAULTS to `included` for every curated output. `excluded` is permitted
+                        # ONLY via an explicitly declared + justified exclusion rule (mirrors the
+                        # fail-closed semantic-canonicalizer pattern of §4). An undeclared/silent
+                        # exclusion FAILS CLOSED (treated as `included`, i.e. the omission is rejected).
+```
+
+Invariants: a curated output MUST carry `role`, `native_schema`, `media_type`, and `artifact_refs`;
+units-bearing numeric fields MUST carry unit tags (missing tag → fail closed); a coordinate/sign
+convention is mandatory *where applicable* and omitting it for a directional quantity fails.
+Every curated output is digest-eligible by default: `digest_contribution` defaults to `included`, and
+an output may be `excluded` from `output_equality_digest` ONLY through an explicitly declared and
+justified exclusion rule (the same fail-closed pattern §4 uses for the semantic canonicalizer). An
+undeclared/silent exclusion fails closed. **Rationale:** an unguarded exclusion could silently drop a
+nondeterministic curated output (e.g. a `selected_report` PDF with an embedded timestamp) from the
+digest, so the exact-rerun equality check (§4, AC5) would pass while the real emitted bytes differ —
+a masked reproducibility defect that defeats AC5. Requiring exclusions to be declared + justified keeps
+the digest honest.
+
+### 2. Curated vs excluded taxonomy
+
+Every curated output is digest-eligible **by default** (§1 `digest_contribution` defaults to
+`included`); a curated output leaves the digest set ONLY through an explicitly declared + justified
+exclusion rule, never silently. This resolves the §1/§4 boundary: "all curated is digest-eligible" is
+the default, and the sole escape is a fail-closed declared exclusion.
+
+```text
+CURATED (recorded + digest-eligible by default):
+  curated_primary_result       the algorithm's authoritative engineering output(s)
+  supporting_validation_evidence  goldens, residuals, convergence traces that substantiate the result
+  selected_report              a curated human-facing artifact (e.g. a PDF one-pager) chosen for publication
+  decision_support             screens/underwriting outputs meant to inform a decision
+
+EXCLUDED (transient — NEVER recorded, NEVER digested, NEVER published):
+  scratch/intermediate scratch files, solver temp dirs, re-derivable caches, volatile logs,
+  anything not declared curated. Exclusion is by DECLARED allowlist of curated roles; an undeclared
+  output defaults to EXCLUDED (fail-closed: unlabelled ≠ curated).
+```
+
+### 3. Non-overlapping success vs failed terminal-run output requirements
+
+```text
+status = succeeded          => MUST carry >=1 curated_primary_result; MAY carry the other curated roles;
+                               MUST NOT carry a failure signature.
+status = reproducible_failure => MUST carry a normalized failure signature (§3a) + curated diagnostic
+                               artifacts; MUST NOT carry curated_primary_result / metrics / insights /
+                               decision_support outputs. It appears ONLY in the report's health analysis.
+```
+
+The two requirement sets are **disjoint**: a record set satisfying one MUST violate the other. A
+"succeeded" run bearing a failure signature, or a "failed" run bearing a primary result or feeding
+metrics, fails validation closed.
+
+#### 3a. Stable normalized diagnostic signature
+
+```text
+failure_signature = { phase, code, signature_digest }
+  phase             normalized enum (e.g. input_validation | solve | postprocess | export)
+  code              normalized failure code (declared vocabulary, not a raw exception string)
+  signature_digest  sha256(canonical_json(NORMALIZED evidence)) where normalization STRIPS:
+                      absolute paths -> repo-relative or "<path>" tokens
+                      volatile timestamps -> removed
+                      pids / hostnames / tmpdir nonces / memory addresses -> removed
+                    and RETAINS the stable fault shape (phase, code, normalized message skeleton,
+                    normalized stack frame set). Same fault on two machines => identical signature_digest.
+
+  Stack-frame normalization: REPO frames keep their repo-relative path + `func`. Third-party / stdlib /
+  venv frames are normalized by module `qualname` — DROP the file path, KEEP `module.func` — so venv
+  paths (`/home/a/.venv` vs `/home/b/.venv`) do not break cross-machine signature stability, and
+  distinct third-party frames do NOT over-collapse to a single `<path>` token.
+```
+
+Curated diagnostic artifacts (a trimmed log, a residual plot) are referenced as artifacts (#3429);
+their *volatile* bytes are not what the signature hashes — the normalized shape is.
+
+### 4. Versioned `output_equality_digest` (owned by this contract)
+
+`#3428` mints `run_id` (excluding outputs). This contract defines the **separate** digest `#3428`'s
+exact-rerun check compares.
+
+**Ownership across the one-way blocking edge (#3428 blocks #3431):** #3428 references the
+`output_equality_digest` **concept** and owns ONLY the mismatch → reject-with-no-mutation **policy**,
+injecting the digest as an opaque/stub value it does not compute; #3431 **owns the digest's
+computation** (scheme, `mode`, canonical ordering, and value below). Ownership is therefore
+unambiguous: #3428 decides what happens on mismatch, #3431 decides how the digest is produced.
+
+```text
+output_equality_digest = {
+  version       digest-scheme version (bumped when the scheme changes; recorded per run)
+  mode          "raw_byte" (DEFAULT) | "semantic:<canonicalizer_id>@<ver>" (ONLY declared exception)
+  value         sha256 over:
+                  raw_byte  : sha256(canonical_json(SORTED list of the per-artifact sha256 of every
+                              digest-eligible curated OutputRecord)). Each artifact already carries a
+                              sha256 per #3429; canonical_json reuses #3428's pinned canonicalization.
+                              This is a digest-of-digests, NOT a raw-byte concatenation — concatenation
+                              is boundary-ambiguous (`[A][B]` and `[AB][]` collide), so it is forbidden.
+                  semantic  : the DECLARED canonicalizer's normalized form of those outputs
+}
+```
+
+Rules (fail-closed throughout):
+- **Default is raw-byte.** No canonicalization unless a semantic canonicalizer is **explicitly
+  declared** for the algorithm's output schema.
+- An output that claims a semantic canonicalizer that is **not declared/registered** fails closed
+  (an undeclared canonicalizer is never inferred or silently applied).
+- On an **exact rerun** (same `run_id`), the recomputed `output_equality_digest` MUST match the stored
+  one. A **mismatch fails publication** and **cannot overwrite** the prior immutable record — it is a
+  reproducibility defect, surfaced, never merged.
+- The digest `version` and `mode` are stored with the run so a later reader knows exactly how equality
+  was decided.
+
+### 5. Rolling HTML report contract (one per algorithm)
+
+```text
+reports/<algorithm>/report.html            # ONE rolling report per algorithm, in the SOURCE repo
+  MANDATORY sections (always present):
+    Inputs    the algorithm's replayable public inputs (per #3430), pinned
+    Outputs   curated OutputRecords (roles, native schema, units, convention, validation/review state,
+              artifact links)
+  OPTIONAL sections (rendered ONLY when applicable to the algorithm/run set):
+    metrics | plots | comparisons | uncertainty | diagnostics | insights | decision_briefs
+  ALWAYS-present run panorama:
+    latest run + historical runs, comparing IMMUTABLE historical runs
+    FAILED runs are rendered in a CLEARLY SEPARATED health-analysis section — visible, but they
+      contribute NOTHING to metrics / insights / comparisons / decision briefs
+    EVERY displayed run links to an EXACT Hugging Face revision (immutable commit sha)
+    eligibility is rendered FROM the source-repo publications.jsonl ledger (#3433), never inferred
+      from HF visibility
+```
+
+Report invariants:
+- **No per-run HTML reports.** Exactly one rolling report per algorithm; new runs update it in place.
+- **Exact-revision pins only.** A moving/`main`/branch reference (not an immutable commit sha) FAILS —
+  consistent with #3433 CROSS_VERIFIED and its "moving reference must fail" rule.
+- **Draft/pin lifecycle (consumed by #3433):** the report is **drafted unpinned at state 3** (egress
+  Gate B scans the draft), then **finalized only after pinning the exact verified HF revision at state
+  6** (egress Gate D re-scans the FINAL pinned bytes before the source-repo commit). This contract
+  MUST NOT assume the report is pinned at draft time.
+- **Data authority vs presentation:** the immutable run records (in the HF dataset) remain the **data
+  authority**; the report is a **projection**. Git history of `report.html` preserves the report's
+  *evolution*, but never becomes the source of truth for run data.
+- **Safe HTML only:** all run-derived text is escaped/sanitized; no unsafe HTML (no injected
+  `<script>`, event handlers, `javascript:` URIs, or raw untrusted markup) can reach the rendered
+  report. Untrusted content that would inject executable markup fails the render closed.
+
+---
+
+## Pseudocode
+
+```text
+# --- Output record admission ---
+for each declared curated output:
+    require role in curated taxonomy; else EXCLUDED (unlabelled => excluded, fail-closed)
+    require native_schema{id,version}, media_type, artifact_refs (#3429, by sha256)
+    require unit tag on every units-bearing field           # missing tag => FAIL
+    require convention where quantity is directional         # missing => FAIL
+    set validation_state / review_state
+    digest_contribution defaults to "included"; "excluded" only via a declared + justified rule
+      (undeclared/silent exclusion => FAIL CLOSED)
+    reject any output whose payload violates its declared native_schema{id,version}   # AC9
+transient/undeclared outputs => NOT recorded, NOT digested
+
+# --- Non-overlapping success/failure ---
+if status == succeeded:            require >=1 curated_primary_result; forbid failure_signature
+if status == reproducible_failure: require normalized failure_signature + diagnostic artifacts;
+                                   forbid primary_result/metrics/insights/decision_support
+assert requirement-sets disjoint (violating overlap => FAIL)
+
+# --- Failure signature normalization ---
+signature_digest = sha256(canonical_json(strip(paths, timestamps, pids, hosts, nonces))(evidence))
+# same fault, two machines => identical digest
+
+# --- Output equality digest (computation OWNED here; mismatch POLICY owned by #3428) ---
+mode = "raw_byte" UNLESS an explicitly declared semantic canonicalizer exists
+if mode claims semantic but canonicalizer undeclared: FAIL CLOSED
+raw_byte value = sha256(canonical_json(SORTED per-artifact sha256 of every digest-eligible output))
+                 # digest-of-digests, reuses #3428 canonical_json; NOT raw-byte concatenation
+output_equality_digest = { version, mode, value }
+on exact rerun (same run_id): recompute; MISMATCH => #3428 policy rejects, NO overwrite of prior record
+
+# --- Rolling report render ---
+render ONE report per algorithm: MANDATORY Inputs + Outputs; optional sections ONLY when applicable
+show latest + historical (immutable) runs; SEPARATE failed runs into health analysis (no metric/insight/decision)
+link every displayed run to an EXACT HF revision (moving ref => FAIL)
+render eligibility from source-repo publications.jsonl (#3433), not HF visibility
+escape/sanitize all run-derived text (unsafe HTML => FAIL); draft unpinned@state3, finalize pinned@state6
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Update | `docs/architecture/algorithm-run-dataset-contract.yaml` (**stacked on parent PR #3452**; YAML is 404 on `main`) | add — as a STRICTLY ADDITIVE, NON-OVERLAPPING section (all five siblings edit this one file; land in dependency order or via one integration PR) — the normative Output record schema + curated/excluded taxonomy + success/failure requirements + `output_equality_digest` scheme + report-section rules |
+| Create | `assetutilities/src/assetutilities/workflow_api/output_contract.py` (DECIDED home) | Output record validation; unit/convention checks; failure-signature normalizer; versioned `output_equality_digest`; importable by #3433 projection |
+| Create | `assetutilities/src/assetutilities/workflow_api/report_template.{py,html}` | rolling-report template + reference renderer (mandatory Inputs/Outputs, applicable optional sections, failed-run separation, exact-revision pins, HTML sanitization) — consumed by #3433 |
+| Create | `assetutilities/tests/workflow_api/test_output_contract.py` + `fixtures/output/{valid,invalid}/…` | valid/invalid output + failure-signature + digest fixtures |
+| Create | `assetutilities/tests/workflow_api/test_report_contract.py` + `fixtures/report/{valid,invalid}/…` | report structure, exact-revision pin, unsafe-HTML, failure-leakage fixtures |
+| Update | `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` (in PR #3452) | output-selection rules + report-section rules + curated/excluded + failure-signature examples |
+| Create | `tests/architecture/test_output_report_contract_parity.py` | assert the decision-manual output/report section matches the contract YAML |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, workflow registry, HF dataset, rolling report, or credential is
+modified by this planning issue. Pilot rolling reports are authored under #3433's pilot gates (dm
+#1505 / wed #927), not here.
+
+---
+
+## TDD Test List
+
+Every acceptance criterion maps to a failing-first test.
+
+| Test | Acceptance criterion | Expected |
+|---|---|---|
+| `test_output_record_defines_all_contract_fields` | AC1 (role/native schema/media type/shape/units/convention/validation/review/artifact refs) | omitting any required field rejects |
+| `test_units_bearing_field_missing_unit_tag_fails` | AC1 (units) | units-bearing field with no unit tag → FAIL closed |
+| `test_directional_quantity_missing_convention_fails` | AC1 (coordinate/sign convention where applicable) | directional output without convention rejected |
+| `test_output_native_schema_not_flattened` | AC1 + parent (preserve native schema) | nested engineering payload round-trips without flattening |
+| `test_curated_vs_excluded_taxonomy` | AC2 | curated roles recorded; undeclared/transient output EXCLUDED (unlabelled → excluded) |
+| `test_success_and_failure_requirements_are_disjoint` | AC3 | succeeded needs primary result + no signature; failure needs signature + no primary; overlap fails |
+| `test_failed_run_carries_no_primary_result_or_metrics` | AC3 + AC(failure leakage) | failed run with a primary result / metric contribution rejected |
+| `test_failure_signature_is_stable_across_machines` | AC4 | same fault, different cwd/host/timestamps → identical `signature_digest` |
+| `test_failure_signature_strips_volatile_noise` | AC4 | timestamps/paths/pids removed; stable shape retained |
+| `test_digest_contribution_defaults_included_and_exclusion_must_be_declared` | AC5 (§1/§2/§4 reconcile) | curated output defaults `digest_contribution: included`; a silent/undeclared `excluded` fails closed; only an explicitly declared + justified exclusion rule removes it from the digest |
+| `test_output_equality_digest_default_is_raw_byte` | AC5 (+ #3428 boundary) | absent a declared canonicalizer, digest is raw-byte |
+| `test_raw_byte_digest_is_sorted_per_artifact_sha_not_concatenation` | AC5 | raw_byte value = sha256(canonical_json(sorted per-artifact sha256)); boundary-ambiguous concatenation rejected |
+| `test_undeclared_semantic_canonicalizer_fails_closed` | AC5 | claimed-but-undeclared canonicalizer rejected |
+| `test_exact_rerun_output_digest_mismatch_fails_no_overwrite` | AC5 | mismatch fails publication; prior immutable record intact |
+| `test_report_has_mandatory_inputs_and_outputs_sections` | AC6 | report missing Inputs or Outputs rejected |
+| `test_report_optional_sections_only_when_applicable` | AC6 | non-applicable optional section omitted, not empty-rendered |
+| `test_report_shows_latest_and_historical_separates_failed` | AC7 | failed runs isolated in health section; excluded from metrics/insights/comparisons/decisions |
+| `test_report_links_every_run_to_exact_hf_revision` | AC7 | each displayed run links to an immutable commit sha |
+| `test_report_stale_or_moving_revision_link_fails` | AC7 (+ #3433 moving-ref rule) | `main`/branch/moving ref → FAIL |
+| `test_report_renders_eligibility_from_source_ledger` | AC7 (+ #3433) | eligibility read from `publications.jsonl`, not HF visibility |
+| `test_output_violating_declared_native_schema_rejected` | AC9 (schema mismatch) | an output whose payload violates its declared `native_schema{id,version}` is rejected (dedicated case, not only the umbrella fixtures test) |
+| `test_report_rejects_unsafe_html_content` | AC9 (unsafe HTML) | injected `<script>`/handler/`javascript:` sanitized or render fails |
+| `test_one_rolling_report_no_per_run_html` | AC6/AC8 + parent | one report per algorithm; no per-run HTML emitted |
+| `test_git_history_preserves_report_evolution_records_are_authority` | AC8 | concrete observable: two committed report revisions exist in git history AND the run records are unmutated across them (report is regenerable from the records; records never rewritten to match the report) |
+| `test_invalid_fixtures_cover_all_required_cases` | AC9 | fixtures cover schema mismatch, missing units, unsafe HTML, stale revision links, failure leakage, output digest mismatch |
+| `test_decision_manual_matches_output_report_contract` | AC10 | manual output-selection + report-section rules ↔ contract YAML parity |
+| `test_legal_and_abs_path_scans_pass` | AC (process) | `legal-sanity-scan.sh --diff-only` + `check-no-abs-paths.sh` exit 0 on changed files |
+
+Tests are written first and fail before implementation exists. Non-testable process gates (full-suite
+green, legal-scan closeout, substantive multi-provider review) are classified as process/CI gates and
+enforced at closeout, not silently dropped.
+
+---
+
+## Acceptance Criteria
+
+Verbatim from issue #3431:
+
+- [ ] The Output contract defines role, native schema, media type, shape/row count, units,
+      coordinate/sign convention where applicable, validation state, review state, and artifact
+      references.
+- [ ] Curated primary results, supporting validation evidence, selected reports, and decision-support
+      outputs are distinguishable from excluded transient outputs.
+- [ ] Successful and failed terminal runs have explicit, non-overlapping output requirements.
+- [ ] Failure evidence excludes volatile timestamps/path noise and yields a stable normalized
+      diagnostic signature.
+- [ ] Exact reruns must match curated output digests; mismatches fail publication and cannot overwrite
+      prior records.
+- [ ] One standard rolling HTML report per algorithm renders mandatory Inputs and Outputs sections and
+      only applicable optional sections.
+- [ ] The report shows latest and historical runs, clearly separates failed runs, and links every
+      displayed run to an exact Hugging Face revision.
+- [ ] Repository Git history preserves report evolution while immutable run records remain the data
+      authority.
+- [ ] Valid/invalid fixtures cover schema mismatch, missing units, unsafe HTML content, stale revision
+      links, failure leakage into metrics, and output digest mismatch.
+- [ ] The decision manual documents the output selection and report-section rules.
+
+Process (this plan):
+
+- [ ] TDD tests are written first and fail before implementation; every acceptance criterion above
+      maps to at least one failing-first test in the TDD list.
+- [ ] The full suite, the legal scan (`scripts/legal/legal-sanity-scan.sh --diff-only`), and
+      `scripts/enforcement/check-no-abs-paths.sh` pass on changed files.
+
+---
+
+## Sequencing & Gate
+
+**Blocked by #3428 (deterministic run identity) and #3429 (content-addressed artifact).** This
+contract owns the `output_equality_digest` that #3428's exact-rerun check compares (compute here;
+mismatch policy in #3428), and its Output records reference #3429 artifacts by digest — so it cannot
+land before both. It extends the parent run-dataset contract, whose YAML
+(`docs/architecture/algorithm-run-dataset-contract.yaml`) and decision manual are **404 on `main` and
+exist only in parent draft PR #3452**; this implementation is therefore **STACKED ON PR #3452** and
+coordinates the Output/report schema with it, and must not fork the closed-schema behavior. All five
+sibling contracts edit that same contract YAML as **STRICTLY ADDITIVE, NON-OVERLAPPING sections**,
+landing in dependency order (or coalesced via ONE integration PR) so no sibling clobbers another's
+section. It is a HITL contract child of epic #3427 and **requires its own reviewed plan and explicit
+own-approval** — parent #3427 approval does not authorize it. Downstream consumer #3433 depends on this
+report template + output contract reference implementation.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Result |
+|---|---|---|---|
+| r1 | Claude | BLOCK | 1 MAJOR (`digest_contribution` §1/§2 contradiction: free included\|excluded toggle vs "all curated is digest-eligible") + MINORs (raw_byte digest = sorted per-artifact sha256 not concatenation; #3428/#3431 digest ownership boundary; non-repo failure-frame `qualname` normalization) + NITs (dedicated native-schema-mismatch test; concretized AC8 git-history observable). ALL remediated. |
+
+No unavailable provider counts as approval; any depth reduction is disclosed for owner acceptance.
+
+---
+
+## Risks and Open Questions
+
+- **Semantic-canonicalizer scope risk:** an over-permissive semantic mode would let two genuinely
+  different output sets hash equal, masking a reproducibility defect. Mitigation: raw-byte is the
+  default; a semantic canonicalizer applies only when **explicitly declared and registered** for the
+  output schema, is versioned in the stored digest, and an undeclared canonicalizer fails closed.
+- **Native-schema-vs-flattening tension:** preserving native domain schema (Parquet/JSONL/tensor
+  shapes) while keeping outputs digestible risks either over-flattening (losing engineering meaning)
+  or under-specifying the digest. Mitigation: outputs reference content-addressed artifacts (#3429)
+  by byte digest; the record carries native `schema_id`/`schema_version`/shape/units so meaning is
+  preserved alongside the digest.
+- **Report draft/pin coupling risk:** #3433 drafts the report unpinned (state 3) and pins it later
+  (state 6); a contract that assumed pin-at-draft would break the consumer. Mitigation: the report
+  contract explicitly models the unpinned-draft → exact-revision-pin lifecycle and forbids moving
+  references only at finalization.
+- **Parent-contract coupling risk:** the contract YAML + decision manual are 404 on `main`, present
+  only in parent draft PR #3452, so this work is **stacked on #3452**. Mitigation: coordinate the
+  Output/report schema with #3452; fail closed on schema drift; a parity test binds the manual to the
+  YAML.
+- **Sibling YAML-collision risk:** all five sibling contracts edit the single contract YAML in #3452.
+  Mitigation: each sibling adds a STRICTLY ADDITIVE, NON-OVERLAPPING section and they land in
+  dependency order (or are coalesced into ONE integration PR), so no sibling clobbers another's
+  section.
+- **Reference-implementation home — DECIDED:** `assetutilities.workflow_api.output_contract` +
+  `report_template` (inherits #3433's owner-confirmed `assetutilities.workflow_api` placement, so
+  #3433's publication module imports one implementation, consistent with #3428's identity home). No
+  longer an open question.
+
+---
+
+## Complexity: T2
+
+A normative contract slice with a small deterministic reference implementation (output validation,
+failure-signature normalizer, versioned `output_equality_digest`, report renderer) plus valid/invalid
+fixtures. Not T3: single-domain, no external platform transaction, no cross-system commit — the HF
+upload/pin/verify choreography lives in #3433. But it is load-bearing: it owns the output digest the
+identity contract compares and the report template the publication workflow renders, so its
+fail-closed semantics and HTML-safety proofs are consequential.

--- a/docs/plans/2026-07-11-issue-3432-algorithm-metric-definition-observation-contract.md
+++ b/docs/plans/2026-07-11-issue-3432-algorithm-metric-definition-observation-contract.md
@@ -1,0 +1,464 @@
+# Plan for [#3432](https://github.com/vamseeachanta/workspace-hub/issues/3432): Algorithm-Specific Metric Definition and Observation Contract
+
+> **Status:** adversarial-reviewed (r1 BLOCK remediated; ready for user review)
+> **Complexity:** T2
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3432
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3432-{claude,codex,gemini}.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` — the shared `ResultEnvelope`
+  produces `result_hash` (location-independent content hash for `kind: files`), a volatile-key-pruned
+  `input_hash` (`VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}`), `code_version()` →
+  `{package_version, git_sha}` (best-effort, does **not** prove a clean tree), and `reproducible`
+  (`None` unless an opt-in double run runs). It carries **no** metric abstraction: there is no metric
+  identifier, no unit/dimension field, no quality state, no not-applicable representation, and no
+  observation-to-definition-version binding. Any per-domain scalar an algorithm emits today lands as
+  an untyped, unlabeled, unit-less value inside a curated output payload. The metric contract adds the
+  missing typed Metric Definition + Metric Observation layer and treats these envelope hashes as
+  *execution evidence*, never as metric identity or metric values.
+- `digitalmodel/src/digitalmodel/workflow_api/{runner,provenance,golden}.py` +
+  `docs/registry/workflows.yaml` (`schema_version: 2`, per-row integer `version` + `status`/`latest`).
+  Algorithms are registered and routed here, but the registry has **no** metric declaration surface —
+  it routes execution, it does not declare an algorithm's metric vocabulary. The metric definition set
+  is a **new, separately versioned** descriptor owned per algorithm; it is *not* the integer registry
+  version and is never inferred from it.
+- **Gap:** no `metric_id` / `metric_definition_version` / Metric Observation record exists anywhere;
+  no machine-validatable unit/dimension, data-type, applicability, directionality, or quality-rule
+  field; no not-applicable / null discipline; no mechanism binding a historical observation to the
+  exact definition version used; and no rule preventing failed-run values from entering a metric
+  population or preventing a report from equating two different algorithms' metrics.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Parent run-dataset contract (metrics-algorithm-specific, no cross-algorithm equivalence, successful-runs-only) | binding, extended here | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (in **draft PR #3452** `feature/issue-3427-hf-run-ledger-plan`, **not yet on `main`**) |
+| Sibling identity contract (`run_id`, canonical_json + SHA-256, terminal status, failed-run exclusion) | binding, consumed | `#3428` plan (this session) |
+| Sibling output/report contract (rolling HTML report renders metric tables/trends/comparisons; failed-run health) | binding, consumed | `#3431` plan/issue |
+| Data/execution/report boundaries | reusable | `docs/architecture/execution-manifest.schema.yaml` |
+| Issue lifecycle + approval | binding | `AGENTS.md`, `docs/plans/README.md` |
+| Legal/abs-path scans | binding | `scripts/legal/legal-sanity-scan.sh`, `scripts/enforcement/check-no-abs-paths.sh` |
+
+No engineering-calculation standard governs the *contract* layer itself. Each algorithm's metric
+definitions carry their own domain-standard citation obligation (the metric's `derivation reference`
+field is where that citation lands); the contract mandates the field, not any specific standard.
+
+### Documents consulted
+
+- Issue [#3432](https://github.com/vamseeachanta/workspace-hub/issues/3432): metric definitions are
+  **algorithm-scoped**; Phase 1 imposes **no** universal engineering-metric vocabulary — each
+  algorithm owns its definitions while sharing a common record envelope; only validated successful runs
+  contribute observations; failed runs stay visible in run-health reporting but do not enter metric
+  populations; metric definitions are versioned **independently** from observations; rolling reports
+  render tables/trends/comparisons **without treating unlike algorithm metrics as equivalent**; any
+  cross-algorithm ontology is **explicitly deferred** until repeated-run evidence justifies one. (Its
+  eight acceptance criteria are copied verbatim below.)
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427): locked decision
+  "Metrics remain algorithm-specific; no cross-algorithm equivalence is inferred"; "Reproducible
+  successful and failed runs may be public. Failed runs carry normalized failure evidence but cannot
+  contribute metrics, insights, or decision conclusions"; applicable domain sections may add metrics,
+  plots, comparisons, uncertainty, diagnostics, insights, decision briefs.
+- Sibling identity contract [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428) plan
+  (read at `/tmp/wh3433/docs/plans/2026-07-11-issue-3428-...md`): a Metric Observation identifies its
+  `run_id` and its metric-definition version; the same `canonical_json` (UTF-8, lexicographic keys,
+  explicit `null`/`"NA"`, unit-tagged numerics) + SHA-256 conventions apply; terminal status is
+  `succeeded | reproducible_failure`, and only `succeeded` runs (non-rejected, reproducible) may carry
+  observations that enter metric populations.
+- Sibling output/report contract [#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431):
+  one rolling HTML report per algorithm renders **mandatory Inputs/Outputs** plus **applicable**
+  Metrics/plots/comparisons/uncertainty; the report separates failed runs into health analysis and
+  links each displayed run to an exact HF revision. This metric contract states **how the report
+  consumes metric observations** (per-algorithm tables/trends/single-algorithm comparisons); it does
+  **not** redefine the report.
+- Publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) plan (skimmed
+  at `/tmp/wh3433/docs/plans/2026-07-11-issue-3433-...md`): the per-repository HF dataset has a
+  `metrics/` table populated from **succeeded runs only**; metric observations are projected there, and
+  reproducible failures are excluded from metrics **and** insights **and** decisions. This contract
+  defines the record shape that the `#3433` projection serializes into that `metrics/` table.
+
+### Gaps identified
+
+- No normative record separates an algorithm-scoped **Metric Definition** (stable id, algorithm owner,
+  independently versioned, label, meaning, unit/dimension, data type, derivation reference,
+  applicability rule, directionality, quality rule) from a **Metric Observation** (binds `run_id` +
+  exact definition version; value, quality state, derivation evidence, optional uncertainty).
+- No machine-validatable discipline for **units** and **null / not-applicable** states (a
+  not-applicable metric and a genuine measured value must be distinguishable and both must be typed).
+- No mechanism binding a **historical observation to the exact definition version** used, and no rule
+  that definitions version **independently** from observations.
+- No rule keeping **failed/rejected/non-reproducible** run values out of metric populations while
+  leaving them visible in run-health.
+- No invariant that each metric has **exactly one algorithm owner** and that reports render
+  tables/trends/comparisons with **no cross-algorithm equivalence/comparison edge**, plus an explicit
+  **deferral** of any cross-algorithm ontology.
+
+### Evidence (verified 2026-07-11)
+
+```text
+#3432             OPEN  status:needs-plan lane:claude priority:high — Blocked by #3428, #3431
+#3431             OPEN  status:needs-plan lane:claude — Blocked by #3428, #3429
+#3428             OPEN  status:needs-plan lane:claude — Blocked by: none (identity root)
+#3427             OPEN  status:plan-approved (parent tracker) — "metrics remain algorithm-specific; no cross-algorithm equivalence"
+DRAFT PR #3452    feat: define algorithm run ledger for Hugging Face datasets (branch feature/issue-3427-hf-run-ledger-plan; parent contract; NOT on main)
+404 @main         docs/architecture/algorithm-run-dataset-contract.yaml (per #3428 + #3433 plans, this session)
+EXISTS            assetutilities …/workflow_api/envelope.py (result_hash/input_hash/code_version/reproducible; NO metric layer)
+EXISTS            digitalmodel docs/registry/workflows.yaml (schema_version 2; integer version; NO metric declaration surface)
+```
+
+Distinct sources: issue #3432; parent #3427; sibling identity plan #3428; sibling output/report
+#3431; publication child #3433 plan; ResultEnvelope implementation; dm workflow registry — more than
+the required three.
+
+---
+
+## Deliverable
+
+A normative, machine-validated **algorithm-scoped metric contract**: the record shapes for a
+**Metric Definition** and a **Metric Observation**; an explicit, machine-validatable unit/dimension +
+data-type discipline and an unambiguous **not-applicable / null** representation; an
+**independent-versioning** rule that binds every historical observation to the exact definition
+version used; a **fail-closed population rule** that admits only observations from validated
+successful runs; a **single-algorithm-owner** invariant that forbids any cross-algorithm equivalence
+or comparison edge in reports; valid/invalid fixtures spanning scalar, categorical, vector/series
+reference, uncertainty, not-applicable, and invalid observations; and a small reference validator
+that proves definition/observation validation, population exclusion, and the no-cross-algorithm-edge
+rule. **This plan does not implement anything** — it fixes the contract, the fixtures, and a
+first-fail TDD list. Code lands only after adversarial review and explicit user approval, and after
+the parent contract (#3427) and blocking siblings (#3428, #3431) land on `main`.
+
+---
+
+## Design
+
+### Metric Definition (algorithm-scoped, independently versioned)
+
+```text
+MetricDefinition
+  metric_id              stable, human-meaningful, algorithm-scoped:
+                         "<algorithm_id>/<metric_slug>"   (e.g. "digitalmodel:viv-parametric/max_a_over_d")
+                         stable across definition versions; NOT a digest.
+  algorithm_id           the SINGLE owning algorithm (#3428 stable id). Exactly ONE owner per metric_id.
+                         A metric_id is namespaced under its algorithm_id; two algorithms CANNOT share one.
+                         NORMATIVE: metric_id MUST be prefixed by its algorithm_id, validated as
+                         definition.algorithm_id == prefix(metric_id) — a whole-prefix match, NOT a
+                         split-on-last-"/" (an algorithm_id/workflow_id may itself contain "/").
+  definition_version     semantic version of THIS definition, incremented INDEPENDENTLY of any run/observation.
+                         A definition change (unit, data type, derivation, applicability, directionality,
+                         quality rule, meaning) requires a NEW definition_version; older versions are retained.
+  label                  short human display label (report column header).
+  meaning                normative prose: what the metric means for THIS algorithm; explicitly non-transferable
+                         to any other algorithm.
+  unit_or_dimension      machine-validatable: { dimension, unit } for numeric metrics
+                         (e.g. {dimension: "length/length", unit: "dimensionless"} or {dimension:"stress", unit:"MPa"});
+                         categorical/reference metrics declare unit_or_dimension: "NA" explicitly (never omitted).
+                         NOTE: this DEFINITION-level unit_or_dimension: "NA" ("this metric has no dimension
+                         concept") is UNRELATED to the OBSERVATION-level quality_state: not_applicable value
+                         "NA" ("the metric did not apply this run"). Two distinct meanings share the token by
+                         coincidence; a validator MUST NOT conflate them.
+  data_type              one of: scalar_number | categorical | vector_series_reference | boolean
+                         (vector_series_reference points at a content-addressed artifact (#3429), NOT an inline array).
+  derivation_reference   how the value is derived + domain-standard citation (formula id / doc ref / code symbol).
+  applicability_rule     machine-checkable predicate over run identity/inputs deciding when the metric APPLIES;
+                         when it does not apply, the observation MUST be not_applicable (below), not absent, not null-as-zero.
+  directionality         ALWAYS REQUIRED: higher_is_better | lower_is_better | target(<value>) | none.
+                         "none" is the explicit value for metrics with no intrinsic better/worse ordering.
+                         DELIBERATE STRENGTHENING: AC1 says "directionality when meaningful"; this contract
+                         strengthens that to always-required-with-explicit-"none" so applicability is never
+                         silently omitted (an absent field cannot be distinguished from "no ordering"). This
+                         is intentional, not scope over-reach — reviewers should read it as fail-closed rigor.
+  quality_rule           machine-checkable validity predicate (range/domain/enum/monotonicity) the value must satisfy
+                         to be quality_state: valid.
+```
+
+### Metric Observation (binds run + exact definition version)
+
+```text
+MetricObservation
+  run_id                 the observed run (#3428). MUST reference a run whose terminal status is `succeeded`
+                         (non-rejected, reproducible) to be POPULATION-eligible.
+  metric_id              the observed metric (its algorithm_id MUST equal the run's algorithm_id — enforced).
+  metric_definition_version  the EXACT MetricDefinition version used at observation time; pinned and immutable.
+                             Historical observations retain their original version even after the definition advances.
+  value                  typed per data_type; unit-tagged for numerics; canonical_json-encoded (#3428 conventions).
+  quality_state          valid | not_applicable | invalid | missing
+                           - valid          -> value present, passes quality_rule; POPULATION-eligible
+                           - not_applicable -> applicability_rule is false; value MUST be the explicit NA sentinel; NOT in population
+                           - invalid        -> value present but fails quality_rule; NOT in population; retained for health/audit
+                           - missing        -> value could not be produced; value = null; NOT in population
+  derivation_evidence    evidence linking value to its derivation (source artifact ref (#3429), formula inputs,
+                          or output-record pointer (#3431)); machine-traceable.
+  uncertainty            OPTIONAL: { kind: stddev|interval|distribution_ref, ... } when supplied; absent is explicit.
+```
+
+### Units + null / not-applicable (unambiguous + machine-validatable)
+
+- Every numeric metric value carries its **unit tag**; a unit-less numeric where a dimension is
+  declared is **rejected**, never silently hashed or averaged (same rule as `#3428`'s canonical_json
+  unit discipline).
+- **Not-applicable is a first-class typed state**, distinct from a missing value and from a numeric
+  zero: `quality_state: not_applicable` with an explicit `"NA"` sentinel value. A report renders it as
+  "N/A", never as a blank that could read as zero or as an absent row.
+- `null` (`quality_state: missing`) is likewise explicit and distinct from `not_applicable`. The four
+  quality states are mutually exclusive and machine-validated.
+
+### Independent versioning (definition ⟂ observation)
+
+- `MetricDefinition.definition_version` increments on any semantic change to the definition and is
+  **decoupled** from run/observation timelines. Old versions are never mutated or deleted.
+- The definition store is **append-only**: a published `(metric_id, definition_version)` pair is
+  **immutable**. Re-registering an existing `(metric_id, definition_version)` with ANY differing field
+  (unit/dimension, data type, derivation, applicability, directionality, quality rule, meaning, label)
+  **fails closed** — it is never silently overwritten. A semantic change MUST mint a NEW
+  `definition_version`; this is what prevents silent mutation of the definition under past observations
+  (the AC4 invariant).
+- Each `MetricObservation` pins the **exact** `metric_definition_version` used. A definition upgrade
+  never rewrites historical observations; a trend chart that spans a version boundary is rendered with
+  the version boundary **visible**, never silently splicing incompatible definitions.
+
+### Fail-closed population rule (only validated successful runs)
+
+An observation enters a metric **population** (the set feeding tables/trends/comparisons in reports,
+insights, and decisions) **iff** all hold: the run's terminal status is `succeeded`
+(non-rejected, reproducible per `#3428`); `quality_state == valid`; the observation's `metric_id`
+algorithm owner equals the run's `algorithm_id`; and the pinned definition version validates. Any
+observation from a `reproducible_failure` / rejected / non-reproducible run — or with
+`quality_state ∈ {not_applicable, invalid, missing}` — is **excluded** from metrics, insights, and
+decisions, while remaining **visible in run-health reporting** (per `#3431`). Fail-closed: an
+observation of ambiguous provenance is excluded, not admitted.
+
+### Single-algorithm owner + no cross-algorithm equivalence (report consumption)
+
+- Each `metric_id` has **exactly one** owning `algorithm_id`; the contract forbids a metric shared by
+  two algorithms and forbids any equivalence/mapping edge asserting "metric X of algorithm A equals
+  metric Y of algorithm B."
+- The rolling report (owned by `#3431`, **consumed** here) renders **per-algorithm** metric tables,
+  per-algorithm trends across that algorithm's immutable historical runs, and comparisons **only among
+  runs of the same algorithm**. There is **no** comparison edge, shared axis, or normalization that
+  places two different algorithms' metrics on equal footing.
+- Any cross-algorithm ontology (a universal engineering-metric vocabulary or equivalence graph) is
+  **explicitly deferred** until real repeated-run evidence across algorithms justifies one; Phase 1
+  ships none, and the contract records this deferral as a normative non-goal.
+
+### Crosswalk (evidence, never metric identity)
+
+`ResultEnvelope.result_hash` / `input_hash` / `code_version` / `reproducible` are retained as
+*execution evidence* and may appear under an observation's `derivation_evidence`; none is a metric
+value, a metric identifier, or a definition version.
+
+---
+
+## Pseudocode
+
+```text
+# --- definition registration (per algorithm, independently versioned) ---
+require metric_id namespaced under exactly one algorithm_id
+assert definition.algorithm_id == prefix(metric_id)   # whole-prefix match, NOT split-on-last-"/"
+require definition_version, label, meaning, unit_or_dimension (explicit "NA" if categorical/reference),
+        data_type in {scalar_number, categorical, vector_series_reference, boolean},
+        derivation_reference, applicability_rule, directionality (ALWAYS required; explicit "none" allowed),
+        quality_rule
+reject if metric_id owner conflicts with an existing owner (no shared / cross-algorithm metric)
+# APPEND-ONLY immutable store: a published (metric_id, definition_version) is immutable
+if (metric_id, definition_version) already published:
+    reject unless EVERY field is byte-identical    # any differing field -> FAIL CLOSED; mint a NEW version
+store version immutably; never mutate/delete prior definition_versions
+
+# --- observation admission ---
+require run_id (#3428), metric_id, metric_definition_version (pin exact), value, quality_state,
+        derivation_evidence; uncertainty optional (absence explicit)
+assert observation.metric_id.algorithm_id == run.algorithm_id                    # owner match
+assert numeric value carries unit tag matching definition dimension              # else reject (unit discipline)
+classify quality_state:
+    applicability_rule false            -> not_applicable (value == "NA" sentinel)
+    value present & passes quality_rule -> valid
+    value present & fails quality_rule  -> invalid
+    value unproducible                  -> missing (value == null)
+
+# --- population membership (fail-closed) ---
+in_population(obs) := run.terminal_status == succeeded (non-rejected, reproducible)   # #3428
+                   AND obs.quality_state == valid
+                   AND obs.metric_id.algorithm_id == run.algorithm_id
+                   AND definition_version validates
+# reproducible_failure / rejected / non-reproducible OR not_applicable/invalid/missing -> EXCLUDED
+# excluded observations remain VISIBLE in run-health reporting (#3431), never in metrics/insights/decisions
+
+# --- report consumption (no cross-algorithm equivalence) ---
+render per-algorithm tables/trends/comparisons over in_population(obs) grouped by algorithm_id
+FORBID any comparison/equivalence edge between distinct algorithm_ids
+trend spanning a definition_version boundary -> render boundary visibly; never splice unlike versions
+DEFER any cross-algorithm ontology (normative non-goal, Phase 1)
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Update | `docs/architecture/algorithm-run-dataset-contract.yaml` (coordinated with parent **PR #3452**, not yet on `main`) | add the normative MetricDefinition + MetricObservation record schemas, unit/quality-state enums, population rule |
+| Create | `assetutilities/src/assetutilities/workflow_api/metrics.py` (**reference-impl home DECIDED** — inherits `#3433`'s owner-confirmed `assetutilities.workflow_api` placement) | definition/observation validation, unit + not-applicable discipline, append-only immutable definition store, `in_population` predicate, no-cross-algorithm-edge check; importable by `#3433` projection |
+| Create | `assetutilities/tests/workflow_api/test_metrics.py` + `fixtures/metrics/{valid,invalid}/…` | scalar/categorical/vector-series/uncertainty/not-applicable/invalid + failed-run + no-cross-algorithm fixtures |
+| Update | `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` (in PR #3452) | metric definition/observation examples, population-exclusion rule, no-cross-algorithm-equivalence + deferral section |
+| Create | `tests/architecture/test_metric_contract_parity.py` | assert the decision-manual metric section matches the contract YAML |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, workflow registry, dataset, HF revision, or credential is
+modified by this issue.
+
+**Stacked on parent PR #3452.** Both `docs/architecture/algorithm-run-dataset-contract.yaml` and
+`docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html` **404 on `main`** — they exist
+only in draft **PR #3452** (`feature/issue-3427-hf-run-ledger-plan`). This implementation must be
+STACKED ON #3452 (branch from it), not from `main`, or the files to edit will not exist.
+
+**Shared-file merge coordination.** All five sibling contracts (**#3428–#3432**) edit the SAME
+`algorithm-run-dataset-contract.yaml` + decision-manual as **strictly additive, non-overlapping**
+sections. Since #3432 is blocked only by #3428+#3431, siblings #3429/#3430 may land in any relative
+order — so land these edits in **dependency order** (#3428 → #3431 → #3432), or fold them into a single
+**integration PR** onto #3452, to avoid clobbering (per the "N additive lanes sharing a file → one
+integration PR" rule).
+
+---
+
+## TDD Test List
+
+Every acceptance criterion maps to at least one first-fail test.
+
+| Test | Verifies (AC) | Expected |
+|---|---|---|
+| `test_metric_definition_carries_all_required_fields` | AC1: id, algorithm id, definition version, label, meaning, unit/dimension, data type, derivation reference, applicability rule, directionality, quality rule | omit any field → definition rejected |
+| `test_metric_observation_binds_run_and_definition_version` | AC2: observation records run, definition version, value, quality state, derivation evidence, optional uncertainty | missing run/version/value/quality/evidence → rejected; uncertainty optional |
+| `test_units_and_not_applicable_are_machine_validatable` | AC3: unit tag required for numerics; not_applicable/null are explicit, typed, distinct | unit-less numeric rejected; NA ≠ null ≠ 0 all distinguished |
+| `test_definition_versions_independently_history_retained` | AC4: definition versions increment independently; historical observation retains exact version | definition upgrade leaves prior observations pinned + intact |
+| `test_definition_version_is_immutable_once_published` | AC4: append-only immutable definition store — no silent mutation of the definition under past observations | re-registering an existing `(metric_id, definition_version)` with ANY differing field (e.g. `unit_or_dimension` MPa→ksi) is REJECTED (fail closed); a semantic change MUST mint a NEW version |
+| `test_failed_or_rejected_or_nonreproducible_run_excluded_from_population` | AC5: failed/rejected/non-reproducible runs cannot enter metric populations | `reproducible_failure`/rejected/non-reproducible observation excluded; still visible in run-health |
+| `test_report_renders_without_cross_algorithm_equivalence` | AC6: tables/trends/comparisons render without treating unlike algorithm metrics as equivalent | per-algorithm grouping only; no comparison edge between distinct `algorithm_id`s |
+| `test_fixtures_cover_scalar_categorical_vector_uncertainty_na_invalid` | AC7: fixtures cover scalar, categorical, vector/series reference, uncertainty, not-applicable, invalid | each fixture class validates/rejects as specified |
+| `test_cross_algorithm_ontology_is_deferred_non_goal` | AC8: any cross-algorithm ontology explicitly deferred | contract declares deferral; no equivalence graph present; attempt to add a cross-algorithm equivalence edge rejected |
+| `test_single_algorithm_owner_per_metric_id` | AC1/AC6 invariant: exactly one owning algorithm per metric | second algorithm claiming same `metric_id` rejected |
+| `test_observation_owner_must_match_run_algorithm` | AC5/AC6: observation `metric_id` owner must equal run's `algorithm_id` | owner mismatch rejected |
+| `test_quality_states_mutually_exclusive_and_typed` | AC3: valid/not_applicable/invalid/missing exclusive; only `valid` is population-eligible | invalid/missing/NA excluded from population |
+| `test_definition_version_boundary_visible_in_trend` | AC4/AC6: trend spanning a version boundary does not splice unlike definitions | boundary rendered visibly, not merged silently |
+| `test_envelope_hashes_are_evidence_not_metric_identity` | crosswalk: `result_hash`/`input_hash`/`code_version` never become metric id/value/version | metric records independent of envelope hashes |
+| `test_decision_manual_matches_metric_contract` | AC parity: manual metric section ↔ contract YAML | structure + examples agree |
+
+Fixtures explicitly include: a **scalar** numeric with unit; a **categorical** value; a
+**vector/series reference** (content-addressed artifact ref, not inline array); an observation **with
+uncertainty**; a **not-applicable** observation (applicability_rule false, NA sentinel); an
+**invalid** observation (fails quality_rule); a **failed-run** observation (excluded from population,
+visible in health); and a **cross-algorithm-equivalence** attempt (rejected). Tests are written first
+and fail before implementation exists. Non-testable process gates (full-suite green, legal-scan
+closeout, multi-provider review) are enforced at closeout, not silently dropped.
+
+---
+
+## Acceptance Criteria
+
+Verbatim from issue #3432:
+
+- [ ] A metric definition carries a stable identifier, algorithm identifier, definition version,
+      label, meaning, unit/dimension, data type, derivation reference, applicability rule,
+      directionality when meaningful, and quality rule.
+- [ ] A metric observation identifies its run and metric definition version and records value,
+      quality state, derivation evidence, and uncertainty when supplied.
+- [ ] Units and null/not-applicable states are unambiguous and machine-validatable.
+- [ ] Metric definitions are versioned independently from observations; historical observations retain
+      the exact definition used.
+- [ ] Failed, rejected, or non-reproducible runs cannot enter metric populations.
+- [ ] Rolling algorithm reports can render metric tables, trends, and comparisons without treating
+      unlike algorithm metrics as equivalent.
+- [ ] Contract fixtures cover scalar, categorical, vector/series reference, uncertainty,
+      not-applicable, and invalid observations.
+- [ ] Scope explicitly defers any cross-algorithm ontology until real repeated-run evidence justifies
+      one.
+
+Process gates (this plan):
+
+- [ ] TDD tests are written first and fail before implementation; the full suite passes on changed
+      files.
+- [ ] The legal scan (`scripts/legal/legal-sanity-scan.sh --diff-only`) passes on changed files.
+- [ ] `scripts/enforcement/check-no-abs-paths.sh` passes on changed files.
+
+---
+
+## Sequencing & Gate
+
+**Blocked by [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428) (run identity —
+supplies `run_id`, terminal status, canonical_json + SHA-256 conventions) and
+[#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431) (output/report — the report that
+consumes these observations and the curated-output/artifact references an observation's
+`derivation_evidence` points at).** This contract extends the parent run-dataset contract, which is
+in **draft PR #3452** on `feature/issue-3427-hf-run-ledger-plan` and is **not yet on `main`** — the
+metric schema must be coordinated with that PR and must not fork its closed-schema behavior;
+implementation is sequenced behind the parent contract + #3428 + #3431 landing on `main`. The
+publication child [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) consumes this
+record shape for its succeeded-runs-only `metrics/` table.
+
+**Stacked on PR #3452 + shared-file merge ordering.** The contract YAML and decision-manual exist only
+in draft **PR #3452**, not on `main`, so implementation branches from **#3452**, not `main`. All five
+siblings (**#3428–#3432**) edit those SAME two files as strictly additive, non-overlapping sections;
+#3429/#3430 are unblocked and may land in any relative order, so land these edits in **dependency order**
+(#3428 → #3431 → #3432) or via a single **integration PR** onto #3452 to avoid clobbering.
+
+**HITL contract work.** This issue starts at `status:needs-plan`; implementation requires this
+reviewed plan plus **explicit owner approval** — parent #3427 approval does not authorize it, and no
+child implementation begins from approval of the epic alone.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Result |
+|---|---|---|---|
+| r1 | Claude | BLOCK | 1 MAJOR (immutable-definition-store invariant untested — AC4's "no silent mutation of past observations" had no adversarial rejection test) + MINORs (shared-file merge coordination; `unit_or_dimension: "NA"` vs `quality_state: not_applicable` "NA" token collision; `metric_id` prefix-validation rule; AC1 directionality strengthening; reference-impl home + stacked-on #3452). **ALL REMEDIATED** this revision. |
+
+No unavailable provider counts as approval; any depth reduction is disclosed for explicit owner
+acceptance, consistent with the parent and siblings.
+
+---
+
+## Risks and Open Questions
+
+- **Not-applicable-vs-missing conflation risk:** if the four quality states are not enforced
+  distinctly, a report could render a genuinely inapplicable metric as a blank read as zero, corrupting
+  a trend. Mitigation: `quality_state` is a closed enum with an explicit `"NA"` sentinel and a
+  first-fail test asserting NA ≠ null ≠ 0; only `valid` is population-eligible.
+- **Definition-drift trend risk:** a silent definition upgrade could splice incompatible values into
+  one trend. Mitigation: every observation pins its exact `metric_definition_version`; trends across a
+  version boundary render the boundary visibly (tested).
+- **Premature cross-algorithm ontology risk:** pressure to unify metrics across algorithms before
+  evidence exists would violate the epic's locked "no cross-algorithm equivalence." Mitigation: single
+  owner per `metric_id`, no equivalence edge, and an explicit deferral non-goal — a cross-algorithm
+  equivalence attempt is a *rejected* test case, not a TODO.
+- **Vector/series inline-payload risk:** inlining large series into an observation would bloat the
+  `metrics/` table and lose native meaning. Mitigation: `data_type: vector_series_reference` points at
+  a content-addressed artifact (#3429); the observation carries the reference, not the array.
+- **Silent-definition-mutation risk (AC4 core):** re-registering an existing
+  `(metric_id, definition_version)` with a changed field (e.g. `unit_or_dimension` MPa→ksi) would
+  retroactively alter the meaning of every past observation pinned to that version. Mitigation: the
+  definition store is **append-only / immutable**; `test_definition_version_is_immutable_once_published`
+  asserts any differing-field re-registration FAILS CLOSED, forcing a new `definition_version`.
+- **Reference-implementation home — DECIDED:** `assetutilities.workflow_api.metrics` (inherits
+  `#3433`'s owner-confirmed `assetutilities.workflow_api` placement, so `#3433`'s projection imports one
+  implementation). No longer open.
+- **Parent-contract coupling + shared-file clobber risk:** the contract YAML and decision-manual are in
+  draft PR #3452 (404 on `main`), and all five siblings (#3428–#3432) edit them as additive,
+  non-overlapping sections; #3429/#3430 land in any order. Mitigation: STACK this work on #3452; land in
+  dependency order (#3428 → #3431 → #3432) or via one integration PR; fail closed on schema drift.
+
+---
+
+## Complexity: T2
+
+A single-domain, algorithm-scoped contract slice with a small reference validator + fixtures. Not T3:
+no external platform, no cross-system transaction, no multi-repository publication (that is `#3433`).
+It is nonetheless load-bearing — its population rule and single-owner / no-cross-algorithm-equivalence
+invariants are what keep every downstream comparison, insight, and decision brief evidence-bound and
+algorithm-scoped, so its fail-closed proofs must hold.

--- a/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
+++ b/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
@@ -1,6 +1,6 @@
 # Plan for [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433): Per-Repository Hugging Face Projection and Staged Promotion
 
-> **Status:** plan-review (adversarial self-review r1 remediated + r2-verified NO-MAJOR; owner-reviewed the two placement/namespace decisions)
+> **Status:** plan-approved (owner-approved 2026-07-11); hardened through Claude r1 + Codex r2 (both MAJOR→remediated) + Claude r3 verification (NO-MAJOR, all findings closed)
 > **Complexity:** T3
 > **Date:** 2026-07-11
 > **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3433
@@ -233,17 +233,36 @@ the envelope's best-effort `git_sha`.
 One dataset per source repo (`aceengineer/digitalmodel-runs`, `aceengineer/worldenergydata-runs`);
 a separate global catalog **indexes** datasets and never merges domain-native records.
 
+**HF dataset (data plane)** — one dataset per source repo:
+
 ```text
-<dataset-root>/
+<dataset-root>/                  # aceengineer/{digitalmodel,worldenergydata}-runs
   README.md                      # dataset card: metadata, schema versions, license summary
-  runs/       part-*.parquet      # append-only shards, one row per run (identity + status + refs); eligibility gated by publications/
+  runs/       part-*.parquet      # append-only shards, one row per run (identity + status + refs)
   inputs/     part-*.parquet      # replay-critical inputs (JSONL fallback for deeply nested payloads)
   outputs/    part-*.parquet      # curated native outputs (JSONL where schema is non-tabular)
   metrics/    part-*.parquet      # metric observations (succeeded runs only)
-  publications/ part-*.jsonl      # append-only Publication acceptance records (see §3)
   objects/<sha256[:2]>/<sha256>   # content-addressed blob store; deduplicated within dataset
-  catalog-index.json (global catalog side) # points at each dataset revision; no combined run table
 ```
+
+**Source repo (authority plane)** — NOT in the HF dataset:
+
+```text
+<source-repo>/
+  reports/<algorithm>/report.html                  # one rolling report per algorithm; pins exact HF revisions
+  reports/<algorithm>/publications.jsonl           # APPEND-ONLY Publication acceptance ledger (§3) — SOLE eligibility authority
+  <catalog side> catalog-index.json                # global catalog: points at each dataset revision; no combined run table
+```
+
+The Publication acceptance ledger lives in the **source repo, not the HF dataset** (Codex r2): a
+run row is committed into HF revision R1 at HF_CANDIDATE (state 5), but acceptance is decided only
+after cross-verification (state 7). Writing acceptance back into HF would require a second commit
+R2 that the report never pinned and Gate C never scanned — an unverified byte set. Because
+acceptance is a source-repository *authority* act (the parent contract keeps the rolling report
+and authority in the source repo), the append-only `publications.jsonl` ledger is committed to the
+source repo via ordinary atomic git commits. HF stays a pure content-addressed **data** store; the
+source repo is the **authority**. A run's analysis eligibility is read from `publications.jsonl`,
+never inferred from HF visibility.
 
 Parquet is the default (columnar, HF-recommended); JSONL is the escape hatch for nested
 engineering payloads that would lose meaning if flattened (e.g. dm #1528's synchronized
@@ -264,40 +283,62 @@ HF candidate is authoritative for *nothing* until the append-only Publication re
 (4) REVIEW_APPROVED explicit human promotion review recorded; UNAVAILABLE review channel != approval
 (5) HF_CANDIDATE    egress Gate C re-scans dataset card + all upload bytes (fail-closed) BEFORE commit;
                     immutable single-commit HF revision created; exact commit sha captured;
-                    EVERY content-addressed object re-downloaded + re-hashed                -> still INELIGIBLE
-(6) REPORT_PINNED   source-repo rolling report updated to pin the EXACT verified revision
+                    EVERY uploaded byte (objects + shards + card) re-downloaded + re-hashed   -> still INELIGIBLE
+(6) REPORT_PINNED   source-repo report updated to pin EXACT rev; egress Gate D re-scans FINAL pinned
+                    report bytes (fail-closed); committed as a PROVISIONAL pin ("pending acceptance")
 (7) CROSS_VERIFIED  cross-system check: HF objects resolve at the revision AND report links resolve to it
-(8) ACCEPTED        append-only Publication record written                                  -> analysis-ELIGIBLE
+(8) ACCEPTED        Publication writer validates the evidence-bearing journal proofs for states 0–7,
+                    scans the record, appends it to source-repo publications.jsonl                -> ELIGIBLE
+
+Terminal failure states (explicitly modeled, not prose):
+(Q) QUARANTINED     any pre-HF-commit failure; no HF write occurred; resumable or abortable
+(A) ABANDONED       R1 irreparably corrupt (post-upload object/shard/card re-hash mismatch, or a
+                    permanently unavailable object) — R1 cannot be repaired; candidate is terminal;
+                    a corrective revision R2 re-publishes the same run_id (never an overwrite: R1 was
+                    never accepted). Reader prefers the accepted revision; ABANDONED candidates are inert.
 ```
 
 Run records are written once and **never mutate** from candidate to accepted; acceptance is a
-*separate* append-only Publication row. Only the Publication record confers analysis eligibility.
-Every transition requires its predecessor — there is no bypass edge to ACCEPTED.
+*separate* append-only Publication row in the **source repo**. Only the Publication record confers
+analysis eligibility, and the **Publication writer is not a directly callable append** (Codex r2):
+it validates the evidence-bearing journal — each of states 0–7 recorded a verifiable proof (scan
+digests, replay-equality proof, captured revision, post-upload re-hash results, cross-verify
+result) — rejects a malformed, skipped, or manually constructed journal, and refuses to write
+acceptance absent complete proofs. Every transition requires its predecessor; there is no bypass
+edge to ACCEPTED, and topology alone is not trusted — the writer re-checks the proofs.
 
 ### 4. Immutable HF revision + object verification
 
 - `create_commit` produces a single commit whose returned revision (commit SHA) is captured
   verbatim into the candidate record. The publisher **never** force-pushes, deletes, or
   overwrites; new runs are additive shards + new content objects.
-- Immediately after upload, every content-addressed object referenced by the candidate is
-  re-fetched from the dataset revision and re-hashed; any mismatch fails the candidate before
-  REPORT_PINNED (the candidate stays ineligible; see recovery below).
+- Immediately after upload, **every uploaded byte** referenced by the candidate — content-addressed
+  objects **and** the Parquet/JSONL shards **and** the dataset card/README — is re-fetched from the
+  dataset revision and re-hashed against the staged bytes (Codex r2: object-only re-hashing left
+  shards and card unverified). Any mismatch, or a permanently unavailable object, marks the candidate
+  **ABANDONED** (R1 is immutable and cannot be repaired) and triggers a corrective revision R2; it
+  never advances to REPORT_PINNED.
 - The source-repo rolling report is finalized only after it pins the exact verified revision;
   a moving/`main` reference (not an immutable revision) fails CROSS_VERIFIED.
 
 ### 5. Public-egress / legal / secret validation
 
-The egress gate is one composed check invoked at **three** enforcement points, because the bytes
-it must cover are produced at different states: source records exist at state 1, the rolling report
-is rendered at state 3, and the dataset card + upload shards are assembled at state 5. Scanning
-only at state 1 would let a secret introduced during report rendering or card assembly reach
-Hugging Face. Every invocation fails closed:
+The egress gate is one composed check invoked at **four gates** (Gate D fires before *each*
+source-repo commit — the pinned report at state 6 and the Publication record at state 8), because
+public bytes are produced (and *mutated*) at different states; each invocation scans the bytes at
+the last moment before they become public and fails closed. Scanning only early would let a secret introduced during
+report rendering, card assembly, or the report-pin edit reach a public surface:
 
 - **Gate A — at VALIDATED (state 1):** over projection records, every replay-critical input, and
   every content-addressed artifact (the source bytes).
-- **Gate B — immediately after REPORT_DRAFTED (state 3):** over the rendered rolling HTML report.
+- **Gate B — immediately after REPORT_DRAFTED (state 3):** over the rendered rolling HTML report draft.
 - **Gate C — immediately before `create_commit` (state 5):** over the dataset card/README and
-  **every byte staged for upload** (shards + new content objects), so nothing unscanned is committed.
+  **every byte staged for upload** (Parquet/JSONL shards + new content objects), so nothing
+  unscanned is committed to HF.
+- **Gate D — immediately before the source-repo commit at REPORT_PINNED (state 6) (Codex r2):** over
+  the **final pinned report bytes** (state 6 mutates the report to insert the revision pin *after*
+  Gate B scanned the draft) **and** the Publication acceptance record before it is appended to
+  `publications.jsonl` at ACCEPTED (state 8). No byte reaches a public git surface unscanned.
 
 The composed check runs, at each point:
 
@@ -326,25 +367,32 @@ actual repo.
 
 ### 6. Rollback / resume behavior
 
-A durable append-only **promotion journal** (local, per run) records each stage's completion and
-an idempotency key. On restart the workflow replays from the last completed stage; every stage is
-idempotent (re-running EMITTED/VALIDATED/REPLAYED recomputes deterministically; re-running
-HF_CANDIDATE reuses the captured revision rather than committing twice).
+A durable append-only **evidence-bearing promotion journal** (local, per run) records, for each
+stage, not merely an ordinal but a **verifiable proof** (scan digests, replay-equality proof,
+captured revision, post-upload re-hash results, cross-verify result) plus an idempotency key. On
+restart the workflow **validates the recorded proofs** and resumes from the last *proven* stage — it
+does not trust a bare `stage` ordinal (Codex r2: a corrupted or advanced-without-evidence journal
+must not be believed). Every stage is idempotent (EMITTED/VALIDATED/REPLAYED recompute
+deterministically; HF_CANDIDATE reuses the captured revision rather than committing twice).
 
-- **Failure before HF_CANDIDATE:** no HF write occurred; quarantine locally and resume/abort. No
-  partially-accepted run is ever exposed.
-- **HF_CANDIDATE succeeds, then REPORT_PINNED fails, or CROSS_VERIFIED fails (either sub-check:
-  HF objects not resolving at the revision, or report links not resolving to it):** the candidate
-  revision is immutable and cannot be deleted atomically, so it **remains** but no Publication
-  record is written → it stays analysis-ineligible. Because the `runs/` row for this deterministic
-  `run_id` is already committed at revision R1, recovery is **retry pin/verify against R1 only** —
-  it does **not** create a second candidate, which would either duplicate the `run_id` row across
-  shards (violating the no-attempt-record / no-overwrite invariant) or be blocked by no-overwrite.
-  Supersession is reserved for failures **before** a successful `create_commit`. The dataset reader
-  deduplicates run rows by `run_id` across shards, and the Publication record is the **sole**
-  authority for "accepted", so an un-accepted R1 is inert regardless of visibility.
-- **Interrupted mid-stage:** the journal + idempotency keys guarantee replay never double-commits
-  and never advances past an unverified gate.
+- **Failure before HF_CANDIDATE → QUARANTINED:** no HF write occurred; quarantine locally and
+  resume/abort. No partially-accepted run is ever exposed.
+- **HF_CANDIDATE succeeds, then a TRANSIENT downstream failure (REPORT_PINNED edit fails, a link
+  temporarily unresolvable, a network CROSS_VERIFY hiccup):** R1 is intact and immutable, so recovery
+  is **retry pin/verify against R1** — it does **not** create a second candidate, which would
+  duplicate the `run_id` row (violating no-attempt-record / no-overwrite). No Publication record
+  exists yet, so R1 is inert.
+- **HF_CANDIDATE succeeds, then R1 is IRREPARABLE (post-upload object/shard/card re-hash mismatch, or
+  a permanently unavailable object) → ABANDONED:** R1 cannot be repaired (immutable, no atomic
+  delete), so the candidate is marked **terminal ABANDONED** and a **corrective revision R2**
+  re-publishes the same `run_id`. This is **not** an overwrite — R1 was never accepted (no Publication
+  record), so the no-overwrite invariant (which protects *accepted* runs) is not violated, and no
+  attempt record is created. The dataset reader deduplicates run rows by `run_id` and prefers the
+  revision named by the Publication ledger; ABANDONED R1 is inert.
+- **The Publication ledger is the SOLE authority for "accepted"** (source repo), so any un-accepted
+  R1 — transient-pending or ABANDONED — is analysis-ineligible regardless of HF visibility.
+- **Interrupted mid-stage:** the journal proofs + idempotency keys guarantee replay never
+  double-commits and never advances past an unproven gate.
 
 ---
 
@@ -355,28 +403,34 @@ load per-repo publication.yml (dataset target, algorithm->report map)   # no cre
 resolve HF + GitHub tokens from environment ONLY; assert namespace ownership preflight (no secret persisted)
 
 for each locally emitted RunProjection:
-    journal = open_or_resume_journal(run_id)                # idempotent replay
-    if journal.stage < VALIDATED:
+    journal = open_or_resume_journal(run_id)          # resume from last PROVEN stage; validate proofs, not ordinals
+    if not journal.proven(VALIDATED):
         assert strict identity (clean commit, schema vers, env digest, seed, exec params)   # #3428
         assert inputs public-admissible (redistributable, pinned, hashed, schema-valid, complete)  # #3430
         assert artifacts content-addressed + residency-legal (#3429); outputs curated + native (#3431)
         egress GATE A: legal + secret + abs-path + per-input license (+ #3013 validator | fail-closed shim) over source bytes
-        FAIL CLOSED on any miss
-    if journal.stage < REPLAYED:
-        deterministic reproduce OR exact-equality verify; mismatch -> reject (no overwrite)
+        FAIL CLOSED on any miss -> QUARANTINED; record proof(scan digests, identity)
+    if not journal.proven(REPLAYED):
+        deterministic reproduce OR exact-equality verify; mismatch -> reject (no overwrite); record replay proof
         failed-but-reproducible -> normalized failure evidence; EXCLUDE from metrics/insights/decisions
-    if journal.stage < REPORT_DRAFTED:
+    if not journal.proven(REPORT_DRAFTED):
         render rolling HTML draft (unpinned)
-        egress GATE B: legal + secret + abs-path over the rendered report; FAIL CLOSED
-    if journal.stage < REVIEW_APPROVED: require explicit human review; UNAVAILABLE channel != approval -> stop
-    if journal.stage < HF_CANDIDATE:
-        egress GATE C: legal + secret + abs-path over dataset card + EVERY byte staged for upload; FAIL CLOSED
+        egress GATE B: scan the rendered draft; FAIL CLOSED
+    if not journal.proven(REVIEW_APPROVED): require explicit human review; ABSENT/UNAVAILABLE channel != approval -> stop
+    if not journal.proven(HF_CANDIDATE):
+        egress GATE C: scan dataset card + EVERY byte staged for upload (shards + objects); FAIL CLOSED
         rev = hf.create_commit(dataset_target, additive shards + new content objects)   # immutable single commit
-        capture rev verbatim; re-download + re-hash EVERY content object; mismatch -> fail (candidate stays ineligible)
-    if journal.stage < REPORT_PINNED:   update source report to pin EXACT rev (moving ref -> fail)
-    if journal.stage < CROSS_VERIFIED:  verify HF objects @rev AND report links @rev
-    append Publication acceptance record (append-only) -> run becomes analysis-ELIGIBLE
-    # Run record itself never mutated candidate->accepted
+        capture rev verbatim; re-download + re-hash EVERY uploaded byte (objects + shards + card)
+        mismatch/unavailable -> mark ABANDONED, emit corrective revision R2 (same run_id, not an overwrite); record proof(rev, rehash)
+    if not journal.proven(REPORT_PINNED):
+        update source report to pin EXACT rev (moving ref -> fail)
+        egress GATE D: scan FINAL pinned report bytes; FAIL CLOSED; commit PROVISIONAL pin to source repo
+    if not journal.proven(CROSS_VERIFIED):
+        verify HF objects @rev AND report links @rev; transient fail -> retry against R1; record proof
+    # ACCEPTED: Publication writer re-validates journal proofs for states 0-7, scans the record (GATE D),
+    #           then appends it to source-repo publications.jsonl  -> run becomes analysis-ELIGIBLE
+    publication_writer.accept(journal)   # rejects malformed/skipped/hand-built journals; NOT a bare append
+    # Run record itself never mutated candidate->accepted; eligibility read from publications.jsonl only
 ```
 
 ---
@@ -387,14 +441,15 @@ for each locally emitted RunProjection:
 |---|---|---|
 | Create | `assetutilities/…/workflow_api/publication/projection.py` (DECIDED home) | build `RunProjection` from `ResultEnvelope` + record contracts; bind strict identity |
 | Create | `…/publication/dataset_schema.py` | Parquet/JSONL table writers + content-addressed object store + integrity re-reader |
-| Create | `…/publication/promotion.py` | nine-state machine + durable idempotent promotion journal |
-| Create | `…/publication/hf_client.py` | env-backed auth, single-commit revision, post-upload object re-verification, token redaction |
-| Create | `…/publication/egress.py` | compose legal + secret + abs-path + license gate; #3013 validator or bounded shim |
-| Create | `…/publication/report_pin.py` | pin source-repo rolling report to the exact verified revision |
-| Create | `…/publication/publication_record.py` | append-only Publication acceptance log; sole eligibility authority |
+| Create | `…/publication/promotion.py` | 9-state machine + terminal QUARANTINED/ABANDONED states + evidence-bearing, proof-validating journal |
+| Create | `…/publication/hf_client.py` | env-backed auth, single-commit revision, post-upload re-verification of **all uploaded bytes**, corrective-R2 path, token redaction |
+| Create | `…/publication/egress.py` | compose legal + secret + abs-path + license gate at Gates A/B/C/D; #3013 validator or fail-closed shim |
+| Create | `…/publication/report_pin.py` | pin source-repo rolling report to the exact verified revision (provisional pin + Gate D) |
+| Create | `…/publication/publication_record.py` | Publication writer: re-validates journal proofs, appends to **source-repo** `publications.jsonl`; sole eligibility authority (NOT a bare append) |
 | Create | `…/publication/cli.py` | thin CLI; policy in helper modules |
 | Create | `…/publication/schemas/*.schema.json` | projection/dataset record schemas |
 | Create | `<repo>/docs/registry/publication.yml` (dm, wed) | dataset target + algorithm→report mappings; credential-free |
+| Create | `<source-repo>/reports/<algorithm>/{report.html,publications.jsonl}` (at pilot time, dm #1505 / wed #927) | rolling report + append-only Publication acceptance ledger in the **source repo** (authority plane) |
 | Create | `assetutilities/tests/workflow_api/publication/` | TDD suite (below) |
 | Create | `workspace-hub docs/governance/2026-07-11-hf-projection-staged-promotion-notes.md` | design companion, bound to parent contract version |
 | Update | `docs/plans/README.md` | plan index status |
@@ -431,8 +486,21 @@ wed #927), each under its own approval gate — **not** under this planning issu
 | `test_tokens_never_reach_logs_or_reports` | env-backed auth; redaction | token in env | absent from all emitted text |
 | `test_egress_validator_composes_when_present_and_shims_fail_closed_when_absent` | #3013 present → composed; absent → shim enforces covered subset fail-closed + names uncovered checks | validator-present + validator-absent fixtures | present: real validator invoked; absent: `egress_validator.available=false`, `uncovered[...]` recorded, covered subset still fails closed |
 | `test_legal_and_abs_path_scans_pass` | no restricted ids/secrets/machine paths | changed paths | scanners exit 0 |
+| `test_publication_ledger_lives_in_source_repo_not_hf_dataset` | acceptance record in source-repo `publications.jsonl`; no `publications/` in HF dataset; no R2 for acceptance | dataset + source-repo fixtures | ledger in source repo; HF revision unchanged by acceptance |
+| `test_publication_writer_rejects_malformed_or_hand_built_journal` | writer re-validates state 0–7 proofs; manual/skipped-journal acceptance refused | forged/incomplete journals | acceptance rejected; topology-only bypass blocked |
+| `test_irreparable_R1_abandons_and_corrective_R2_republishes` | post-upload rehash mismatch/unavailable object → ABANDONED terminal + R2 same `run_id`, not an overwrite | corrupt-R1 fixture | R1 ABANDONED + inert; R2 accepted; no attempt record |
+| `test_journal_resume_validates_proofs_not_ordinals` | corrupted/advanced-without-evidence journal not trusted; resume re-checks proofs | tampered-journal fixture | unproven stage re-run; no advance past unproven gate |
+| `test_egress_gate_D_scans_final_pinned_report_and_publication_record` | state-6 report-pin mutation + the Publication record are scanned before their source-repo commit | secret-in-pinned-report + secret-in-record fixtures | Gate D fails closed; nothing committed |
+| `test_post_upload_verifies_all_bytes_not_only_objects` | shards + card re-hashed at revision, not just content objects | tampered-shard + tampered-card fixtures | mismatch → ABANDONED |
+| `test_exact_repeat_creates_no_attempt_record` | exact repeat resolves to same `run_id`, adds no row/attempt | repeat fixture | no new run/attempt row |
+| `test_failed_runs_excluded_from_insights_and_decisions` | reproducible failures excluded from insights + decisions, not only metrics | failed-run fixture | absent from insight/decision populations |
+| `test_dataset_backed_data_as_of_run_timestamp_fails` | dataset-backed algorithm whose `data_as_of` is a run timestamp (not a pinned snapshot) fails admission | wed-style fixture | rejected (per #3430) |
+| `test_admission_rejects_invalid_schema_missing_input_and_nondeterministic_replay` | invalid schema, missing replay input, nondeterministic replay all fail closed | admission fixtures | each rejected |
+| `test_absent_human_approval_blocks` | absent (not merely unavailable) promotion approval blocks acceptance | no-approval fixture | promotion stops |
 
-Tests are written first and fail before implementation exists.
+Tests are written first and fail before implementation exists. Non-testable process gates (full-suite
+green, legal-scan closeout, substantive multi-provider review) are explicitly classified as
+process/CI gates rather than unit tests, and enforced at closeout — not silently dropped.
 
 ---
 
@@ -449,8 +517,8 @@ Tests are written first and fail before implementation exists.
       from metrics, insights, and decisions.
 - [ ] Exact repeats resolve to the deterministic `run_id`, create no attempt record, and never
       overwrite immutable outputs.
-- [ ] Publication captures the exact HF commit/revision and re-verifies every content-addressed
-      object after upload.
+- [ ] Publication captures the exact HF commit/revision and re-verifies **every uploaded byte**
+      (content-addressed objects, Parquet/JSONL shards, and the dataset card) after upload.
 - [ ] The source-repository rolling HTML report is finalized only after it pins the exact verified
       dataset revision.
 - [ ] Interrupted promotion is resumable or rolls back without exposing a partially accepted run,
@@ -478,8 +546,9 @@ not authorize it.** Implementation is additionally sequenced behind:
 3. Authenticated HF namespace ownership preflight (no persisted secret) — owned here, run at
    implementation start, not during planning.
 
-The issue stays at `status:needs-plan` until adversarial review completes and the user approves.
-The uploader is **not** implemented under this plan.
+The issue is **`status:plan-approved`** (owner-approved 2026-07-11). The uploader is **not**
+implemented under this plan, and implementation does not begin until the confirming r3 review closes
+the Codex r2 findings and the sequencing preconditions (1)–(3) above are met.
 
 ---
 
@@ -487,13 +556,22 @@ The uploader is **not** implemented under this plan.
 
 | Round | Reviewer | Verdict | Findings | Result |
 |---|---|---|---|---|
-| r1 | Claude (adversarial self-review) | **BLOCK → remediated** | 1 MAJOR (egress gate scanned report + upload bytes before they existed; no pre-upload re-gate), 5 MINOR (untested cross-verify recovery; supersession vs deterministic `run_id` conflict; missing tests for AC1/AC2/AC10 compose-when-present; cross-repo scan location; #3013 shim must fail-closed on covered subset) | All applied in this revision: three-point egress gate (A/B/C); retry-against-R1-only recovery + reader dedup by `run_id`; four new failing-first tests; library-home made a hard precondition covering scan invocation; shim fails closed + names uncovered checks |
+| r1 | Claude (adversarial self-review) | **BLOCK → remediated** | 1 MAJOR (egress gate scanned report + upload bytes before they existed; no pre-upload re-gate), 5 MINOR (untested cross-verify recovery; supersession vs deterministic `run_id` conflict; missing tests for AC1/AC2/AC10 compose-when-present; cross-repo scan location; #3013 shim must fail-closed on covered subset) | Applied: three-point egress gate; retry-against-R1 recovery; four new tests; library-home hard precondition; shim fails closed + names uncovered checks |
+| r2 | Codex (`codex exec`, structured) | **MAJOR → remediated** | Publication ledger wrongly inside the HF dataset (would need an unverified R2); ACCEPTED appendable without proof re-validation; irreparable-R1 had no terminal recovery; failure states were prose not modeled; post-scan gaps (state-6 report-pin edit + the Publication record unscanned; post-upload re-hash covered only objects, not shards/card); admission + AC 1:1 test gaps | Applied in this revision: **Publication ledger moved to the source repo** (HF = data plane, source repo = authority plane); Publication writer re-validates evidence-bearing journal proofs (not a bare append); terminal **QUARANTINED / ABANDONED** states + corrective-R2 recovery; **Gate D** scans final pinned report + the Publication record; post-upload re-hash extended to **all uploaded bytes**; 12 new failing-first tests (ledger location, writer proof-validation, ABANDONED/R2, proof-validating resume, Gate D, all-byte verify, no-attempt-record, insights/decisions exclusion, `data_as_of`, invalid-schema/missing-input/nondeterministic, absent-approval); non-testable gates classified |
 
-r1 was a single-provider adversarial self-review. Before implementation, the plan targets the
-standard multi-provider gate (Claude + Codex substantive; Gemini subject to noninteractive-auth
-availability on this machine). **No unavailable provider result will be interpreted as approval**,
-and any T3→T2 review-depth reduction will be disclosed in the approval packet for explicit owner
-acceptance, consistent with the parent.
+r1 was a Claude self-review; r2 was a substantive Codex review that found genuine architecture
+defects r1 missed (the Publication-ledger residency being the deepest) — vindicating the
+multi-provider gate. Gemini remains subject to noninteractive-auth availability on this machine and
+was not run; **no unavailable provider result is interpreted as approval**, and the T3→T2 depth
+reduction (Gemini absent) is disclosed for explicit owner acceptance, consistent with the parent.
+| r3 | Claude (verification) | **NO-MAJOR** | Confirmed all six Codex r2 findings CLOSED with matching design/pseudocode/test text; caught one residual MINOR — two lines still said "every content-addressed object" (narrower than the authoritative "every uploaded byte") | Both lines corrected to "every uploaded byte (objects + shards + card)"; Gate-count wording tightened |
+
+r1 was a Claude self-review; r2 was a substantive Codex review that found genuine architecture
+defects r1 missed (the Publication-ledger residency being the deepest) — vindicating the
+multi-provider gate; r3 confirmed the r2 remediations closed cleanly. Gemini remains subject to
+noninteractive-auth availability on this machine and was not run; **no unavailable provider result
+is interpreted as approval**, and the T3→T2 depth reduction (Gemini absent) is disclosed for
+explicit owner acceptance, consistent with the parent.
 
 ---
 

--- a/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
+++ b/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
@@ -1,6 +1,6 @@
 # Plan for [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433): Per-Repository Hugging Face Projection and Staged Promotion
 
-> **Status:** plan-approved (owner-approved 2026-07-11); hardened through Claude r1 + Codex r2 (both MAJOR→remediated) + Claude r3 verification (NO-MAJOR, all findings closed)
+> **Status:** plan-approved (owner-approved 2026-07-11); review gate CLEARED — Claude r1 + Codex r2 (both MAJOR→remediated) + Claude r3 (NO-MAJOR); owner accepted the T3→T2 depth reduction (Gemini unavailable on this machine). Implementation gated only by the upstream #3427 + #3428–#3432 merge.
 > **Complexity:** T3
 > **Date:** 2026-07-11
 > **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3433
@@ -570,8 +570,9 @@ r1 was a Claude self-review; r2 was a substantive Codex review that found genuin
 defects r1 missed (the Publication-ledger residency being the deepest) — vindicating the
 multi-provider gate; r3 confirmed the r2 remediations closed cleanly. Gemini remains subject to
 noninteractive-auth availability on this machine and was not run; **no unavailable provider result
-is interpreted as approval**, and the T3→T2 depth reduction (Gemini absent) is disclosed for
-explicit owner acceptance, consistent with the parent.
+is interpreted as approval**. The T3→T2 depth reduction (Gemini absent) was disclosed to and
+**explicitly accepted by the owner on 2026-07-11**, consistent with the parent. The review gate is
+cleared; implementation is gated only by the upstream #3427 + #3428–#3432 merge to `main`.
 
 ---
 

--- a/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
+++ b/docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md
@@ -1,0 +1,537 @@
+# Plan for [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433): Per-Repository Hugging Face Projection and Staged Promotion
+
+> **Status:** plan-review (adversarial self-review r1 remediated + r2-verified NO-MAJOR; owner-reviewed the two placement/namespace decisions)
+> **Complexity:** T3
+> **Date:** 2026-07-11
+> **Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3433
+> **Client:** N/A
+> **Lane:** lane:codex
+> **Review artifacts:** `scripts/review/results/2026-07-11-plan-3433-claude.md` | `...-codex.md` | `...-gemini.md`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- **Parent contract source (not yet on `main`).** `docs/plans/2026-07-10-issue-3427-repository-linked-algorithm-run-datasets.md`,
+  `docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html`, and the planned
+  `docs/architecture/algorithm-run-dataset-contract.yaml` exist at commit
+  `01054d8d7a499e54c70abfdf0317b7c8b0463a92` but that commit has **diverged** from
+  `origin/main` (verified `2026-07-11` via `gh api .../compare/01054d8d...HEAD` → `diverged`;
+  `gh api .../contents/...@main` → `404` for all three). This publication child **consumes**
+  those contracts, so its implementation is sequenced *after* the parent contract and the
+  record-schema children (#3428–#3432) land on `main`. The plan therefore fixes the record
+  *shape* it depends on and adds a version-pinned compatibility check rather than assuming
+  the schemas are present.
+- `assetutilities/src/assetutilities/workflow_api/envelope.py` supplies the shared
+  `ResultEnvelope`, `code_version()` (`{package_version, git_sha}`), a volatile-key-pruned
+  `input_hash` (`VOLATILE_TOP_KEYS = {"Analysis", "default", "cfg_array"}`), a location-
+  independent content `result_hash` for `kind: files`, and `reproducible` (`None` unless an
+  opt-in double run is requested). **Gap:** `git_sha` does not prove a clean tree and
+  `input_hash` prunes real top-level inputs, so these are *execution evidence*, not strict
+  public identity. The projection envelope will re-bind identity and reference these values
+  as evidence only — never alias them.
+- `digitalmodel/src/digitalmodel/workflow_api/{runner,provenance,golden}.py` and
+  `docs/registry/workflows.yaml` (`schema_version: 2`, versioned `<repo>:<id>@N` routing,
+  `status`/`latest` triple) supply the landed runner, the `stamp_provenance` assembler
+  (delegates to `assetutilities…make_provenance`, parameterized by `package_name`), the
+  golden harness, and workflow goldens. The publisher will **crosswalk** these surfaces as
+  evidence inputs; it will not re-create a runner or alias the integer registry `version`
+  as the semantic algorithm version.
+- `worldenergydata/src/worldenergydata/workflow_api/runner.py` consumes the same envelope but
+  currently stamps `data_as_of` as a run timestamp, not a pinned source-data snapshot; the
+  public input contract (#3430) requires the snapshot form. The publisher fails closed when
+  `data_as_of` is a run timestamp for a dataset-backed algorithm.
+- **Gap:** no reusable projection, dataset-schema writer, staged-promotion state machine,
+  HF client with post-upload object verification, egress/legal/secret gate composition,
+  report-pin, or append-only Publication record exists anywhere in the ecosystem.
+
+### Standards
+
+| Standard | Status | Source |
+|---|---|---|
+| Issue lifecycle and user approval | binding | `AGENTS.md`, `docs/plans/README.md` |
+| Parent run-dataset contract (identity, records, states, exclusions) | binding, consumed | `#3427` plan + `docs/architecture/algorithm-run-dataset-contract.yaml` (pending merge) |
+| Record-schema children (identity/artifact/input/output/metric) | binding, consumed | `#3428`, `#3429`, `#3430`, `#3431`, `#3432` |
+| Data/execution/report boundaries | reusable, extension required | `docs/architecture/execution-manifest.schema.yaml`, `docs/architecture/report-evidence-bundle.schema.yaml` |
+| Legal/public-egress scan | binding | `scripts/legal/legal-sanity-scan.sh`, `.legal-deny-list.yaml` |
+| No-absolute-paths enforcement | binding | `scripts/enforcement/check-no-abs-paths.sh` |
+| Ecosystem public-egress validator | consumed **when available**; bounded compatibility dependency until then | `#3013` (Phase B validator) under `#2975` (Phase A contract) |
+| Control-plane discovery | applicable | `docs/standards/CONTROL_PLANE_CONTRACT.md` |
+| Hugging Face upload / commit / revision semantics | applicable external platform contract | <https://huggingface.co/docs/huggingface_hub/guides/upload>, <https://huggingface.co/docs/hub/datasets-cards> |
+
+No engineering calculation standard applies to this publication-infrastructure issue; the
+pilot algorithms (dm #1505, wed #927) retain their own calculation citation obligations.
+
+### LLM Wiki pages consulted
+
+- No domain wiki page governs cross-repository run publication. Per the durable/transient
+  boundary, the normative architecture is the parent contract YAML + decision manual; GitHub
+  issues, this plan, and review artifacts are execution-state evidence.
+
+### Documents consulted
+
+- Issue [#3433](https://github.com/vamseeachanta/workspace-hub/issues/3433) body + owner
+  comment: fixes the emit→validate→replay→draft→review→HF-candidate→pin→verify→append-only
+  acceptance sequence, the "acceptance not visibility" atomicity rule, the candidate-
+  ineligibility invariant, the HF-success-then-pin/verify-failure recovery requirement, the
+  "no unavailable review channel counts as approval" rule, and the independent child gate.
+- Parent [#3427](https://github.com/vamseeachanta/workspace-hub/issues/3427) plan (read at
+  `01054d8d`): one dataset per repo, catalog-only aggregation, strict public input policy,
+  failed-run analysis-ineligibility, byte identity vs versioned semantic equality digest,
+  ResultEnvelope-as-evidence crosswalk, HF-as-storage-only for replay-critical inputs +
+  curated outputs.
+- Blocking children [#3428](https://github.com/vamseeachanta/workspace-hub/issues/3428)
+  (deterministic run identity + algorithm version), [#3429](https://github.com/vamseeachanta/workspace-hub/issues/3429)
+  (content-addressed artifact + HF residency), [#3430](https://github.com/vamseeachanta/workspace-hub/issues/3430)
+  (replayable public input + snapshot), [#3431](https://github.com/vamseeachanta/workspace-hub/issues/3431)
+  (curated output + rolling HTML report), [#3432](https://github.com/vamseeachanta/workspace-hub/issues/3432)
+  (algorithm-scoped metric): supply the record shapes the projection serializes. **All five
+  are `status:needs-plan`** — an explicit ordering constraint recorded below.
+- Ecosystem [#2975](https://github.com/vamseeachanta/workspace-hub/issues/2975) (flywheel
+  manifest/provenance/routing) and [#3013](https://github.com/vamseeachanta/workspace-hub/issues/3013)
+  (public-egress validator + allowlist-only public projection, deny-list-inside-allowed-values,
+  public identity registry): the publisher composes these controls when present and records a
+  bounded shim until then, per #3433 acceptance criterion 10.
+- Pilots [digitalmodel #1505](https://github.com/vamseeachanta/digitalmodel/issues/1505)
+  (public synthetic VIV parametric: ≥3 variations + 1 exact replay, clean-room reproduce) and
+  [worldenergydata #927](https://github.com/vamseeachanta/worldenergydata/issues/927) (public
+  BSEE): both are `Blocked by #3433` and are the first consumers of the workflow this plan
+  designs. dm [#1528](https://github.com/vamseeachanta/digitalmodel/issues/1528) (coupled
+  sloshing CFD, `status:plan-approved`) is a *future producer* whose per-run machine-readable
+  manifest (input hashes, solver version, case hash, output files, report hash) is a concrete
+  test of the projection envelope's domain-native output handling.
+- Hugging Face upload docs: `create_commit` gives a single atomic commit returning an exact
+  revision; `preupload_lfs`/large-file handling and content-addressed storage support the
+  additive-shard + blob-store layout; dataset cards carry machine-readable metadata.
+
+### Gaps identified
+
+- No projection record binds the strict public identity (clean commit, input/output schema
+  versions, environment digest, seed, execution params) to the five domain-native record
+  categories in one machine-readable, serialize-ready envelope.
+- No dataset-schema writer emits per-repository Parquet/JSONL tables plus a deduplicated
+  content-addressed object store, and no reader re-validates artifact integrity from dataset
+  bytes without trusting the manifest.
+- No promotion state machine enforces the nine gates, keeps Run records immutable across
+  candidate→accepted, and treats a visible HF candidate as analysis-ineligible until an
+  append-only Publication record accepts it.
+- No HF client authenticates from the environment, creates an immutable single-commit
+  revision, re-downloads and re-hashes every content-addressed object post-upload, and
+  guarantees tokens never reach logs or reports.
+- No egress gate composes legal + secret + absolute-path + per-input license resolution and
+  defers to the #3013 ecosystem validator when available with a recorded bounded shim.
+- No promotion journal makes an interrupted promotion resumable or safely rolled back,
+  including the HF-success-then-pin/verify-failure recovery paths.
+
+### Evidence (embedded verification)
+
+**Issue / ref statuses** (verified `2026-07-11` via `gh`):
+
+```text
+#3433                    OPEN  status:needs-plan, lane:codex, publication child (this plan)
+#3428..#3432             OPEN  status:needs-plan  (record-schema contracts this plan consumes)
+#3427                    OPEN  status:plan-approved (parent); contract artifacts diverged from main
+digitalmodel #1505       OPEN  status:needs-plan  Blocked by #3433 (synthetic pilot, first consumer)
+worldenergydata #927     (parent-plan-referenced public BSEE pilot, Blocked by #3433)
+digitalmodel #1528       OPEN  status:plan-approved (future producer: CFD run manifest)
+#2975 / #3013            OPEN  ecosystem flywheel contract + public-egress validator
+```
+
+**Ref existence / divergence** (verified `2026-07-11`):
+
+```text
+DIVERGED  workspace-hub 01054d8d...origin/main  (parent contract commit not on main)
+404 @main docs/plans/2026-07-10-issue-3427-...md
+404 @main docs/governance/2026-07-10-algorithm-run-dataset-decision-manual.html
+404 @main docs/architecture/algorithm-run-dataset-contract.yaml
+EXISTS    docs/architecture/execution-manifest.schema.yaml (on main)
+EXISTS    scripts/legal/legal-sanity-scan.sh, scripts/enforcement/check-no-abs-paths.sh (on main)
+EXISTS    assetutilities …/workflow_api/envelope.py  (ResultEnvelope, make_provenance)
+EXISTS    digitalmodel …/workflow_api/{runner,provenance,golden}.py; docs/registry/workflows.yaml (schema_version 2)
+```
+
+**Reproduction proofs:** N/A. This is a publication-infrastructure design; it alleges no
+runtime regression. The divergence check above is a read-only sequencing probe.
+
+Distinct sources: issue #3433 + owner comment; parent #3427 plan; five record-schema children;
+two ecosystem controls; two pilots + one future producer; ResultEnvelope + provenance
+implementations; dm registry; three official Hugging Face pages — more than the required three.
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | `docs/plans/2026-07-11-issue-3433-per-repository-hf-projection-and-staged-promotion.md` |
+| Publication decision note (design companion) | `docs/governance/2026-07-11-hf-projection-staged-promotion-notes.md` |
+| Reusable projection + promotion library | `assetutilities/src/assetutilities/workflow_api/publication/` (DECIDED home — owner-confirmed 2026-07-11) |
+| Per-repository publication config | `<repo>/docs/registry/publication.yml` (dataset target + algorithm→report mappings; no creds/paths) |
+| Projection record schema | `assetutilities/src/assetutilities/workflow_api/publication/schemas/*.schema.json` |
+| Contract / behavior tests | `assetutilities/tests/workflow_api/publication/` |
+| Plan review — Claude / Codex / Gemini | `scripts/review/results/2026-07-11-plan-3433-{claude,codex,gemini}.md` |
+
+The unsuffixed provider paths hold the latest review used for the live gate; immutable round
+snapshots use `-<provider>-rN.md` and name the exact revision reviewed.
+
+---
+
+## Deliverable
+
+A reusable, credential-free, machine-validated **projection and staged-promotion workflow**
+that takes an owning repository's locally emitted run envelopes, admits only public-safe
+reproducible runs, publishes them to that repository's dedicated Hugging Face dataset at an
+immutable verified revision, pins the source-repository rolling report to that revision, and
+records acceptance in an append-only Publication log — resumable or safely rolled back at every
+stage, with no run ever visible as "accepted" until cross-system verification passes.
+
+**This plan does not implement the uploader.** It defines the run envelope, the dataset schema,
+the promotion state machine, the immutable-revision + object-verification behavior, the
+egress/legal/secret gate, and the rollback/resume behavior, plus a first-fail TDD list. Code
+lands only after this plan is adversarially reviewed and explicitly approved, and after the
+parent contract (#3427) and the record-schema children (#3428–#3432) are on `main`.
+
+---
+
+## Design
+
+### 1. Projection-ready run envelope
+
+A `RunProjection` record is the local, pre-publication, serialize-ready superset of the
+execution `ResultEnvelope`. It binds **strict public identity** and the five domain-native
+record categories, and references execution-evidence hashes without aliasing them as identity.
+
+```text
+RunProjection
+  identity:
+    repository            {repo, owning_dataset}          # one dataset per repo; catalog indexes, never combines
+    algorithm_id          stable id (e.g. "digitalmodel:viv-parametric")
+    algorithm_version_id  = H(semver, clean_git_commit, input_schema_ver, output_schema_ver, env_digest)   # #3428
+    run_id                = H(algorithm_version_id, canonical_input_set_digest, seed, exec_params)          # #3428, excludes outputs
+    output_equality_digest  versioned: raw-byte by default; explicit declared canonicalizer otherwise      # #3427/#3431
+  status                  succeeded | reproducible_failure   # failed carries normalized failure evidence; never enters metrics
+  inputs[]   -> Input records (#3430): role, schema_ver, canonical repr, digest, required_for_replay,
+                                        redistribution evidence, public locator | HF-resident artifact ref
+  outputs[]  -> Output records (#3431): role, native schema, units/convention, validation/review state,
+                                         curated-vs-excluded flag, artifact refs
+  metrics[]  -> Metric observations (#3432): definition_ver, value, quality, uncertainty  (succeeded runs only)
+  artifacts[] -> Artifact records (#3429): sha256, size, media type, native format, schema ref, residency policy
+  evidence:   result_envelope excerpt (input_hash, result_hash, code_version, reproducible)  # evidence ONLY, not identity
+```
+
+Invariants: `run_id` excludes outputs (an exact rerun with mismatched curated output digests is
+a reproducibility defect that fails publication, never a new revision). Exact repeats resolve to
+the same `run_id` and create **no** attempt record and **no** overwrite. `git_sha` from the
+ResultEnvelope is retained under `evidence` but a *dirty* tree fails the `algorithm_version_id`
+clean-commit check — the projection re-derives identity from a verified clean commit, not from
+the envelope's best-effort `git_sha`.
+
+### 2. Dataset schema (per-repository Hugging Face layout)
+
+One dataset per source repo (`aceengineer/digitalmodel-runs`, `aceengineer/worldenergydata-runs`);
+a separate global catalog **indexes** datasets and never merges domain-native records.
+
+```text
+<dataset-root>/
+  README.md                      # dataset card: metadata, schema versions, license summary
+  runs/       part-*.parquet      # append-only shards, one row per run (identity + status + refs); eligibility gated by publications/
+  inputs/     part-*.parquet      # replay-critical inputs (JSONL fallback for deeply nested payloads)
+  outputs/    part-*.parquet      # curated native outputs (JSONL where schema is non-tabular)
+  metrics/    part-*.parquet      # metric observations (succeeded runs only)
+  publications/ part-*.jsonl      # append-only Publication acceptance records (see §3)
+  objects/<sha256[:2]>/<sha256>   # content-addressed blob store; deduplicated within dataset
+  catalog-index.json (global catalog side) # points at each dataset revision; no combined run table
+```
+
+Parquet is the default (columnar, HF-recommended); JSONL is the escape hatch for nested
+engineering payloads that would lose meaning if flattened (e.g. dm #1528's synchronized
+time-history traces). Every `objects/` entry is addressed and named by its SHA-256 so identical
+bytes referenced by multiple runs/roles resolve to one object. A reader re-hashes object bytes to
+revalidate integrity **without trusting** the row's asserted digest.
+
+### 3. Staged promotion state machine
+
+Acceptance is atomic; **visibility is not**. GitHub and HF cannot commit together, so a visible
+HF candidate is authoritative for *nothing* until the append-only Publication record accepts it.
+
+```text
+(0) EMITTED         local RunProjection written                          -> analysis-INELIGIBLE
+(1) VALIDATED       schemas + identity + hashes + license + egress Gate A (source bytes) all pass (fail-closed)
+(2) REPLAYED        deterministic reproduce / exact-equality verify pass; failed runs get normalized evidence
+(3) REPORT_DRAFTED  rolling HTML report draft rendered (NOT pinned); egress Gate B re-scans the report (fail-closed)
+(4) REVIEW_APPROVED explicit human promotion review recorded; UNAVAILABLE review channel != approval
+(5) HF_CANDIDATE    egress Gate C re-scans dataset card + all upload bytes (fail-closed) BEFORE commit;
+                    immutable single-commit HF revision created; exact commit sha captured;
+                    EVERY content-addressed object re-downloaded + re-hashed                -> still INELIGIBLE
+(6) REPORT_PINNED   source-repo rolling report updated to pin the EXACT verified revision
+(7) CROSS_VERIFIED  cross-system check: HF objects resolve at the revision AND report links resolve to it
+(8) ACCEPTED        append-only Publication record written                                  -> analysis-ELIGIBLE
+```
+
+Run records are written once and **never mutate** from candidate to accepted; acceptance is a
+*separate* append-only Publication row. Only the Publication record confers analysis eligibility.
+Every transition requires its predecessor — there is no bypass edge to ACCEPTED.
+
+### 4. Immutable HF revision + object verification
+
+- `create_commit` produces a single commit whose returned revision (commit SHA) is captured
+  verbatim into the candidate record. The publisher **never** force-pushes, deletes, or
+  overwrites; new runs are additive shards + new content objects.
+- Immediately after upload, every content-addressed object referenced by the candidate is
+  re-fetched from the dataset revision and re-hashed; any mismatch fails the candidate before
+  REPORT_PINNED (the candidate stays ineligible; see recovery below).
+- The source-repo rolling report is finalized only after it pins the exact verified revision;
+  a moving/`main` reference (not an immutable revision) fails CROSS_VERIFIED.
+
+### 5. Public-egress / legal / secret validation
+
+The egress gate is one composed check invoked at **three** enforcement points, because the bytes
+it must cover are produced at different states: source records exist at state 1, the rolling report
+is rendered at state 3, and the dataset card + upload shards are assembled at state 5. Scanning
+only at state 1 would let a secret introduced during report rendering or card assembly reach
+Hugging Face. Every invocation fails closed:
+
+- **Gate A — at VALIDATED (state 1):** over projection records, every replay-critical input, and
+  every content-addressed artifact (the source bytes).
+- **Gate B — immediately after REPORT_DRAFTED (state 3):** over the rendered rolling HTML report.
+- **Gate C — immediately before `create_commit` (state 5):** over the dataset card/README and
+  **every byte staged for upload** (shards + new content objects), so nothing unscanned is committed.
+
+The composed check runs, at each point:
+
+- **Legal:** `scripts/legal/legal-sanity-scan.sh` (deny-list) over the in-scope bytes + text.
+- **Secret:** token/credential pattern scan; HF/GitHub tokens are read from the environment only
+  and are redacted from all emitted text (projection, report, logs, dataset card).
+- **Absolute paths / machine state:** `scripts/enforcement/check-no-abs-paths.sh`; any local
+  absolute path or undocumented machine state fails public eligibility.
+- **Per-input license (Gate A):** each replay-critical input carries redistribution evidence;
+  restricted, ambiguous-license, private, client-specific, or pointer-only inputs fail (a
+  dataset-level license cannot grant rights absent from a source).
+- **Ecosystem public-egress validator (#3013) when available:** the gate composes it (allowlist-
+  only public projection, deny-list-inside-allowed-values, public-identity-registry-backed ID
+  validation, deterministic ID pattern). Until #3013 lands, a **bounded compatibility shim**
+  enforces the local subset **fail-closed** and records `egress_validator: {available: false,
+  compat_shim_version, uncovered: [public_identity_registry_id_check, ...]}` — the marker both
+  makes the reduced coverage visible (per #3433 AC 10) and **names what the shim cannot verify**
+  (e.g. registry-backed ID validation, which has no substrate until #2975/#3013 land) rather than
+  passing runs through under a bare "unavailable" flag.
+
+Scripts note: `legal-sanity-scan.sh` and `check-no-abs-paths.sh` are workspace-hub-resident. For
+code that lands outside workspace-hub (see Open Question 1), the gate invokes them via a pinned,
+vendored copy or a cross-repo call resolved by the control-plane; the library-home decision must
+settle this before implementation so "scans pass on changed files" is enforceable in the code's
+actual repo.
+
+### 6. Rollback / resume behavior
+
+A durable append-only **promotion journal** (local, per run) records each stage's completion and
+an idempotency key. On restart the workflow replays from the last completed stage; every stage is
+idempotent (re-running EMITTED/VALIDATED/REPLAYED recomputes deterministically; re-running
+HF_CANDIDATE reuses the captured revision rather than committing twice).
+
+- **Failure before HF_CANDIDATE:** no HF write occurred; quarantine locally and resume/abort. No
+  partially-accepted run is ever exposed.
+- **HF_CANDIDATE succeeds, then REPORT_PINNED fails, or CROSS_VERIFIED fails (either sub-check:
+  HF objects not resolving at the revision, or report links not resolving to it):** the candidate
+  revision is immutable and cannot be deleted atomically, so it **remains** but no Publication
+  record is written → it stays analysis-ineligible. Because the `runs/` row for this deterministic
+  `run_id` is already committed at revision R1, recovery is **retry pin/verify against R1 only** —
+  it does **not** create a second candidate, which would either duplicate the `run_id` row across
+  shards (violating the no-attempt-record / no-overwrite invariant) or be blocked by no-overwrite.
+  Supersession is reserved for failures **before** a successful `create_commit`. The dataset reader
+  deduplicates run rows by `run_id` across shards, and the Publication record is the **sole**
+  authority for "accepted", so an un-accepted R1 is inert regardless of visibility.
+- **Interrupted mid-stage:** the journal + idempotency keys guarantee replay never double-commits
+  and never advances past an unverified gate.
+
+---
+
+## Pseudocode
+
+```text
+load per-repo publication.yml (dataset target, algorithm->report map)   # no creds, no abs paths
+resolve HF + GitHub tokens from environment ONLY; assert namespace ownership preflight (no secret persisted)
+
+for each locally emitted RunProjection:
+    journal = open_or_resume_journal(run_id)                # idempotent replay
+    if journal.stage < VALIDATED:
+        assert strict identity (clean commit, schema vers, env digest, seed, exec params)   # #3428
+        assert inputs public-admissible (redistributable, pinned, hashed, schema-valid, complete)  # #3430
+        assert artifacts content-addressed + residency-legal (#3429); outputs curated + native (#3431)
+        egress GATE A: legal + secret + abs-path + per-input license (+ #3013 validator | fail-closed shim) over source bytes
+        FAIL CLOSED on any miss
+    if journal.stage < REPLAYED:
+        deterministic reproduce OR exact-equality verify; mismatch -> reject (no overwrite)
+        failed-but-reproducible -> normalized failure evidence; EXCLUDE from metrics/insights/decisions
+    if journal.stage < REPORT_DRAFTED:
+        render rolling HTML draft (unpinned)
+        egress GATE B: legal + secret + abs-path over the rendered report; FAIL CLOSED
+    if journal.stage < REVIEW_APPROVED: require explicit human review; UNAVAILABLE channel != approval -> stop
+    if journal.stage < HF_CANDIDATE:
+        egress GATE C: legal + secret + abs-path over dataset card + EVERY byte staged for upload; FAIL CLOSED
+        rev = hf.create_commit(dataset_target, additive shards + new content objects)   # immutable single commit
+        capture rev verbatim; re-download + re-hash EVERY content object; mismatch -> fail (candidate stays ineligible)
+    if journal.stage < REPORT_PINNED:   update source report to pin EXACT rev (moving ref -> fail)
+    if journal.stage < CROSS_VERIFIED:  verify HF objects @rev AND report links @rev
+    append Publication acceptance record (append-only) -> run becomes analysis-ELIGIBLE
+    # Run record itself never mutated candidate->accepted
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Create | `assetutilities/…/workflow_api/publication/projection.py` (DECIDED home) | build `RunProjection` from `ResultEnvelope` + record contracts; bind strict identity |
+| Create | `…/publication/dataset_schema.py` | Parquet/JSONL table writers + content-addressed object store + integrity re-reader |
+| Create | `…/publication/promotion.py` | nine-state machine + durable idempotent promotion journal |
+| Create | `…/publication/hf_client.py` | env-backed auth, single-commit revision, post-upload object re-verification, token redaction |
+| Create | `…/publication/egress.py` | compose legal + secret + abs-path + license gate; #3013 validator or bounded shim |
+| Create | `…/publication/report_pin.py` | pin source-repo rolling report to the exact verified revision |
+| Create | `…/publication/publication_record.py` | append-only Publication acceptance log; sole eligibility authority |
+| Create | `…/publication/cli.py` | thin CLI; policy in helper modules |
+| Create | `…/publication/schemas/*.schema.json` | projection/dataset record schemas |
+| Create | `<repo>/docs/registry/publication.yml` (dm, wed) | dataset target + algorithm→report mappings; credential-free |
+| Create | `assetutilities/tests/workflow_api/publication/` | TDD suite (below) |
+| Create | `workspace-hub docs/governance/2026-07-11-hf-projection-staged-promotion-notes.md` | design companion, bound to parent contract version |
+| Update | `docs/plans/README.md` | plan index status |
+
+No source-repository algorithm code, existing runner, workflow registry, or credential store is
+modified by this issue. HF datasets are created/appended only during pilot execution (dm #1505 /
+wed #927), each under its own approval gate — **not** under this planning issue.
+
+---
+
+## TDD Test List
+
+| Test | Verifies | Input | Expected |
+|---|---|---|---|
+| `test_projection_binds_strict_identity_not_envelope_alias` | identity re-bound; envelope hashes are evidence only | envelope + clean/dirty fixtures | dirty tree rejected; identity ≠ `input_hash`/`git_sha` |
+| `test_run_id_excludes_outputs_and_is_deterministic` | same version+inputs+seed → same `run_id` across machines; outputs not in `run_id` | repeat fixtures | identical `run_id`; output change keeps `run_id` |
+| `test_exact_rerun_output_mismatch_fails_closed` | curated-output digest mismatch rejects, no overwrite | matched/mismatched reruns | mismatch rejected; prior record intact |
+| `test_public_input_admission_is_strict` | restricted/pointer-only/unlicensed/unpinned/unhashed/incomplete fail | input policy cases | each unsafe case rejected |
+| `test_dataset_is_per_repository_and_content_addressed` | one dataset per repo; identical bytes dedupe to one object; catalog never combines | two-repo fixtures | distinct targets; single object id; no combined table |
+| `test_artifact_integrity_revalidated_from_bytes` | reader re-hashes objects, ignores asserted digest | tampered-byte fixture | tamper detected |
+| `test_promotion_state_machine_has_no_bypass_to_accepted` | ACCEPTED reachable only through all gates | transition graph | no shortcut edge |
+| `test_candidate_is_analysis_ineligible_until_publication_record` | visible HF candidate confers nothing until append-only accept | candidate w/o Publication row | ineligible |
+| `test_run_record_never_mutates_candidate_to_accepted` | Run row immutable; acceptance is separate append | before/after accept | Run bytes unchanged |
+| `test_unavailable_review_channel_is_not_approval` | missing review ≠ approval | unavailable-channel fixture | promotion stops |
+| `test_hf_revision_is_captured_and_objects_verified` | exact revision captured; every object re-verified post-upload | mock HF commit + object fetch | revision pinned; mismatch fails candidate |
+| `test_report_pins_exact_immutable_revision` | moving/`main` ref fails; exact revision passes | report-pin fixtures | moving ref rejected |
+| `test_failed_runs_excluded_from_metrics` | reproducible failures visible but analysis-ineligible | failed-run fixture | no metric contribution |
+| `test_resume_replays_from_last_stage_idempotently` | interrupted promotion resumes; no double-commit | journal at each stage | single commit; correct resume |
+| `test_hf_success_then_pin_failure_recovers_by_retry_against_R1` | pin-failure recovery retries R1, no second candidate, no acceptance | pin-failure fixture | no Publication row; retry against captured rev; no duplicate run row |
+| `test_hf_success_then_cross_verify_failure_recovers_without_acceptance` | verify-failure (objects@rev / report-links@rev) recovery distinct from pin-failure | cross-verify-failure fixture | no Publication row; candidate inert |
+| `test_egress_regate_on_report_and_upload_bytes_before_commit` | secret injected at report (state 3) or card/shard (state 5) is caught pre-upload | secret-in-report + secret-in-card fixtures | Gate B / Gate C fail closed; no `create_commit` |
+| `test_publication_config_rejects_credentials_and_abs_paths` | `publication.yml` with an embedded token or machine path is rejected | bad-config fixtures | config load fails closed |
+| `test_projection_roundtrips_all_five_record_categories` | inputs/outputs/metrics/artifacts + envelope serialize→read back preserving native meaning | full-record fixture | lossless round-trip; native schema intact |
+| `test_tokens_never_reach_logs_or_reports` | env-backed auth; redaction | token in env | absent from all emitted text |
+| `test_egress_validator_composes_when_present_and_shims_fail_closed_when_absent` | #3013 present → composed; absent → shim enforces covered subset fail-closed + names uncovered checks | validator-present + validator-absent fixtures | present: real validator invoked; absent: `egress_validator.available=false`, `uncovered[...]` recorded, covered subset still fails closed |
+| `test_legal_and_abs_path_scans_pass` | no restricted ids/secrets/machine paths | changed paths | scanners exit 0 |
+
+Tests are written first and fail before implementation exists.
+
+---
+
+## Acceptance Criteria
+
+- [ ] A repository configures its dataset target + algorithm→report mappings via
+      `publication.yml` with no embedded credentials or machine-specific paths.
+- [ ] Projection preserves the common run envelope and domain-native input/output/metric/artifact
+      records in machine-readable Parquet or JSONL, binding strict identity distinct from the
+      execution envelope's evidence hashes.
+- [ ] Public admission fails closed for dirty source, missing replay inputs, invalid schemas,
+      unresolved licenses, bad hashes, nondeterministic exact reruns, or unapproved promotion.
+- [ ] Validated reproducible failures publish with normalized failure evidence and are excluded
+      from metrics, insights, and decisions.
+- [ ] Exact repeats resolve to the deterministic `run_id`, create no attempt record, and never
+      overwrite immutable outputs.
+- [ ] Publication captures the exact HF commit/revision and re-verifies every content-addressed
+      object after upload.
+- [ ] The source-repository rolling HTML report is finalized only after it pins the exact verified
+      dataset revision.
+- [ ] Interrupted promotion is resumable or rolls back without exposing a partially accepted run,
+      including the HF-success-then-pin/verify-failure recovery paths.
+- [ ] Authentication is environment-backed; logs and reports cannot disclose tokens.
+- [ ] The workflow composes the #3013 ecosystem public-egress validator when available and records
+      a bounded compatibility dependency until then.
+- [ ] Run records never mutate candidate→accepted; a visible HF candidate is analysis-ineligible
+      until the append-only Publication record accepts it.
+- [ ] TDD tests are written first and fail before implementation; the full suite, the legal scan
+      (`--diff-only`), and `check-no-abs-paths.sh` pass on changed files.
+- [ ] Final Claude and Codex review artifacts contain substantive reviews with no unresolved MAJOR
+      finding; any unavailable provider is recorded as unavailability, not approval, and the reduced
+      review depth is disclosed in the approval packet.
+
+---
+
+## Sequencing & Gate
+
+**This child requires its own reviewed plan and explicit user approval; parent #3427 approval does
+not authorize it.** Implementation is additionally sequenced behind:
+
+1. Parent contract (#3427) YAML + decision manual merged to `origin/main` (currently diverged).
+2. Record-schema children #3428–#3432 planned, approved, and their record shapes merged.
+3. Authenticated HF namespace ownership preflight (no persisted secret) — owned here, run at
+   implementation start, not during planning.
+
+The issue stays at `status:needs-plan` until adversarial review completes and the user approves.
+The uploader is **not** implemented under this plan.
+
+---
+
+## Adversarial Review Summary
+
+| Round | Reviewer | Verdict | Findings | Result |
+|---|---|---|---|---|
+| r1 | Claude (adversarial self-review) | **BLOCK → remediated** | 1 MAJOR (egress gate scanned report + upload bytes before they existed; no pre-upload re-gate), 5 MINOR (untested cross-verify recovery; supersession vs deterministic `run_id` conflict; missing tests for AC1/AC2/AC10 compose-when-present; cross-repo scan location; #3013 shim must fail-closed on covered subset) | All applied in this revision: three-point egress gate (A/B/C); retry-against-R1-only recovery + reader dedup by `run_id`; four new failing-first tests; library-home made a hard precondition covering scan invocation; shim fails closed + names uncovered checks |
+
+r1 was a single-provider adversarial self-review. Before implementation, the plan targets the
+standard multi-provider gate (Claude + Codex substantive; Gemini subject to noninteractive-auth
+availability on this machine). **No unavailable provider result will be interpreted as approval**,
+and any T3→T2 review-depth reduction will be disclosed in the approval packet for explicit owner
+acceptance, consistent with the parent.
+
+---
+
+## Risks and Open Questions
+
+- **Cross-system transaction risk:** GitHub + HF cannot commit atomically. Mitigation: candidate
+  visibility is non-authoritative; acceptance gates on verified HF objects + a pinned report + an
+  append-only Publication record.
+- **Dependency-ordering risk:** the parent contract and record-schema children are not yet on
+  `main`. Mitigation: implementation is explicitly sequenced behind their merge; the plan pins the
+  record shapes and adds a version-compatibility check that fails closed on drift.
+- **Egress-coverage risk:** #3013 is unbuilt. Mitigation: bounded compatibility shim + an explicit,
+  visible dependency marker; no silent reduction of egress coverage.
+- **Scale risk:** many small objects degrade HF usability. Mitigation: append-only Parquet shard +
+  content-object thresholds tuned against current HF limits at implementation.
+- **Namespace/auth risk:** the final HF organization and credentials are unverified by this planning
+  issue. Mitigation: authenticated ownership preflight at implementation start; no secret written to
+  any repo or log.
+
+**Resolved decisions (owner-confirmed 2026-07-11):**
+
+1. **Library home — DECIDED: `assetutilities.workflow_api.publication`.** Both pilots already import
+   `assetutilities.workflow_api`, so one shared implementation serves dm + wed. Because
+   `legal-sanity-scan.sh` and `check-no-abs-paths.sh` are workspace-hub-resident, the egress gate
+   will invoke them from assetutilities via a **pinned, vendored copy** (checksum-pinned to the
+   workspace-hub source, refreshed by a control-plane check) so "scans pass on changed files"
+   (AC 12) is enforceable in the code's own repo. This is now a fixed implementation constraint,
+   not an open question.
+2. **HF organization/namespace — DECIDED: `aceengineer/*`** (`aceengineer/digitalmodel-runs`,
+   `aceengineer/worldenergydata-runs`); credentials supplied via **environment at run time**, never
+   persisted to any repo or log. The authenticated namespace-ownership preflight (no persisted
+   secret) runs at implementation start.
+
+---
+
+## Complexity: T3
+
+Systemic, cross-repository publication architecture with legal, identity, determinism, external-
+platform, and recovery consequences, consumed by two independently gated pilots. Targets a three-
+provider adversarial plan review; provider availability will be recorded truthfully and any depth
+reduction disclosed for explicit owner acceptance.


### PR DESCRIPTION
## Reviewed plans for the record-schema contract chain (epic #3427)

Five HITL contract children, planned in dependency order and each **adversarially reviewed (r1 BLOCK → remediated)**. Planning only — **no implementation**. Each keeps its own approval gate.

| Issue | Contract | Owns |
|---|---|---|
| #3428 | Deterministic run identity | `algorithm_version_id`/`run_id`; pinned canonicalization (RFC 8785 JCS + `decimal.normalize` + NFC + `canonicalization_version`); `execution_parameters` vs `parameter_set` boundary |
| #3429 | Content-addressed artifact | SHA-256 of **stored** bytes; role-free identity; integrity-from-bytes; fail-closed residency |
| #3430 | Replayable public input | `canonical_input_set_digest` (excludes fetch-volatile fields); snapshot-identity admission; ambiguous-license fail-closed |
| #3431 | Curated output + rolling report | `output_equality_digest` (raw-byte default, governed membership fail-closed); normalized failure signature; report aligned to #3433 Gate B/D + source-repo ledger |
| #3432 | Algorithm metric | algorithm-scoped, one owner per metric; immutable definition versions; failures excluded from metrics/insights/decisions |

### Review
Each plan got an independent adversarial reviewer — **all five returned BLOCK with legitimate MAJORs (9 total)**, all remediated. Highlights: pinned the identity canonicalization (was under-specified → could diverge/collide); artifact digest hashes **stored** bytes not decoded (the decoded-bytes idea broke content-addressing + replay); excluded `retrieval_time` from the input identity digest; governed the output `digest_contribution` toggle fail-closed; added the immutable-definition-version rejection test. Review artifacts are local (gitignored `scripts/review/results/`).

### Decisions & sequencing
- Reference-impl homes decided = `assetutilities.workflow_api.{identity,artifact,inputs,output_contract,metrics}` (inherits #3433's owner-confirmed placement).
- All five **stack on parent contract PR #3452**; their `algorithm-run-dataset-contract.yaml` edits are **strictly additive, non-overlapping sections** landing in dependency order (or one integration PR).
- Implementation is gated behind #3452 merging to `main` + each child's own approval.

Refs #3428 #3429 #3430 #3431 #3432 #3427 · Cross-ref #3433 #3452 · digitalmodel#1505 · worldenergydata#927

Moving each issue to `status:plan-review`.