### PR TITLE
fix(equivalence): key ref blobs by machine id — same-role boxes no longer clobber (#3516)

### DIFF
--- a/scripts/monitoring/equivalence-fingerprint.sh
+++ b/scripts/monitoring/equivalence-fingerprint.sh
@@ -18,15 +18,19 @@ OUT=""
 
 host="$(hostname 2>/dev/null || echo unknown)"
 
-# Role: env override, else map known hosts to setup-cron.sh roles, else unknown.
+# Identity (#3516): env overrides, else resolve machine_id + role from the
+# workstation registry (schedule_variant = role). Collision-safe fallback
+# unknown-<host> keeps two unregistered boxes from ever sharing a blob name.
 role="${EQUIV_ROLE:-}"
-if [ -z "$role" ]; then
-  case "$host" in
-    ace-linux-1) role="full" ;;        # dev-primary / orchestration hub
-    ace-linux-2) role="contribute" ;;  # dev-secondary
-    *) role="unknown" ;;
-  esac
+machine="${EQUIV_MACHINE:-}"
+if [ -z "$role" ] || [ -z "$machine" ]; then
+  ident="$(python3 "$REPO_ROOT/scripts/monitoring/equivalence_state.py" resolve-identity \
+    --registry "$REPO_ROOT/config/workstations/registry.yaml" --hostname "$host" 2>/dev/null || true)"
+  [ -z "$machine" ] && machine="${ident%% *}"
+  [ -z "$role" ] && role="${ident##* }"
 fi
+[ -z "$machine" ] && machine="unknown-$host"
+[ -z "$role" ] && role="unknown"
 
 # Clone position vs origin/main (best-effort fetch; soft on network failure).
 git fetch -q origin main 2>/dev/null
@@ -74,10 +78,10 @@ if [ -e "$lock" ] && ! pgrep -x git >/dev/null 2>&1; then
 fi
 
 # Emit JSON via python for safe quoting.
-python3 - "$role" "$host" "$clone_head" "$behind" "$ahead" "$hv" "$hinstall" "$reg_sha" "$age_learning" "$age_session" "$on_main" "$lock_stale" <<'PY' > "${OUT:-/dev/stdout}"
+python3 - "$role" "$host" "$machine" "$clone_head" "$behind" "$ahead" "$hv" "$hinstall" "$reg_sha" "$age_learning" "$age_session" "$on_main" "$lock_stale" <<'PY' > "${OUT:-/dev/stdout}"
 import json, sys, hashlib, os
 from datetime import datetime, timezone
-role, host, head, behind, ahead, hv, hinstall, reg, al, as_, on_main_s, lock_stale_s = sys.argv[1:13]
+role, host, machine, head, behind, ahead, hv, hinstall, reg, al, as_, on_main_s, lock_stale_s = sys.argv[1:14]
 def fhash(path):
     try:
         with open(path, "rb") as fh:
