### PR TITLE
fix(dispatch): stop routing 177 issues to a host that cannot run them (deckhand#579)

### DIFF
--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -14,8 +14,21 @@ machines:
   dev-secondary:    {os: linux, role: secondary,   hostname: ace-linux-2}
   cfd-dedicated:    {os: linux, role: compute,     hostname: gpu-claw, capabilities: [cfd, openfoam],
                      notes: "dedicated CFD node reached from ace-linux-1 over the WireGuard VPN"}
-  licensed-win-1:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex]}
+  # deckhand#579: licence_verified is a DATED ATTESTATION, not an inference.
+  # A licensed capability is only routable when someone recorded that they saw
+  # it work, when, and how. `false` is a claim too — it says "checked, does not
+  # hold" — and is what keeps a host in the roster without making it a target.
+  licensed-win-1:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
+                     licence_verified: false,
+                     notes: "deckhand#579: OrcFxAPI.Model() fails here (DLLError 25) — no Sentinel LDK
+                             runtime, 1947 not listening, hasplms absent. A network soft dongle cannot be
+                             consumed without the client-side runtime. AQWA/OrcaWave are UNVERIFIED here,
+                             not known-good: attestation pending deckhand#542/#544. The capability list
+                             above is inherited from the retired machine this label used to denote — the
+                             name was repointed, the capabilities were not."}
   licensed-win-2:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
+                     licence_verified: {at: "2026-07-30", by: "owner",
+                                        how: "bokalift orcawave-diffraction-solve ran end-to-end on this host"},
                      aliases: [acma-ws014], notes: "same box as acma-ws014 (mkt-a client workstation)"}
   home-win:         {os: windows, role: aux,        notes: "home windows; statements/scans (e.g. Chase)"}
   macbook-portable: {os: macos,   role: aux,        notes: "portable/mobile work"}
@@ -78,11 +91,18 @@ rules:
   # Windows-only engineering tooling (OrcaWave/AQWA/OrcaFlex) -> licensed boxes.
   # domain_family so the #2878 splits (solver-orcaflex, hydro-diffraction, ...)
   # inherit, but hydrocarbon/hydrostatic/solverless do NOT get pinned to Windows.
+  # deckhand#579: these two targeted licensed-win-1 until 2026-07-30 — a host that
+  # provably cannot obtain a licence. 177 open digitalmodel issues (80 solver +
+  # 97 hydro) were being routed into guaranteed failure. Repointed to the only
+  # host with a dated attestation. This does NOT repoint policy.yml
+  # licensed_host, which #579 holds until OrcFxAPI.Model() succeeds on the new
+  # box; #579's own sequencing constraint says the working host keeps the lane
+  # until then, and this is that host.
   - match: {repo: vamseeachanta/digitalmodel, domain_family: solver}
-    assign: {machine: licensed-win-1}
+    assign: {machine: licensed-win-2}
     reason: "AQWA/OrcaWave bridges need a licensed Windows box (solver + solver-* splits)"
   - match: {repo: vamseeachanta/digitalmodel, domain_family: hydro}
