### PR TITLE
fix(hf): enforce and verify dataset visibility on every publish (#3483)

### DIFF
--- a/.claude/skills/data/hf-dataset-publishing/SKILL.md
+++ b/.claude/skills/data/hf-dataset-publishing/SKILL.md
@@ -146,8 +146,13 @@ assume failure.** Once `/is-valid` reports valid and `/rows` returns data, the v
   - Public-domain **federal** data (BSEE / NOAA / USGS) → **public**, `license: cc-by-4.0`.
   - **Vendor-licensed / private / client** data → must **NOT** be published to a public HF
     dataset. A **private** repo is OK only with **explicit owner** sign-off.
-  - **Synthetic / own-analysis** output → publisher's choice.
+  - **Synthetic / own-analysis** output → publisher's choice. Calculations *derived from*
+    codes and standards are own analysis, not republished standard text — publishable.
   - If unsure of the source's provenance, default to **private** and ask the owner.
+  - **Visibility is enforced on every publish, not just at creation** (workspace-hub#3483).
+    Re-publishing with `--public` now flips an existing private dataset, and the tool reads
+    the visibility back off the remote and exits non-zero if it disagrees with what you
+    asked for. The manual `update_repo_settings(...)` workaround is no longer needed.
 
 ## DATA-QUALITY GATE (load-bearing — do not skip)
 

--- a/scripts/hf/save_results_to_hf.py
+++ b/scripts/hf/save_results_to_hf.py
@@ -17,7 +17,8 @@ Design goals (why this is generic):
     deeper is JSON-stringified (lossless).
   * Sanitizes NaN/inf -> null. Writes parquet (HF datasets-server auto-renders it).
   * Emits a dataset card with a viewer `configs:` block + sha256 provenance.
-  * PRIVATE by default (fail-safe); --public only for redistributable data.
+  * PRIVATE by default (fail-safe); --public only for redistributable data. Visibility is
+    enforced on every publish and read back off the remote, not just set at creation.
   * Verifies via list_repo_files + the datasets-server /is-valid API.
 
 DATA-QUALITY REMINDER (printed at the end): faithful-to-source != correct. A generic
@@ -58,6 +59,47 @@ def trigger_deploy_hook(enabled=True, url_env=DEPLOY_HOOK_ENV, timeout=15):
         print(f"deploy-hook: trigger failed ({e.__class__.__name__}: {e}) — "
               "publish still succeeded")
         return None
+
+
+def ensure_visibility(api, repo_id, public):
+    """Force the remote's visibility to match what the caller asked for (workspace-hub#3483).
+
+    `create_repo(..., private=..., exist_ok=True)` only applies `private=` when it actually
+    CREATES the repo. On a repo that already exists it is a silent no-op, so a dataset first
+    published private and re-published with --public stayed private while the tool printed
+    PUBLIC. Call this unconditionally after create_repo — it is idempotent, so there is no
+    need to know whether the repo pre-existed.
+
+    `api` is duck-typed on purpose: huggingface_hub is imported lazily inside main(), and
+    keeping this function free of that import is what lets the tests exercise it without
+    the package installed. Older hub versions expose update_repo_visibility instead of
+    update_repo_settings.
+    """
+    private = not public
+    if hasattr(api, "update_repo_settings"):
+        api.update_repo_settings(repo_id=repo_id, repo_type="dataset", private=private)
+    elif hasattr(api, "update_repo_visibility"):  # hub < 0.25
+        api.update_repo_visibility(repo_id=repo_id, repo_type="dataset", private=private)
+    else:
+        sys.exit("VISIBILITY: this huggingface_hub exposes neither update_repo_settings nor "
+                 "update_repo_visibility — cannot guarantee the dataset's visibility. Upgrade "
+                 "huggingface_hub and retry (see workspace-hub#3483).")
+    return private
+
+
+def verify_visibility(api, repo_id, public):
+    """Read the visibility back off the remote and fail loudly if it disagrees.
+
+    The tool already refuses to trust `upload_folder`'s return value and re-checks the files
+    with list_repo_files; visibility gets the same treatment. #3483 went unnoticed for a day
+    precisely because the tool printed its INTENT ("PUBLIC") rather than an observation.
+    """
+    actual_private = bool(getattr(api.dataset_info(repo_id), "private", False))
+    if actual_private is not (not public):
+        sys.exit(f"VISIBILITY FAILED: asked for {'PUBLIC' if public else 'PRIVATE'} but "
+                 f"{repo_id} is {'PRIVATE' if actual_private else 'PUBLIC'} on the remote. "
+                 "Do not treat this dataset as published (see workspace-hub#3483).")
+    return actual_private
 
 
 def _flatten(rec, prefix="", out=None):
@@ -305,6 +347,10 @@ def main():
     try:
         api.create_repo(repo_id=args.repo_id, repo_type="dataset",
                         private=not args.public, exist_ok=True)
+        # create_repo's private= is create-time only, so it is a no-op on an existing
+        # repo. Force it explicitly (workspace-hub#3483). Inside this try so a read-only
+        # token still gets the WRITE-scope diagnosis below rather than a raw 401/403.
+        ensure_visibility(api, args.repo_id, args.public)
         info = api.upload_folder(
             folder_path=str(out), repo_id=args.repo_id, repo_type="dataset",
             commit_message=f"results via save_results_to_hf.py ({args.source_repo or 'n/a'})")
@@ -315,8 +361,11 @@ def main():
                      "Create a WRITE token at https://huggingface.co/settings/tokens and retry.")
         raise
     rev = getattr(info, "oid", None) or getattr(info, "commit_id", None)
+    # Report what the REMOTE says, not what we asked for — exits non-zero on a mismatch.
+    actual_private = verify_visibility(api, args.repo_id, args.public)
     print(f"published: https://huggingface.co/datasets/{args.repo_id}  "
-          f"({'PUBLIC' if args.public else 'PRIVATE'})  revision={rev}")
+          f"({'PRIVATE' if actual_private else 'PUBLIC'} — confirmed on remote)  "
+          f"revision={rev}")
     # Verify the bytes actually landed (don't just trust the upload return).
     files = set(api.list_repo_files(repo_id=args.repo_id, repo_type="dataset", revision=rev))
     expected = {"README.md"} | {f"{t}.parquet" for t in tables_meta}

