### PR TITLE
feat(schedule): run equivalence-sentinel on all cron machines; enroll gpu-claw in equality-report (#3505 #3506 #3507)

### DIFF
--- a/config/scheduled-tasks/schedule-tasks.yaml
+++ b/config/scheduled-tasks/schedule-tasks.yaml
@@ -31,7 +31,7 @@ tasks:
   - id: equality-report
     label: Machine-equality self-report (#2801)
     schedule: "30 4 * * 1"
-    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2]
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2, gpu-claw]
     roles: [control-plane, comms-dispatch, sim-worker]
     requires: [bash, python3, uv, git]
     command: >-
@@ -128,8 +128,11 @@ tasks:
   - id: equivalence-sentinel
     label: Machine-equivalence drift sentinel (#3059)
     schedule: "17 */6 * * *"
-    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2]
-    roles: [control-plane, comms-dispatch]
+    # #3505/#3506 root cause: the win boxes were roster-EXPECTED to publish
+    # (#3502 absent-fingerprint) but never in this machines list — the sentinel
+    # was simply not scheduled there. gpu-claw added at enrollment (#3507).
+    machines: [dev-primary, ace-linux-1, dev-secondary, ace-linux-2, ace-win-1, ace-win-2, gpu-claw]
+    roles: [control-plane, comms-dispatch, sim-worker]
     requires: [bash, python3, uv, git, claude]
     command: >-
       PATH=$HOME/.local/bin:$HOME/.npm-global/bin:$PATH;


### PR DESCRIPTION
**Root cause fix for #3505/#3506** and the schedule half of #3507. Owner directive in-session 2026-07-13 ("proceed with gpu-claw onboarding").

## Finding
The #3502 roster (registry `schedule_variant != none`) EXPECTS ace-win-1/ace-win-2/gpu-claw to publish equivalence fingerprints — but `equivalence-sentinel` in `schedule-tasks.yaml` only targeted the two Linux dev boxes. The Windows boxes were never scheduled to run the sentinel at all; no on-box mystery, pure scheduling gap. (Heartbeats confirm all boxes alive and polling.)

## Change (config-only)
- `equivalence-sentinel`: machines += ace-win-1, ace-win-2, gpu-claw; roles += sim-worker (comment records the root cause)
- `equality-report`: machines += gpu-claw (win boxes were already in)
- `equality-matrix-refresh` untouched — aggregation stays on the primary

## On-box state (gpu-claw, done this session, non-disruptive)
hub cloned to /home/undi/ws/workspace-hub · digitalmodel symlinked as sibling · uv 0.11.28 installed. Repo MOVES from the relocation plan are deliberately deferred: the box is live-dispatching, and moving deckhand/digitalmodel under a running dispatcher risks in-flight runs. After merge: `setup-cron.sh` on gpu-claw applies the jobs; win boxes pick the task up via their scheduler sync.

## Verification
Wiring/single-source/cron-deps test files: **20 passed, 1 skipped** (schedule wiring test included).