### PR TITLE
fix(cron): key setup-cron Task-Scheduler skip on registry os, not schedule variant (#3507)

### DIFF
--- a/scripts/cron/cron_render.py
+++ b/scripts/cron/cron_render.py
@@ -113,6 +113,10 @@ def build_context(
         "log": str(log),
         "schedule_variant": schedule_variant,
         "schedule_tokens": ordered_schedule_tokens,
+        # Scheduler routing (#3507): setup-cron.sh must key its Windows-Task-Scheduler
+        # skip on the registry os, not the schedule variant. Default linux — a missing
+        # os must not silently skip cron reconciliation.
+        "os": str(entry.get("os") or "linux").lower(),
     }
 
 
@@ -209,7 +213,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--cron-lines", action="store_true")
     parser.add_argument(
         "--field",
-        choices=["machine_id", "schedule_variant", "workspace_hub", "log", "known"],
+        choices=["machine_id", "schedule_variant", "workspace_hub", "log", "known", "os"],
         default=None,
     )
     args = parser.parse_args(argv)

--- a/scripts/cron/setup-cron.sh
+++ b/scripts/cron/setup-cron.sh
@@ -47,7 +47,11 @@ SCHEDULE_VARIANT="$(uv run --no-project python "$CRON_RENDER" \
   --machine "$TARGET_MACHINE" --field schedule_variant)"
 
 echo "Host: ${TARGET_MACHINE} → machine: ${CANONICAL_MACHINE} → cron_variant: ${SCHEDULE_VARIANT}"
-if [[ "$SCHEDULE_VARIANT" == "contribute-minimal" ]]; then
+# #3507: key the Task-Scheduler skip on the registry os field, NOT the schedule
+# variant — gpu-claw is a linux contribute-minimal box and must get real crons.
+MACHINE_OS="$(uv run --no-project python "$CRON_RENDER" \
+  --machine "$TARGET_MACHINE" --field os)"
+if [[ "$MACHINE_OS" == "windows" ]]; then
   echo "This machine uses Windows Task Scheduler; Linux cron reconciliation is skipped."
   exit 0
 fi

--- a/tests/cron/test_cron_render.py
+++ b/tests/cron/test_cron_render.py
@@ -153,3 +153,22 @@ def test_expand_command_only_replaces_exact_workspace_and_log_variables(monkeypa
     assert f"{REPO}_BACKUP" not in expanded
     assert f"echo /tmp/workspace-hub-cron.log /tmp/workspace-hub-cron.log" in expanded
     assert f" {REPO} {REPO} " in expanded
+
+
+def test_build_context_exposes_registry_os_for_scheduler_routing():
+    """#3507 gpu-claw incident: setup-cron.sh skipped Linux cron reconciliation for
+    ANY contribute-minimal machine, equating the schedule variant with Windows.
+    The discriminator must be the registry os field, exposed via build_context."""
+    registry = {"machines": {
+        "gpu-claw": {"hostname": "gpu-claw", "os": "linux",
+                     "schedule_variant": "contribute-minimal"},
+        "ace-win-1": {"hostname": "acma-ansys05", "os": "windows",
+                      "schedule_variant": "contribute-minimal"},
+        "legacy-box": {"hostname": "legacy-box",
+                       "schedule_variant": "contribute"},
+    }}
+    render = _load_renderer()
+    assert render.build_context("gpu-claw", registry=registry)["os"] == "linux"
+    assert render.build_context("ace-win-1", registry=registry)["os"] == "windows"
+    # missing os defaults to linux — cron reconciliation must not silently skip
+    assert render.build_context("legacy-box", registry=registry)["os"] == "linux"


### PR DESCRIPTION
Found live during gpu-claw onboarding (#3507): `setup-cron.sh` line 50 skipped Linux cron reconciliation for ANY `contribute-minimal` machine — the variant doubled as a Windows proxy from when only ace-win-1/2 used it. gpu-claw (linux + contribute-minimal, enrolled in #3508) ran the sentinel fine manually but got **zero crons installed**, so its fingerprint would silently stale in 6h.

## Change
- `cron_render.build_context` exposes `os` from the registry entry (defaults to linux — a missing os must not silently skip reconciliation); `--field os` added to the CLI
- `setup-cron.sh` keys the Task-Scheduler skip on `os == windows`

## Verification
- TDD: new test red (`KeyError: 'os'`) → green; `tests/cron/` **264 passed** with the identical 18 pre-existing environment-dependent failures as unmodified main (stash-verified)
- CLI: `gpu-claw → linux`, `ace-win-1 → windows`, `dev-primary → linux`
- `bash -n` clean

Post-merge: rerun `setup-cron.sh` on gpu-claw (tunnel-window script ready) — its crons install and #3507's on-box half completes.