### PR TITLE
feat(tmux): reboot survival via resurrect+continuum, 50k scrollback

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -42,5 +42,24 @@ set -g renumber-windows on
 # Faster escape (important for vim/vi users)
 set -sg escape-time 10
 
-# Increase scrollback
-set -g history-limit 10000
+# Increase scrollback (generous — long autonomous logs)
+set -g history-limit 50000
+
+# ---- Reboot survival: tmux-resurrect + tmux-continuum --------------------
+# Sessions already survive disconnects (tmux server) and logouts (systemd
+# linger), but NOT reboots. These plugins autosave session layout/cwd every
+# 15 min and restore it when the tmux server first starts after boot.
+#
+# One-time install per machine (no TPM needed):
+#   git clone https://github.com/tmux-plugins/tmux-resurrect ~/.tmux/plugins/tmux-resurrect
+#   git clone https://github.com/tmux-plugins/tmux-continuum ~/.tmux/plugins/tmux-continuum
+#
+# Machines without the plugins skip this block silently.
+set -g @resurrect-capture-pane-contents 'on'
+set -g @continuum-save-interval '15'
+set -g @continuum-restore 'on'
+# Load order matters: continuum depends on resurrect's save/restore scripts.
+if-shell "[ -r ~/.tmux/plugins/tmux-resurrect/resurrect.tmux ]" \
+  "run-shell ~/.tmux/plugins/tmux-resurrect/resurrect.tmux"
+if-shell "[ -r ~/.tmux/plugins/tmux-continuum/continuum.tmux ]" \
+  "run-shell ~/.tmux/plugins/tmux-continuum/continuum.tmux"


### PR DESCRIPTION
## What
Two additions to the shared fleet tmux config (`config/tmux/tmux.conf`, symlinked to `~/.tmux.conf` on each box):

1. **Scrollback 10000 → 50000** — matches the newer `setup-remote-access.sh` default; cheap insurance for long autonomous logs.
2. **Reboot survival** — guarded load of `tmux-resurrect` + `tmux-continuum`: autosaves session layout/cwd every 15 min, auto-restores on first tmux server start after a reboot. Completes the persistence stack: disconnects (tmux) → logouts (systemd linger) → **reboots (this PR)**.

## Safety
- `if-shell` guards: machines **without** the plugins skip the block silently — merging this breaks nothing anywhere.
- Per-box opt-in = two `git clone` one-liners, documented inline in the conf.

## Verified on ace-linux-1
- Plugins installed; config smoke-tested on an isolated tmux server (`-L cfgtest`): loads clean, `history-limit 50000`, resurrect keybindings live (`prefix C-s` save / `prefix C-r` restore).
- Continuum's autosave hook correctly deferred in the test because another (the real) tmux server was running — that's continuum's intended multi-server guard; it engages on a normal single-server start.

## Note
Takes effect per box after repo pull, at next tmux **server** start (existing servers keep old settings until restarted).