### PR TITLE
feat(dispatch): decouple provider choice from budget bypass (deckhand#584 R9)

### DIFF
--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -283,17 +283,49 @@ def codex_weekly_remaining(override=None):
         return None
 
 
-def lane_quota_demotion(provider, source, remaining_pct, defaults):
-    """Return (provider, demoted). Suspends ONLY the lane-derived codex choice
-    when weekly remaining is strictly below QUOTA_GATE_PCT. ai:/rule codex
-    carries human/rule authority and is never altered; None (unknown quota)
-    fails open. A demoted card keeps provider_explicit=False at the call site,
-    so labels_for() writes no ai: label — demotion leaves no sticky residue.
+#: Carries the SPEND decision, separately from the provider choice (deckhand#584
+#: R9). Without it, an `ai:` label chose the provider AND silently opted out of
+#: the budget guard — one label making two decisions, the second invisible at
+#: the point of labelling.
+QUOTA_OVERRIDE_LABEL = "quota:override"
+
+
+def quota_demotion(provider, source, remaining_pct, defaults, labels=None):
+    """Return (provider, demoted). Suspends a codex choice from ANY source when
+    weekly remaining is strictly below QUOTA_GATE_PCT.
+
+    R9 (deckhand#584, owner 2026-07-30): `ai:` and rule-sourced codex are no
+    longer exempt. The provider choice and the budget bypass are different
+    decisions — "codex does this work better" is about a task, "spend into a
+    suspended pool" is about the month — so they now need different labels.
+    Rule-sourced is demotable too, decided rather than inherited: a capability
+    rule is MACHINE-decided and has even less claim on a budget guard than a
+    human's deliberate `ai:`.
+
+    `QUOTA_OVERRIDE_LABEL` is the only bypass, and it is a spend decision only —
+    it never chooses a provider.
+
+    `None` remaining FAILS OPEN: the gate is an optimisation on top of routing
+    (#3030) and an unreachable quota source must not strand heavy work. That is
+    deliberately the opposite of the write gate's fail-closed posture — the cost
+    of a wrong answer differs in each direction.
+
+    A demoted card keeps provider_explicit=False at the call site, so
+    labels_for() writes no ai: label — demotion leaves no sticky residue. An
+    EXISTING `ai:` label is not removed: it records the operator's intent, while
+    the gate governs this run's execution.
     """
-    if (provider == "codex" and source == "lane"
-            and remaining_pct is not None and remaining_pct < QUOTA_GATE_PCT):
+    if provider != "codex":
+        return provider, False
+    if QUOTA_OVERRIDE_LABEL in (labels or []):
+        return provider, False
+    if remaining_pct is not None and remaining_pct < QUOTA_GATE_PCT:
         return defaults.get("provider"), True
     return provider, False
+
+
+#: Back-compat alias — the old name said "lane" and the restriction is gone.
+lane_quota_demotion = quota_demotion
 
 
 def propose(args) -> list[dict]:
@@ -328,12 +360,16 @@ def propose(args) -> list[dict]:
         provider, provider_explicit, provider_source = resolve_provider(
             labels, assign, defaults)
         quota_demoted = False
-        if provider == "codex" and provider_source == "lane":
+        # R9: NO source restriction here. This call site previously carried its
+        # own `provider_source == "lane"` guard, so relaxing only the function
+        # would have left the exemption fully intact — the fix would look done
+        # and do nothing.
+        if provider == "codex":
             if quota_remaining is _QUOTA_UNSET:  # one quota read per run
                 quota_remaining = codex_weekly_remaining(
                     override=getattr(args, "codex_remaining", None))
-            provider, quota_demoted = lane_quota_demotion(
-                provider, provider_source, quota_remaining, defaults)
+            provider, quota_demoted = quota_demotion(
+                provider, provider_source, quota_remaining, defaults, labels=labels)
         routed_by = "manual" if existing_machine else "rule"
 
         proposals.append({

--- a/tests/dispatch/test_route_quota_decoupling.py
+++ b/tests/dispatch/test_route_quota_decoupling.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""TDD tests for R9 — separating the provider choice from the budget bypass.
+
+deckhand#584 slice 3. Owner decision 2026-07-30.
+
+## The defect
+
+`route.py` exempted `ai:`- and rule-sourced codex from the 10% weekly quota gate:
+only a `lane:`-derived choice was demotable. So an `ai:codex` label chose the
+provider AND silently opted the issue out of the spend guard — one label making
+two decisions, the second invisible at the point of labelling.
+
+Those intents genuinely differ. *"Codex does this work better"* is a judgement
+about a task. *"Spend into a suspended pool"* is a judgement about the month.
+
+## After
+
+`ai:` and rule choose the provider; **neither bypasses the gate**. A separate
+`quota:override` label carries the spend decision, explicitly and visibly.
+
+Rule-sourced codex is demotable too, decided rather than inherited: a capability
+rule choosing codex is MACHINE-decided, so it has even less claim on a budget
+guard than a human's deliberate `ai:` label.
+
+## Why now
+
+Zero `ai:` labels exist today, so the exemption has never fired and this change
+costs nothing. The moment slice 4 creates those labels, changing this would mean
+changing the meaning of labels already in use.
+
+Hermetic: pure functions, explicit args, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_route_quota_decoupling.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+
+DEFAULTS = {"provider": "claude"}
+BELOW = 5.0   # strictly below QUOTA_GATE_PCT (10)
+ABOVE = 40.0
+
+
+# --------------------------------------------------------------------------
+# the R9 change: ai: and rule no longer bypass the gate
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule", "default"])
+def test_codex_is_demoted_below_threshold_regardless_of_source(source):
+    """The budget guard applies to everyone.
+
+    Previously only `source == "lane"` was demotable, so an `ai:codex` label was
+    a silent spend-guard bypass.
+    """
+    provider, demoted = R.quota_demotion("codex", source, BELOW, DEFAULTS, labels=[])
+    assert demoted is True
+    assert provider == "claude"
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule"])
+def test_codex_is_not_demoted_above_threshold(source):
+    provider, demoted = R.quota_demotion("codex", source, ABOVE, DEFAULTS, labels=[])
+    assert demoted is False
+    assert provider == "codex"
+
+
+# --------------------------------------------------------------------------
+# quota:override carries the SPEND decision, separately
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["lane", "ai", "rule"])
+def test_quota_override_bypasses_the_gate_for_any_source(source):
+    provider, demoted = R.quota_demotion(
+        "codex", source, BELOW, DEFAULTS, labels=["quota:override"]
+    )
+    assert demoted is False
+    assert provider == "codex"
+
+
+def test_quota_override_alone_does_not_choose_a_provider():
+    """It is a SPEND decision, not a routing one. A non-codex provider is untouched."""
+    provider, demoted = R.quota_demotion(
+        "claude", "lane", BELOW, DEFAULTS, labels=["quota:override"]
+    )
+    assert provider == "claude"
+    assert demoted is False
+
+
+def test_ai_label_without_override_is_demoted():
+    """The exact case R9 exists for: quality choice, no spend decision."""
+    provider, demoted = R.quota_demotion(
+        "codex", "ai", BELOW, DEFAULTS, labels=["ai:codex"]
+    )
+    assert demoted is True, "an ai: label must not silently bypass the budget guard"
+    assert provider == "claude"
+
+
+def test_ai_label_with_override_is_not_demoted():
+    """Both decisions made, both visible."""
+    provider, demoted = R.quota_demotion(
+        "codex", "ai", BELOW, DEFAULTS, labels=["ai:codex", "quota:override"]
+    )
+    assert demoted is False
+    assert provider == "codex"
+
+
+# --------------------------------------------------------------------------
+# preserved behaviour — these must not regress
+# --------------------------------------------------------------------------
+
+
+def test_unknown_quota_still_fails_open():
+    """`None` means the quota source was unreachable.
+
+    The gate is an optimisation on top of routing (#3030); an unreachable quota
+    source must never strand heavy work. Fail OPEN here is deliberate and is the
+    opposite of the write gate's fail-closed — different failure costs.
+    """
+    provider, demoted = R.quota_demotion("codex", "ai", None, DEFAULTS, labels=[])
+    assert demoted is False
+    assert provider == "codex"
+
+
+@pytest.mark.parametrize("provider", ["claude", "agy", "hermes"])
+def test_non_codex_providers_are_never_demoted(provider):
+    """The gate is codex-quota specific."""
+    got, demoted = R.quota_demotion(provider, "lane", BELOW, DEFAULTS, labels=[])
+    assert got == provider
+    assert demoted is False
+
+
+def test_threshold_is_strictly_below_not_at():
+    """Preserves the documented `< QUOTA_GATE_PCT` boundary."""
+    at_gate = float(R.QUOTA_GATE_PCT)
+    _, demoted_at = R.quota_demotion("codex", "lane", at_gate, DEFAULTS, labels=[])
+    _, demoted_below = R.quota_demotion("codex", "lane", at_gate - 0.01, DEFAULTS, labels=[])
+    assert demoted_at is False
+    assert demoted_below is True
+
+
+# --------------------------------------------------------------------------
+# the call site must lose its DUPLICATE guard
+# --------------------------------------------------------------------------
+
+
+def test_call_site_does_not_re_restrict_to_lane_source():
+    """`propose()` had its own `provider_source == "lane"` condition.
+
+    Changing only the function would leave the exemption fully intact at the
+    call site — the fix would look done and do nothing. This is the same
+    declared-but-unwired shape as an uncalled safety gate.
+    """
+    import inspect
+
+    # Scan EXECUTABLE lines only. The call site documents the removed guard to
+    # explain why relaxing the function alone was insufficient, and a raw
+    # substring scan would flag that explanation as the defect. (Fourth time
+    # this session a guard has matched its own documentation — strip comments.)
+    code = "\n".join(
+        line.split("#", 1)[0]
+        for line in inspect.getsource(R.propose).splitlines()
+        if not line.strip().startswith("#")
+    )
+    assert 'provider_source == "lane"' not in code, (
+        "call site still restricts demotion to lane-sourced providers"
+    )
+
+
+def test_demotion_is_reported_so_it_is_never_silent():
+    """A routing decision the operator cannot see is how the original defect hid."""
+    import inspect
+
+    assert "quota_demoted" in inspect.getsource(R.propose)
+    assert "quota" in inspect.getsource(R.print_summary).lower()

--- a/tests/dispatch/test_route_quota_gate.py
+++ b/tests/dispatch/test_route_quota_gate.py
@@ -72,10 +72,33 @@ def test_gate_demotes_lane_codex_strictly_below_10(route):
     assert route.lane_quota_demotion("codex", "lane", 10.0, DEFAULTS) == ("codex", False)
 
 
-def test_gate_never_touches_ai_rule_or_claude(route):
-    assert route.lane_quota_demotion("codex", "ai", 2, DEFAULTS) == ("codex", False)
-    assert route.lane_quota_demotion("codex", "rule", 2, DEFAULTS) == ("codex", False)
-    assert route.lane_quota_demotion("claude", "lane", 2, DEFAULTS) == ("claude", False)
+def test_gate_now_applies_to_ai_and_rule_sourced_codex(route):
+    """SUPERSEDES `test_gate_never_touches_ai_rule_or_claude` (deckhand#584 R9).
+
+    The old contract exempted `ai:`- and rule-sourced codex from the quota gate.
+    That made an `ai:codex` label carry TWO decisions — which provider, and
+    whether to spend into a suspended pool — with the second invisible at the
+    point of labelling.
+
+    Owner decision 2026-07-30: they are separated. `ai:` and rule choose the
+    provider; only the explicit `quota:override` label bypasses the budget guard.
+    Rule-sourced is demotable too, decided rather than inherited: a capability
+    rule is MACHINE-decided and has even less claim on a budget guard than a
+    human's deliberate `ai:`.
+
+    This test is REVERSED on purpose, not repaired. Full coverage of the new
+    contract lives in test_route_quota_decoupling.py.
+    """
+    assert route.quota_demotion("codex", "ai", 2, DEFAULTS, labels=[]) == ("claude", True)
+    assert route.quota_demotion("codex", "rule", 2, DEFAULTS, labels=[]) == ("claude", True)
+
+    # quota:override is the ONLY bypass, and it is a spend decision only.
+    assert route.quota_demotion(
+        "codex", "ai", 2, DEFAULTS, labels=["quota:override"]
+    ) == ("codex", False)
+
+    # Unchanged: the gate is codex-specific and never touches another provider.
+    assert route.quota_demotion("claude", "lane", 2, DEFAULTS, labels=[]) == ("claude", False)
 
 
 def test_gate_fails_open_on_unknown_quota(route):


### PR DESCRIPTION
Third slice of deckhand#584. **Stacked**: merge [#3713](https://github.com/vamseeachanta/workspace-hub/pull/3713) → [#3715](https://github.com/vamseeachanta/workspace-hub/pull/3715) → this.

## The defect

`route.py` exempted `ai:`- and rule-sourced codex from the 10% weekly quota gate — only a
`lane:`-derived choice was demotable. So an `ai:codex` label carried **two** decisions: which provider,
and whether to spend into a suspended pool. The second was invisible at the point of labelling.

Those intents genuinely differ. *"Codex does this work better"* is a judgement about a task.
*"Spend into a suspended pool"* is a judgement about the month.

**20 new tests; 112 dispatch tests pass.**

## After

| | |
|---|---|
| `ai:` / rule | choose the provider; **do not** bypass the gate |
| `quota:override` | the **only** bypass — a spend decision, never a routing one |

Rule-sourced codex is demotable too, **decided rather than inherited**: a capability rule is
machine-decided and has even less claim on a budget guard than a human's deliberate `ai:`. Left
unaddressed it would have been settled by omission.

## The call site had a duplicate guard

`propose()` carried its own `provider_source == "lane"` condition. **Relaxing only the function would
have left the exemption fully intact** — the fix would look done and do nothing. Same
declared-but-unwired shape as an uncalled safety gate. A test asserts the call site no longer
re-restricts.

## An existing test is reversed, not repaired

`test_gate_never_touches_ai_rule_or_claude` encoded the old contract. It now asserts the new one and
documents the reversal in place, pointing at the full coverage. Changing behaviour while leaving a
test asserting the opposite is how a contract silently rots — and this plan's own first draft
repeated `route.py`'s stale help text as fact for exactly that reason.

## Preserved deliberately

**Unknown quota (`None`) still fails OPEN.** The gate is an optimisation on top of routing (#3030) and
an unreachable quota source must not strand heavy work.

That is the *opposite* of the write gate's fail-closed posture in #3715, and intentionally so: the
cost of a wrong answer differs by direction. Wrongly writing labels is expensive and hard to reverse;
wrongly stranding work is expensive and obvious. Same codebase, opposite defaults, each argued.

## Why now

**Zero `ai:` labels exist**, so the exemption has never fired and this costs nothing today. The moment
slice 4 creates them, this becomes a change to the meaning of labels already in use.

Refs: deckhand#584, workspace-hub#3029, #3030