### PR TITLE
feat(readiness): Phase 3 — agy readiness probes, cost tracking, statusline

### DIFF
--- a/scripts/productivity/sections/ai-usage-summary.sh
+++ b/scripts/productivity/sections/ai-usage-summary.sh
@@ -178,6 +178,8 @@ ALIAS_MAP = {
     "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5",
+    "gemini 3.1 pro (high)": "gemini-3.1-pro-preview",
+    "gemini 3.1 pro": "gemini-3.1-pro-preview",
 }
 
 def _load_registry_ctx():
@@ -225,12 +227,10 @@ codex_model  = read_toml_key(codex_src, "model") or "not set"
 codex_effort = read_toml_key(codex_src, "model_reasoning_effort") or "—"
 rows.append(("codex", codex_model, ctx_label(codex_model), f"effort={codex_effort}", codex_src.name))
 
-# ── Gemini ────────────────────────────────────────────────────────────────────
-gemini_cfg   = read_json(home / ".gemini/settings.json")
-gemini_model = (gemini_cfg.get("model") or {}).get("name") or str(gemini_cfg.get("model") or "not set")
-gemini_thinking = gemini_cfg.get("thinking", {})
-gemini_effort = f"thinking_budget={gemini_thinking.get('budget','—')}" if gemini_thinking else "—"
-rows.append(("gemini", gemini_model, ctx_label(gemini_model), gemini_effort, "~/.gemini/settings.json"))
+# ── Agy (Antigravity, Gemini-backed — routed third lane since #3573) ─────────
+agy_cfg   = read_json(home / ".gemini/antigravity-cli/settings.json")
+agy_model = (agy_cfg.get("model") or {}).get("name") or str(agy_cfg.get("model") or "not set")
+rows.append(("agy", agy_model, ctx_label(agy_model), "—", "~/.gemini/antigravity-cli/settings.json"))
 
 print("| Provider | Model | Context | Effort/Thinking | Config Source |")
 print("|----------|-------|---------|-----------------|---------------|")

--- a/scripts/readiness/ai-agent-readiness.sh
+++ b/scripts/readiness/ai-agent-readiness.sh
@@ -70,7 +70,7 @@ echo "--- AI agent readiness: ${RUN_TS} ---"
 # ─────────────────────────────────────────────────────────────────────────────
 # 1. Per-agent: presence + version check
 # ─────────────────────────────────────────────────────────────────────────────
-AGENTS=(claude codex gemini)
+AGENTS=(claude codex gemini agy)  # gemini = legacy soak probe; agy = routed third lane (#3573)
 
 for agent in "${AGENTS[@]}"; do
   cli_min=$(_yaml_get "$agent" "cli_min")
@@ -86,6 +86,7 @@ for agent in "${AGENTS[@]}"; do
     claude)  raw_version=$(claude --version 2>/dev/null | head -1 || true) ;;
     codex)   raw_version=$( codex --version 2>/dev/null | head -1 || true) ;;
     gemini)  raw_version=$(gemini --version 2>/dev/null | head -1 || true) ;;
