### PR TITLE
feat(equivalence): fleet publish-health monitoring in the equality matrix (#3502)

### DIFF
--- a/.claude/skills/workspace-hub/equivalence-publish-health/SKILL.md
+++ b/.claude/skills/workspace-hub/equivalence-publish-health/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: equivalence-publish-health
+description: Diagnose and fix a machine whose equivalence-state fingerprint publish is absent, stale, or gate-length slow (the wh#3500 pre-push RUN_ALL deadlock signature). Use when the equality matrix shows PUBLISH-GATED / PUBLISH-STALE / MISSING-EVIDENCE on the publish-health row, or the sentinel reports absent-fingerprint / publish-slow divergences.
+---
+
+# Equivalence publish health — triage and fix
+
+The machine-equivalence sentinel (`scripts/monitoring/equivalence-sentinel.sh`, daily cron)
+publishes each box's fingerprint to the `equivalence-state` git ref. A box whose publish
+cannot land is INVISIBLE to drift detection — and the #3500 incident showed the publish
+itself can be deadlocked by the repo's own pre-push hook.
+
+## The deadlock signature (wh#3500)
+
+`refs/heads/equivalence-state` is a **disconnected plumbing-built chain** (hash-object /
+mktree / commit-tree). The pre-push hook cannot attribute its diff, so:
+
+1. Remote ref absent → every push gates as **new-branch `RUN_ALL`** → full tier-1 suites +
+   coverage (60+ min, FUSE-heavy, holds the uv cache lock machine-wide).
+2. The hour-long gate keeps the push from completing → **the ref is never created** →
+   next cycle repeats. The gate blocks the very push that would end the gating.
+
+Also note: a merge-base fallback (#3198) does NOT fix this — the state chain has no
+merge-base with `origin/main`, so "conservative RUN_ALL" catches it every time.
+
+## How it surfaces
+
+| Surface | Signal |
+|---|---|
+| Equality matrix (`build-equality-matrix.py`) | `publish_health` row: **PUBLISH-GATED** (failed/>60s), **PUBLISH-STALE** (>26h), **MISSING-EVIDENCE** (never published) |
+| Sentinel divergences | `absent-fingerprint` (roster machine missing from the ref), `publish-slow` (fingerprint carries `last_publish_duration_s` > 60) |
+| Locally on the box | `.claude/state/equivalence/publish-health.json` (`{ts, duration_s, rc}`) |
+
+## Triage (run on the affected box)
+
+```bash
+git ls-remote origin refs/heads/equivalence-state          # ref exists at all?
+cat .claude/state/equivalence/publish-health.json           # last publish outcome
+grep -c GIT_PRE_PUSH_SKIP scripts/monitoring/equivalence_state.py   # 0 = pre-#3500 script
+ps -eo pid,etimes,args | grep -E "run-all-tests|pytest"      # gate currently burning?
+```
+
+- **Script pre-dates the fix** (grep = 0): sync the checkout to main (`git fetch origin
+  main` + fast-forward). The fixed `equivalence_state.py` pushes with `GIT_PRE_PUSH_SKIP=1`
+  — the hook's **audited** soft bypass (each use logs one JSONL line to
+  `logs/hooks/pre-push-bypass.jsonl`). Never hand-strip the hook instead.
+- **Ref absent remotely**: one successful publish creates it and breaks the loop for the
+  whole fleet (existing-ref pushes diff as state-files-only and exit the hook early).
+  Run `bash scripts/monitoring/equivalence-sentinel.sh` once, confirm it returns in seconds.
+- **Sentinel never installed**: check the box's cron (`setup-cron.sh --check`) — an
+  absent-fingerprint machine with no sentinel cron needs the cron, not a hook fix.
+- **publish-health.json missing but sentinel runs**: the sentinel pre-dates #3502; sync main.
+
+## Related
+
+- Issues: wh#3500 (deadlock + fix), wh#3502 (this monitoring), wh#3198 (hook merge-base fix)
+- Skill: `worktree-pre-push-bypass-for-tier1-checks` (the same audited bypass for worktree pushes)
+- Memory: `reference_ace_linux_1_oom_hang_2026_07_12` (incident that surfaced the deadlock)
+- Registry roster consumed by the absent check: `config/workstations/registry.yaml`
+  (`schedule_variant != none` ⇒ expected to publish daily)

--- a/config/agents/skill-index-full.yaml
+++ b/config/agents/skill-index-full.yaml
@@ -4278,6 +4278,12 @@ skills:
   name: ecosystem-terminology
   when_to_use: 'ecosystem-terminology Canonical names, abbreviations, and relationship vocabulary for the workspace-hub ecosystem. Load this when naming repos, modules, machines, files, or expanding acronyms to ensure consistency across humans and agents. type: reference workspace-hub'
   when_to_use_source: backfill
+- description: Diagnose and fix a machine whose equivalence-state fingerprint publish is absent, stale, or gate-length slow (the wh#3500 pre-push RUN_ALL deadlock signature). Use when the equality matrix shows PUBLISH-GATED / PUBLISH-STALE / MISSING-EVIDENCE on the publish-health row, or the sentinel reports absent-fingerprint / publish-slow divergences.
+  family: workspace-hub
+  id: workspace-hub/equivalence-publish-health
+  name: equivalence-publish-health
+  when_to_use: equivalence-publish-health Diagnose and fix a machine whose equivalence-state fingerprint publish is absent, stale, or gate-length slow (the wh#3500 pre-push RUN_ALL deadlock signature). Use when the equality matrix shows PUBLISH-GATED / PUBLISH-STALE / MISSING-EVIDENCE on the publish-health row, or the sentinel reports absent-fingerprint / publish-slow divergences. workspace-hub
+  when_to_use_source: backfill
 - description: Fix false-positive pre-commit failures where workspace-hub's CLAUDE.md line-limit hook blocks edits to auto-generated wiki schema files under knowledge/wikis/.
   family: workspace-hub
   id: workspace-hub/exclude-wiki-claude-md-from-harness-line-limit-hook

--- a/scripts/monitoring/equivalence-sentinel.sh
+++ b/scripts/monitoring/equivalence-sentinel.sh
@@ -30,8 +30,31 @@ role="$($PY -c "import json,sys;print(json.load(open(sys.argv[1]))['role'])" "$f
 # check emits "ERROR: directory not found" for them. Downgrade that benign token
 # here (not in the shared check-all.sh) so cron-health does not false-flag this
 # job — real publish failures keep their error wording.
+#
+# Publish-health (#3502): the publish is timed and recorded so the equality
+# matrix can flag a gate-length publish (#3500 signature). The PREVIOUS cycle's
+# duration is stamped into this cycle's fingerprint so it travels in the ref
+# and is visible fleet-centrally.
+publish_health="$REPO_ROOT/.claude/state/equivalence/publish-health.json"
+$PY - "$fp_local" "$publish_health" <<'PY'
+import json, sys
+fp_path, ph_path = sys.argv[1], sys.argv[2]
+try:
+    dur = json.load(open(ph_path)).get("duration_s")
+except Exception:
+    dur = None
+if isinstance(dur, (int, float)) and not isinstance(dur, bool):
+    fp = json.load(open(fp_path))
+    fp["last_publish_duration_s"] = dur
+    json.dump(fp, open(fp_path, "w"), indent=1)
+PY
+publish_start="$(date +%s)"
 $PY "$MON/equivalence_state.py" publish --repo "$REPO_ROOT" --role "$role" --file "$fp_local" 2>&1 \
   | sed -e 's/^/[publish] /' -e 's/ERROR: directory not found:/SKIP (absent sibling):/'
+publish_rc="${PIPESTATUS[0]}"
+publish_dur="$(( $(date +%s) - publish_start ))"
+printf '{"ts": "%s", "duration_s": %s, "rc": %s}\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$publish_dur" "$publish_rc" > "$publish_health"
 
 # 3. collect + 4. compare (in one python pass)
 report="$REPO_ROOT/.claude/state/equivalence/divergences-latest.json"
@@ -44,7 +67,11 @@ try:
 except store.StoreUnavailable as e:
     print(f"[collect] store unavailable: {e}", file=sys.stderr)
     sys.exit(3)
-divs = cmp.compare(fps)
+# Roster-aware (#3502): machines that run the daily cron but have no
+# fingerprint in the ref are flagged (absence = gate-blocked publish or
+# sentinel not installed). Degrades open if the registry is unreadable.
+roster = cmp.load_expected_machines("config/workstations/registry.yaml")
+divs = cmp.compare(fps, expected_machines=roster or None)
 json.dump({"boxes": len(fps), "divergences": divs}, open(sys.argv[1], "w"), indent=1)
 print(f"[compare] {len(fps)} box(es), {len(divs)} divergence(s)")
 for d in divs:

--- a/scripts/monitoring/equivalence_compare.py
+++ b/scripts/monitoring/equivalence_compare.py
@@ -39,13 +39,76 @@ def _parse_ts(s):
         return None
 
 
-def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0):
+def _parse_registry_minimal(text):
+    """No-pyyaml fallback for the registry: extracts only what the roster needs
+    (machines/<name>/{hostname, hostname_aliases, schedule_variant}). The sentinel
+    runs under ``uv run --no-project`` where pyyaml is not guaranteed."""
+    machines, cur, in_machines = {}, None, False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        key, _, val = line.strip().partition(":")
+        val = val.strip()
+        if indent == 0:
+            in_machines, cur = (key == "machines"), None
+            continue
+        if not in_machines:
+            continue
+        if indent == 2 and not val:
+            cur = key
+            machines[cur] = {}
+        elif indent == 4 and cur and val:
+            if val.startswith("[") and val.endswith("]"):
+                machines[cur][key] = [v.strip().strip("'\"")
+                                      for v in val[1:-1].split(",") if v.strip()]
+            else:
+                machines[cur][key] = val.strip("'\"")
+    return {"machines": machines}
+
+
+def load_expected_machines(registry_path):
+    """Roster of machines expected to publish: ``config/workstations/registry.yaml``
+    entries whose ``schedule_variant`` is set and not ``none`` (i.e. they run the
+    daily cron). Degrades open (empty roster → check skipped) on any failure so a
+    missing/unparseable registry never turns the sentinel into a false alarm."""
+    try:
+        with open(registry_path) as fh:
+            text = fh.read()
+        try:
+            import yaml
+            data = yaml.safe_load(text) or {}
+        except ImportError:
+            data = _parse_registry_minimal(text)
+        roster = []
+        for name, m in sorted((data.get("machines") or {}).items()):
+            m = m or {}
+            if str(m.get("schedule_variant") or "none").lower() == "none":
+                continue
+            roster.append({"machine": name, "hostname": m.get("hostname"),
+                           "aliases": list(m.get("hostname_aliases") or [])})
+        return roster
+    except Exception as e:  # noqa: BLE001 — degrade open by design
+        print(f"WARN: expected-machines roster unavailable ({e}); "
+              f"absent-fingerprint check skipped", file=sys.stderr)
+        return []
+
+
+def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0,
+            expected_machines=None, publish_slow_s=60.0):
     """Compare fingerprint dicts; return divergences sorted worst-first.
 
     A divergence is ``{severity, code, detail, boxes}``. Empty list == equivalent.
     Role-aware: cron *set* differences between roles are expected and NOT flagged;
     only registry/harness equivalence, clone lag, hub-cron freshness, and
     reporting staleness are checked.
+
+    ``expected_machines`` (#3502): roster from ``load_expected_machines`` — any
+    roster machine with no fingerprint in the store is flagged; a box whose
+    publish is gate-blocked (#3500) can never land its fingerprint, so absence
+    IS the deadlock symptom. ``publish_slow_s`` flags publishes that landed but
+    took gate-length time (re-emergent hook gating).
     """
     out: list[dict] = []
     if not fps:
@@ -144,6 +207,35 @@ def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0):
                             f"{r}: orphan .git/index.lock ~{age:.0f} min old with no holder — git automation may be frozen",
                             {r: round(float(age), 1)}))
 