--- a/tests/hf/test_save_results_to_hf.py
+++ b/tests/hf/test_save_results_to_hf.py
@@ -112,3 +112,92 @@ def test_trigger_deploy_hook_never_raises_on_failure(monkeypatch):
     monkeypatch.setattr(srhf.urllib.request, "urlopen", boom)
     # a failed rebuild trigger must NEVER fail an otherwise-successful publish
     assert srhf.trigger_deploy_hook() is None
+
+
+# --- visibility enforcement (workspace-hub#3483) -------------------------------------
+# create_repo(private=..., exist_ok=True) only applies private= at CREATION, so an
+# existing dataset kept its old visibility while the tool printed the requested one.
+
+
+class _FakeApi:
+    """Duck-typed stand-in for HfApi — no huggingface_hub import needed."""
+
+    def __init__(self, private=True):
+        self._private = private
+        self.calls = []
+
+    def update_repo_settings(self, repo_id, repo_type, private):
+        self.calls.append(("settings", repo_id, repo_type, private))
+        self._private = private
+
+    def dataset_info(self, repo_id):
+        return type("Info", (), {"private": self._private})()
+
+
+class _LegacyApi:
+    """Older hub (< 0.25): exposes update_repo_visibility and NOT update_repo_settings.
+
+    Deliberately does not inherit _FakeApi — inheriting would leave update_repo_settings
+    resolvable via the MRO, so hasattr() would still find it and the fallback branch
+    would never be exercised.
+    """
+
+    def __init__(self, private=True):
+        self._private = private
+        self.calls = []
+
+    def update_repo_visibility(self, repo_id, repo_type, private):
+        self.calls.append(("visibility", repo_id, repo_type, private))
+        self._private = private
+
+    def dataset_info(self, repo_id):
+        return type("Info", (), {"private": self._private})()
+
+
+def test_ensure_visibility_flips_existing_private_repo_to_public():
+    api = _FakeApi(private=True)  # dataset already exists, and is private
+    srhf.ensure_visibility(api, "aceengineer/x", public=True)
+    assert api.calls == [("settings", "aceengineer/x", "dataset", False)]
+
+
+def test_ensure_visibility_enforces_private_rather_than_relying_on_default():
+    api = _FakeApi(private=False)  # already public; --public NOT passed
+    srhf.ensure_visibility(api, "aceengineer/x", public=False)
+    # private-by-default is a fail-safe only if it is actually asserted on the remote
+    assert api.calls == [("settings", "aceengineer/x", "dataset", True)]
+
+
+def test_ensure_visibility_falls_back_to_update_repo_visibility_on_older_hub():
+    api = _LegacyApi(private=True)
+    assert not hasattr(api, "update_repo_settings")
+    srhf.ensure_visibility(api, "aceengineer/x", public=True)
+    assert api.calls == [("visibility", "aceengineer/x", "dataset", False)]
+
+
+def test_ensure_visibility_exits_when_no_visibility_api_exists():
+    class _Ancient:
+        pass
+    with pytest.raises(SystemExit) as e:
+        srhf.ensure_visibility(_Ancient(), "aceengineer/x", public=True)
+    assert "VISIBILITY" in str(e.value)
+
+
+def test_verify_visibility_returns_actual_when_it_matches():
+    api = _FakeApi(private=False)
+    assert srhf.verify_visibility(api, "aceengineer/x", public=True) is False
+
+
+def test_verify_visibility_exits_when_remote_disagrees():
+    # the #3483 failure mode: asked for public, remote is still private
+    api = _FakeApi(private=True)
+    with pytest.raises(SystemExit) as e:
+        srhf.verify_visibility(api, "aceengineer/x", public=True)
+    msg = str(e.value)
+    assert "VISIBILITY FAILED" in msg and "PRIVATE" in msg
+
+
+def test_ensure_then_verify_is_the_fixed_path():
+    # end to end on the duck-typed api: the flip makes the readback agree
+    api = _FakeApi(private=True)
+    srhf.ensure_visibility(api, "aceengineer/x", public=True)
+    assert srhf.verify_visibility(api, "aceengineer/x", public=True) is False


