### PR TITLE
fix(legal): legal-sanity-scan repo resolution for sibling checkouts

### DIFF
--- a/scripts/legal/legal-sanity-scan.sh
+++ b/scripts/legal/legal-sanity-scan.sh
@@ -7,9 +7,22 @@
 # Usage:
 #   legal-sanity-scan.sh [--repo=<name>] [--all] [--diff-only] [--json]
 #
+# Environment:
+#   LEGAL_SCAN_REPO_ROOTS    Semicolon- or newline-separated list of root
+#                            directories to resolve repo names against.
+#                            (Semicolons, not colons — ':' collides with
+#                            Windows drive letters under git-bash.)
+#                            When set it WINS: names resolve ONLY against the
+#                            listed roots; no fallback to the defaults.
+#   LEGAL_SCAN_RESOLVE_ONLY  When "1", print the resolved repo path(s) and
+#                            exit 0 before any scanning happens. Minimal
+#                            dry-run hook used by tests/legal/ to assert the
+#                            resolution contract without needing deny-lists.
+#
 # Exit codes:
 #   0  All clear (no block-severity violations)
 #   1  Block-severity violations found
+#   2  Usage or resolution error (repo not found; --all resolved zero repos)
 # =============================================================================
 set -euo pipefail
 
@@ -90,14 +103,20 @@ for arg in "$@"; do
       echo "Usage: legal-sanity-scan.sh [--repo=<name>] [--all] [--diff-only] [--json]"
       echo ""
       echo "Options:"
-      echo "  --repo=<name>   Scan a specific submodule"
-      echo "  --all           Scan all submodules"
+      echo "  --repo=<name>   Scan a specific repo (submodule or sibling checkout)"
+      echo "  --all           Scan all submodules (or LEGAL_SCAN_REPO_ROOTS repos)"
       echo "  --diff-only     Only scan files changed in git diff (HEAD)"
       echo "  --json          Output results as JSON"
+      echo ""
+      echo "Environment:"
+      echo "  LEGAL_SCAN_REPO_ROOTS    Semicolon- or newline-separated repo roots;"
+      echo "                           wins over nested/sibling/walk-up defaults"
+      echo "  LEGAL_SCAN_RESOLVE_ONLY  =1: print resolved path(s), skip scanning"
       echo ""
       echo "Exit codes:"
       echo "  0  Pass (no block-severity violations)"
       echo "  1  Block violations found"
+      echo "  2  Usage or resolution error (repo not found; --all resolved zero repos)"
       exit 0
       ;;
     *) echo "Unknown argument: $arg" >&2; exit 2 ;;
@@ -150,6 +169,82 @@ parse_exclusions() {
       next;
     }
   ' "$file"
+}
+
+# --------------------------------------------------------------------------
+# split_repo_roots: print LEGAL_SCAN_REPO_ROOTS one root per line.
+# Separators: semicolons or newlines (':' would collide with Windows drive
+# letters under git-bash).
+# --------------------------------------------------------------------------
+split_repo_roots() {
+  printf '%s\n' "${LEGAL_SCAN_REPO_ROOTS:-}" | tr ';' '\n'
+}
+
+# --------------------------------------------------------------------------
+# resolve_repo_path: resolve a repository name to a directory.
+# Shared by --repo and --all.
+#
+# Order:
+#   1. LEGAL_SCAN_REPO_ROOTS wins when set: resolve against each listed root
+#      in order; if none match, FAIL (no fallthrough to defaults — the env
+#      being set means the caller took explicit control).
+#   2. Defaults, in order:
+#        nested   $WORKSPACE_ROOT/<name>          (preserves original behavior)
+#        sibling  $(dirname "$WORKSPACE_ROOT")/<name>
+#        walk-up  <ancestor>/<name> from WORKSPACE_ROOT, max 8 levels
+#
+# On success: sets RESOLVED_REPO_PATH, returns 0.
+# On failure: returns 1 with RESOLVE_CANDIDATES holding every path tried.
+# --------------------------------------------------------------------------
+resolve_repo_path() {
+  local name="$1"
+  RESOLVED_REPO_PATH=""
+  RESOLVE_CANDIDATES=()
+
+  if [[ -n "${LEGAL_SCAN_REPO_ROOTS:-}" ]]; then
+    local root
+    while IFS= read -r root; do
+      [[ -z "$root" ]] && continue
+      RESOLVE_CANDIDATES+=("$root/$name")
+      if [[ -d "$root/$name" ]]; then
+        RESOLVED_REPO_PATH="$root/$name"
+        return 0
+      fi
+    done < <(split_repo_roots)
+    return 1
+  fi
+
+  # Default 1: nested under the workspace root (original behavior)
+  RESOLVE_CANDIDATES+=("$WORKSPACE_ROOT/$name")
+  if [[ -d "$WORKSPACE_ROOT/$name" ]]; then
+    RESOLVED_REPO_PATH="$WORKSPACE_ROOT/$name"
+    return 0
+  fi
+
+  # Default 2: sibling of the workspace root
+  local parent
+  parent="$(dirname "$WORKSPACE_ROOT")"
+  RESOLVE_CANDIDATES+=("$parent/$name")
+  if [[ -d "$parent/$name" ]]; then
+    RESOLVED_REPO_PATH="$parent/$name"
+    return 0
+  fi
+
+  # Default 3: bounded walk-up from the workspace root (max 8 levels)
+  local ancestor="$parent"
+  local depth=0
+  while [[ $depth -lt 8 ]]; do
+    [[ "$ancestor" == "$(dirname "$ancestor")" ]] && break
+    ancestor="$(dirname "$ancestor")"
+    RESOLVE_CANDIDATES+=("$ancestor/$name")
+    if [[ -d "$ancestor/$name" ]]; then
+      RESOLVED_REPO_PATH="$ancestor/$name"
+      return 0
+    fi
+    depth=$((depth + 1))
+  done
+
+  return 1
 }
 
 # --------------------------------------------------------------------------