+    # 9. roster machine absent from the store -> WARNING (#3502). A gate-blocked
+    # publish (#3500) can never land its fingerprint — absence IS the symptom;
+    # the other possibility (sentinel not installed) equally needs surfacing.
+    if expected_machines:
+        seen = {str(f.get("hostname") or "").lower() for f in fps}
+        seen |= {str(r).lower() for r in roles}
+        seen.discard("")
+        for m in expected_machines:
+            names = {str(m.get("hostname") or "").lower(),
+                     str(m.get("machine") or "").lower()}
+            names |= {str(a).lower() for a in (m.get("aliases") or [])}
+            names.discard("")
+            if names and not (names & seen):
+                label = m.get("machine") or m.get("hostname") or "?"
+                out.append(_div(WARNING, "absent-fingerprint",
+                                f"{label}: no fingerprint in equivalence-state — publish may be "
+                                f"gate-blocked (#3500) or the sentinel is not running there",
+                                {label: "absent"}))
+
+    # 10. publish landed but took gate-length time -> WARNING (#3502). Detects a
+    # re-emergent pre-push gate even when the push eventually succeeds.
+    for r, f in zip(roles, fps):
+        dur = f.get("last_publish_duration_s")
+        if isinstance(dur, (int, float)) and not isinstance(dur, bool) and dur > publish_slow_s:
+            out.append(_div(WARNING, "publish-slow",
+                            f"{r}: last equivalence publish took {dur:.0f}s "
+                            f"(> {publish_slow_s:.0f}s) — pre-push gate suspected (#3500)",
+                            {r: round(float(dur), 1)}))
+
     out.sort(key=lambda d: _SEV_RANK[d["severity"]])
     return out
 