@@ -103,7 +107,7 @@ def num(x):
 def s(x): return None if x in ("null", "") else x
 fp = {
     "fingerprint_version": 1,
-    "role": role, "hostname": host,
+    "role": role, "hostname": host, "machine_id": machine,
     "ts": datetime.now(timezone.utc).isoformat(),
     "clone_head": s(head),
     "behind_origin": num(behind), "ahead_origin": num(ahead),

--- a/scripts/monitoring/equivalence-sentinel.sh
+++ b/scripts/monitoring/equivalence-sentinel.sh
@@ -24,6 +24,9 @@ mkdir -p "$(dirname "$fp_local")"
 # 1. fingerprint this box
 bash "$MON/equivalence-fingerprint.sh" --out "$fp_local" 2>/dev/null || { echo "fingerprint failed"; exit 1; }
 role="$($PY -c "import json,sys;print(json.load(open(sys.argv[1]))['role'])" "$fp_local" 2>/dev/null || echo unknown)"
+# #3516: blobs are keyed by machine_id (same-role boxes must not clobber).
+machine="$($PY -c "import json,sys;print(json.load(open(sys.argv[1])).get('machine_id') or '')" "$fp_local" 2>/dev/null || echo "")"
+[ -z "$machine" ] && machine="$role"
 
 # 2. publish to the shared git ref (soft — network/auth issues must not crash the cron)
 # Absent sibling repos are EXPECTED on single-repo machines; the underlying
@@ -49,7 +52,7 @@ if isinstance(dur, (int, float)) and not isinstance(dur, bool):
     json.dump(fp, open(fp_path, "w"), indent=1)
 PY
 publish_start="$(date +%s)"
-$PY "$MON/equivalence_state.py" publish --repo "$REPO_ROOT" --role "$role" --file "$fp_local" 2>&1 \
+$PY "$MON/equivalence_state.py" publish --repo "$REPO_ROOT" --machine "$machine" --file "$fp_local" 2>&1 \
   | sed -e 's/^/[publish] /' -e 's/ERROR: directory not found:/SKIP (absent sibling):/'
 publish_rc="${PIPESTATUS[0]}"
 publish_dur="$(( $(date +%s) - publish_start ))"

--- a/scripts/monitoring/equivalence_compare.py
+++ b/scripts/monitoring/equivalence_compare.py
@@ -113,7 +113,9 @@ def compare(fps, *, behind_warn=10, stale_h=6.0, learning_max_h=48.0,
     out: list[dict] = []
     if not fps:
         return out
-    roles = [f.get("role") or f.get("hostname") or "?" for f in fps]
+    # #3516: label boxes by machine_id first — two same-role boxes (ace-win-1/2)
+    # must not merge into one key in divergence "boxes" dicts.
+    roles = [f.get("machine_id") or f.get("role") or f.get("hostname") or "?" for f in fps]
 
     # 1. model-registry divergence across boxes -> CRITICAL (config not equivalent)
     reg = {f.get("registry_sha256") for f in fps if f.get("registry_sha256")}

--- a/scripts/monitoring/equivalence_state.py
+++ b/scripts/monitoring/equivalence_state.py
@@ -4,7 +4,7 @@
 Mirrors the proven ``dispatch_leader.py`` GitLeaderStateStore idiom: state lives in
 a dedicated ref (``equivalence-state``) written with git plumbing (hash-object /
 mktree / commit-tree) and pushed with ``--force-with-lease`` — so it never churns
-``main``. The ref's tree holds one ``<role>.json`` blob per box.
+``main``. The ref's tree holds one ``<machine_id>.json`` blob per box (#3516).
 
 Part of the machine-equivalence drift sentinel (#3059, epic #3058).
 """
@@ -17,6 +17,39 @@ import subprocess
 import sys
 
 DEFAULT_REF = "equivalence-state"
+
+# Pre-#3516 blobs were keyed by ROLE — two same-role boxes (ace-win-1/2, both
+# contribute-minimal) would silently clobber each other. Blobs are now keyed by
+# registry machine id; these legacy names are self-cleaned on each publish.
+LEGACY_ROLE_NAMES = {"full", "contribute", "contribute-minimal", "none", "unknown"}
+
+
+def resolve_identity(registry_path, hostname):
+    """(machine_id, role) for a hostname from config/workstations/registry.yaml.
+    Matches hostname or hostname_aliases case-insensitively; role = schedule_variant.
+    Collision-safe fallback ("unknown-<hostname>", "unknown") on any failure so two
+    unregistered boxes can never share a blob name (#3516)."""
+    fallback = (f"unknown-{hostname}", "unknown")
+    try:
+        with open(registry_path) as fh:
+            text = fh.read()
+        try:
+            import yaml
+            data = yaml.safe_load(text) or {}
+        except ImportError:
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from equivalence_compare import _parse_registry_minimal
+            data = _parse_registry_minimal(text)
+        want = str(hostname).lower()
+        for machine_id, m in sorted((data.get("machines") or {}).items()):
+            m = m or {}
+            names = {str(m.get("hostname") or "").lower(), str(machine_id).lower()}
+            names |= {str(a).lower() for a in (m.get("hostname_aliases") or [])}
+            if want in names:
+                return (machine_id, str(m.get("schedule_variant") or "unknown"))
+        return fallback
+    except Exception:  # noqa: BLE001 — degrade to collision-safe fallback by design
+        return fallback
 
 
 class StoreUnavailable(RuntimeError):
@@ -80,12 +113,30 @@ def collect(repo, *, remote="origin", ref=DEFAULT_REF):
     return fps
 
 
-def publish(repo, role, content, *, remote="origin", ref=DEFAULT_REF, retries=3):
-    """Publish this box's fingerprint as <role>.json into the ref. CAS with retry."""
-    name = f"{role}.json"
+def publish(repo, machine, content, *, remote="origin", ref=DEFAULT_REF, retries=3):
+    """Publish this box's fingerprint as <machine>.json into the ref. CAS with retry.
+
+    Migration (#3516): any LEGACY role-named blob whose fingerprint hostname matches
+    THIS box's hostname is dropped from the tree — self-cleaning, no manual step.
+    Other boxes' legacy blobs are left for their own next publish to clean."""
+    name = f"{machine}.json"
+    try:
+        own_host = str(json.loads(content).get("hostname") or "").lower()
+    except ValueError:
+        own_host = ""
     for _ in range(retries):
         parent = _fetch_tip(repo, remote, ref)
         entries = _tree_entries(repo, parent)
+        if own_host:
+            for legacy in [n for n in entries
+                           if n[:-len(".json")] in LEGACY_ROLE_NAMES and n != name]:
+                show = _git(repo, "cat-file", "-p", entries[legacy])
+                if show.returncode == 0:
+                    try:
+                        if str(json.loads(show.stdout).get("hostname") or "").lower() == own_host:
+                            del entries[legacy]
+                    except ValueError:
+                        pass
         h = _git(repo, "hash-object", "-w", "--stdin", _input=content)
         if h.returncode != 0:
             raise StoreUnavailable(f"hash-object failed: {h.stderr.strip()[:200]}")
@@ -95,7 +146,7 @@ def publish(repo, role, content, *, remote="origin", ref=DEFAULT_REF, retries=3)
         if mk.returncode != 0:
             raise StoreUnavailable(f"mktree failed: {mk.stderr.strip()[:200]}")
         tree = mk.stdout.strip()
-        commit_args = ["commit-tree", tree, "-m", f"chore(equivalence): {role} fingerprint"]
+        commit_args = ["commit-tree", tree, "-m", f"chore(equivalence): {machine} fingerprint"]
         if parent:
             commit_args += ["-p", parent]
         c = _git(repo, *commit_args)
@@ -121,19 +172,29 @@ def publish(repo, role, content, *, remote="origin", ref=DEFAULT_REF, retries=3)
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description="Publish/collect equivalence fingerprints via git ref")
-    ap.add_argument("cmd", choices=["publish", "collect"])
+    ap.add_argument("cmd", choices=["publish", "collect", "resolve-identity"])
     ap.add_argument("--repo", default=".")
-    ap.add_argument("--role", help="role for publish (e.g. full, contribute)")
+    ap.add_argument("--machine", help="machine id for publish blob name (#3516)")
+    ap.add_argument("--role", help="DEPRECATED for publish (used as blob key when --machine absent)")
+    ap.add_argument("--registry", help="registry.yaml for resolve-identity")
+    ap.add_argument("--hostname", help="hostname for resolve-identity")
     ap.add_argument("--file", help="fingerprint JSON file to publish")
     ap.add_argument("--remote", default="origin")
     ap.add_argument("--ref", default=DEFAULT_REF)
     a = ap.parse_args(argv)
     try:
+        if a.cmd == "resolve-identity":
+            if not a.registry or not a.hostname:
+                ap.error("resolve-identity requires --registry and --hostname")
+            machine, role = resolve_identity(a.registry, a.hostname)
+            print(f"{machine} {role}")
+            return 0
         if a.cmd == "publish":
-            if not a.role or not a.file:
-                ap.error("publish requires --role and --file")
+            key = a.machine or a.role
+            if not key or not a.file:
+                ap.error("publish requires --machine (or legacy --role) and --file")
             content = open(a.file).read()
-            ok = publish(a.repo, a.role, content, remote=a.remote, ref=a.ref)
+            ok = publish(a.repo, key, content, remote=a.remote, ref=a.ref)
             print("published" if ok else "publish lost CAS race after retries", file=sys.stderr)
             return 0 if ok else 1
         fps = collect(a.repo, remote=a.remote, ref=a.ref)

--- a/tests/monitoring/test_equivalence_compare.py
+++ b/tests/monitoring/test_equivalence_compare.py
@@ -230,3 +230,15 @@ def test_minimal_registry_parser_matches_needed_fields():
     assert m["dev-primary"]["hostname_aliases"] == ["vamsee-linux1"]
     assert m["dev-primary"]["schedule_variant"] == "full"
     assert m["macbook-portable"]["schedule_variant"] == "none"
+
+
+def test_same_role_boxes_keep_distinct_labels_via_machine_id():
+    """#3516: divergence 'boxes' dicts key by label — two contribute-minimal boxes
+    must not collapse into one key. machine_id wins over role."""
+    fps = [_fp("contribute-minimal", hostname="acma-ansys05",
+               machine_id="ace-win-1", last_publish_duration_s=500.0),
+           _fp("contribute-minimal", hostname="acma-ws014",
+               machine_id="ace-win-2", last_publish_duration_s=700.0)]
+    slow = [d for d in ec.compare(fps) if d["code"] == "publish-slow"]
+    assert len(slow) == 2
+    assert {list(d["boxes"].keys())[0] for d in slow} == {"ace-win-1", "ace-win-2"}

--- a/tests/monitoring/test_equivalence_state.py
+++ b/tests/monitoring/test_equivalence_state.py
@@ -7,6 +7,7 @@ cycle and the push never lands (see #3500 / #3198). These tests pin that the
 push subprocess env carries ``GIT_PRE_PUSH_SKIP=1`` (and nothing else does).
 """
 import importlib.util
+import json
 import os
 import types
 
@@ -94,3 +95,107 @@ def test_non_push_git_calls_do_not_set_bypass(monkeypatch):
     assert rec.non_push_calls()  # sanity: flow used plumbing
     for _, env in rec.non_push_calls():
         assert env is None
+
+
+# ── #3516: machine-keyed blobs — same-role boxes must not clobber each other ──
+
+class TreeRecorder(GitRecorder):
+    """Recorder with a scripted existing ref tree (name -> content json str)."""
+
+    def __init__(self, tree):
+        super().__init__(parent_exists=True)
+        self.tree = tree  # {"full.json": '{"hostname": "ace-linux-1", ...}'}
+        self._sha_to_name = {f"sha{i}": n for i, n in enumerate(sorted(tree))}
+
+    def __call__(self, argv, input=None, capture_output=None, text=None, env=None):
+        sub = argv[3]
+        if sub == "ls-tree":
+            self.calls.append((argv, env))
+            out = "".join(f"100644 blob {sha}\t{name}\n"
+                          for sha, name in self._sha_to_name.items())
+            return types.SimpleNamespace(returncode=0, stdout=out, stderr="")
+        if sub == "cat-file" and argv[4] == "-p":
+            self.calls.append((argv, env))
+            name = self._sha_to_name.get(argv[5], "")
+            return types.SimpleNamespace(returncode=0, stdout=self.tree.get(name, ""), stderr="")
+        return super().__call__(argv, input=input, capture_output=capture_output,
+                                text=text, env=env)
+
+    def mktree_input(self):
+        for argv, _ in self.calls:
+            pass
+        return None
+
+
+def _mktree_inputs(rec):
+    return [argv for argv, _ in rec.calls if argv[3] == "mktree"]
+
+
+def test_publish_keys_blob_by_machine_id(monkeypatch):
+    rec = GitRecorder(parent_exists=False)
+    captured = {}
+    real_run = rec.__call__
+
+    def spy(argv, input=None, **kw):
+        if argv[3] == "mktree":
+            captured["mktree_in"] = input
+        return real_run(argv, input=input, **kw)
+
+    monkeypatch.setattr(es.subprocess, "run", spy)
+    assert es.publish("/fake/repo", "gpu-claw", '{"hostname": "gpu-claw"}') is True
+    assert "gpu-claw.json" in captured["mktree_in"]
+
+
+def test_publish_self_cleans_own_legacy_role_blob(monkeypatch):
+    """A box republishing under its machine-id must drop ITS old role-named blob
+    (migration is self-cleaning), while leaving other boxes' legacy blobs alone."""
+    rec = TreeRecorder({
+        "full.json": '{"hostname": "ace-linux-1"}',
+        "contribute.json": '{"hostname": "ace-linux-2"}',
+    })
+    captured = {}
+    real_run = rec.__call__
+
+    def spy(argv, input=None, **kw):
+        if argv[3] == "mktree":
+            captured["mktree_in"] = input
+        return real_run(argv, input=input, **kw)
+
+    monkeypatch.setattr(es.subprocess, "run", spy)
+    assert es.publish("/fake/repo", "dev-primary", '{"hostname": "ace-linux-1"}') is True
+    tree_in = captured["mktree_in"]
+    assert "dev-primary.json" in tree_in          # new machine-keyed blob
+    assert "full.json" not in tree_in             # own legacy blob dropped
+    assert "contribute.json" in tree_in           # other box's legacy blob kept
+
+
+def test_resolve_identity_from_registry(tmp_path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(
+        "machines:\n"
+        "  dev-primary:\n    hostname: ace-linux-1\n    hostname_aliases: [vamsee-linux1]\n"
+        "    schedule_variant: full\n"
+        "  gpu-claw:\n    hostname: gpu-claw\n    schedule_variant: contribute-minimal\n"
+    )
+    assert es.resolve_identity(str(reg), "gpu-claw") == ("gpu-claw", "contribute-minimal")
+    assert es.resolve_identity(str(reg), "ace-linux-1") == ("dev-primary", "full")
+    assert es.resolve_identity(str(reg), "VAMSEE-LINUX1") == ("dev-primary", "full")
+    # unknown host: collision-safe fallback, never a shared name
+    assert es.resolve_identity(str(reg), "mystery-box") == ("unknown-mystery-box", "unknown")
+    assert es.resolve_identity(str(tmp_path / "nope.yaml"), "x") == ("unknown-x", "unknown")
+
+
+def test_same_role_machines_do_not_clobber_end_to_end(tmp_path):
+    """Integration (#3516 reproduction inverted): two machines, same role,
+    publish machine-keyed -> collect sees BOTH."""
+    import subprocess as sp
+    origin = tmp_path / "origin.git"; work = tmp_path / "work"
+    sp.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    sp.run(["git", "init", "-q", str(work)], check=True)
+    sp.run(["git", "-C", str(work), "remote", "add", "origin", str(origin)], check=True)
+    fp1 = json.dumps({"role": "contribute-minimal", "hostname": "acma-ansys05"})
+    fp2 = json.dumps({"role": "contribute-minimal", "hostname": "acma-ws014"})
+    assert es.publish(str(work), "ace-win-1", fp1) is True
+    assert es.publish(str(work), "ace-win-2", fp2) is True
+    boxes = es.collect(str(work))
+    assert sorted(b["hostname"] for b in boxes) == ["acma-ansys05", "acma-ws014"]


### PR DESCRIPTION
Closes #3516 (plan approved by owner in-session; reproduction evidence on the issue).

## Defects fixed
1. **Role-keyed blobs**: `publish()` wrote `<role>.json` — reproduced clobber: two same-role machines → one visible box. ace-win-1/2 (both `contribute-minimal`) would have collided on their first cycles after #3512.
2. **Hardcoded 2-host role map**: `equivalence-fingerprint.sh` knew only ace-linux-1/2; gpu-claw published as `unknown.json` (live in the ref now).

## Change
- Blobs keyed `<machine_id>.json`; role stays a fingerprint FIELD (comparator reads fields — verified, no grouping changes needed)
- `resolve_identity()` from the workstation registry (yaml + no-pyyaml fallback; alias-aware; collision-safe `unknown-<hostname>` fallback) + `resolve-identity` CLI
- **Self-cleaning migration**: each box's publish drops its OWN legacy role-named blob (hostname-matched); no manual ref surgery, converges in one cycle per box
- Sentinel publishes `--machine`; comparator labels machine_id-first so same-role boxes keep distinct divergence keys

## Verification
- TDD red→green; **135 passed** across monitoring + affected readiness suites, incl. a real-git integration test proving two same-role machines both survive collect()
- CLI vs real registry: `ace-linux-1→dev-primary full`, `gpu-claw→gpu-claw contribute-minimal`, `ace-win-1→ace-win-1 contribute-minimal`, unknown host → `unknown-<host>`
- `bash -n` clean on both shell scripts

## Sequencing
This unblocks the ace-win-1/2 operator onboarding (#3505/#3506) — they must NOT start publishing before this lands.