### PR TITLE
fix(monitoring): equivalence-state publish pushes with audited pre-push bypass (#3500)

### DIFF
--- a/scripts/monitoring/equivalence_state.py
+++ b/scripts/monitoring/equivalence_state.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -22,9 +23,18 @@ class StoreUnavailable(RuntimeError):
     pass
 
 
-def _git(repo, *args, _input=None):
+def _git(repo, *args, _input=None, _env=None):
+    env = {**os.environ, **_env} if _env else None
     return subprocess.run(["git", "-C", repo, *args], input=_input,
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, env=env)
+
+
+# The equivalence-state ref is a disconnected plumbing-built chain: the
+# pre-push hook can never attribute its diff (no merge-base with main) and
+# gates every publish as a new-branch RUN_ALL — a 60+ min full-suite run that
+# keeps the ref from ever landing (#3500, sub-case of #3198). Push with the
+# hook's audited soft bypass; each use is logged to pre-push-bypass.jsonl.
+_PUSH_ENV = {"GIT_PRE_PUSH_SKIP": "1"}
 
 
 def _fetch_tip(repo, remote, ref):
@@ -94,9 +104,11 @@ def publish(repo, role, content, *, remote="origin", ref=DEFAULT_REF, retries=3)
         commit = c.stdout.strip()
         if parent:
             push = _git(repo, "push", remote, f"{commit}:refs/heads/{ref}",
-                        f"--force-with-lease=refs/heads/{ref}:{parent}")
+                        f"--force-with-lease=refs/heads/{ref}:{parent}",
+                        _env=_PUSH_ENV)
         else:
-            push = _git(repo, "push", remote, f"{commit}:refs/heads/{ref}")
+            push = _git(repo, "push", remote, f"{commit}:refs/heads/{ref}",
+                        _env=_PUSH_ENV)
         if push.returncode == 0:
             return True
         blob = (push.stdout + push.stderr).lower()

--- a/tests/monitoring/test_equivalence_state.py
+++ b/tests/monitoring/test_equivalence_state.py
@@ -1,0 +1,96 @@
+"""Tests for the equivalence-state publisher push path (#3500).
+
+The publish push targets the dedicated ``equivalence-state`` ref — a
+disconnected plumbing-built chain. Without the audited pre-push bypass the
+hook's new-branch guard runs the FULL tier-1 suite (60+ min) on every cron
+cycle and the push never lands (see #3500 / #3198). These tests pin that the
+push subprocess env carries ``GIT_PRE_PUSH_SKIP=1`` (and nothing else does).
+"""
+import importlib.util
+import os
+import types
+
+_SPEC = importlib.util.spec_from_file_location(
+    "equivalence_state",
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "monitoring", "equivalence_state.py"),
+)
+es = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(es)
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+class GitRecorder:
+    """subprocess.run stand-in scripted per git subcommand."""
+
+    def __init__(self, parent_exists):
+        self.parent_exists = parent_exists
+        self.calls = []  # (args, env) tuples
+
+    def __call__(self, argv, input=None, capture_output=None, text=None, env=None):
+        sub = argv[3]  # ["git", "-C", repo, <subcommand>, ...]
+        self.calls.append((argv, env))
+        ok = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        if sub == "ls-remote":
+            if not self.parent_exists:
+                return types.SimpleNamespace(returncode=2, stdout="", stderr="")
+            return types.SimpleNamespace(returncode=0, stdout=f"{SHA_A}\trefs/heads/x\n", stderr="")
+        if sub == "rev-parse":
+            return types.SimpleNamespace(returncode=0, stdout=SHA_A + "\n", stderr="")
+        if sub == "ls-tree":
+            return ok
+        if sub in ("hash-object", "mktree", "commit-tree"):
+            return types.SimpleNamespace(returncode=0, stdout=SHA_B + "\n", stderr="")
+        return ok  # fetch, push, ...
+
+    def push_calls(self):
+        return [(a, e) for a, e in self.calls if a[3] == "push"]
+
+    def non_push_calls(self):
+        return [(a, e) for a, e in self.calls if a[3] != "push"]
+
+
+def _run_publish(monkeypatch, parent_exists):
+    rec = GitRecorder(parent_exists)
+    monkeypatch.setattr(es.subprocess, "run", rec)
+    assert es.publish("/fake/repo", "full", "{}") is True
+    return rec
+
+
+def test_create_push_sets_prepush_bypass_env(monkeypatch):
+    """Ref-creation push (remote ref absent) must carry GIT_PRE_PUSH_SKIP=1."""
+    rec = _run_publish(monkeypatch, parent_exists=False)
+    pushes = rec.push_calls()
+    assert len(pushes) == 1
+    _, env = pushes[0]
+    assert env is not None
+    assert env.get("GIT_PRE_PUSH_SKIP") == "1"
+
+
+def test_update_push_sets_prepush_bypass_env(monkeypatch):
+    """CAS update push (--force-with-lease) must also carry the bypass."""
+    rec = _run_publish(monkeypatch, parent_exists=True)
+    pushes = rec.push_calls()
+    assert len(pushes) == 1
+    argv, env = pushes[0]
+    assert any(a.startswith("--force-with-lease") for a in argv)
+    assert env is not None
+    assert env.get("GIT_PRE_PUSH_SKIP") == "1"
+
+
+def test_bypass_env_inherits_parent_environment(monkeypatch):
+    """The push env must be an overlay on os.environ, not a bare dict —
+    git needs PATH/HOME/credentials from the parent environment."""
+    monkeypatch.setenv("EQ_TEST_SENTINEL", "present")
+    rec = _run_publish(monkeypatch, parent_exists=False)
+    _, env = rec.push_calls()[0]
+    assert env.get("EQ_TEST_SENTINEL") == "present"
+
+
+def test_non_push_git_calls_do_not_set_bypass(monkeypatch):
+    """Only the push is exempted; plumbing calls keep the default env."""
+    rec = _run_publish(monkeypatch, parent_exists=True)
+    assert rec.non_push_calls()  # sanity: flow used plumbing
+    for _, env in rec.non_push_calls():
+        assert env is None