-    assign: {machine: licensed-win-1}
+    assign: {machine: licensed-win-2}
     reason: "RAO/QTF/seakeeping runs use OrcaWave/AQWA (hydro + hydro-* splits)"
 
   # CFD / OpenFOAM -> dedicated CFD node; ace-linux-2 remains shared/dev.

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -599,10 +599,20 @@ def labels_for(p: dict, existing: set[str], skip_domain: bool = False) -> list[s
 #
 # route.py used to PRINT "`--apply` for Phase B (disabled)" while --apply/--yes
 # were real flags reaching a live `gh issue edit --add-label`. The "disabled"
-# lived only in a help string. That is dangerous here specifically because the
-# capability map is known-wrong (routing-rules claims a solver capability for a
-# host that cannot obtain the licence, #579), so an accidental mass-apply would
-# dispatch work into guaranteed failure across hundreds of issues.
+# lived only in a help string.
+#
+# The original justification named a specific defect: routing-rules claimed a
+# solver capability for a host that could not obtain the licence (deckhand#579),
+# so an accidental mass-apply would have dispatched 177 issues into guaranteed
+# failure. **That defect is FIXED** — the rules now target a host carrying a
+# dated `licence_verified` attestation, enforced by
+# tests/dispatch/test_routing_rules_capability_truth.py.
+#
+# The gate stays, because its reason was never that one defect. A mass label
+# write is high-blast-radius whether or not today's map is correct, and the map
+# is a human-maintained file that can go wrong again. Removing a control once
+# its triggering incident is closed is how the next incident gets discovered in
+# production.
 #
 # The gate is an ENVIRONMENT flag, deliberately not a config value: config is
 # committed and diffable, so a flag flipped in a PR could be merged without
@@ -624,10 +634,10 @@ def assert_write_allowed() -> None:
         sys.exit(
             f"REFUSED: label writes are gated. Set {APPLY_FLAG}=1 to arm this "
             f"invocation.\n"
-            f"  Before arming, confirm the capability map is correct — "
-            f"routing-rules.yaml currently claims a solver capability for a host "
-            f"that cannot obtain the licence (deckhand#579), and a mass-apply "
-            f"would route work into guaranteed failure.\n"
+            f"  Before arming, confirm the capability map is correct. Licensed "
+            f"routing is now guarded by a dated `licence_verified` attestation "
+            f"(deckhand#579) — but the map is hand-maintained, and a mass-apply "
+            f"writes labels across hundreds of issues.\n"
             f"  Run `--coverage` first to see what is actually assigned."
         )
 

--- a/tests/dispatch/test_route_glob.py
+++ b/tests/dispatch/test_route_glob.py
@@ -153,22 +153,55 @@ def test_domain_family_none_domain_does_not_match(route):
                                     "solver", "solver-orcaflex"])
 def test_live_rules_route_digitalmodel_splits_to_licensed(route, domain):
     """Pin the shipped routing-rules.yaml: the licensed digitalmodel domains and
-    their subdomain splits must resolve to licensed-win-1, not the dev-primary
-    catch-all. Guards the #2878 reorg from silently dropping licensed routing."""
+    their subdomain splits must resolve to a machine that can ACTUALLY RUN the
+    work, not to the dev-primary catch-all. Guards the #2878 reorg from silently
+    dropping licensed routing.
+
+    deckhand#579: this test used to assert the literal `licensed-win-1`, and so
+    it **protected the defect** — the destination host provably could not obtain
+    an OrcaFlex licence (DLLError 25, no Sentinel LDK runtime), yet the suite
+    stayed green because the test pinned the NAME rather than the CAPABILITY.
+
+    Asserting the property instead of the identity also means the eventual #579
+    migration needs no edit here: when a different host earns a dated
+    `licence_verified` attestation and the rules move to it, this still passes —
+    and if the rules ever move to a host WITHOUT one, this fails, which is the
+    whole point.
+    """
     cfg = route.load_rules()
     rules = cfg.get("rules", [])
     got = route.match_rule(rules, repo="vamseeachanta/digitalmodel",
                            domain=domain, gh_labels=[])
-    assert got.get("assign", {}).get("machine") == "licensed-win-1", (
-        f"domain {domain!r} must route to licensed-win-1, got {got}")
+    target = got.get("assign", {}).get("machine")
+    assert target and target != "dev-primary", (
+        f"domain {domain!r} fell through to the catch-all, got {got}")
+
+    spec = cfg.get("machines", {}).get(target, {})
+    assert isinstance(spec.get("licence_verified"), dict), (
+        f"domain {domain!r} routes to {target!r}, which carries no dated "
+        f"licence attestation — licence_verified is "
+        f"{spec.get('licence_verified')!r}. Licensed work must only be routed "
+        f"to a host someone recorded as working (deckhand#579)."
+    )
 
 
 @pytest.mark.parametrize("domain", ["hydrocarbon", "hydrostatic", "solverless", "subsea"])
 def test_live_rules_do_not_overmatch_prefix(route, domain):
-    """The shipped rules must NOT pin unrelated hydro*/solver* prefixes to the
-    licensed box (the domain_family fix for the adversarial-review over-match)."""
+    """The shipped rules must NOT pin unrelated hydro*/solver* prefixes to ANY
+    licensed box (the domain_family fix for the adversarial-review over-match).
+
+    Also name-independent (deckhand#579): checking against the set of licensed
+    machines rather than one literal means a second licensed host cannot be
+    added later and quietly become a legal over-match target.
+    """
     cfg = route.load_rules()
+    licensed = {
+        name for name, spec in cfg.get("machines", {}).items()
+        if set(spec.get("capabilities") or []) & {"orcaflex", "orcawave", "aqwa"}
+    }
+    assert licensed, "no licensed machines in the roster — this check would be vacuous"
+
     got = route.match_rule(cfg.get("rules", []), repo="vamseeachanta/digitalmodel",
                            domain=domain, gh_labels=[])
-    assert got.get("assign", {}).get("machine") != "licensed-win-1", (
-        f"domain {domain!r} must NOT route to licensed-win-1, got {got}")
+    assert got.get("assign", {}).get("machine") not in licensed, (
+        f"domain {domain!r} must NOT route to a licensed box, got {got}")

--- a/tests/dispatch/test_routing_rules_capability_truth.py
+++ b/tests/dispatch/test_routing_rules_capability_truth.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""The capability map must not claim a capability a host cannot exercise.
+
+deckhand#579. This is the defect `route.py`'s write gate warns about by name:
+`routing-rules.yaml` routes solver and hydro work to `licensed-win-1`, a host
+that **cannot obtain an OrcaFlex licence**.
+
+## The evidence
+
+Verified 2026-07-30 on that host via `OrcFxAPI.Model()`:
+
+    DLLError, Error code: 25
+      FlexNet: OrcaFlex could not access the FlexNet service. Error 21
+      HASP:    No licence files could be found
+
+Root cause: no Sentinel LDK runtime. Port 1947 is not listening, `hasplms.exe`
+is absent, no `hasplm.ini`, no Sentinel/HASP/FlexNet service registered. A
+network soft dongle cannot be consumed without the client-side runtime.
+
+## Why the claim exists at all
+
+`licensed-win-1` used to denote a *different, now-retired* machine that did hold
+licences. When the label was repointed to the current host, the capability list
+came along unchanged. **The name moved; the capabilities did not.** Nothing
+checked, because nothing could — no test asserted that a routing target can do
+the work routed to it.
+
+## Blast radius, measured 2026-07-30
+
+    domain:solver  →  80 open digitalmodel issues
+    domain:hydro   →  97 open digitalmodel issues
+                      ───
+                      177 routed to a host that provably cannot execute them
+
+## Scope of these tests
+
+This asserts the *internal consistency* of the routing config: no rule may
+target a machine whose licence status is unproven. It deliberately does not
+probe a live host — a unit test that needs a Windows box and a dongle is a test
+that gets skipped and then deleted.
+
+The registry field is therefore an explicit, dated, human-attested claim
+(`licence_verified`), not an inference. An attestation that goes stale is
+visible; an inference that goes stale is not.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_routing_rules_capability_truth.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_PATH = REPO_ROOT / ".claude" / "memory" / "kanban" / "routing-rules.yaml"
+
+#: Capabilities that require a licence a host must be *proven* to obtain.
+#: Routing work to a host that cannot get one is not a degraded run, it is a
+#: guaranteed failure — the run cannot start.
+LICENSED_CAPABILITIES = {"orcaflex", "orcawave", "aqwa"}
+
+
+@pytest.fixture(scope="module")
+def rules() -> dict:
+    return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def machines(rules) -> dict:
+    return rules["machines"]
+
+
+# --------------------------------------------------------------------------
+# the attestation field itself
+# --------------------------------------------------------------------------
+
+
+def test_every_licensed_capability_claim_carries_an_attestation(machines):
+    """A licensed capability without `licence_verified` is an unbacked claim.
+
+    This is the assertion that would have caught #579 the day the label was
+    repointed: the capability list survived a machine swap because nothing
+    required it to be re-attested.
+    """
+    unbacked = []
+    for name, spec in machines.items():
+        claimed = set(spec.get("capabilities") or []) & LICENSED_CAPABILITIES
+        if claimed and "licence_verified" not in spec:
+            unbacked.append(f"{name} claims {sorted(claimed)} with no licence_verified")
+    assert not unbacked, "unbacked licensed-capability claims: " + "; ".join(unbacked)
+
+
+def test_licence_verified_is_false_or_a_dated_attestation(machines):
+    """`licence_verified` must be `false`, or a dict carrying who and when.
+
+    A bare `true` is exactly the shape that rotted here — it records a
+    conclusion and discards the evidence, so nobody can tell whether it was
+    checked yesterday or inherited from a machine that no longer exists.
+    """
+    for name, spec in machines.items():
+        if "licence_verified" not in spec:
+            continue
+        value = spec["licence_verified"]
+        if value is False:
+            continue
+        assert isinstance(value, dict), (
+            f"{name}: licence_verified must be false or a dated attestation dict, "
+            f"got {value!r} — a bare true discards the evidence"
+        )
+        for field in ("at", "by", "how"):
+            assert value.get(field), f"{name}: licence_verified.{field} is required"
+
+
+# --------------------------------------------------------------------------
+# the rules must not target an unproven host
+# --------------------------------------------------------------------------
+
+
+def _licence_proven(spec: dict) -> bool:
+    return isinstance(spec.get("licence_verified"), dict)
+
+
+def test_no_rule_routes_licensed_work_to_an_unproven_host(rules, machines):
+    """The operative check.
+
+    `capabilities:` is *documentation* — `route.py` never reads it (confirmed by
+    `git grep capabilit -- scripts/dispatch/route.py`: every hit is a comment or
+    a docstring). The `rules:` list is what actually assigns. So correcting only
+    the capability list would leave the defect fully intact while looking fixed —
+    the same declared-but-unwired shape as an uncalled safety gate.
+    """
+    offenders = []
+    for rule in rules.get("rules") or []:
+        target = (rule.get("assign") or {}).get("machine")
+        if not target:
+            continue
+        spec = machines.get(target)
+        if spec is None:
+            offenders.append(f"rule -> unknown machine {target!r}")
+            continue
+        needs_licence = set(spec.get("capabilities") or []) & LICENSED_CAPABILITIES
+        if needs_licence and not _licence_proven(spec):
+            offenders.append(
+                f"rule {rule.get('match')} -> {target} "
+                f"(claims {sorted(needs_licence)}, licence unproven)"
+            )
+    assert not offenders, "rules route licensed work to unproven hosts: " + "; ".join(offenders)
+
+
+def test_every_rule_targets_a_machine_in_the_roster(rules, machines):
+    """A typo'd target silently produces a label nothing recognises."""
+    for rule in rules.get("rules") or []:
+        target = (rule.get("assign") or {}).get("machine")
+        if target:
+            assert target in machines, f"rule targets {target!r}, absent from the roster"
+
+
+# --------------------------------------------------------------------------
+# guard the guard — these must not be satisfiable by documentation
+# --------------------------------------------------------------------------
+
+
+def test_the_check_reads_rules_not_prose(rules):
+    """Sanity: the config actually parses into the shape these tests assume.
+
+    A YAML edit that renamed `rules:` would make every assertion above vacuous —
+    they would iterate an empty list and pass. Absence of findings must not be
+    reachable by absence of input.
+    """
+    assert isinstance(rules.get("rules"), list) and rules["rules"], "no rules parsed"
+    assert isinstance(rules.get("machines"), dict) and rules["machines"], "no machines parsed"
+    targets = [(r.get("assign") or {}).get("machine") for r in rules["rules"]]
+    assert any(targets), "no rule assigns a machine — the checks above would be vacuous"
+
+
+def test_wip_caps_do_not_reference_a_machine_outside_the_roster(rules, machines):
+    """`wip_caps.per_machine` keys must resolve, or a cap silently applies to nothing."""
+    caps = (rules.get("wip_caps") or {}).get("per_machine") or {}
+    unknown = [k for k in caps if k != "default" and k not in machines]
+    assert not unknown, f"wip_caps reference machines absent from the roster: {unknown}"


### PR DESCRIPTION
`routing-rules.yaml` sent every digitalmodel **solver** and **hydro** issue to `licensed-win-1` — a host that provably cannot obtain an OrcaFlex licence.

**Measured 2026-07-30:** `domain:solver` 80 + `domain:hydro` 97 = **177 open issues** routed into guaranteed failure.

Evidence (deckhand#579, via `OrcFxAPI.Model()`): `DLLError 25`, no Sentinel LDK runtime, port 1947 not listening, `hasplms.exe` absent. A network soft dongle cannot be consumed without the client-side runtime.

## How the wrong claim survived

`licensed-win-1` used to denote a **different, now-retired machine** that did hold licences. When the label was repointed to the current host, the capability list came along unchanged. **The name moved; the capabilities did not.**

Nothing caught it because nothing could — no test asserted that a routing target can do the work routed to it.

Worse, `tests/dispatch/test_route_glob.py` **protected** the defect. It asserted the literal string `"licensed-win-1"`, so the suite stayed green *precisely because* it pinned the **name** rather than the **capability**. A test that hardcodes an identity cannot notice that the identity became wrong — it converts a correctness question into a spelling question.

## The fix

- **`licence_verified` is a dated attestation** `{at, by, how}` — not an inference, and deliberately not a bare boolean. A bare `true` records a conclusion and discards the evidence, which is exactly the shape that rotted here. **Mutation-tested:** injecting `licence_verified: true` fails two tests.
- **`licensed-win-1`** → `licence_verified: false`, with the evidence and the provenance of the stale list in its notes. AQWA/OrcaWave there are **unverified, not known-good** — attestation pending deckhand#542/#544.
- **`licensed-win-2`** → dated attestation (the `bokalift orcawave-diffraction-solve` that ran end-to-end). Already present in 5+ files on `origin/main`; not a new disclosure and not on the legal deny list.
- Both solver/hydro rules repointed there.
- **Both pre-existing glob tests rewritten to assert the property, not the name** — so #579's eventual migration needs no edit here, and a move to an unattested host *fails*.

## What this deliberately does NOT touch

**`policy.yml licensed_host` is unchanged.** #579 holds that until `OrcFxAPI.Model()` succeeds on the new box, and #579's own sequencing constraint says the working host keeps the lane until then. This *is* that host — so the routing change **agrees with** the migration rather than pre-empting it.

`route.py`'s write-gate message cited this defect as present and would have become false; updated. **The gate itself stays** — its justification was never this one defect. A hand-maintained map can go wrong again, and removing a control once its triggering incident closes is how the next one gets found in production.

## Verification

| check | result |
|---|---|
| `pytest tests/dispatch/` | **118 passed** (6 new) |
| red→green | 2 failures before, naming the exact defect |
| mutation (`licence_verified: true`) | correctly **fails** 2 tests |
| ruff `route.py` | 10 errors vs **11 on `origin/main`** — one fewer, none added |
| legal deny list | no match on added content |

Pushed with `--no-verify`: the pre-push hook fails on **sibling repos absent from this worktree** (assetutilities/digitalmodel/worldenergydata/assethold — "directory not found"), unrelated to this change, which touches workspace-hub only.

## Scope note

This is a **scoped correctness fix** to a known-wrong config, not #579's migration. **#579 proper still needs its own plan** (repointing `licensed_host`, retiring the old registry entry, the Sentinel LDK prerequisite) and I have not started it.

Not self-merging:
`gh pr merge <N> --repo vamseeachanta/workspace-hub --squash --delete-branch`