### PR DESCRIPTION
Closes #3483. Plan approved on the issue 2026-07-28.

## The bug

`scripts/hf/save_results_to_hf.py` created the repo with `private=not args.public, exist_ok=True` and never touched visibility again. `create_repo`'s `private=` only applies when it actually **creates** the repo — on one that already exists it is a silent no-op. So a dataset first published private and re-published with `--public` stayed private while the tool printed `PUBLIC`. Confirmed live on `aceengineer/digitalmodel-diffraction-rao` (2026-07-12) and worked around by hand.

## The fix

**`ensure_visibility(api, repo_id, public)`** — forces the requested visibility immediately after `create_repo`. Idempotent, so it does not need to know whether the repo pre-existed. Falls back to `update_repo_visibility` for hub < 0.25, and exits loudly if neither API is present rather than publishing with unknown visibility.

**`verify_visibility(api, repo_id, public)`** — reads visibility back off the remote via `dataset_info(...).private` and exits non-zero if it disagrees with what was asked for. The `published:` line now reports what the remote says, marked `confirmed on remote`.

The readback is the part worth arguing for. The issue's minimal fix — add the `update_repo_settings` call — is correct and sufficient to stop *this* bug. But this bug was invisible for a day because the tool printed its **intent** as though it were an **observation**, and the same file already rejects that pattern twenty lines later: it refuses to trust `upload_folder`'s return and re-checks with `list_repo_files`. Visibility now gets the same treatment, which is what stops the class of bug rather than the instance.

Both calls sit inside the existing `try`, so a read-only token still produces the actionable "token lacks WRITE scope" diagnosis instead of a raw 401/403.

## Tests

7 new, network-free, against a duck-typed fake `api` — no `huggingface_hub` import, matching the existing file's style (the package is not in this repo's env, which is why the tool imports it lazily inside `main()`):

- existing **private** repo + `--public` → asserts `update_repo_settings(private=False)` is called (the test the issue asked for)
- `--public` omitted on an existing **public** repo → asserts `private=True` is actively enforced, not merely defaulted
- older hub exposing only `update_repo_visibility` → asserts the fallback is taken. The fake deliberately does not inherit from the modern fake; inheriting would leave `update_repo_settings` resolvable through the MRO and the fallback branch would never run
- neither API present → asserts a `SystemExit`
- readback matches → returns actual visibility; readback disagrees → `SystemExit` naming both the requested and actual state
- ensure-then-verify end to end

`uv run --with pandas pytest tests/hf/ -q` → **20 passed**.

`--with pandas` is needed because `test_numeric_stats_reports_min_max_nulls` imports pandas and this repo does not declare it. That test **already fails on unmodified `main`** for the same reason (12 passed, 1 failed on the baseline) — pre-existing dev-dependency gap, not a regression from this PR, and left alone here rather than widened into a deps change.

## Docs

One line in `.claude/skills/data/hf-dataset-publishing/SKILL.md` recording that visibility is now enforced and verified on every publish, so the manual `update_repo_settings` workaround can be dropped. Also records the owner directive of 2026-07-28 that calculations derived from codes and standards are own analysis and publishable — the routing section previously left that ambiguous.

## Not in scope

`--public` on a **new** repo was already correct; only the existing-repo path changes. No change to deploy-hook behavior — batch publishing uses `--no-deploy-hook` per the decision recorded on aceengineer-website#97.

## Why now

Step 1 of the capability-promotion program (aceengineer-website#97). ~15 grouped datasets publish through this tool; several target dataset ids that already exist, which is exactly the path this bug breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