+    agy)     raw_version=$(agy --version 2>/dev/null | head -1 || true) ;;
   esac
 
   parsed_version=$(printf '%s' "$raw_version" \

--- a/scripts/readiness/ai-agent-versions.yaml
+++ b/scripts/readiness/ai-agent-versions.yaml
@@ -19,5 +19,15 @@ codex:
   default_model: "gpt-5.5"
 
 gemini:
+  # LEGACY (#3573): retired from worker/reviewer routing; probed through the
+  # soak window only. agy (below) is the routed Gemini surface.
   cli_min: "0.27.0"
   default_model: "gemini-2.5-pro"
+
+agy:
+  # Antigravity CLI — third worker/reviewer provider (#3573). Fleet as of
+  # 2026-07-17: 1.1.3 (ace-linux-1). default_model tracks
+  # model-registry latest_models.agy_primary (persisted as a display label
+  # in ~/.gemini/antigravity-cli/settings.json, #3086).
+  cli_min: "1.0.0"
+  default_model: "gemini-3.1-pro"

--- a/scripts/readiness/provider-cost-tracker.sh
+++ b/scripts/readiness/provider-cost-tracker.sh
@@ -79,6 +79,8 @@ FALLBACK_PRICING = {
     ("codex",  ""):        (2.00,   8.00),
     ("gemini", "pro"):     (1.25,   5.00),
     ("gemini", "flash"):   (0.15,   0.60),
+    ("agy",    "pro"):     (1.25,   5.00),   # Antigravity, Gemini-backed (#3573)
+    ("agy",    "flash"):   (0.15,   0.60),
     ("openai", "gpt-4"):   (2.00,   8.00),
 }
 DEFAULT_RATE = (3.00, 15.00)
@@ -153,6 +155,8 @@ def infer_provider_model(last_msg):
     m = last_msg.lower()
     if re.search(r'\bcodex\b|o4-mini|openai codex', m):
         return "codex", "codex-cli"
+    if re.search(r'\bagy\b|antigravity', m):
+        return "agy", "gemini-3-1-pro"
     if re.search(r'\bgemini\b', m):
         return "gemini", "gemini-pro"
     if re.search(r'\bfable\b|\bmythos\b', m):

--- a/scripts/readiness/provider_harness_parity.py
+++ b/scripts/readiness/provider_harness_parity.py
@@ -19,7 +19,8 @@ CAPABILITIES = ("memory:read", "skills:invoke", "workflow:gates")
 
 EXPECTED_DIVERGENCE_REASONS = {
     "external_skill_dirs_configured",
-    # gemini (agy) is router-first-class but dispatch-unsupported (#3190): no local
+    # The "gemini" row = the Gemini surface (agy since #3573; headless dispatch #3207).
+    # Skill dispatch remains unsupported on that surface: no local
     # skill adapter — a known, accepted gap, not a defect.
     "gemini_skill_dispatch_unsupported",
 }
@@ -180,7 +181,8 @@ def _skills_invoke(provider: str, workspace: Path, home: Path, installed: bool) 
             return _cap("expected_divergence", "external_skill_dirs_configured")
         return _cap("absent", "hermes_skill_registry_missing")
     if provider == "gemini":
-        # agy is router-first-class but dispatch-unsupported (#3190): no local skill
+        # Gemini surface = agy (#3573; headless dispatch #3207). Skill dispatch remains
+        # unsupported there: no local skill
         # adapter — an explicit, accepted divergence (not a defect).
         return _cap("expected_divergence", "gemini_skill_dispatch_unsupported")
     return _cap("unknown", "unknown_provider")


### PR DESCRIPTION
Part of #3573 (Phase 3 of 3; Phases 1–2 = #3574/#3575, merged).

## What
- **ai-agent-readiness.sh** probes `agy --version` (fleet 1.1.3); gemini stays as a legacy soak probe
- **ai-agent-versions.yaml**: agy floor 1.0.0; default model tracks `latest_models.agy_primary`
- **provider-cost-tracker.sh**: agy pricing rows + `agy|antigravity` session classifier (gemini classifier kept so legacy sessions still parse)
- **ai-usage-summary.sh**: statusline provider row is now **agy** (reads `~/.gemini/antigravity-cli/settings.json`, maps the display-label model to its context window) — ties #3087
- **provider_harness_parity.py**: stale #3190 comments corrected. The parity/equality row key **stays `gemini`** on purpose — it denotes the Gemini surface (agy since #3573), and per-host equality snapshots key on it; renaming is a cross-machine schema migration filed as a follow-on issue.

## Ops already applied (label migration)
`agent:agy` created; 5 open `agent:gemini` issues relabeled (#1962 #2003 #2005 #2006 #2733); `agent:gemini` description marked DEPRECATED. Code dual-reads both labels during the soak (Phase 1).

## Verification
- `tests/readiness/test_provider_harness_parity.py`: 20/20
- bash -n / py_compile / YAML parse clean on all touched files

## Not in this PR
Equality-matrix rebuild: the equality pipeline re-greens via cron (`feedback_dev_primary_equality_green_is_self_healing`); the gemini→agy row rename lands with the schema-migration follow-on.