@@ -172,11 +264,16 @@ def main(argv=None):
     ap.add_argument("--behind-warn", type=int, default=10)
     ap.add_argument("--stale-h", type=float, default=6.0)
     ap.add_argument("--learning-max-h", type=float, default=48.0)
+    ap.add_argument("--publish-slow-s", type=float, default=60.0)
+    ap.add_argument("--registry", default=None,
+                    help="config/workstations/registry.yaml — enables absent-fingerprint check")
     ap.add_argument("--json", action="store_true", help="emit JSON")
     a = ap.parse_args(argv)
     fps = load_dir(a.dir)
+    expected = load_expected_machines(a.registry) if a.registry else None
     divs = compare(fps, behind_warn=a.behind_warn, stale_h=a.stale_h,
-                   learning_max_h=a.learning_max_h)
+                   learning_max_h=a.learning_max_h,
+                   expected_machines=expected, publish_slow_s=a.publish_slow_s)
     if a.json:
         print(json.dumps({"boxes": len(fps), "divergences": divs}, indent=2))
     else:

--- a/scripts/readiness/build-equality-matrix.py
+++ b/scripts/readiness/build-equality-matrix.py
@@ -346,6 +346,48 @@ def skill_link_health_verdict(report: dict) -> str:
     return "SKILL-LINKS-DRIFTED" if repairable > 0 else "SKILL-LINKS-OK"
 
 
