### PR TITLE
feat(hf): rebuild-on-publish via Vercel Deploy Hook [C5]

### DIFF
--- a/.claude/skills/data/hf-dataset-publishing/SKILL.md
+++ b/.claude/skills/data/hf-dataset-publishing/SKILL.md
@@ -178,6 +178,24 @@ labeled, queryable surface is a natural audit trigger, so audit here.
 - Org **Gradio/Docker Spaces need a paid HF plan** (datasets are free). Relevant only if this
   data later gets a viz **Space** — the dataset itself costs nothing.
 
+## Rebuild-on-publish (C5, workspace-hub#3488)
+
+Publishing a **registered** dataset (one that has a `config/capabilities.yaml` entry in
+`aceengineer-website`) should refresh the live site automatically — "live" data without a
+live runtime dependency.
+
+- `save_results_to_hf.py` POSTs a **Vercel Deploy Hook** after a verified publish, so the
+  site rebuilds and picks up the new rows (the build re-fetches HF and re-bakes snapshots).
+- The hook URL is a **secret**, read from `$VERCEL_DEPLOY_HOOK_URL` — **never committed**.
+  Setting that env var on a publishing host is the opt-in ("publishes from here refresh the
+  site"). Unset → the publish still succeeds, it just doesn't trigger a rebuild.
+- Suppress per-run with `--no-deploy-hook`. A failed/absent hook never fails the publish.
+- **Backstop:** `aceengineer-website/.github/workflows/nightly-rebuild.yml` triggers a nightly
+  rebuild (covers datasets updated out-of-band), reading the same URL from a GH Actions secret.
+- Owner setup (once): Vercel → project **Settings → Git → Deploy Hooks** → create a `main`
+  hook → store the URL as `$VERCEL_DEPLOY_HOOK_URL` (publishing hosts) **and** as the
+  `VERCEL_DEPLOY_HOOK_URL` GitHub Actions secret in `aceengineer-website`.
+
 ## Bundled resources
 
 - **`publish_analysis_to_hf.py`** — reusable helper: verifies `hf auth whoami`, creates the

--- a/scripts/hf/save_results_to_hf.py
+++ b/scripts/hf/save_results_to_hf.py
@@ -26,8 +26,38 @@ outliers; withhold implausible columns + file an issue before trusting a public 
 See workspace-hub/.claude/skills/data/hf-dataset-publishing/ and the license routing rule
 .claude/rules/codes-standards-data-routing.md before going --public.
 """
-import argparse, hashlib, json, math, sys
+import argparse, hashlib, json, math, os, sys, urllib.request
 from pathlib import Path
+
+DEPLOY_HOOK_ENV = "VERCEL_DEPLOY_HOOK_URL"
+
+
+def trigger_deploy_hook(enabled=True, url_env=DEPLOY_HOOK_ENV, timeout=15):
+    """Rebuild-on-publish (C5, workspace-hub#3488): POST the Vercel Deploy Hook so the
+    website rebuilds with the freshly-published rows. The hook URL is a SECRET read from
+    the environment ($VERCEL_DEPLOY_HOOK_URL) — never committed. Setting that env var on
+    a publishing host is itself the opt-in ("publishes from here refresh the site").
+
+    No-op (returns None) when disabled or the env var is unset. NEVER raises — a failed
+    rebuild trigger must not fail an otherwise-successful publish.
+    """
+    if not enabled:
+        return None
+    url = os.environ.get(url_env)
+    if not url:
+        print(f"deploy-hook: ${url_env} not set — skipping site rebuild trigger")
+        return None
+    try:
+        req = urllib.request.Request(
+            url, data=b"{}", method="POST",
+            headers={"content-type": "application/json"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"deploy-hook: triggered site rebuild (HTTP {resp.status})")
+            return resp.status
+    except Exception as e:  # noqa: BLE001 — deliberately swallow; publish already succeeded
+        print(f"deploy-hook: trigger failed ({e.__class__.__name__}: {e}) — "
+              "publish still succeeded")
+        return None
 
 
 def _flatten(rec, prefix="", out=None):
@@ -196,6 +226,9 @@ def main():
                     help="URL of the cat:data/bug issue filed for the withheld columns (shown in the card)")
     ap.add_argument("--out", default=None, help="staging dir (default: temp)")
     ap.add_argument("--dry-run", action="store_true", help="build + report, do NOT publish")
+    ap.add_argument("--no-deploy-hook", action="store_true",
+                    help="do NOT POST the Vercel Deploy Hook after publish (default: trigger a "
+                         f"site rebuild when ${DEPLOY_HOOK_ENV} is set — see workspace-hub#3488)")
     args = ap.parse_args()
     withhold = {c.strip() for c in (args.withhold or "").split(",") if c.strip()}
 
@@ -291,6 +324,9 @@ def main():
     if missing:
         sys.exit(f"VERIFY FAILED: expected files missing at revision {rev}: {sorted(missing)}")
     print(f"verified {len(expected)} files on the remote at revision {rev}.")
+    # C5 (workspace-hub#3488): kick a website rebuild so the new rows go live. Best-effort
+    # — a failed/absent hook never fails the (already-verified) publish.
+    trigger_deploy_hook(enabled=not args.no_deploy_hook)
     print(f"is-valid (indexing lags a few min — poll, don't assume failure): "
           f"https://datasets-server.huggingface.co/is-valid?dataset={args.repo_id}")
     for t in tables_meta:

--- a/tests/hf/test_save_results_to_hf.py
+++ b/tests/hf/test_save_results_to_hf.py
@@ -63,3 +63,52 @@ def test_refuses_runs_target(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         srhf.main()
     assert "runs" in str(exc.value).lower()
+
+
+# --- C5 (wh#3488): rebuild-on-publish Vercel Deploy Hook trigger ---
+
+class _FakeResp:
+    status = 200
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def test_trigger_deploy_hook_fires_when_env_set(monkeypatch):
+    calls = {}
+    def fake_urlopen(req, timeout=None):
+        calls["url"] = req.full_url
+        calls["method"] = req.get_method()
+        return _FakeResp()
+    monkeypatch.setenv("VERCEL_DEPLOY_HOOK_URL", "https://hook.example/deploy/abc")
+    monkeypatch.setattr(srhf.urllib.request, "urlopen", fake_urlopen)
+    status = srhf.trigger_deploy_hook()
+    assert status == 200
+    assert calls["url"] == "https://hook.example/deploy/abc"
+    assert calls["method"] == "POST"  # deploy hooks require POST
+
+
+def test_trigger_deploy_hook_skips_when_env_unset(monkeypatch):
+    monkeypatch.delenv("VERCEL_DEPLOY_HOOK_URL", raising=False)
+    called = {"n": 0}
+    monkeypatch.setattr(srhf.urllib.request, "urlopen",
+                        lambda *a, **k: called.__setitem__("n", called["n"] + 1))
+    assert srhf.trigger_deploy_hook() is None
+    assert called["n"] == 0  # no network call when the hook isn't configured
+
+
+def test_trigger_deploy_hook_disabled_flag_skips(monkeypatch):
+    monkeypatch.setenv("VERCEL_DEPLOY_HOOK_URL", "https://hook.example/deploy/abc")
+    called = {"n": 0}
+    monkeypatch.setattr(srhf.urllib.request, "urlopen",
+                        lambda *a, **k: called.__setitem__("n", called["n"] + 1))
+    assert srhf.trigger_deploy_hook(enabled=False) is None
+    assert called["n"] == 0
+
+
+def test_trigger_deploy_hook_never_raises_on_failure(monkeypatch):
+    monkeypatch.setenv("VERCEL_DEPLOY_HOOK_URL", "https://hook.example/deploy/abc")
+    def boom(*a, **k):
+        raise OSError("network down")
+    monkeypatch.setattr(srhf.urllib.request, "urlopen", boom)
+    # a failed rebuild trigger must NEVER fail an otherwise-successful publish
+    assert srhf.trigger_deploy_hook() is None


### PR DESCRIPTION
Part of epic **#3485** — **C5 (freshness).** Closes **#3488**. Plan approved by owner 2026-07-12.

Makes publishing a dataset **automatically refresh the website** — "live" data without a live runtime dependency.

## Changes
- **`scripts/hf/save_results_to_hf.py`** — new `trigger_deploy_hook()`: after a *verified* publish, POST the Vercel Deploy Hook so the site rebuilds and picks up the new rows (the build re-fetches HF + re-bakes snapshots).
  - Hook URL is a **secret**, read from `$VERCEL_DEPLOY_HOOK_URL` — **never committed**. Setting that env var on a publishing host is the opt-in.
  - **Best-effort:** a failed or absent hook never fails an already-verified publish (the trigger runs *after* upload + byte-verify). Suppress per-run with `--no-deploy-hook`.
- **`tests/hf/test_save_results_to_hf.py`** — TDD (written first, RED→GREEN): fires a POST to the URL when the env is set; skips when unset or `enabled=False`; **never raises** on POST failure. **13/13 pass.**
- **skill `SKILL.md`** — documents the trigger flow + one-time owner setup.

## Acceptance (#3488)
- ✅ Publishing a dataset triggers a Vercel deploy (when the hook env is configured).
- ✅ Deploy-hook secret is **not committed** (env/GH-secret only).
- ⏳ Nightly backstop → separate PR in `aceengineer-website` (`.github/workflows/nightly-rebuild.yml`).
- ⏳ "Rebuild pulls newest rows / changed value on the live page" → verifiable once the owner creates the Deploy Hook and sets `$VERCEL_DEPLOY_HOOK_URL`.

## Owner action to activate
Vercel → **Settings → Git → Deploy Hooks** (main) → store the URL as `$VERCEL_DEPLOY_HOOK_URL` on publishing hosts **and** as the `VERCEL_DEPLOY_HOOK_URL` GitHub Actions secret in `aceengineer-website`.

Gates: no secrets in code (env-only); TDD satisfied; abs-path clean; ruff/governance advisory jobs unaffected.