@@ -261,23 +356,76 @@ if [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]]; then
 fi
 
 if [[ -n "$TARGET_REPO" ]]; then
-  # Scan specific repo
-  repo_path="$WORKSPACE_ROOT/$TARGET_REPO"
-  if [[ ! -d "$repo_path" ]]; then
-    echo "ERROR: Repository not found: $repo_path" >&2
+  # Scan specific repo (shared resolver: env roots, nested, sibling, walk-up)
+  if ! resolve_repo_path "$TARGET_REPO"; then
+    {
+      echo "ERROR: Repository not found: $TARGET_REPO"
+      echo "Candidates tried:"
+      for c in "${RESOLVE_CANDIDATES[@]}"; do
+        echo "  - $c"
+      done
+    } >&2
     exit 2
+  fi
+  repo_path="$RESOLVED_REPO_PATH"
+  if [[ "${LEGAL_SCAN_RESOLVE_ONLY:-}" == "1" ]]; then
+    echo "$repo_path"
+    exit 0
   fi
   [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]] && echo "Scanning: $TARGET_REPO"
   scan_directory "$repo_path" "$TARGET_REPO" || true
 
 elif [[ "$SCAN_ALL" == "true" ]]; then
-  # Scan all submodules
-  while IFS= read -r sub; do
-    [[ -z "$sub" ]] && continue
-    sub_path="$WORKSPACE_ROOT/$sub"
-    [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]] && echo "Scanning: $sub"
-    scan_directory "$sub_path" "$sub" || true
-  done < <(git -C "$WORKSPACE_ROOT" submodule --quiet foreach 'echo $sm_path' 2>/dev/null)
+  # Enumerate scan targets: submodules first (original behavior); when the
+  # submodule list is empty and LEGAL_SCAN_REPO_ROOTS is set, fall back to the
+  # immediate child directories of each listed root that contain a .git entry
+  # (sibling checkouts). An empty enumeration is a hard error — a legal scan
+  # must never pass by scanning nothing.
+  scan_paths=()
+  scan_labels=()
+
+  submodules="$(git -C "$WORKSPACE_ROOT" submodule --quiet foreach 'echo $sm_path' 2>/dev/null || true)"
+  if [[ -n "$submodules" ]]; then
+    while IFS= read -r sub; do
+      [[ -z "$sub" ]] && continue
+      if resolve_repo_path "$sub"; then
+        scan_paths+=("$RESOLVED_REPO_PATH")
+      else
+        scan_paths+=("$WORKSPACE_ROOT/$sub")
+      fi
+      scan_labels+=("$sub")
+    done <<< "$submodules"
+  elif [[ -n "${LEGAL_SCAN_REPO_ROOTS:-}" ]]; then
+    while IFS= read -r root; do
+      [[ -z "$root" ]] && continue
+      [[ -d "$root" ]] || continue
+      for child in "$root"/*/; do
+        child="${child%/}"
+        [[ -d "$child" ]] || continue
+        [[ -e "$child/.git" ]] || continue
+        scan_paths+=("$child")
+        scan_labels+=("$(basename "$child")")
+      done
+    done < <(split_repo_roots)
+  fi
+
+  if [[ ${#scan_paths[@]} -eq 0 ]]; then
+    echo "ERROR: --all found no repositories to scan (no submodules; no LEGAL_SCAN_REPO_ROOTS repos)" >&2
+    echo "A legal scan must never pass by scanning nothing. Set LEGAL_SCAN_REPO_ROOTS or run from a checkout with submodules." >&2
+    exit 2
+  fi
+
+  if [[ "${LEGAL_SCAN_RESOLVE_ONLY:-}" == "1" ]]; then
+    printf '%s\n' "${scan_paths[@]}"
+    exit 0
+  fi
+
+  i=0
+  while [[ $i -lt ${#scan_paths[@]} ]]; do
+    [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]] && echo "Scanning: ${scan_labels[$i]}"
+    scan_directory "${scan_paths[$i]}" "${scan_labels[$i]}" || true
+    i=$((i + 1))
+  done
 
 else
   # Scan workspace root (non-submodule files)

--- a/tests/legal/test_repo_resolution.py
+++ b/tests/legal/test_repo_resolution.py
@@ -1,0 +1,55 @@
+"""Pytest wrapper for the legal-sanity-scan repo-resolution contract tests.
+
+Runs tests/legal/test_repo_resolution.sh under git-bash (llm-wiki-acma#299).
+Skips with a clear reason when no usable bash is available.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+BASH_SCRIPT = TEST_DIR / "test_repo_resolution.sh"
+
+
+def _find_bash():
+    """Locate git-bash: probe the standard install path, then PATH.
+
+    Avoids C:\\Windows\\System32\\bash.exe (WSL launcher) — it cannot run
+    repo-relative scripts without a configured distro.
+    """
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    candidates = [
+        Path(program_files) / "Git" / "bin" / "bash.exe",
+        Path(r"C:\Program Files\Git\bin\bash.exe"),
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    found = shutil.which("bash")
+    if found and "system32" not in found.lower():
+        return found
+    return None
+
+
+def test_repo_resolution_contract():
+    bash = _find_bash()
+    if bash is None:
+        pytest.skip(
+            "bash not found (probed '%ProgramFiles%\\Git\\bin\\bash.exe' and "
+            "PATH) — cannot run legal-sanity-scan resolution tests"
+        )
+    result = subprocess.run(
+        [bash, str(BASH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"bash resolution tests failed (exit {result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )

--- a/tests/legal/test_repo_resolution.sh
+++ b/tests/legal/test_repo_resolution.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Resolution-contract tests for scripts/legal/legal-sanity-scan.sh
+# (llm-wiki-acma#299 — sibling/env/walk-up repo resolution; --all refuses
+# empty enumeration).
+#
+# Builds a temp sandbox with fake WORKSPACE_ROOT + nested/sibling layouts and
+# drives the scanner through the LEGAL_SCAN_RESOLVE_ONLY=1 dry-run hook, which
+# prints the resolved path(s) and exits before any scanning happens.
+#
+# Run under bash (git-bash on Windows): bash tests/legal/test_repo_resolution.sh
+# Exit 0 = all assertions passed.
+# =============================================================================
+set -u
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+SCANNER_SRC="$REPO_ROOT/scripts/legal/legal-sanity-scan.sh"
+
+if [[ ! -f "$SCANNER_SRC" ]]; then
+  echo "FATAL: scanner not found at $SCANNER_SRC" >&2
+  exit 1
+fi
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# The scanner derives WORKSPACE_ROOT from its own location (scripts/legal/../..)
+# so we install a copy inside a fake workspace root two levels deep.
+# Layout:
+#   $SANDBOX/grand/parent/fakews/scripts/legal/legal-sanity-scan.sh
+#   $SANDBOX/grand/parent/fakews/<nested repos>
+#   $SANDBOX/grand/parent/<sibling repos>
+#   $SANDBOX/grand/<walk-up repo>
+#   $SANDBOX/envroots/{rootA,rootB}/<env repos>
+FAKEWS="$SANDBOX/grand/parent/fakews"
+mkdir -p "$FAKEWS/scripts/legal"
+cp "$SCANNER_SRC" "$FAKEWS/scripts/legal/legal-sanity-scan.sh"
+SCANNER="$FAKEWS/scripts/legal/legal-sanity-scan.sh"
+
+run_scanner() {
+  # run_scanner [args...] — stdout to $OUT, stderr to $ERR, exit code to $RC
+  OUT="$(bash "$SCANNER" "$@" 2>"$SANDBOX/stderr.txt")"
+  RC=$?
+  ERR="$(cat "$SANDBOX/stderr.txt")"
+}
+
+echo "=== legal-sanity-scan repo-resolution contract ==="
+
+# ---------------------------------------------------------------------------
+# 1. nested-wins: repo exists both nested and as sibling -> nested resolves
+# ---------------------------------------------------------------------------
+mkdir -p "$FAKEWS/dualrepo" "$SANDBOX/grand/parent/dualrepo"
+LEGAL_SCAN_RESOLVE_ONLY=1 run_scanner --repo=dualrepo --quiet
+expected="$(cd "$FAKEWS/dualrepo" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == "$expected" ]]; then
+  pass "nested-wins (resolved $OUT)"
+else
+  fail "nested-wins (rc=$RC out='$OUT' expected='$expected')"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. sibling-fallback: repo exists only beside the workspace root
+# ---------------------------------------------------------------------------
+mkdir -p "$SANDBOX/grand/parent/sibonly"
+LEGAL_SCAN_RESOLVE_ONLY=1 run_scanner --repo=sibonly --quiet
+expected="$(cd "$SANDBOX/grand/parent/sibonly" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == "$expected" ]]; then
+  pass "sibling-fallback (resolved $OUT)"
+else
+  fail "sibling-fallback (rc=$RC out='$OUT' expected='$expected')"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. walk-up: repo exists only two levels above the workspace root
+# ---------------------------------------------------------------------------
+mkdir -p "$SANDBOX/grand/walkrepo"
+LEGAL_SCAN_RESOLVE_ONLY=1 run_scanner --repo=walkrepo --quiet
+expected="$(cd "$SANDBOX/grand/walkrepo" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == "$expected" ]]; then
+  pass "walk-up (resolved $OUT)"
+else
+  fail "walk-up (rc=$RC out='$OUT' expected='$expected')"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. env-override-wins: repo exists nested AND under an env root -> env wins
+# ---------------------------------------------------------------------------
+mkdir -p "$FAKEWS/envrepo" "$SANDBOX/envroots/rootA/envrepo"
+LEGAL_SCAN_RESOLVE_ONLY=1 LEGAL_SCAN_REPO_ROOTS="$SANDBOX/envroots/rootA" \
+  run_scanner --repo=envrepo --quiet
+expected="$(cd "$SANDBOX/envroots/rootA/envrepo" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == "$expected" ]]; then
+  pass "env-override-wins (resolved $OUT)"
+else
+  fail "env-override-wins (rc=$RC out='$OUT' expected='$expected')"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. env semicolon list: repo only under the second of two roots
+# ---------------------------------------------------------------------------
+mkdir -p "$SANDBOX/envroots/rootB/semirepo"
+LEGAL_SCAN_RESOLVE_ONLY=1 \
+  LEGAL_SCAN_REPO_ROOTS="$SANDBOX/envroots/rootA;$SANDBOX/envroots/rootB" \
+  run_scanner --repo=semirepo --quiet
+expected="$(cd "$SANDBOX/envroots/rootB/semirepo" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == "$expected" ]]; then
+  pass "env semicolon-separated roots (resolved $OUT)"
+else
+  fail "env semicolon-separated roots (rc=$RC out='$OUT' expected='$expected')"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. env-set-but-missing: env set, repo exists nested but NOT under env roots
+#    -> exit 2 (no fallthrough to defaults), candidates listed
+# ---------------------------------------------------------------------------
+mkdir -p "$FAKEWS/nestedonly"
+LEGAL_SCAN_RESOLVE_ONLY=1 LEGAL_SCAN_REPO_ROOTS="$SANDBOX/envroots/rootA" \
+  run_scanner --repo=nestedonly --quiet
+if [[ $RC -eq 2 && "$ERR" == *"ERROR: Repository not found: nestedonly"* \
+      && "$ERR" == *"$SANDBOX/envroots/rootA/nestedonly"* ]]; then
+  pass "env-set-but-missing refuses with exit 2 + candidates"
+else
+  fail "env-set-but-missing (rc=$RC err='$ERR')"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. not-found: no env, repo nowhere -> exit 2, candidates listed
+# ---------------------------------------------------------------------------
+LEGAL_SCAN_RESOLVE_ONLY=1 run_scanner --repo=no-such-repo --quiet
+if [[ $RC -eq 2 && "$ERR" == *"ERROR: Repository not found: no-such-repo"* \
+      && "$ERR" == *"Candidates tried:"* ]]; then
+  pass "not-found exit 2 + candidates listed"
+else
+  fail "not-found (rc=$RC err='$ERR')"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. --all with no submodules and no env -> exit 2 (never pass scanning nothing)
+# ---------------------------------------------------------------------------
+LEGAL_SCAN_RESOLVE_ONLY=1 run_scanner --all --quiet
+if [[ $RC -eq 2 && "$ERR" == *"ERROR: --all found no repositories to scan"* ]]; then
+  pass "--all empty enumeration refuses with exit 2"
+else
+  fail "--all empty enumeration (rc=$RC err='$ERR')"
+fi
+
+# ---------------------------------------------------------------------------
+# 9. --all with env roots -> enumerates child dirs holding a .git entry
+#    (rootA: gitrepo1 [.git dir], nogit [no .git]; rootB: gitrepo2 [.git file])
+# ---------------------------------------------------------------------------
+mkdir -p "$SANDBOX/envroots/rootA/gitrepo1/.git" \
+         "$SANDBOX/envroots/rootA/nogit" \
+         "$SANDBOX/envroots/rootB/gitrepo2"
+echo "gitdir: elsewhere" > "$SANDBOX/envroots/rootB/gitrepo2/.git"
+LEGAL_SCAN_RESOLVE_ONLY=1 \
+  LEGAL_SCAN_REPO_ROOTS="$SANDBOX/envroots/rootA;$SANDBOX/envroots/rootB" \
+  run_scanner --all --quiet
+exp1="$(cd "$SANDBOX/envroots/rootA/gitrepo1" && pwd)"
+exp2="$(cd "$SANDBOX/envroots/rootB/gitrepo2" && pwd)"
+if [[ $RC -eq 0 && "$OUT" == *"$exp1"* && "$OUT" == *"$exp2"* \
+      && "$OUT" != *"nogit"* ]]; then
+  pass "--all with env roots enumerates .git children only"
+else
+  fail "--all with env roots (rc=$RC out='$OUT')"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Problem

`scripts/legal/legal-sanity-scan.sh` anchors `WORKSPACE_ROOT` to the workspace-hub checkout (correct — the global `.legal-deny-list.yaml` lives there), but:

- `--repo=<name>` resolved ONLY `$WORKSPACE_ROOT/<name>`, so sibling checkouts (repos beside workspace-hub, e.g. `D:\ws\llm-wiki-acma`) failed loud with exit 2.
- `--all` enumerated `git submodule foreach`; on a sibling layout it finds zero submodules, scans **nothing**, and exits 0 — a silent pass on a legal gate.

## Fix (resolution only — deny-list and scanning logic untouched)

Shared resolver used by `--repo` and `--all`:

1. **`LEGAL_SCAN_REPO_ROOTS` wins when set** — semicolon- or newline-separated roots (semicolons because `:` collides with Windows drive letters under git-bash). Names resolve only against the listed roots, in order; no match → exit 2 listing every candidate tried (env set = caller took explicit control; no fallthrough to defaults).
2. **Defaults, in order:** nested `$WORKSPACE_ROOT/<name>` (byte-for-byte original behavior when present) → sibling `$(dirname WORKSPACE_ROOT)/<name>` → bounded walk-up from `WORKSPACE_ROOT` (max 8 levels).
3. No match → same `ERROR: Repository not found` shape as before, now listing all candidates tried, exit 2.

`--all`:

- Non-empty submodule enumeration → today's behavior kept.
- Empty enumeration + `LEGAL_SCAN_REPO_ROOTS` set → scans immediate child directories of each listed root that contain a `.git` entry.
- Empty enumeration and no env → **explicit error, exit 2** — a legal scan must never pass by scanning nothing.

Also adds `LEGAL_SCAN_RESOLVE_ONLY=1`, a minimal dry-run hook that prints resolved path(s) and exits 0 before scanning (used by the tests).

## Tests

- `tests/legal/test_repo_resolution.sh` — sandboxed bash suite: nested-wins, sibling-fallback, walk-up, env-override-wins, semicolon multi-root, env-set-but-missing → exit 2, not-found → exit 2, `--all` empty enumeration → exit 2, `--all` with env roots enumerates `.git` children only. **9/9 passing** under git-bash on Windows.
- `tests/legal/test_repo_resolution.py` — pytest wrapper (probes `%ProgramFiles%\Git\bin\bash.exe` then PATH, avoids the WSL `System32\bash.exe` launcher; `pytest.skip` with reason when bash is absent). Passing.

## Context

Required by vamseeachanta/llm-wiki-acma#299 (plan r2): the legal scan is a mandatory **publish gate** for `publish-hf` — the gate refuses without a legal-scan receipt, and on sibling layouts the scanner could not resolve target repos at all (and `--all` silently passed). This PR is on the critical path to that issue's first real publish.