+# ── publish-health verdict (#3502) — is the equivalence publish landing, fast? ──
+PUBLISH_SLOW_S = 60.0      # gate-length publish = the #3500 pre-push RUN_ALL signature
+PUBLISH_STALE_H = 26.0     # daily cron + 2h grace
+
+
+def publish_health_verdict(report: dict, now: datetime | None = None) -> str:
+    """Grade the last equivalence-state publish (written by equivalence-sentinel.sh).
+    PUBLISH-GATED on a failed or gate-length (>60s) publish — the #3500 pre-push
+    deadlock signature; PUBLISH-STALE when the last publish predates the daily-cron
+    window (sentinel dead or blocked); PUBLISH-OK otherwise. Fail-closed
+    MISSING-EVIDENCE on missing/garbled/future evidence — a box that never
+    published has no record, which is exactly the #3500 absent case."""
+    ph = report.get("dimensions", {}).get("publish_health")
+    if not isinstance(ph, dict):
+        return "MISSING-EVIDENCE"
+    stamp = ph.get("last_publish_at")
+    if not isinstance(stamp, str):
+        return "MISSING-EVIDENCE"
+    try:
+        ts = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return "MISSING-EVIDENCE"     # includes the collector's "missing" sentinel
+    now = now or datetime.now(timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    age_h = (now - ts).total_seconds() / 3600.0
+    if age_h < 0:                     # future stamp ⇒ untrustworthy
+        return "MISSING-EVIDENCE"
+    rc = ph.get("last_publish_rc")
+    dur = ph.get("last_publish_duration_s")
+    failed = isinstance(rc, int) and not isinstance(rc, bool) and rc != 0
+    gated = (isinstance(dur, (int, float)) and not isinstance(dur, bool)
+             and dur > PUBLISH_SLOW_S)
+    if failed or gated:
+        return "PUBLISH-GATED"
+    if age_h > PUBLISH_STALE_H:
+        return "PUBLISH-STALE"
+    return "PUBLISH-OK"
+
+
 # ── value extraction for uniform dims ────────────────────────────────────────
 def extract_value(dim: str, report: dict):
     d = report.get("dimensions", {})
@@ -462,6 +504,8 @@ def verdict_for(dim: str, machine: str, reports: dict, baselines: dict,
         return memory_freshness_verdict(rep)
     if dim == "skill_link_health":          # shared-skill-link propagation — per-box facts
         return skill_link_health_verdict(rep)
+    if dim == "publish_health":             # equivalence publish landing/speed — per-box facts
+        return publish_health_verdict(rep)
     if dim in COLD_DIMS:
         return cold_verdict(dim, rep, baselines.get(machine), probed_repos)
     # Stale peers are EXCLUDED from the uniform value list so a stale report can never
@@ -491,7 +535,8 @@ def load_reports() -> dict[str, dict]:
 
 BASE_DISPLAY_DIMS = ["compute", "data_access", "solvers", "harness", "python_cmd", "skills",
                      "kanban", "memory", "behavior", "scheduler", "session_curation",
-                     "skill_currency", "memory_freshness", "skill_link_health"]
+                     "skill_currency", "memory_freshness", "skill_link_health",
+                     "publish_health"]
 DISPLAY_DIMS = BASE_DISPLAY_DIMS + provider_rows()
 
 # ── render grouping (#2801 collapsible-rows enhancement) ─────────────────────
@@ -514,6 +559,8 @@ GROUPS = [
     ("skills-currency", "Skill currency — all providers up to date vs canonical", ["skill_currency"]),
     ("memory-freshness", "Memory freshness — memory surfaces refreshed recently", ["memory_freshness"]),
     ("skill-links", "Skill-link health — shared skills propagated to ecosystem repos", ["skill_link_health"]),
+    ("publish-health", "Publish health — equivalence fingerprint publish landing fast on every box",
+        ["publish_health"]),
 ]
 
 # Worst-of severity for the collapsed group rollup. Higher = more operator attention.
@@ -521,13 +568,14 @@ GROUPS = [
 # all-good group collapses to a single green "OK" so a clean box reads at a glance.
 ROLLUP_SEVERITY = {
     "BELOW-BASELINE": 6, "DIVERGES": 6, "CURATED-EXPIRED": 6, "SKILLS-DRIFTED": 6, "MEMORY-EXPIRED": 6,
+    "PUBLISH-GATED": 6,
     "MISSING-BASELINE": 5, "NO-MAJORITY": 5, "CURATED-STALE": 5, "SKILLS-INDEX-STALE": 5, "MEMORY-STALE": 5,
-    "SKILL-LINKS-DRIFTED": 5,
+    "SKILL-LINKS-DRIFTED": 5, "PUBLISH-STALE": 5,
     "MISSING-EVIDENCE": 4, "PENDING": 4,
     "STALE-CHECKOUT": 3,
     "EXPECTED-DIFF": 1, "EXPECTED-DIVERGENCE": 1, "UNREACHABLE": 1, "ABSENT": 1,
     "CONFORMS": 0, "EQUAL": 0, "PARITY": 0, "CURATED-FRESH": 0, "SKILLS-CURRENT": 0, "MEMORY-FRESH": 0,
-    "SKILL-LINKS-OK": 0,
+    "SKILL-LINKS-OK": 0, "PUBLISH-OK": 0,
 }
 
 
@@ -546,7 +594,7 @@ def rollup_verdict(verdicts: list[str]) -> tuple[str, str]:
 #    .claude/skills/workspace-hub/ecosystem-equivalence-reconcile/SKILL.md + reconcile-ecosystem.sh
 OK_VERDICTS = {"CONFORMS", "EQUAL", "PARITY", "EXPECTED-DIFF", "EXPECTED-DIVERGENCE",
                "UNREACHABLE", "ABSENT", "CURATED-FRESH", "SKILLS-CURRENT", "MEMORY-FRESH",
-               "SKILL-LINKS-OK"}
+               "SKILL-LINKS-OK", "PUBLISH-OK"}
 
 
 def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
@@ -608,6 +656,15 @@ def remediate(dim: str, verdict: str) -> tuple[str, str, bool] | None:
         return ("shared-skill links are missing/broken on ecosystem repos (froze at link time) — "
                 "re-sync via scripts/skills/resync-skill-links.sh --apply (or propagate-ecosystem.sh "
                 "--skills-only)", "this box", False)
+    if verdict == "PUBLISH-GATED":
+        return ("last equivalence publish failed or took gate-length time (>60s) — the wh#3500 "
+                "pre-push RUN_ALL deadlock signature; check the box's pre-push hook and that "
+                "equivalence_state.py pushes with GIT_PRE_PUSH_SKIP=1 (skill "
+                "equivalence-publish-health)", "this box", False)
+    if verdict == "PUBLISH-STALE":
+        return ("no equivalence publish in >26h — the sentinel cron is dead or blocked on this box; "
+                "run scripts/monitoring/equivalence-sentinel.sh manually and check its cron/logs",
+                "this box", False)
     return ("investigate this cell's report", "operator", False)
 
 
@@ -727,7 +784,7 @@ def main() -> None:
 <style>body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;max-width:1100px}}table{{border-collapse:collapse;width:100%}}
 th,td{{border:1px solid #ddd;padding:.4rem .6rem;font-size:.8rem;text-align:center}}thead th{{background:#2d3748;color:#fff}}
 tbody th{{background:#edf2f7;text-align:left}}.conforms,.equal,.parity,.ok,.curated-fresh,.skills-current,.memory-fresh{{background:#c6f6d5}}.ok{{font-weight:700}}
-.below-baseline,.diverges,.curated-expired,.skills-drifted,.memory-expired{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale,.memory-stale,.skill-links-drifted{{background:#feebc8}}.skill-links-ok{{background:#c6f6d5}}
+.below-baseline,.diverges,.curated-expired,.skills-drifted,.memory-expired,.publish-gated{{background:#fed7d7}}.no-majority,.missing-baseline,.curated-stale,.skills-index-stale,.memory-stale,.skill-links-drifted,.publish-stale{{background:#feebc8}}.skill-links-ok,.publish-ok{{background:#c6f6d5}}
 .expected-diff,.expected-divergence{{background:#e9d8fd}}
 .pending,.missing-evidence{{background:#fffaf0}}.unreachable,.absent,.na{{background:#f7fafc;color:#a0aec0}}
 .stale-checkout{{background:#e2e8f0;color:#4a5568;font-style:italic}}

--- a/scripts/readiness/collect-equality.sh
+++ b/scripts/readiness/collect-equality.sh
@@ -373,6 +373,23 @@ else
 fi
 provider_harness_yaml="$(printf '%s\n' "$provider_harness_yaml" | sed 's/^/    /')"
 
+# ── publish_health (#3502): last equivalence-state publish outcome, written by
+#    equivalence-sentinel.sh. A gate-length duration or a stale/missing record is
+#    the #3500 pre-push-deadlock signature; the matrix renders it per machine.
+ph_file="${WS}/.claude/state/equivalence/publish-health.json"
+ph_ts="missing"; ph_dur="null"; ph_rc="null"
+if [[ -f "$ph_file" ]] && have python3; then
+  read -r ph_ts ph_dur ph_rc < <(python3 - "$ph_file" <<'PY' 2>/dev/null || echo "missing null null"
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get("ts") or "missing", d.get("duration_s", "null"), d.get("rc", "null"))
+except Exception:
+    print("missing null null")
+PY
+) || true
+fi
+
 # ── emit (generated_at + headroom + mtime + job_count + checkout_sha are EXCLUDED from the
 #          hash; dirty + behind_main + origin_ref_age_h ARE hashed — A1/BC5: exclude the pure
 #          churn (sha) ONLY, so every freshness-state field stays live in the committed report
@@ -439,6 +456,10 @@ ${provider_harness_yaml}
     healthy: ${slh_healthy}
     repairable: ${slh_repairable}
     worst_state: ${slh_worst}
+  publish_health:
+    last_publish_at: "$(yesc "$ph_ts")"
+    last_publish_duration_s: ${ph_dur}
+    last_publish_rc: ${ph_rc}
 YAML
 FULL="generated_at: \"${RUN_TS}\""$'\n'"${BODY}"
 

--- a/tests/monitoring/test_equivalence_compare.py
+++ b/tests/monitoring/test_equivalence_compare.py
@@ -147,3 +147,86 @@ def test_load_dir_skips_malformed(tmp_path):
     (tmp_path / "bad.json").write_text("{not json")
     fps = ec.load_dir(str(tmp_path))
     assert len(fps) == 1
+
+
+# ── #3502: fleet publish-health — absent-fingerprint + publish-slow ──────────
+
+ROSTER = [
+    {"machine": "dev-primary", "hostname": "ace-linux-1", "aliases": ["vamsee-linux1"]},
+    {"machine": "dev-secondary", "hostname": "ace-linux-2", "aliases": []},
+    {"machine": "ace-win-1", "hostname": "acma-ansys05", "aliases": []},
+]
+
+
+def test_absent_fingerprint_flags_roster_machines_missing_from_store():
+    divs = ec.compare([_fp("full", hostname="ace-linux-1")], expected_machines=ROSTER)
+    absent = [d for d in divs if d["code"] == "absent-fingerprint"]
+    assert {list(d["boxes"].keys())[0] for d in absent} == {"dev-secondary", "ace-win-1"}
+    assert all(d["severity"] == ec.WARNING for d in absent)
+
+
+def test_absent_fingerprint_matches_on_alias():
+    divs = ec.compare([_fp("full", hostname="vamsee-linux1")], expected_machines=ROSTER[:1])
+    assert not [d for d in divs if d["code"] == "absent-fingerprint"]
+
+
+def test_absent_fingerprint_silent_without_roster():
+    divs = ec.compare([_fp("full", hostname="ace-linux-1")])
+    assert not [d for d in divs if d["code"] == "absent-fingerprint"]
+
+
+def test_all_roster_machines_present_no_absent_divergence():
+    fps = [_fp("full", hostname="ace-linux-1"),
+           _fp("contribute", hostname="ace-linux-2"),
+           _fp("contribute-minimal", hostname="acma-ansys05")]
+    divs = ec.compare(fps, expected_machines=ROSTER)
+    assert not [d for d in divs if d["code"] == "absent-fingerprint"]
+
+
+def test_publish_slow_flags_gate_length_publish():
+    divs = ec.compare([_fp("full"), _fp("contribute", last_publish_duration_s=3720.0)])
+    slow = [d for d in divs if d["code"] == "publish-slow"]
+    assert len(slow) == 1 and slow[0]["severity"] == ec.WARNING
+    assert "contribute" in slow[0]["boxes"]
+
+
+def test_publish_fast_not_flagged():
+    divs = ec.compare([_fp("full", last_publish_duration_s=1.5)])
+    assert not [d for d in divs if d["code"] == "publish-slow"]
+
+
+def test_load_expected_machines_filters_non_cron(tmp_path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(
+        "machines:\n"
+        "  dev-primary:\n    hostname: ace-linux-1\n    hostname_aliases: [vamsee-linux1]\n"
+        "    schedule_variant: full\n"
+        "  macbook-portable:\n    hostname: Vamsees-MacBook-Air\n    schedule_variant: none\n"
+        "  dev-secondary:\n    hostname: ace-linux-2\n    schedule_variant: contribute\n"
+    )
+    roster = ec.load_expected_machines(str(reg))
+    assert {m["machine"] for m in roster} == {"dev-primary", "dev-secondary"}
+    assert roster[0]["aliases"] == ["vamsee-linux1"]
+
+
+def test_load_expected_machines_degrades_open_on_missing_file(tmp_path):
+    assert ec.load_expected_machines(str(tmp_path / "nope.yaml")) == []
+
+
+def test_minimal_registry_parser_matches_needed_fields():
+    text = (
+        "machines:\n"
+        "  dev-primary:\n"
+        "    hostname: ace-linux-1\n"
+        "    hostname_aliases: [vamsee-linux1]\n"
+        "    schedule_variant: full  # daily\n"
+        "  macbook-portable:\n"
+        "    hostname: Vamsees-MacBook-Air\n"
+        "    schedule_variant: none\n"
+    )
+    data = ec._parse_registry_minimal(text)
+    m = data["machines"]
+    assert m["dev-primary"]["hostname"] == "ace-linux-1"
+    assert m["dev-primary"]["hostname_aliases"] == ["vamsee-linux1"]
+    assert m["dev-primary"]["schedule_variant"] == "full"
+    assert m["macbook-portable"]["schedule_variant"] == "none"

--- a/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
+++ b/tests/readiness/fixtures/equality-ace-win-1.sample.yaml
@@ -108,3 +108,7 @@ dimensions:
     healthy: 42
     repairable: 0
     worst_state: HEALTHY
+  publish_health:
+    last_publish_at: "2026-05-30T03:55:12Z"
+    last_publish_duration_s: 2
+    last_publish_rc: 0

--- a/tests/readiness/test_collect_equality_ps1_schema.py
+++ b/tests/readiness/test_collect_equality_ps1_schema.py
@@ -59,7 +59,8 @@ def _win1_baseline() -> dict:
 # ════════════════════════════════════════════════════════════════════════════
 EXPECTED_DIMS = {"compute", "data_access", "solvers", "harness", "skills",
                  "kanban", "memory", "behavior", "scheduler", "provider_harness",
-                 "session_curation", "skill_currency", "memory_freshness", "skill_link_health"}
+                 "session_curation", "skill_currency", "memory_freshness", "skill_link_health",
+                 "publish_health"}
 
 
 def test_ps1_sample_output_parses_schema_v4_with_provider_harness():

--- a/tests/readiness/test_publish_health_verdict.py
+++ b/tests/readiness/test_publish_health_verdict.py
@@ -1,0 +1,85 @@
+"""TDD tests for #3502 — publish_health matrix verdict (follow-on to #3500).
+
+Targets build_equality_matrix.publish_health_verdict: PUBLISH-GATED when the last
+equivalence publish failed or took gate-length time (>60s — the #3500 pre-push
+RUN_ALL deadlock signature); PUBLISH-STALE when the last publish is older than the
+daily-cron window; PUBLISH-OK otherwise; fail-closed MISSING-EVIDENCE on
+missing/garbled facts (a box that NEVER published has no record at all).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "readiness" / "build-equality-matrix.py"
+
+spec = importlib.util.spec_from_file_location("build_equality_matrix", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+bem = importlib.util.module_from_spec(spec)
+sys.modules["build_equality_matrix"] = bem
+spec.loader.exec_module(bem)
+
+NOW = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _rep(**ph) -> dict:
+    base = {"last_publish_at": "2026-07-13T11:00:00Z",
+            "last_publish_duration_s": 2, "last_publish_rc": 0}
+    base.update(ph)
+    return {"dimensions": {"publish_health": base}}
+
+
+def test_ok_fresh_fast_publish():
+    assert bem.publish_health_verdict(_rep(), now=NOW) == "PUBLISH-OK"
+
+
+def test_gated_on_gate_length_duration():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_duration_s=3720), now=NOW) == "PUBLISH-GATED"
+
+
+def test_gated_on_nonzero_rc():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_rc=3), now=NOW) == "PUBLISH-GATED"
+
+
+def test_gated_dominates_stale():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_at="2026-07-10T00:00:00Z", last_publish_duration_s=900),
+        now=NOW) == "PUBLISH-GATED"
+
+
+def test_stale_when_older_than_daily_window():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_at="2026-07-12T00:00:00Z"), now=NOW) == "PUBLISH-STALE"
+
+
+def test_missing_evidence_without_dimension():
+    assert bem.publish_health_verdict({"dimensions": {}}, now=NOW) == "MISSING-EVIDENCE"
+
+
+def test_missing_evidence_on_never_published_sentinel_value():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_at="missing"), now=NOW) == "MISSING-EVIDENCE"
+
+
+def test_missing_evidence_on_future_stamp():
+    assert bem.publish_health_verdict(
+        _rep(last_publish_at="2026-07-14T00:00:00Z"), now=NOW) == "MISSING-EVIDENCE"
+
+
+def test_dim_registered_in_display_and_groups():
+    assert "publish_health" in bem.BASE_DISPLAY_DIMS
+    assert any("publish_health" in dims for _, _, dims in bem.GROUPS)
+    assert bem.ROLLUP_SEVERITY["PUBLISH-GATED"] == 6
+    assert bem.ROLLUP_SEVERITY["PUBLISH-STALE"] == 5
+    assert bem.ROLLUP_SEVERITY["PUBLISH-OK"] == 0
+    assert "PUBLISH-OK" in bem.OK_VERDICTS
+
+
+def test_remediation_for_gated_names_the_deadlock():
+    action, owner, by_design = bem.remediate("publish_health", "PUBLISH-GATED")
+    assert "3500" in action and by_design is False


### PR DESCRIPTION
Closes #3502. Plan approved by owner in-session 2026-07-12 (`status:plan-approved` on the issue). Follow-on to #3500/#3501.

## What (plan items A–D)

**A — comparator** (`equivalence_compare.py`): `absent-fingerprint` WARNING for every registry machine (`config/workstations/registry.yaml`, `schedule_variant != none` = runs the daily cron) with no fingerprint in the `equivalence-state` ref — absence IS the #3500 gate-deadlock symptom. `publish-slow` WARNING when a fingerprint's `last_publish_duration_s` exceeds 60 s (gate re-emergence with an eventually-landing push). Roster loader has a no-pyyaml fallback parser (the sentinel runs under `uv run --no-project`) and degrades open.

**B — sentinel** (`equivalence-sentinel.sh`): times the publish, writes `.claude/state/equivalence/publish-health.json` `{ts,duration_s,rc}`, stamps the previous cycle's duration into the fingerprint (so it travels in the ref and is visible fleet-centrally), passes the roster to compare.

**C — equality matrix**: new `publish_health` dimension in `collect-equality.sh` (the `.ps1` delegates to the canonical `.sh`, so Windows boxes inherit it); builder gains `publish_health_verdict` — **PUBLISH-GATED** (failed or >60 s, red, severity 6), **PUBLISH-STALE** (>26 h, amber, severity 5), **PUBLISH-OK** (green), fail-closed **MISSING-EVIDENCE** — plus group row, rollup severity, CSS, and remediation-playbook entries. Rides the existing daily equality cron on every box; zero new cron jobs.

**D — skill**: `.claude/skills/workspace-hub/equivalence-publish-health/SKILL.md` — the deadlock signature, per-box triage commands, and the audited-bypass fix recipe. **Post-merge:** run `scripts/propagate-ecosystem.sh --skills-only` on the primary to sync it across ecosystem repos (owner directive).

## Current fleet reality this will surface immediately
The ref today holds ONE fingerprint (ace-linux-1). On the first post-merge sentinel cycle the matrix should flag `dev-secondary`, `ace-win-1`, `ace-win-2` as absent — converting silence into a named work-list (child issues per box as needed, plan item E).

## Tests (TDD, red→green)
- `tests/monitoring/test_equivalence_compare.py`: 24 pass (9 new — absent/alias/roster-off/all-present/slow/fast/loader-filter/degrade-open/fallback-parser)
- `tests/readiness/test_publish_health_verdict.py`: 10 new cases incl. wiring + remediation
- `tests/readiness/test_collect_equality_ps1_schema.py` + golden fixture extended (108 pass with builder+collector suites)
- Full `tests/monitoring/ + tests/readiness/`: 416 passed; the 27 failures are **pre-existing environment-dependent tests, verified identical on unmodified main via stash** (sync-agent-configs/telegram/hermes-config areas untouched by this diff)
- Functional smoke: collector emits the dimension from a real `publish-health.json` (`last_publish_at/duration_s/rc`)