### PR TITLE
fix(hf): don't let a top-level section map swallow the whole file (#3699)

### DIFF
--- a/scripts/hf/save_results_to_hf.py
+++ b/scripts/hf/save_results_to_hf.py
@@ -120,8 +120,32 @@ def _is_list_of_dicts(v):
     return isinstance(v, list) and len(v) > 0 and all(isinstance(x, dict) for x in v)
 
 
+def _contains_nested_table(d):
+    """True if any value of `d` is itself table-shaped (a list-of-dicts, or a dict whose
+    values are lists-of-dicts). Such a dict is a SECTION MAP, not a row set."""
+    for v in d.values():
+        if _is_list_of_dicts(v):
+            return True
+        if isinstance(v, dict) and any(_is_list_of_dicts(x) for x in v.values()):
+            return True
+    return False
+
+
 def _is_dict_of_dicts(v):
-    return isinstance(v, dict) and len(v) > 0 and all(isinstance(x, dict) for x in v.values())
+    """A dict whose values are all dicts AND which holds no nested tables.
+
+    The second condition matters (workspace-hub#3699). A results file commonly looks like
+    {"meta": {...}, "min_wall_pass": {...}, "series": {"DNV-ST-F101": [rows...], ...}} —
+    every top-level value is a dict, so without the guard the WHOLE FILE collapses into one
+    row-per-section table, the real per-series tables are never found, and the mixed column
+    types that produces fail parquet conversion outright.
+
+    Keeps the plain case intact: {"w1": {"depth": 10}, "w2": {"depth": 20}} holds only
+    scalars, so it is still read as one table of two rows.
+    """
+    if not (isinstance(v, dict) and len(v) > 0 and all(isinstance(x, dict) for x in v.values())):
+        return False
+    return not _contains_nested_table(v)
 
 
 def discover_tables(obj, name=""):

--- a/tests/hf/test_save_results_to_hf.py
+++ b/tests/hf/test_save_results_to_hf.py
@@ -201,3 +201,48 @@ def test_ensure_then_verify_is_the_fixed_path():
     api = _FakeApi(private=True)
     srhf.ensure_visibility(api, "aceengineer/x", public=True)
     assert srhf.verify_visibility(api, "aceengineer/x", public=True) is False
+
+
+# --- section maps vs row sets (workspace-hub#3699) ------------------------------------
+# A dict whose values are all dicts is only a table if it holds no nested tables.
+
+
+def test_section_map_with_nested_series_is_not_one_table():
+    # the real shape from digitalmodel/docs/api/structural/wall-thickness-explorer.json
+    doc = {
+        "meta": {"od_mm": 273.0, "grade": "X65"},
+        "min_wall_pass": {"DNV-ST-F101": 19.5, "DNV-ST-F201": 8.0},
+        "series": {
+            "DNV-ST-F101": [{"w": 8.0, "u": 8.7}, {"w": 8.5, "u": 7.9}],
+            "DNV-ST-F201": [{"w": 8.0, "u": 0.59}],
+        },
+    }
+    t = srhf.discover_tables(doc)
+    # must NOT collapse the file into a single records table
+    assert "records" not in t
+    # each series is its own table, found by recursing past the section map
+    assert t["series.DNV-ST-F101"] == [{"w": 8.0, "u": 8.7}, {"w": 8.5, "u": 7.9}]
+    assert len(t["series.DNV-ST-F201"]) == 1
+
+
+def test_section_map_does_not_mix_scalar_and_list_into_one_column():
+    # the exact parquet failure: DNV-ST-F101 held a float in one row and a
+    # JSON-stringified list in another, giving an unconvertible object column
+    doc = {"min_wall_pass": {"A": 19.5}, "series": {"A": [{"w": 1.0}]}}
+    t = srhf.discover_tables(doc)
+    for rows in t.values():
+        for row in rows:
+            for col, val in row.items():
+                assert not isinstance(val, dict), f"{col} still nested"
+
+
+def test_plain_dict_of_dicts_is_still_one_table():
+    # regression guard: the documented behaviour must not change
+    t = srhf.discover_tables({"w1": {"depth": 10}, "w2": {"depth": 20}})
+    assert "records" in t and {r["_id"] for r in t["records"]} == {"w1", "w2"}
+
+
+def test_contains_nested_table_detects_both_shapes():
+    assert srhf._contains_nested_table({"s": [{"a": 1}]})            # list-of-dicts
+    assert srhf._contains_nested_table({"s": {"k": [{"a": 1}]}})     # dict-of-lists-of-dicts
+    assert not srhf._contains_nested_table({"s": {"a": 1}})          # plain scalars


### PR DESCRIPTION
Closes #3699. Blocks the C1 publishing wave (aceengineer-website#97, digitalmodel#1646).

## The bug

`discover_tables()` treated any dict-of-dicts as a row set. A results file commonly looks like:

```json
{ "meta": {...}, "code_reference": {...}, "min_wall_pass": {...},
  "series": { "DNV-ST-F101": [ {...}, ... ], ... } }
```

Every top-level value is a dict, so the **whole file collapsed into one 4-row table**, one row per section, and the six real tables inside `series` were never found. The resulting `DNV-ST-F101` column held a float from `min_wall_pass` in one row and a JSON-stringified list from `series` in another:

```
ArrowTypeError: Expected bytes, got a 'float' object
```

The crash is lucky. Had it converted, we'd have silently published one meaningless 4-row table instead of six 41-row tables — and nothing downstream would have flagged it.

## The fix

A dict-of-dicts is a table only when it holds no nested tables; otherwise it's a section map and we recurse. `_contains_nested_table()` checks both shapes that indicate this — a value that is a list-of-dicts, or a dict whose values are lists-of-dicts.

The documented plain case is untouched: `{"w1": {"depth": 10}, "w2": {"depth": 20}}` holds only scalars, so it remains one table of two rows. That's asserted by a regression test rather than assumed.

## Verified against the file that triggered it

`digitalmodel/docs/api/structural/wall-thickness-explorer.json`, before: exception. After: six per-standard series tables, and the per-column stats are plausible on inspection — wall thickness 8–28 mm, utilisation 0.014–8.4 (>1 means fail, matching the `safe: false` rows), no nulls, no negatives. That eyeball is the data-quality gate the skill requires, done here rather than deferred.

## Tests

4 new, network-free: the real section-map shape yields per-series tables and no `records`; no column mixes a scalar with a nested list; the plain dict-of-dicts regression guard; and `_contains_nested_table` on both nesting shapes.

`uv run --with pandas pytest tests/hf/ -q` → **24 passed**.

## Scope

This shape is common across the ~72 sidecar JSONs under `digitalmodel/docs/api/` that C1 publishes, so it isn't a one-file quirk — it would have hit most of the wave.

Note the two repo-wide gates `Scheduler Mutation Surface Guard` and `strict-scan / authority` are red on every PR here (#3698), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)