### PR DESCRIPTION
Closes #3500. Plan approved by owner in-session 2026-07-12 (`status:plan-approved` on the issue).

## What
Adds an optional `_env` overlay to `_git()` in `scripts/monitoring/equivalence_state.py` and sets `GIT_PRE_PUSH_SKIP=1` on **only the two `git push` invocations** (ref-create and CAS `--force-with-lease` update). All plumbing calls (`ls-remote`/`fetch`/`hash-object`/`mktree`/`commit-tree`) keep the default environment.

## Why
`refs/heads/equivalence-state` is a disconnected plumbing-built chain — the pre-push hook can never attribute its diff, gates every publish as new-branch `RUN_ALL` (full tier-1 suites + coverage, 60+ min on the FUSE mount), and the push never completes: the remote ref **does not exist**, so every sentinel cron cycle re-runs the full suite forever. Full forensics on #3500 (observed live 2026-07-12; also serialized all uv operations machine-wide via the uv cache lock for the duration).

`GIT_PRE_PUSH_SKIP` is the hook's designed, **audited** soft bypass — each use appends a JSONL record to `logs/hooks/pre-push-bypass.jsonl`.

## Interaction with #3198
Independent of and complementary to #3198's hook-side merge-base fix — that fix's conservative no-merge-base fallback would still RUN_ALL this ref every cycle.

## Tests
`tests/monitoring/test_equivalence_state.py` — 4 new cases (TDD, red→green): create-push carries bypass; CAS update push carries bypass; env is an `os.environ` overlay (PATH/credentials preserved); non-push git calls keep `env=None`. Full `tests/monitoring/` suite: **26 passed**.

## Verification plan (post-merge)
Run `equivalence-sentinel.sh` once on ace-linux-1: push completes in seconds, `ls-remote` shows the ref, one audit line appended, no test suite spawned. Once the ref exists, subsequent publishes diff as state-files-only and exit the hook early even on boxes without this fix.