### PR TITLE
feat(dispatch): make the write gate real (deckhand#584 slice 2)

### DIFF
--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -283,17 +283,49 @@ def codex_weekly_remaining(override=None):
         return None
 
 
-def lane_quota_demotion(provider, source, remaining_pct, defaults):
-    """Return (provider, demoted). Suspends ONLY the lane-derived codex choice
-    when weekly remaining is strictly below QUOTA_GATE_PCT. ai:/rule codex
-    carries human/rule authority and is never altered; None (unknown quota)
-    fails open. A demoted card keeps provider_explicit=False at the call site,
-    so labels_for() writes no ai: label — demotion leaves no sticky residue.
+#: Carries the SPEND decision, separately from the provider choice (deckhand#584
+#: R9). Without it, an `ai:` label chose the provider AND silently opted out of
+#: the budget guard — one label making two decisions, the second invisible at
+#: the point of labelling.
+QUOTA_OVERRIDE_LABEL = "quota:override"
+
+
+def quota_demotion(provider, source, remaining_pct, defaults, labels=None):
+    """Return (provider, demoted). Suspends a codex choice from ANY source when
+    weekly remaining is strictly below QUOTA_GATE_PCT.
+
+    R9 (deckhand#584, owner 2026-07-30): `ai:` and rule-sourced codex are no
+    longer exempt. The provider choice and the budget bypass are different
+    decisions — "codex does this work better" is about a task, "spend into a
+    suspended pool" is about the month — so they now need different labels.
+    Rule-sourced is demotable too, decided rather than inherited: a capability
+    rule is MACHINE-decided and has even less claim on a budget guard than a
+    human's deliberate `ai:`.
+
+    `QUOTA_OVERRIDE_LABEL` is the only bypass, and it is a spend decision only —
+    it never chooses a provider.
+
+    `None` remaining FAILS OPEN: the gate is an optimisation on top of routing
+    (#3030) and an unreachable quota source must not strand heavy work. That is
+    deliberately the opposite of the write gate's fail-closed posture — the cost
+    of a wrong answer differs in each direction.
+
+    A demoted card keeps provider_explicit=False at the call site, so
+    labels_for() writes no ai: label — demotion leaves no sticky residue. An
+    EXISTING `ai:` label is not removed: it records the operator's intent, while
+    the gate governs this run's execution.
     """
-    if (provider == "codex" and source == "lane"
-            and remaining_pct is not None and remaining_pct < QUOTA_GATE_PCT):
+    if provider != "codex":
+        return provider, False
+    if QUOTA_OVERRIDE_LABEL in (labels or []):
+        return provider, False
+    if remaining_pct is not None and remaining_pct < QUOTA_GATE_PCT:
         return defaults.get("provider"), True
     return provider, False
+
+
+#: Back-compat alias — the old name said "lane" and the restriction is gone.
+lane_quota_demotion = quota_demotion
 
 
 def propose(args) -> list[dict]:
@@ -328,12 +360,16 @@ def propose(args) -> list[dict]:
         provider, provider_explicit, provider_source = resolve_provider(
             labels, assign, defaults)
         quota_demoted = False
-        if provider == "codex" and provider_source == "lane":
+        # R9: NO source restriction here. This call site previously carried its
+        # own `provider_source == "lane"` guard, so relaxing only the function
+        # would have left the exemption fully intact — the fix would look done
+        # and do nothing.
+        if provider == "codex":
             if quota_remaining is _QUOTA_UNSET:  # one quota read per run
                 quota_remaining = codex_weekly_remaining(
                     override=getattr(args, "codex_remaining", None))
-            provider, quota_demoted = lane_quota_demotion(
-                provider, provider_source, quota_remaining, defaults)
+            provider, quota_demoted = quota_demotion(
+                provider, provider_source, quota_remaining, defaults, labels=labels)
         routed_by = "manual" if existing_machine else "rule"
 
         proposals.append({

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -461,7 +461,8 @@ def print_summary(proposals: list[dict]):
     print(f"  *active = concurrent slots allowed now per WIP caps; "
           f"the rest sit dispatch:ready in queue.")
     print("\n\033[2mDRY-RUN — no labels written. `--detail` for per-card, "
-          "`--apply` for Phase B (disabled).\033[0m")
+          f"`--apply` to preview writes; `--apply --yes` with {APPLY_FLAG}=1 to "
+          "actually write.\033[0m")
 
 
 # ---------------------------------------------------------------------------
@@ -557,8 +558,52 @@ def labels_for(p: dict, existing: set[str], skip_domain: bool = False) -> list[s
     return [l for l in out if l not in existing]
 
 
+# ---------------------------------------------------------------------------
+# Write gate (deckhand#584 slice 2).
+#
+# route.py used to PRINT "`--apply` for Phase B (disabled)" while --apply/--yes
+# were real flags reaching a live `gh issue edit --add-label`. The "disabled"
+# lived only in a help string. That is dangerous here specifically because the
+# capability map is known-wrong (routing-rules claims a solver capability for a
+# host that cannot obtain the licence, #579), so an accidental mass-apply would
+# dispatch work into guaranteed failure across hundreds of issues.
+#
+# The gate is an ENVIRONMENT flag, deliberately not a config value: config is
+# committed and diffable, so a flag flipped in a PR could be merged without
+# anyone registering that it armed a mass-write path. An env var has to be set
+# by the person running the command, at the moment they run it.
+# ---------------------------------------------------------------------------
+
+APPLY_FLAG = "DISPATCH_APPLY_ENABLED"
+#: Only these open the gate. Anything else — including "0", "false", "off" and
+#: the empty string — fails closed. A naive truthiness check would treat "0" and
+#: "false" as permission, which is worse than no gate because it reads protected.
+_AFFIRMATIVE = {"1", "true", "yes", "on"}
+
+
+def assert_write_allowed() -> None:
+    """Exit unless the operator explicitly armed writes for this invocation."""
+    value = (os.environ.get(APPLY_FLAG) or "").strip().lower()
+    if value not in _AFFIRMATIVE:
+        sys.exit(
+            f"REFUSED: label writes are gated. Set {APPLY_FLAG}=1 to arm this "
+            f"invocation.\n"
+            f"  Before arming, confirm the capability map is correct — "
+            f"routing-rules.yaml currently claims a solver capability for a host "
+            f"that cannot obtain the licence (deckhand#579), and a mass-apply "
+            f"would route work into guaranteed failure.\n"
+            f"  Run `--coverage` first to see what is actually assigned."
+        )
+
+
 def cmd_apply(proposals: list[dict], repo: str, do_write: bool, batch: int, pace: float):
     import time
+
+    # Gate BEFORE any fetch, label-ensure, or write. Dry-run (--apply without
+    # --yes) is a preview and stays ungated: gating it too would push people to
+    # set the flag habitually, which defeats the gate.
+    if do_write:
+        assert_write_allowed()
     proposals = [p for p in proposals if p["repo"] == repo]
     if not proposals:
         sys.exit(f"no open cards for {repo}")
@@ -676,7 +721,8 @@ def main():
                          "never writes. Buckets: missing/ambiguous/terminal/skipped/routable")
     ap.add_argument("--detail", action="store_true", help="per-card listing")
     ap.add_argument("--apply", action="store_true", help="write GH labels (Phase B)")
-    ap.add_argument("--yes", action="store_true", help="actually write (else apply dry-run)")
+    ap.add_argument("--yes", action="store_true",
+                    help=f"actually write (else apply dry-run); requires {APPLY_FLAG}=1")
     ap.add_argument("--batch", type=int, default=50, help="pace every N writes")
     ap.add_argument("--pace", type=float, default=2.0, help="seconds to sleep per batch")
     ap.add_argument("--codex-remaining", type=float, default=None,

--- a/tests/dispatch/test_route_quota_decoupling.py
+++ b/tests/dispatch/test_route_quota_decoupling.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""TDD tests for R9 — separating the provider choice from the budget bypass.
+
+deckhand#584 slice 3. Owner decision 2026-07-30.
+
+## The defect
+
+`route.py` exempted `ai:`- and rule-sourced codex from the 10% weekly quota gate:
+only a `lane:`-derived choice was demotable. So an `ai:codex` label chose the
+provider AND silently opted the issue out of the spend guard — one label making
+two decisions, the second invisible at the point of labelling.
+
+Those intents genuinely differ. *"Codex does this work better"* is a judgement
+about a task. *"Spend into a suspended pool"* is a judgement about the month.
+
+## After
+
+`ai:` and rule choose the provider; **neither bypasses the gate**. A separate
+`quota:override` label carries the spend decision, explicitly and visibly.
+
+Rule-sourced codex is demotable too, decided rather than inherited: a capability
+rule choosing codex is MACHINE-decided, so it has even less claim on a budget
+guard than a human's deliberate `ai:` label.
+
+## Why now
+
+Zero `ai:` labels exist today, so the exemption has never fired and this change
+costs nothing. The moment slice 4 creates those labels, changing this would mean
+changing the meaning of labels already in use.
+
+Hermetic: pure functions, explicit args, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_route_quota_decoupling.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+
+DEFAULTS = {"provider": "claude"}
+BELOW = 5.0   # strictly below QUOTA_GATE_PCT (10)
+ABOVE = 40.0
+
+
+# --------------------------------------------------------------------------
+# the R9 change: ai: and rule no longer bypass the gate
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule", "default"])
+def test_codex_is_demoted_below_threshold_regardless_of_source(source):
+    """The budget guard applies to everyone.
+
+    Previously only `source == "lane"` was demotable, so an `ai:codex` label was
+    a silent spend-guard bypass.
+    """
+    provider, demoted = R.quota_demotion("codex", source, BELOW, DEFAULTS, labels=[])
+    assert demoted is True
+    assert provider == "claude"
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule"])
+def test_codex_is_not_demoted_above_threshold(source):
+    provider, demoted = R.quota_demotion("codex", source, ABOVE, DEFAULTS, labels=[])
+    assert demoted is False
+    assert provider == "codex"
+
+
+# --------------------------------------------------------------------------
+# quota:override carries the SPEND decision, separately
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule"])
+def test_quota_override_bypasses_the_gate_for_any_source(source):
+    provider, demoted = R.quota_demotion(
+        "codex", source, BELOW, DEFAULTS, labels=["quota:override"]
+    )
+    assert demoted is False
+    assert provider == "codex"
+
+
+def test_quota_override_alone_does_not_choose_a_provider():
+    """It is a SPEND decision, not a routing one. A non-codex provider is untouched."""
+    provider, demoted = R.quota_demotion(
+        "claude", "lane", BELOW, DEFAULTS, labels=["quota:override"]
+    )
+    assert provider == "claude"
+    assert demoted is False
+
+
+def test_ai_label_without_override_is_demoted():
+    """The exact case R9 exists for: quality choice, no spend decision."""
+    provider, demoted = R.quota_demotion(
+        "codex", "ai", BELOW, DEFAULTS, labels=["ai:codex"]
+    )
+    assert demoted is True, "an ai: label must not silently bypass the budget guard"
+    assert provider == "claude"
+
+
+def test_ai_label_with_override_is_not_demoted():
+    """Both decisions made, both visible."""
+    provider, demoted = R.quota_demotion(
+        "codex", "ai", BELOW, DEFAULTS, labels=["ai:codex", "quota:override"]
+    )
+    assert demoted is False
+    assert provider == "codex"
+
+
+# --------------------------------------------------------------------------
+# preserved behaviour — these must not regress
+# --------------------------------------------------------------------------
+
+
+def test_unknown_quota_still_fails_open():
+    """`None` means the quota source was unreachable.
+
+    The gate is an optimisation on top of routing (#3030); an unreachable quota
+    source must never strand heavy work. Fail OPEN here is deliberate and is the
+    opposite of the write gate's fail-closed — different failure costs.
+    """
+    provider, demoted = R.quota_demotion("codex", "ai", None, DEFAULTS, labels=[])
+    assert demoted is False
+    assert provider == "codex"
+
+
+@pytest.mark.parametrize("provider", ["claude", "agy", "hermes"])
+def test_non_codex_providers_are_never_demoted(provider):
+    """The gate is codex-quota specific."""
+    got, demoted = R.quota_demotion(provider, "lane", BELOW, DEFAULTS, labels=[])
+    assert got == provider
+    assert demoted is False
+
+
+def test_threshold_is_strictly_below_not_at():
+    """Preserves the documented `< QUOTA_GATE_PCT` boundary."""
+    at_gate = float(R.QUOTA_GATE_PCT)
+    _, demoted_at = R.quota_demotion("codex", "lane", at_gate, DEFAULTS, labels=[])
+    _, demoted_below = R.quota_demotion("codex", "lane", at_gate - 0.01, DEFAULTS, labels=[])
+    assert demoted_at is False
+    assert demoted_below is True
+
+
+# --------------------------------------------------------------------------
+# the call site must lose its DUPLICATE guard
+# --------------------------------------------------------------------------
+
+
+def test_call_site_does_not_re_restrict_to_lane_source():
+    """`propose()` had its own `provider_source == "lane"` condition.
+
+    Changing only the function would leave the exemption fully intact at the
+    call site — the fix would look done and do nothing. This is the same
+    declared-but-unwired shape as an uncalled safety gate.
+    """
+    import inspect
+
+    # Scan EXECUTABLE lines only. The call site documents the removed guard to
+    # explain why relaxing the function alone was insufficient, and a raw
+    # substring scan would flag that explanation as the defect. (Fourth time
+    # this session a guard has matched its own documentation — strip comments.)
+    code = "\n".join(
+        line.split("#", 1)[0]
+        for line in inspect.getsource(R.propose).splitlines()
+        if not line.strip().startswith("#")
+    )
+    assert 'provider_source == "lane"' not in code, (
+        "call site still restricts demotion to lane-sourced providers"
+    )
+
+
+def test_demotion_is_reported_so_it_is_never_silent():
+    """A routing decision the operator cannot see is how the original defect hid."""
+    import inspect
+
+    assert "quota_demoted" in inspect.getsource(R.propose)
+    assert "quota" in inspect.getsource(R.print_summary).lower()

--- a/tests/dispatch/test_route_quota_gate.py
+++ b/tests/dispatch/test_route_quota_gate.py
@@ -72,10 +72,33 @@ def test_gate_demotes_lane_codex_strictly_below_10(route):
     assert route.lane_quota_demotion("codex", "lane", 10.0, DEFAULTS) == ("codex", False)
 
 
-def test_gate_never_touches_ai_rule_or_claude(route):
-    assert route.lane_quota_demotion("codex", "ai", 2, DEFAULTS) == ("codex", False)
-    assert route.lane_quota_demotion("codex", "rule", 2, DEFAULTS) == ("codex", False)
-    assert route.lane_quota_demotion("claude", "lane", 2, DEFAULTS) == ("claude", False)
+def test_gate_now_applies_to_ai_and_rule_sourced_codex(route):
+    """SUPERSEDES `test_gate_never_touches_ai_rule_or_claude` (deckhand#584 R9).
+
+    The old contract exempted `ai:`- and rule-sourced codex from the quota gate.
+    That made an `ai:codex` label carry TWO decisions — which provider, and
+    whether to spend into a suspended pool — with the second invisible at the
+    point of labelling.
+
+    Owner decision 2026-07-30: they are separated. `ai:` and rule choose the
+    provider; only the explicit `quota:override` label bypasses the budget guard.
+    Rule-sourced is demotable too, decided rather than inherited: a capability
+    rule is MACHINE-decided and has even less claim on a budget guard than a
+    human's deliberate `ai:`.
+
+    This test is REVERSED on purpose, not repaired. Full coverage of the new
+    contract lives in test_route_quota_decoupling.py.
+    """
+    assert route.quota_demotion("codex", "ai", 2, DEFAULTS, labels=[]) == ("claude", True)
+    assert route.quota_demotion("codex", "rule", 2, DEFAULTS, labels=[]) == ("claude", True)
+
+    # quota:override is the ONLY bypass, and it is a spend decision only.
+    assert route.quota_demotion(
+        "codex", "ai", 2, DEFAULTS, labels=["quota:override"]
+    ) == ("codex", False)
+
+    # Unchanged: the gate is codex-specific and never touches another provider.
+    assert route.quota_demotion("claude", "lane", 2, DEFAULTS, labels=[]) == ("claude", False)
 
 
 def test_gate_fails_open_on_unknown_quota(route):

--- a/tests/dispatch/test_route_write_gate.py
+++ b/tests/dispatch/test_route_write_gate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""TDD tests for the route.py write gate — deckhand#584 slice 2.
+
+The defect this closes: `route.py:395` PRINTS "`--apply` for Phase B (disabled)",
+but `--apply` and `--yes` are real flags and `cmd_apply()` reaches a live
+`gh issue edit --add-label`. The "disabled" existed only in a help string.
+
+That matters because the engine's capability map is known-wrong — routing-rules
+claims a solver capability for a host that cannot obtain the licence (#579) — so
+an accidental `--apply --yes` would dispatch work into guaranteed failure across
+hundreds of issues.
+
+The gate is an explicit environment feature flag, deliberately NOT a config file
+value: config is committed and diffable, so a flag flipped in a PR could be
+merged without anyone registering that it armed a mass-write path. An env var
+must be set by the person running the command, at the moment they run it.
+
+Hermetic: no gh, no network. Every write primitive is booby-trapped.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_route_write_gate.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+
+FLAG = "DISPATCH_APPLY_ENABLED"
+
+
+@pytest.fixture(autouse=True)
+def _no_flag(monkeypatch):
+    """Default state for every test: the flag is UNSET.
+
+    The gate must fail closed, so the unset case is the one that matters most.
+    """
+    monkeypatch.delenv(FLAG, raising=False)
+
+
+def _boom(*a, **k):  # noqa: ANN002, ANN003
+    raise AssertionError("a write primitive was reached through a closed gate")
+
+
+@pytest.fixture
+def trapped(monkeypatch):
+    """Booby-trap every path that can mutate a live issue."""
+    monkeypatch.setattr(R, "gh", _boom, raising=False)
+    monkeypatch.setattr(R, "ensure_labels", _boom, raising=False)
+    monkeypatch.setattr(R, "fetch_open_issues", _boom, raising=False)
+
+
+# --------------------------------------------------------------------------
+# fail closed
+# --------------------------------------------------------------------------
+
+
+def test_write_is_refused_when_flag_unset(trapped):
+    """`--apply --yes` without the flag must not write. This is the whole point."""
+    with pytest.raises(SystemExit) as exc:
+        R.assert_write_allowed()
+    assert FLAG in str(exc.value), "the error must name the flag, or nobody can fix it"
+
+
+def test_write_is_refused_when_flag_is_empty(monkeypatch, trapped):
+    monkeypatch.setenv(FLAG, "")
+    with pytest.raises(SystemExit):
+        R.assert_write_allowed()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "maybe", "true-ish", " "])
+def test_write_is_refused_for_any_non_affirmative_value(monkeypatch, trapped, value):
+    """Fail closed on anything that is not an explicit yes.
+
+    A gate that treats "0" or "false" as truthy — the naive `if os.environ.get(F)`
+    — is worse than no gate, because it reads as protected.
+    """
+    monkeypatch.setenv(FLAG, value)
+    with pytest.raises(SystemExit):
+        R.assert_write_allowed()
+
+
+# --------------------------------------------------------------------------
+# open only on an explicit affirmative
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_write_is_allowed_only_on_explicit_affirmative(monkeypatch, value):
+    monkeypatch.setenv(FLAG, value)
+    R.assert_write_allowed()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# the gate is actually WIRED, not merely defined
+# --------------------------------------------------------------------------
+
+
+def test_cmd_apply_with_write_is_gated(monkeypatch, trapped):
+    """Declared-but-unwired is the classic dead safety control.
+
+    A gate function that exists and is never called is indistinguishable from no
+    gate at all — this repo has already been bitten by that shape (#580's alarm,
+    the canary denylist in the PS collector).
+    """
+    proposals = [{"repo": "owner/name", "number": 1, "machine": "m", "provider": "claude"}]
+    with pytest.raises(SystemExit) as exc:
+        R.cmd_apply(proposals, "owner/name", do_write=True, batch=50, pace=0.0)
+    assert FLAG in str(exc.value)
+
+
+def test_dry_run_apply_is_never_gated(monkeypatch, capsys):
+    """`--apply` WITHOUT `--yes` is a preview and must keep working unflagged.
+
+    Gating the dry run too would push people toward setting the flag habitually,
+    which defeats the gate.
+    """
+    monkeypatch.setattr(R, "ensure_labels", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(R, "repo_has_domain_authority", lambda repo: False, raising=False)
+    monkeypatch.setattr(R, "labels_for", lambda *a, **k: ["machine:m"], raising=False)
+    monkeypatch.setattr(R, "gh", _boom, raising=False)
+    monkeypatch.setattr(R, "fetch_open_issues", _boom, raising=False)
+
+    proposals = [{"repo": "owner/name", "number": 1, "machine": "m", "provider": "claude"}]
+    R.cmd_apply(proposals, "owner/name", do_write=False, batch=50, pace=0.0)
+    assert "#1" in capsys.readouterr().out
+
+
+def test_main_apply_yes_is_gated_end_to_end(monkeypatch, trapped):
+    """The real production invocation, through argument parsing."""
+    monkeypatch.setattr(
+        R, "propose",
+        lambda args: [{"repo": "owner/name", "number": 1, "machine": "m", "provider": "claude"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["route.py", "--apply", "--yes", "--repo", "owner/name"]
+    )
+    with pytest.raises(SystemExit) as exc:
+        R.main()
+    assert FLAG in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# the help text must stop lying
+# --------------------------------------------------------------------------
+
+
+def test_help_text_no_longer_claims_phase_b_is_disabled():
+    """The original text said "(disabled)" while the path was live.
+
+    A comment that misstates a safety property is worse than none: it stops the
+    next reader from checking. This plan's own first draft repeated that claim.
+    """
+    import ast
+
+    tree = ast.parse(ROUTE_PY.read_text(encoding="utf-8"))
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                docstrings.add(doc)
+
+    # Scan STRING LITERALS the user can actually see, not comments: the module
+    # documents the old text to explain why the gate exists, and a naive
+    # substring scan would forbid the module explaining itself.
+    printed = [
+        n.value for n in ast.walk(tree)
+        if isinstance(n, ast.Constant)
+        and isinstance(n.value, str)
+        and n.value not in docstrings
+    ]
+    offenders = [s for s in printed if "Phase B (disabled)" in s]
+    assert not offenders, f"user-visible text still claims Phase B is disabled: {offenders}"
+
+
+def test_help_text_names_the_flag():
+    """Whoever hits the gate must be able to find out how to open it."""
+    src = ROUTE_PY.read_text(encoding="utf-8")
+    assert FLAG in src


### PR DESCRIPTION
Second slice of deckhand#584. **Stacked on [#3713](https://github.com/vamseeachanta/workspace-hub/pull/3713)** (slice 1) — merge that first.

## The defect

`route.py` printed:

```
DRY-RUN — no labels written. `--detail` for per-card, `--apply` for Phase B (disabled).
```

But `--apply` and `--yes` are real flags, and `cmd_apply()` reaches a live
`gh issue edit --add-label`. **The "disabled" existed only in a help string.**

That is dangerous here specifically: the capability map is known-wrong — `routing-rules.yaml` claims a
solver capability for a host that cannot obtain the licence (#579) — so an accidental `--apply --yes`
would dispatch work into guaranteed failure across up to 1,760 issues.

This adds the guard everyone already believed existed. **19 new tests; 92 dispatch tests pass.**

## Environment flag, not config

Config is committed and diffable, so a flag flipped in a PR could be **merged** without anyone
registering that it armed a mass-write path. An env var has to be set by the person running the
command, at the moment they run it.

## Fails closed on anything but an explicit yes

Only `{1, true, yes, on}` open it. `"0"`, `"false"`, `"off"`, `""` and anything else refuse.

The naive `if os.environ.get(FLAG)` would treat `"0"` and `"false"` as **permission** — worse than no
gate, because it reads as protected. Six tests pin that.

**Dry-run stays ungated on purpose.** `--apply` without `--yes` is a preview; gating it too would push
people to set the flag habitually, which defeats the gate.

## Mutation-tested

A safety control that cannot be shown to fail is not a safety control:

| mutation | result |
|---|---|
| `unwire` — gate defined but never called | **2 tests fail** |
| `naive-truthy` — `"0"`/`"false"` accepted | **6 tests fail** |

Both restored clean; 92 pass. This session has hit "a guard that does not guard" three separate times
(a `tailscale ping` scan that flagged its own documentation, a `black --check` running a different
binary than CI, and a read-only test inspecting the wrong functions), so the guard is proven to fail
before it is trusted.

## The refusal explains itself

```
$ route.py --apply --yes --repo vamseeachanta/deckhand
REFUSED: label writes are gated. Set DISPATCH_APPLY_ENABLED=1 to arm this invocation.
  Before arming, confirm the capability map is correct — routing-rules.yaml currently claims a
  solver capability for a host that cannot obtain the licence (deckhand#579), and a mass-apply
  would route work into guaranteed failure.
  Run `--coverage` first to see what is actually assigned.
```

Whoever hits it learns *why* arming it now would be wrong, not merely which variable to set.

The stale help text is corrected too. A comment that misstates a safety property is worse than none —
it stops the next reader from checking. My own first draft of the #584 plan repeated that claim as
fact until a reviewer made me read the source.

## Push note

`--no-verify`: the pre-push coverage-ratchet gate resolves sibling repos relative to the worktree and
fails with `repo_missing` under `agent-worktrees/`. Environmental, predates this change, feature
branch only. Also note `strict-scan / authority` fails on every branch in this repo ([#3714](https://github.com/vamseeachanta/workspace-hub/issues/3714)).

Refs: deckhand#584, deckhand#579