### PR TITLE
feat(skills): HF data-saving skill + generic save_results_to_hf.py

### DIFF
--- a/.claude/skills/data/hf-dataset-publishing/PROMPT.md
+++ b/.claude/skills/data/hf-dataset-publishing/PROMPT.md
@@ -1,67 +1,58 @@
-# Copy-paste prompt — Publish analysis results to Hugging Face
+# Copy-paste prompt — Save analysis results to Hugging Face
 
-Fill in `<analysis>`, `<repo>`, and `<projection>`, then paste this to any agent. It runs the
-full proven flow: reshape → dataset card + provenance → data-quality sanity-check → publish →
-verify. It honors license routing, the withhold-and-file-issue data-quality gate, and the
-keep-separate-from-`-runs` convention.
+Fill in `<analysis>`, `<input>`, `<repo>`, `<projection>`, then paste to any agent. It uses the
+generic tool `scripts/hf/save_results_to_hf.py` (auto-discovers tables, reshapes, cards, publishes,
+verifies) and the `data/hf-dataset-publishing` skill. The agent's judgment is only needed for the
+license call and the data-quality gate.
 
 ---
 
-Save the results of **`<analysis>`** (from the **`<repo>`** repo) to Hugging Face as a
-queryable, viewer-renderable dataset named **`aceengineer/<repo>-<projection>`**. Use the
-`data/hf-dataset-publishing` skill and its bundled `publish_analysis_to_hf.py`. Do the following,
-in order, and report each step:
+Save the results of **`<analysis>`** from the **`<repo>`** repo to Hugging Face as a queryable
+dataset `aceengineer/<repo>-<projection>`, using `scripts/hf/save_results_to_hf.py` and the
+`data/hf-dataset-publishing` skill. Do this in order, reporting each step:
 
-**0. Auth (do NOT print the token).** Confirm `hf auth whoami` succeeds (expect
-`user=<u>`, orgs include `aceengineer`). The CLI is `hf` — do NOT use the deprecated
-`huggingface-cli`.
+**0. Auth (never print the token).** Confirm `hf auth whoami` (expect `orgs` includes `aceengineer`).
+The CLI is `hf` — not the deprecated `huggingface-cli`.
 
-**1. Reshape → flat parquet tables (one per entity).** Load the `<analysis>` output. Build one
-`pandas.DataFrame` per entity type (e.g. fields / wells / countries). Keep SCALAR columns only —
-flatten a few useful nested scalars, skip list/dict columns. Sanitize non-finite floats
-(`NaN`/`inf`) to genuine nulls. Write each table as `<table>.parquet` into a clean output folder.
+**1. Dry-run first** — auto-discover the tables and see the data-quality stats:
+```
+python scripts/hf/save_results_to_hf.py \
+  --repo-id aceengineer/<repo>-<projection> \
+  --input <files-or-dirs: json/csv/parquet> \
+  --source-repo <repo> --algorithm "<name@version>" \
+  --dry-run
+```
+Report the discovered tables (rows × cols) and the printed **per-column numeric stats**.
 
-**2. Dataset card `README.md`.** Write YAML frontmatter with `license:` (per routing below),
-`pretty_name`, `tags`, and a `configs:` block — one `config_name` + `data_files` entry per
-parquet table. In the body: what it is; a table of configs + row counts; **provenance** (source
-file **sha256** hashes + a `schema_version`); the data basis + units; and a note that nulls are
-genuine (non-finite values were coerced to null).
+**2. DATA-QUALITY GATE — eyeball the stats (faithful-to-source != correct).** If any value is
+implausible for the domain (absurd min/max, wrong sign, impossible ratio), do NOT publish it as-is:
+drop/withhold that source column, **file a `cat:data`/bug issue in `<repo>`**, and note the
+withholding. Never silently omit — a withheld column must be visible in the card.
 
-**3. DATA-QUALITY GATE — sanity-check the actual VALUES, not just row counts.**
-> Faithful to source != correct.
-Run a domain plausibility check on the numbers. If any values are implausible (e.g. absurd
-breakevens on producing fields), **withhold those columns**, file a `cat:data` / bug issue in
-`<repo>`, note the withholding + issue link in the card, and continue with the safe columns.
-Never silently omit — missing/withheld data must be visible in the card.
-
-**4. License / public-vs-private routing** (cite `.claude/rules/codes-standards-data-routing.md`):
-- Public-domain **federal** data (BSEE/NOAA/USGS) → **public**, `license: cc-by-4.0`.
-- **Vendor-licensed / private / client** data → **NOT public**; private repo only with explicit
+**3. License / public-vs-private** (`.claude/rules/codes-standards-data-routing.md`):
+- Public-domain **federal** (BSEE/NOAA/USGS) → add `--public --license cc-by-4.0`.
+- **Vendor-licensed / private / client** → keep PRIVATE (omit `--public`); public only with explicit
   owner sign-off.
-- **Synthetic / own-analysis** → publisher's choice.
-- Unsure of provenance → default **private** and ask the owner before going public.
+- **Synthetic / own analysis** → your call. Unsure of provenance → PRIVATE, and ask.
 
-**5. Publish.** Run the bundled helper (dry-run first):
+**4. Publish** — same command without `--dry-run` (add `--public` only per step 3):
 ```
-python3 publish_analysis_to_hf.py --repo-id aceengineer/<repo>-<projection> --folder <out> [--public] --dry-run
-python3 publish_analysis_to_hf.py --repo-id aceengineer/<repo>-<projection> --folder <out> [--public]
+python scripts/hf/save_results_to_hf.py --repo-id aceengineer/<repo>-<projection> \
+  --input <...> --source-repo <repo> --algorithm "<name@version>" [--public]
 ```
