### PR TITLE
feat(registry): enroll gpu-claw in the machine-equivalence matrix (#3507)

### DIFF
--- a/config/workstations/registry.yaml
+++ b/config/workstations/registry.yaml
@@ -292,6 +292,37 @@ machines:
     notes: >
       Secondary Windows workstation. Mirrors ace-win-1 capabilities.
 
+  gpu-claw:
+    hostname: gpu-claw
+    hostname_aliases: []
+    os: linux
+    role: gpu-executor
+    workspace_root: /home/undi/ws/workspace-hub   # relocation-plan target (HANDOVER.md on box); clone pending
+    tier1_repo_root: /home/undi/ws
+    repo_layout: sibling
+    schedule_variant: contribute-minimal
+    harness_profile:
+      roles: [sim-worker]
+      managed: true
+    ssh: gpu-claw
+    capabilities:
+      agent_clis: [claude]
+      languages: [python3, bash]
+      tools: [git, gh, npm]                        # uv NOT installed yet — onboarding step
+      gpu: nvidia-rtx3090-x2
+    storage:
+      local: /home/undi
+      knowledge: null
+      remote_mounts: []
+    repos:
+      - digitalmodel
+    notes: >
+      GPU executor (2x RTX 3090, 64 GiB, 8 cores; Ubuntu 24.04). First Linux
+      executor of the fleet-dispatch ladder (deckhand#557). Equivalence
+      onboarding PENDING: workspace-hub clone (relocation plan step 2), uv
+      install, sentinel cron. Registered with schedule_variant contribute-minimal
+      so the publish-health matrix row (#3502) shows the gap until onboarded.
+
   macbook-portable:
     hostname: Vamsees-MacBook-Air
     hostname_aliases: [Vamsees-MacBook-Air.local]

--- a/scripts/readiness/harness-config.yaml
+++ b/scripts/readiness/harness-config.yaml
@@ -61,6 +61,15 @@ workstations:
     compute_floor: {cores_min: 8, ram_gib_min: 8}
     required_data_access: [assetutilities, digitalmodel, worldenergydata, assethold]
     solvers_baseline: {orcaflex: absent, orcawave: absent, aqwa: absent, ansys: absent}
+  gpu-claw:
+    ws_hub_path: /home/undi/ws/workspace-hub
+    ssh_target: gpu-claw
+    report_path: .claude/state/harness-readiness-gpu-claw.yaml
+    role: linux-execution
+    # GPU executor (2x RTX 3090, 64 GiB); only digitalmodel required — CFD lane, not full tier-1
+    compute_floor: {cores_min: 8, ram_gib_min: 32}
+    required_data_access: [digitalmodel]
+    solvers_baseline: {orcaflex: absent, orcawave: absent, aqwa: absent, ansys: absent}
   ace-win-1:
     ws_hub_path: 'D:\workspace-hub'
     ssh_target: null


### PR DESCRIPTION
Closes #3507 (registry-enrollment half; on-box onboarding steps remain tracked there — reopen/keep open if preferred). Owner directive in-session 2026-07-12.

## What
- `config/workstations/registry.yaml`: gpu-claw entry — linux gpu-executor, `schedule_variant: contribute-minimal`, `workspace_root: /home/undi/ws/workspace-hub` (relocation-plan target per the box's own HANDOVER.md), sibling layout, capabilities from live triage (uv absent — noted as onboarding step)
- `scripts/readiness/harness-config.yaml`: matching workstation baseline (cores_min 8, ram_gib_min 32, required_data_access [digitalmodel] — CFD lane, not full tier-1, so the matrix doesn't permanently red-flag missing siblings that were never intended there)

## Effect
From merge, the roster-aware `absent-fingerprint` check (#3502) and the publish_health matrix row EXPECT gpu-claw. It will grade red until #3507's on-box steps complete (clone, uv, sentinel cron) — intentional visible pressure replacing silence, same philosophy as #3504-#3506.

## Verification
Registry/harness parity + comparator + builder + cron-health suites: **120 passed**. Facts sourced from read-only ssh triage (no writes made to gpu-claw).