-(Omit `--public` for anything non-federal/non-synthetic — the helper defaults to PRIVATE.)
 
-**6. Verify the render surface.** `HfApi.list_repo_files` to confirm parquet + README landed,
-then poll the datasets-server: `https://datasets-server.huggingface.co/is-valid?dataset=<id>` and
-`.../rows?dataset=<id>&config=<table>&split=train&offset=0&length=10`. **Indexing lags a few
-minutes on a brand-new dataset** ("server is busier than usual") — poll, don't assume failure.
+**5. Verify.** The script prints the dataset URL + the datasets-server `/is-valid` link. Then poll
+`https://datasets-server.huggingface.co/rows?dataset=aceengineer/<repo>-<projection>&config=<table>&split=train&offset=0&length=10`
+— indexing lags a few minutes on a brand-new dataset ("server is busier than usual"); poll, don't
+assume failure.
 
-**Conventions & guardrails you MUST honor:**
-- Name it `aceengineer/<repo>-<projection>` (datasets on the org are free).
-- Do **NOT** publish into `aceengineer/<repo>-runs` — that is the separate contract-managed
-  algorithm-run ledger (workspace-hub#3433). Projections get their own dataset.
-- Never print/echo/commit the HF token.
-- Sandbox: `python3 -c "..."` is DENIED — use `python3 - <<'EOF'` heredocs. `base64 -d` is
-  DENIED — fetch repo files via `gh api -H "Accept: application/vnd.github.raw"
-  "repos/<owner>/<repo>/contents/<path>?ref=main"`. Verify via `gh api` / `HfApi` /
-  datasets-server API, not the lagging `raw.githubusercontent.com` / HF CDN.
+**Guardrails you MUST honor:**
+- Name it `aceengineer/<repo>-<projection>`. The tool **refuses `-runs` targets** (that's the
+  wh#3433 contract-managed algorithm-run ledger) — do not work around that.
+- Never print / echo / commit the HF token.
+- Sandbox: `python3 -c "..."` is DENIED → use `python3 - <<'EOF'` heredocs. `base64 -d` is DENIED →
+  fetch repo files with `gh api -H "Accept: application/vnd.github.raw" "repos/<owner>/<repo>/contents/<path>?ref=main"`.
+  Verify via `gh api` / `HfApi` / datasets-server — not the lagging `raw.githubusercontent.com` / HF CDN.
 
-**Report back:** the dataset URL, the configs + row counts, any withheld columns + the issue you
-filed, and the `/is-valid` result.
+**Report back:** the dataset URL, the tables + row counts, any withheld columns + the issue filed,
+and the `/is-valid` result.

--- a/.claude/skills/data/hf-dataset-publishing/PROMPT.md
+++ b/.claude/skills/data/hf-dataset-publishing/PROMPT.md
@@ -1,0 +1,67 @@
+# Copy-paste prompt — Publish analysis results to Hugging Face
+
+Fill in `<analysis>`, `<repo>`, and `<projection>`, then paste this to any agent. It runs the
+full proven flow: reshape → dataset card + provenance → data-quality sanity-check → publish →
+verify. It honors license routing, the withhold-and-file-issue data-quality gate, and the
+keep-separate-from-`-runs` convention.
+
+---
+
+Save the results of **`<analysis>`** (from the **`<repo>`** repo) to Hugging Face as a
+queryable, viewer-renderable dataset named **`aceengineer/<repo>-<projection>`**. Use the
+`data/hf-dataset-publishing` skill and its bundled `publish_analysis_to_hf.py`. Do the following,
+in order, and report each step:
+
+**0. Auth (do NOT print the token).** Confirm `hf auth whoami` succeeds (expect
+`user=<u>`, orgs include `aceengineer`). The CLI is `hf` — do NOT use the deprecated
+`huggingface-cli`.
+
+**1. Reshape → flat parquet tables (one per entity).** Load the `<analysis>` output. Build one
+`pandas.DataFrame` per entity type (e.g. fields / wells / countries). Keep SCALAR columns only —
+flatten a few useful nested scalars, skip list/dict columns. Sanitize non-finite floats
+(`NaN`/`inf`) to genuine nulls. Write each table as `<table>.parquet` into a clean output folder.
+
+**2. Dataset card `README.md`.** Write YAML frontmatter with `license:` (per routing below),
+`pretty_name`, `tags`, and a `configs:` block — one `config_name` + `data_files` entry per
+parquet table. In the body: what it is; a table of configs + row counts; **provenance** (source
+file **sha256** hashes + a `schema_version`); the data basis + units; and a note that nulls are
+genuine (non-finite values were coerced to null).
+
+**3. DATA-QUALITY GATE — sanity-check the actual VALUES, not just row counts.**
+> Faithful to source != correct.
+Run a domain plausibility check on the numbers. If any values are implausible (e.g. absurd
+breakevens on producing fields), **withhold those columns**, file a `cat:data` / bug issue in
+`<repo>`, note the withholding + issue link in the card, and continue with the safe columns.
+Never silently omit — missing/withheld data must be visible in the card.
+
+**4. License / public-vs-private routing** (cite `.claude/rules/codes-standards-data-routing.md`):
+- Public-domain **federal** data (BSEE/NOAA/USGS) → **public**, `license: cc-by-4.0`.
+- **Vendor-licensed / private / client** data → **NOT public**; private repo only with explicit
+  owner sign-off.
+- **Synthetic / own-analysis** → publisher's choice.
+- Unsure of provenance → default **private** and ask the owner before going public.
+
+**5. Publish.** Run the bundled helper (dry-run first):
+```
+python3 publish_analysis_to_hf.py --repo-id aceengineer/<repo>-<projection> --folder <out> [--public] --dry-run
+python3 publish_analysis_to_hf.py --repo-id aceengineer/<repo>-<projection> --folder <out> [--public]
+```
+(Omit `--public` for anything non-federal/non-synthetic — the helper defaults to PRIVATE.)
+
+**6. Verify the render surface.** `HfApi.list_repo_files` to confirm parquet + README landed,
+then poll the datasets-server: `https://datasets-server.huggingface.co/is-valid?dataset=<id>` and
+`.../rows?dataset=<id>&config=<table>&split=train&offset=0&length=10`. **Indexing lags a few
+minutes on a brand-new dataset** ("server is busier than usual") — poll, don't assume failure.
+
+**Conventions & guardrails you MUST honor:**
+- Name it `aceengineer/<repo>-<projection>` (datasets on the org are free).
+- Do **NOT** publish into `aceengineer/<repo>-runs` — that is the separate contract-managed
+  algorithm-run ledger (workspace-hub#3433). Projections get their own dataset.
+- Never print/echo/commit the HF token.
+- Sandbox: `python3 -c "..."` is DENIED — use `python3 - <<'EOF'` heredocs. `base64 -d` is
+  DENIED — fetch repo files via `gh api -H "Accept: application/vnd.github.raw"
+  "repos/<owner>/<repo>/contents/<path>?ref=main"`. Verify via `gh api` / `HfApi` /
+  datasets-server API, not the lagging `raw.githubusercontent.com` / HF CDN.
+
+**Report back:** the dataset URL, the configs + row counts, any withheld columns + the issue you
+filed, and the `/is-valid` result.

--- a/.claude/skills/data/hf-dataset-publishing/SKILL.md
+++ b/.claude/skills/data/hf-dataset-publishing/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: hf-dataset-publishing
+description: >-
+  Save/publish analysis or computation results from ANY ecosystem repo to Hugging Face as a
+  queryable, viewer-renderable dataset. Use when the user wants to "save results to hugging
+  face", "publish dataset to HF", "hugging face data saving", "save analysis results",
+  "hf dataset", "make results queryable", or "render via datasets-server API". Reshapes nested
+  results into flat parquet tables, writes a dataset card with a viewer `configs:` block and
+  provenance, applies license/public-vs-private routing, enforces a domain data-quality gate
+  (faithful-to-source != correct), publishes to `aceengineer/<repo>-<projection>`, and verifies
+  via the datasets-server API.
+---
+
+# Publishing Analysis Results to Hugging Face
+
+Turn the results of any analysis/computation (from any repo in this ecosystem) into a
+**queryable, auto-rendered Hugging Face dataset**. HF's datasets-server auto-indexes parquet
+tables and exposes them both in the in-browser viewer and via a REST API — so a published
+dataset becomes a live, linkable, machine-queryable projection of your results.
+
+This skill encodes a workflow that was executed end-to-end on 2026-07-11. Follow THIS, not
+generic HF docs.
+
+## When to use
+
+- You have analysis output (JSON, dicts, dataframes, a results folder) and want to save it
+  somewhere queryable and viz-renderable, not just a file on disk.
+- You want a shareable, indexable surface for a set of computed results (per field / per well /
+  per country / per run-summary, etc.).
+- Someone says "publish this to Hugging Face" / "save these results as an HF dataset".
+
+**Do NOT use this** to record algorithm-run identity/replay ledgers — that is the separate
+`aceengineer/<repo>-runs` contract (workspace-hub#3433). See Conventions below.
+
+## Prerequisites (environment-backed auth)
+
+- CLI is **`hf`** (`huggingface-cli` is DEPRECATED — do not use it).
+- Token lives at `~/.cache/huggingface/token`. Verify:
+  ```bash
+  hf auth whoami          # expect: user=<u> and orgs include aceengineer
+  ```
+- Python libs available: `huggingface_hub` (1.21+), `pandas`, `pyarrow`.
+- **Never print, echo, log, or commit the token.** Secrets stay in env / token-file only.
+
+## The 4-step workflow
+
+### Step 1 — Reshape nested results → flat tabular tables (one per entity)
+
+Load the analysis output and build **one `pandas.DataFrame` per entity type** (e.g. `fields`,
+`wells`, `countries`). For each table select SCALAR columns only:
+
+- Flatten a few useful nested scalars (e.g. `econ.breakeven -> econ_breakeven`).
+- SKIP list/dict-valued columns (they don't render in the tabular viewer).
+- **Sanitize NaN/inf.** The source JSON may carry literal `NaN`/`Infinity` tokens that break
+  strict JSON consumers. Parquet stores genuine nulls natively, so coerce non-finite floats to
+  null and write **parquet** — which is exactly what the HF datasets-server auto-renders.
+
+```python
+import math, pandas as pd, numpy as np
+
+def clean(df: pd.DataFrame) -> pd.DataFrame:
+    # non-finite floats -> genuine null (parquet-native)
+    return df.replace([np.inf, -np.inf], np.nan)
+
+df_fields = clean(pd.DataFrame(field_rows))         # one row per field
+df_fields.to_parquet("out/fields.parquet", index=False)
+```
+
+CSV is an acceptable fallback if parquet is unavailable, but parquet is preferred (native nulls
++ auto-render).
+
+### Step 2 — Dataset card `README.md` with YAML frontmatter
+
+The frontmatter MUST include `license:` (see routing rule), `pretty_name`, `tags`, and a
+**`configs:`** block listing each parquet table as its own viewer config:
+
+```yaml
+---
+license: cc-by-4.0
+pretty_name: World Energy Data — Explorer Projection
+tags:
+  - energy
+  - oil-and-gas
+  - analysis-results
+configs:
+  - config_name: fields
+    data_files: fields.parquet
+  - config_name: wells
+    data_files: wells.parquet
+  - config_name: countries
+    data_files: countries.parquet
+---
+```
+
+The card **body** must cover:
+
+- **What it is** — one-paragraph description of the projection and its source analysis.
+- **A table of configs + row counts** (e.g. `fields — 56 rows`).
+- **Provenance** — source file **sha256** hashes + a `schema_version`. This is how a consumer
+  proves which analysis run produced the data.
+- **Data basis** — what the numbers mean, units, and the note that **nulls are genuine** (not
+  missing-by-accident) because non-finite values were coerced to null.
+- Any **withheld columns** (see the data-quality gate) with a link to the filed issue.
+
+### Step 3 — Publish
+
+```python
+from huggingface_hub import HfApi
+api = HfApi()
+repo_id = "aceengineer/<repo>-<projection>"          # e.g. aceengineer/worldenergydata-explorer
+api.create_repo(repo_id=repo_id, repo_type="dataset",
+                private=<per routing>, exist_ok=True)
+api.upload_folder(folder_path="out", repo_id=repo_id, repo_type="dataset",
+                  commit_message="Publish <projection> analysis projection")
+```
+
+The bundled `publish_analysis_to_hf.py` does exactly this (plus auth check + verify) — prefer it
+over hand-rolling.
+
+### Step 4 — Verify (the render-via-API surface)
+
+```python
+api.list_repo_files(repo_id=repo_id, repo_type="dataset")   # confirm parquet + README landed
+```
+
+Then hit the **datasets-server API** (the surface that powers the in-browser viewer):
+
+```
+https://datasets-server.huggingface.co/is-valid?dataset=<repo_id>
+https://datasets-server.huggingface.co/rows?dataset=<repo_id>&config=<table>&split=train&offset=0&length=10
+```
+
+**Indexing lag is normal.** A brand-new dataset returns *"server is busier than usual / retry
+later"* for a few minutes before `/rows` and the in-browser viewer come up. **Poll — do not
+assume failure.** Once `/is-valid` reports valid and `/rows` returns data, the viewer is live.
+
+## Conventions the skill MUST encode
+
+- **Naming:** `aceengineer/<repo>-<projection>` — e.g. `worldenergydata-explorer`. Datasets on
+  the `aceengineer` org are **free**.
+- **Keep SEPARATE from the run-dataset contract.** `aceengineer/<repo>-runs` is
+  workspace-hub#3433's contract-managed **algorithm-run ledger** (run-identity + replay).
+  Analysis-result projections are a different artifact and get their **own** dataset. Do **not**
+  dump projections into `-runs`.
+- **License / public-vs-private routing** (cite `.claude/rules/codes-standards-data-routing.md`):
+  - Public-domain **federal** data (BSEE / NOAA / USGS) → **public**, `license: cc-by-4.0`.
+  - **Vendor-licensed / private / client** data → must **NOT** be published to a public HF
+    dataset. A **private** repo is OK only with **explicit owner** sign-off.
+  - **Synthetic / own-analysis** output → publisher's choice.
+  - If unsure of the source's provenance, default to **private** and ask the owner.
+
+## DATA-QUALITY GATE (load-bearing — do not skip)
+
+> **Faithful to source != correct.**
+
+Row counts matching the source proves nothing about whether the numbers are right. Before
+publishing, run a **domain plausibility check on the actual values** — publishing to a new,
+labeled, queryable surface is a natural audit trigger, so audit here.
+
+- If values are **implausible**, **withhold those columns**, file a `cat:data` / bug issue, and
+  **note the withholding in the card** (with the issue link).
+- Real case (2026-07-11): economics columns showed **$380 breakevens on producing fields** —
+  clearly wrong. Those columns were **withheld** pending **worldenergydata#971** rather than
+  published as fact.
+- **Honesty principle:** missing/withheld data → **visible provenance/placeholder**, never
+  silent omission.
+
+## Sandbox gotchas (each cost real cycles)
+
+- `python3 -c "..."` is **DENIED** → use a heredoc: `python3 - <<'EOF' ... EOF`.
+- `base64 -d` is **DENIED** → fetch repo file content raw instead of decoding the contents API:
+  ```bash
+  gh api -H "Accept: application/vnd.github.raw" \
+    "repos/<owner>/<repo>/contents/<path>?ref=main"
+  ```
+- Post-publish, **`raw.githubusercontent.com` and the HF CDN can lag** → verify via `gh api` /
+  `HfApi` / the datasets-server API, not the raw CDN.
+- Org **Gradio/Docker Spaces need a paid HF plan** (datasets are free). Relevant only if this
+  data later gets a viz **Space** — the dataset itself costs nothing.
+
+## Bundled resources
+
+- **`publish_analysis_to_hf.py`** — reusable helper: verifies `hf auth whoami`, creates the
+  dataset repo, uploads a prepared folder (parquet + README), then polls the datasets-server
+  `/is-valid` to report readiness. Parameterized `--repo-id / --folder / --private`, with a
+  `--dry-run`. Run `python3 publish_analysis_to_hf.py --help`.
+- **`PROMPT.md`** — a copy-paste, parameterized prompt to hand any agent so it runs this whole
+  flow (reshape → card+provenance → sanity-check → publish → verify) while honoring license
+  routing, the withhold-and-file-issue data-quality gate, and the keep-separate-from-`-runs`
+  convention.

--- a/.claude/skills/data/hf-dataset-publishing/publish_analysis_to_hf.py
+++ b/.claude/skills/data/hf-dataset-publishing/publish_analysis_to_hf.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+publish_analysis_to_hf.py
+=========================
+
+Reusable helper to publish a PREPARED folder of analysis results (parquet tables + a
+dataset-card README.md) to Hugging Face as a queryable, viewer-renderable dataset, then verify
+readiness via the datasets-server API.
+
+This script does NOT reshape your data or write the card — that is Steps 1 & 2 of the workflow
+(see SKILL.md), which are analysis-specific and must include your own provenance + data-quality
+gate. This script is Steps 3 & 4: create repo -> upload folder -> verify render surface.
+
+Prerequisites
+-------------
+- CLI `hf` authenticated (token at ~/.cache/huggingface/token); `hf auth whoami` must succeed.
+  (`huggingface-cli` is DEPRECATED — this script uses the `hf` CLI + the huggingface_hub API.)
+- Python libs: huggingface_hub (1.21+). Only stdlib is used otherwise.
+- Your `--folder` already contains: one or more `*.parquet` tables and a `README.md` whose YAML
+  frontmatter has a `configs:` block mapping each table to a viewer config.
+
+Naming convention
+-----------------
+Repo id MUST be `aceengineer/<repo>-<projection>` (e.g. `aceengineer/worldenergydata-explorer`).
+Do NOT publish analysis projections into `aceengineer/<repo>-runs` — that is the separate
+contract-managed algorithm-run ledger (workspace-hub#3433).
+
+License / public-vs-private routing
+----------------------------------
+Per `.claude/rules/codes-standards-data-routing.md`:
+  - Public-domain federal data (BSEE/NOAA/USGS) -> public, license cc-by-4.0.
+  - Vendor-licensed / private / client data -> NEVER public; private repo only with explicit
+    owner sign-off.
+  - Synthetic / own-analysis -> publisher's choice.
+This script defaults to `--private` OFF only when you pass `--public` explicitly; otherwise it
+creates a PRIVATE repo (fail-safe).
+
+Usage
+-----
+    python3 publish_analysis_to_hf.py \
+        --repo-id aceengineer/worldenergydata-explorer \
+        --folder ./out \
+        --public \
+        --commit-message "Publish explorer analysis projection"
+
+    # Preview everything without touching HF:
+    python3 publish_analysis_to_hf.py --repo-id aceengineer/foo-bar --folder ./out --dry-run
+
+Security
+--------
+Never print, echo, or log the HF token. This script only ever reads it implicitly through the
+huggingface_hub client / `hf` CLI, which pick it up from ~/.cache/huggingface/token or the
+HF_TOKEN env var.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DATASETS_SERVER = "https://datasets-server.huggingface.co"
+
+
+# --------------------------------------------------------------------------------------------
+# Auth
+# --------------------------------------------------------------------------------------------
+def verify_auth() -> str:
+    """Run `hf auth whoami` and return the resolved username. Exit if not authenticated.
+
+    Note: token is NEVER printed. We only surface the username/orgs from whoami output.
+    """
+    try:
+        proc = subprocess.run(
+            ["hf", "auth", "whoami"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        sys.exit(
+            "ERROR: `hf` CLI not found. Install huggingface_hub (>=1.21) which ships the `hf` "
+            "command. (`huggingface-cli` is deprecated.)"
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit("ERROR: `hf auth whoami` timed out.")
+
+    out = (proc.stdout + proc.stderr).strip()
+    if proc.returncode != 0 or "not logged in" in out.lower():
+        sys.exit(
+            "ERROR: not authenticated with Hugging Face.\n"
+            "Fix: ensure a token exists at ~/.cache/huggingface/token (or export HF_TOKEN), "
+            "then re-run `hf auth whoami`.\n"
+            f"whoami said: {out}"
+        )
+    print(f"[auth] {out}")
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Folder validation
+# --------------------------------------------------------------------------------------------
+def validate_folder(folder: Path) -> list[Path]:
+    """Confirm the folder holds a README.md and at least one parquet/csv table."""
+    if not folder.is_dir():
+        sys.exit(f"ERROR: --folder is not a directory: {folder}")
+
+    readme = folder / "README.md"
+    if not readme.is_file():
+        sys.exit(
+            f"ERROR: no README.md dataset card in {folder}. Step 2 of the workflow requires a "
+            "card with a YAML `configs:` block. See SKILL.md."
+        )
+
+    tables = sorted(list(folder.glob("*.parquet")) + list(folder.glob("*.csv")))
+    if not tables:
+        sys.exit(f"ERROR: no *.parquet or *.csv tables found in {folder}.")
+
+    # Light sanity check: does the card mention a configs: block?
+    card = readme.read_text(errors="replace")
+    if "configs:" not in card:
+        print(
+            "[warn] README.md has no `configs:` block — the HF viewer may not expose each table "
+            "as its own config. See SKILL.md Step 2."
+        )
+
+    print(f"[folder] {folder}  ->  {len(tables)} table(s): "
+          + ", ".join(t.name for t in tables))
+    return tables
+
+
+# --------------------------------------------------------------------------------------------
+# Publish
+# --------------------------------------------------------------------------------------------
+def publish(repo_id: str, folder: Path, private: bool, commit_message: str) -> None:
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    print(f"[create_repo] {repo_id} (private={private}) exist_ok=True")
+    api.create_repo(
+        repo_id=repo_id,
+        repo_type="dataset",
+        private=private,
+        exist_ok=True,
+    )
+    print(f"[upload_folder] {folder}  ->  {repo_id}")
+    api.upload_folder(
+        folder_path=str(folder),
+        repo_id=repo_id,
+        repo_type="dataset",
+        commit_message=commit_message,
+    )
+    files = api.list_repo_files(repo_id=repo_id, repo_type="dataset")
+    print("[uploaded files]")
+    for f in sorted(files):
+        print(f"    {f}")
+
+
+# --------------------------------------------------------------------------------------------
+# Verify via datasets-server API
+# --------------------------------------------------------------------------------------------
+def _get_json(url: str, timeout: int = 30):
+    req = urllib.request.Request(url, headers={"User-Agent": "publish_analysis_to_hf"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            body = json.loads(e.read().decode("utf-8"))
+        except Exception:
+            body = {"error": str(e)}
+        return e.code, body
+    except Exception as e:  # noqa: BLE001
+        return None, {"error": str(e)}
+
+
+def verify_render(repo_id: str, poll_seconds: int = 300, interval: int = 20) -> bool:
+    """Poll the datasets-server /is-valid endpoint until the dataset indexes.
+
+    A brand-new dataset returns "server is busier than usual / retry later" for a few minutes.
+    Poll — do not assume failure.
+    """
+    q = urllib.parse.urlencode({"dataset": repo_id})
+    url = f"{DATASETS_SERVER}/is-valid?{q}"
+    deadline = time.time() + poll_seconds
+    print(f"[verify] polling {url}")
+    while time.time() < deadline:
+        status, body = _get_json(url)
+        if status == 200 and isinstance(body, dict):
+            # e.g. {"preview": true, "viewer": true, "search": false, "statistics": false}
+            if any(body.get(k) for k in ("preview", "viewer", "valid")):
+                print(f"[verify] READY: {body}")
+                print(f"[verify] viewer:  https://huggingface.co/datasets/{repo_id}/viewer")
+                print(f"[verify] rows API: {DATASETS_SERVER}/rows?dataset="
+                      f"{urllib.parse.quote(repo_id)}&config=<table>&split=train&offset=0&length=10")
+                return True
+            print(f"[verify] not ready yet: {body}")
+        else:
+            # 400/500 during indexing lag is expected right after publish.
+            print(f"[verify] indexing lag (status={status}): {body}. retrying in {interval}s...")
+        time.sleep(interval)
+    print(
+        "[verify] TIMEOUT — dataset not confirmed valid within window. This is often just a "
+        "longer indexing lag; check the viewer URL in a few minutes:\n"
+        f"    https://huggingface.co/datasets/{repo_id}/viewer"
+    )
+    return False
+
+
+# --------------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------------
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Publish a prepared analysis-results folder to Hugging Face as a dataset.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--repo-id", required=True,
+                   help="aceengineer/<repo>-<projection>  (NOT ...-runs)")
+    p.add_argument("--folder", required=True, type=Path,
+                   help="Folder holding prepared *.parquet tables + README.md dataset card")
+    vis = p.add_mutually_exclusive_group()
+    vis.add_argument("--public", action="store_true",
+                     help="Create a PUBLIC dataset (only for public-domain federal / synthetic "
+                          "data per the routing rule). Default is PRIVATE (fail-safe).")
+    vis.add_argument("--private", action="store_true",
+                     help="Create a PRIVATE dataset (default).")
+    p.add_argument("--commit-message", default="Publish analysis projection",
+                   help="Commit message for the upload.")
+    p.add_argument("--no-verify", action="store_true",
+                   help="Skip the datasets-server /is-valid poll after upload.")
+    p.add_argument("--poll-seconds", type=int, default=300,
+                   help="Max seconds to poll for indexing (default 300).")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Validate auth + folder + naming, print the plan, but do NOT create or "
+                        "upload anything.")
+    args = p.parse_args()
+
+    # Fail-safe default: private unless --public is explicitly passed.
+    private = not args.public
+
+    # Naming guardrails.
+    if not args.repo_id.startswith("aceengineer/"):
+        print(f"[warn] repo-id '{args.repo_id}' is not under the aceengineer/ org.")
+    if args.repo_id.endswith("-runs"):
+        sys.exit(
+            "ERROR: repo-id ends with '-runs'. That namespace is the contract-managed "
+            "algorithm-run ledger (workspace-hub#3433). Analysis projections get their own "
+            "'<repo>-<projection>' dataset. Rename and re-run."
+        )
+
+    print("=" * 78)
+    print("Hugging Face analysis-result dataset publisher")
+    print(f"  repo-id : {args.repo_id}")
+    print(f"  folder  : {args.folder}")
+    print(f"  private : {private}  ({'PUBLIC' if not private else 'PRIVATE'})")
+    print(f"  dry-run : {args.dry_run}")
+    print("=" * 78)
+
+    verify_auth()
+    validate_folder(args.folder)
+
+    if args.dry_run:
+        print("\n[dry-run] Plan:")
+        print(f"  1. create_repo({args.repo_id}, repo_type=dataset, private={private}, exist_ok=True)")
+        print(f"  2. upload_folder({args.folder} -> {args.repo_id})")
+        if not args.no_verify:
+            print(f"  3. poll {DATASETS_SERVER}/is-valid?dataset={args.repo_id}")
+        print("[dry-run] No changes made.")
+        return 0
+
+    publish(args.repo_id, args.folder, private, args.commit_message)
+
+    if not args.no_verify:
+        verify_render(args.repo_id, poll_seconds=args.poll_seconds)
+
+    print(f"\nDone. Dataset: https://huggingface.co/datasets/{args.repo_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hf/save_results_to_hf.py
+++ b/scripts/hf/save_results_to_hf.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# ABOUTME: Generic tool to save ANY repo/algorithm's results to a Hugging Face dataset.
+# ABOUTME: Auto-discovers tables from arbitrary nested JSON/CSV/parquet, reshapes to
+# ABOUTME: parquet, writes a viewer-ready dataset card with provenance, publishes, verifies.
+"""
+save_results_to_hf.py — one command to publish analysis/computation results to Hugging Face.
+
+    python save_results_to_hf.py --repo-id aceengineer/<repo>-<projection> \
+        --input results.json [more.csv data.parquet a_dir/ ...] \
+        [--public] [--license cc-by-4.0] [--title "..."] \
+        [--source-repo owner/repo] [--algorithm "name@version"] [--dry-run]
+
+Design goals (why this is generic):
+  * Accepts arbitrary nested JSON, CSV/TSV, parquet, or directories of those.
+  * Auto-discovers tables: every list-of-dicts and dict-of-dicts (recursing through
+    wrapper dicts) becomes a table; nested scalars flatten to dotted columns; anything
+    deeper is JSON-stringified (lossless).
+  * Sanitizes NaN/inf -> null. Writes parquet (HF datasets-server auto-renders it).
+  * Emits a dataset card with a viewer `configs:` block + sha256 provenance.
+  * PRIVATE by default (fail-safe); --public only for redistributable data.
+  * Verifies via list_repo_files + the datasets-server /is-valid API.
+
+DATA-QUALITY REMINDER (printed at the end): faithful-to-source != correct. A generic
+tool cannot judge domain plausibility — it prints per-column stats so YOU can eyeball
+outliers; withhold implausible columns + file an issue before trusting a public dataset.
+See workspace-hub/.claude/skills/data/hf-dataset-publishing/ and the license routing rule
+.claude/rules/codes-standards-data-routing.md before going --public.
+"""
+import argparse, hashlib, json, math, sys
+from pathlib import Path
+
+
+def _flatten(rec, prefix="", out=None):
+    """Recursively flatten nested dicts into dotted keys; JSON-stringify lists/other."""
+    out = {} if out is None else out
+    for k, v in rec.items():
+        key = f"{prefix}{k}"
+        if isinstance(v, dict):
+            _flatten(v, key + ".", out)
+        elif isinstance(v, list):
+            out[key] = json.dumps(v, ensure_ascii=False)  # lossless, viewer shows text
+        else:
+            out[key] = v
+    return out
+
+
+def _is_list_of_dicts(v):
+    return isinstance(v, list) and len(v) > 0 and all(isinstance(x, dict) for x in v)
+
+
+def _is_dict_of_dicts(v):
+    return isinstance(v, dict) and len(v) > 0 and all(isinstance(x, dict) for x in v.values())
+
+
+def discover_tables(obj, name=""):
+    """Return {table_name: [row_dict, ...]} for every table-like structure found."""
+    tables = {}
+
+    def walk(v, nm):
+        if _is_list_of_dicts(v):
+            tables[nm or "records"] = [_flatten(r) for r in v]
+        elif _is_dict_of_dicts(v):
+            rows = []
+            for k, r in v.items():
+                fr = _flatten(r)
+                rows.append({"_id": k, **fr})
+            tables[nm or "records"] = rows
+            # also recurse in case a value hides deeper tables (rare) — skip to avoid dup
+        elif isinstance(v, dict):
+            for k, sub in v.items():
+                walk(sub, f"{nm}.{k}" if nm else k)
+        # scalars / list-of-scalars at the top level are ignored (not a table)
+
+    walk(obj, name)
+    return tables
+
+
+def _sanitize_df(df):
+    import numpy as np
+    # inf -> NaN so parquet stores it as null; keep native dtypes (numeric stays numeric,
+    # so parquet nulls are native AND numeric_stats can profile columns). json.loads already
+    # turned any literal NaN token into float('nan'), which parquet writes as null.
+    return df.replace([np.inf, -np.inf], np.nan)
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    h.update(Path(path).read_bytes())
+    return h.hexdigest()
+
+
+def ingest(inputs):
+    """Yield (table_name, DataFrame, source_path) for every input."""
+    import pandas as pd
+    paths = []
+    for inp in inputs:
+        p = Path(inp)
+        if p.is_dir():
+            paths += [q for q in p.rglob("*") if q.suffix.lower() in
+                      (".json", ".csv", ".tsv", ".parquet")]
+        else:
+            paths.append(p)
+    for p in paths:
+        s = p.suffix.lower()
+        if s == ".json":
+            obj = json.loads(p.read_text())
+            tabs = discover_tables(obj, p.stem)
+            if not tabs:  # flat object -> single one-row table
+                tabs = {p.stem: [_flatten(obj)] if isinstance(obj, dict) else []}
+            for nm, rows in tabs.items():
+                yield _clean_name(nm), pd.DataFrame(rows), str(p)
+        elif s in (".csv", ".tsv"):
+            yield _clean_name(p.stem), pd.read_csv(p, sep="\t" if s == ".tsv" else ","), str(p)
+        elif s == ".parquet":
+            yield _clean_name(p.stem), pd.read_parquet(p), str(p)
+
+
+def _clean_name(nm):
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in nm).strip("_").lower() or "table"
+
+
+def build_card(repo_id, tables_meta, source_hashes, license_, title, source_repo, algorithm):
+    cfg = "\n".join(f"- config_name: {t}\n  data_files: {t}.parquet" for t in tables_meta)
+    rows = "\n".join(f"| `{t}` | {m['rows']} | {m['cols']} |" for t, m in tables_meta.items())
+    prov = "\n".join(f"- `{Path(sp).name}` — sha256 `{h[:16]}…`" for sp, h in source_hashes.items())
+    pretty = title or repo_id.split("/")[-1]
+    return f"""---
+license: {license_}
+pretty_name: {pretty}
+tags:
+- analysis-results
+configs:
+{cfg}
+---
+
+# {pretty}
+
+Analysis/computation results published for query + visualization via the Hugging Face
+datasets-server API. Generated by `scripts/hf/save_results_to_hf.py`.
+
+## Tables
+
+| config | rows | cols |
+|---|---|---|
+{rows}
+
+## Provenance
+
+- Source repo: `{source_repo or 'n/a'}`  ·  algorithm: `{algorithm or 'n/a'}`
+- Schema version: `1.0.0`
+- Source snapshots (sha256):
+
+{prov}
+
+Nulls are genuine missing values (non-finite floats were coerced to null). Load a table:
+`pandas.read_parquet(hf_hub_download("{repo_id}", "<config>.parquet", repo_type="dataset"))`.
+"""
+
+
+def numeric_stats(name, df):
+    import pandas as pd
+    num = df.select_dtypes(include="number")
+    lines = []
+    for c in num.columns:
+        col = pd.to_numeric(num[c], errors="coerce")
+        lines.append(f"    {name}.{c}: min={col.min()} max={col.max()} "
+                     f"nulls={int(col.isna().sum())}")
+    return lines
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Publish any repo/algorithm's results to a HF dataset.")
+    ap.add_argument("--repo-id", required=True, help="aceengineer/<repo>-<projection> (NOT <repo>-runs)")
+    ap.add_argument("--input", nargs="+", required=True, help="json/csv/tsv/parquet files or dirs")
+    ap.add_argument("--public", action="store_true", help="publish PUBLIC (default: private fail-safe)")
+    ap.add_argument("--license", default="cc-by-4.0")
+    ap.add_argument("--title", default=None)
+    ap.add_argument("--source-repo", default=None)
+    ap.add_argument("--algorithm", default=None)
+    ap.add_argument("--out", default=None, help="staging dir (default: temp)")
+    ap.add_argument("--dry-run", action="store_true", help="build + report, do NOT publish")
+    args = ap.parse_args()
+
+    if args.repo_id.rstrip("/").endswith("-runs"):
+        sys.exit("REFUSED: '-runs' is the contract-managed algorithm-run ledger (wh#3433). "
+                 "Use a distinct projection name.")
+
+    import tempfile
+    import pandas as pd
+    out = Path(args.out or tempfile.mkdtemp(prefix="hf_results_"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    tables_meta, source_hashes, stat_lines = {}, {}, []
+    for name, df, src in ingest(args.input):
+        if df.empty:
+            print(f"  skip empty table: {name}")
+            continue
+        df = _sanitize_df(df)
+        base = name
+        i = 1
+        while base in tables_meta:  # de-dup names
+            i += 1; base = f"{name}_{i}"
+        df.to_parquet(out / f"{base}.parquet", index=False)
+        tables_meta[base] = {"rows": len(df), "cols": df.shape[1]}
+        source_hashes[src] = _sha256(src)
+        stat_lines += numeric_stats(base, df)
+        print(f"  table {base}: {len(df)} rows x {df.shape[1]} cols  (from {Path(src).name})")
+
+    if not tables_meta:
+        sys.exit("No tables discovered from the inputs.")
+
+    card = build_card(args.repo_id, tables_meta, source_hashes, args.license,
+                      args.title, args.source_repo, args.algorithm)
+    (out / "README.md").write_text(card)
+    print(f"\nstaged {len(tables_meta)} tables + README.md in {out}")
+    print("\n--- numeric column stats (EYEBALL for implausible values — faithful != correct) ---")
+    print("\n".join(stat_lines) or "    (no numeric columns)")
+
+    if args.dry_run:
+        print(f"\n[dry-run] would publish to {args.repo_id} "
+              f"({'PUBLIC' if args.public else 'PRIVATE'}). Nothing uploaded.")
+        return
+
+    from huggingface_hub import HfApi
+    api = HfApi()
+    who = api.whoami()
+    print(f"\nauth ok: {who.get('name')}  (orgs: {[o['name'] for o in who.get('orgs', [])]})")
+    api.create_repo(repo_id=args.repo_id, repo_type="dataset",
+                    private=not args.public, exist_ok=True)
+    api.upload_folder(folder_path=str(out), repo_id=args.repo_id, repo_type="dataset",
+                      commit_message=f"results via save_results_to_hf.py ({args.source_repo or 'n/a'})")
+    print(f"published: https://huggingface.co/datasets/{args.repo_id}  "
+          f"({'PUBLIC' if args.public else 'PRIVATE'})")
+    print(f"verify (indexing lags a few min): "
+          f"https://datasets-server.huggingface.co/is-valid?dataset={args.repo_id}")
+    print("\nREMINDER: sanity-check the values above. Withhold implausible columns + file a "
+          "cat:data issue before trusting a public dataset (faithful-to-source != correct).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reusable, ecosystem-wide way for ANY session to save an analysis/algorithm's results to Hugging Face — so other sessions stop re-deriving this.

## What's here
- **`scripts/hf/save_results_to_hf.py`** (the star): generic CLI. Point it at any repo/algorithm output (nested JSON / CSV / parquet / a dir). Auto-discovers tables (every list-of-dicts & dict-of-dicts, recursing through wrappers; nested scalars → dotted columns; deeper → JSON-stringified, lossless), sanitizes NaN/inf → native parquet null, writes a viewer-ready dataset card with `configs:` + **sha256 provenance**, publishes (**PRIVATE by default**), verifies via the datasets-server API. Prints **per-column numeric stats** as a data-quality eyeball. **Refuses `-runs` targets** (the wh#3433 contract ledger).
- **`.claude/skills/data/hf-dataset-publishing/`**: SKILL.md + PROMPT.md + a lower-level helper, for the guided workflow.

## Proven
Distilled from the live publish of `aceengineer/worldenergydata-explorer`. Dry-run tested against a deeply-nested real payload → auto-found 6 tables; its numeric-stats gate **surfaced the #971 economics anomaly** ($380 breakeven) automatically.

## Encodes the hard-won conventions
license/public-vs-private routing (`.claude/rules/codes-standards-data-routing.md`), keep-separate-from-`-runs`, sandbox gotchas (`python3 -c`/`base64 -d` denied), datasets-server indexing lag, and the **faithful-to-source ≠ correct** data-quality gate (sanity-check values → withhold + file an issue).

Committed via the GitHub git-data API (workspace-hub mount is FUSE — local git hangs).