### PR TITLE
feat(windows): audit-first inbound SSH provisioning for the Windows fleet hosts

### DIFF
--- a/docs/runbooks/windows-remote-exec.md
+++ b/docs/runbooks/windows-remote-exec.md
@@ -28,12 +28,18 @@ If the audit reports a hostname you did not expect, stop and report it on #3721 
 
 ## Step 1 — audit (safe, changes nothing, no admin needed)
 
-Open PowerShell, `cd` to the workspace-hub checkout (`D:\workspace-hub` on the Windows boxes), and run:
+Open PowerShell and `cd` to the workspace-hub checkout. **The path is not the same on every host** — verified 2026-07-31, one Windows host uses `D:\ws\workspace-hub` (the same `ws` convention as gpu-claw's `~/ws`), not `D:\workspace-hub`. Find it rather than assuming:
 
 ```
+:: whichever of these exists
+if exist D:\ws\workspace-hub  cd /d D:\ws\workspace-hub
+if exist D:\workspace-hub     cd /d D:\workspace-hub
+
 git pull --ff-only
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1
 ```
+
+The script itself resolves its own repo root from `$PSScriptRoot`, so once you are in the right checkout the path never has to be passed.
 
 You get a section per area — Identity, OpenSSH Server, Authorized keys, Firewall, Default shell, Licensed-run poller — with `[ok]`, `[gap]`, and `[info]` lines, plus an evidence JSON path at the end.
 
@@ -55,7 +61,7 @@ The audit exits non-zero when gaps remain, so it can later be scheduled as an al
 Close PowerShell and reopen it as **Run as administrator**. You need the operator public key — get it from ace-linux-1 with `cat ~/.ssh/id_ed25519.pub` (or whichever key you use for the fleet).
 
 ```
-cd D:\workspace-hub
+cd /d D:\ws\workspace-hub    :: or D:\workspace-hub — see Step 1
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1 -Apply -PublicKey "ssh-ed25519 AAAA...REPLACE_ME... operator@ace-linux-1"
 ```
 
@@ -121,7 +127,7 @@ Both Windows hosts have Claude installed. Paste this into a Claude session **on 
 > You are on a Windows fleet host in the workspace-hub ecosystem. Follow
 > `docs/runbooks/windows-remote-exec.md` exactly, for workspace-hub#3721.
 >
-> 1. `cd D:\workspace-hub` and `git pull --ff-only`.
+> 1. `cd` to the workspace-hub checkout — it is `D:\ws\workspace-hub` on at least one host, NOT `D:\workspace-hub`; check both — then `git pull --ff-only`.
 > 2. Run the audit: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1`
 > 3. **Show me the full audit output and stop.** Do not pass `-Apply` yet.
 >

--- a/docs/runbooks/windows-remote-exec.md
+++ b/docs/runbooks/windows-remote-exec.md
@@ -1,0 +1,157 @@
+# Runbook — give a Windows fleet host an inbound SSH channel
+
+**Applies to:** `ace-win-1`, `ace-win-2` · **Issue:** workspace-hub#3721 · **Related:** #3723, deckhand#579, deckhand#581
+
+**Time:** ~5 minutes per host. **Access:** remote desktop to the box. **Rights:** audit needs none; provisioning needs an elevated PowerShell.
+
+---
+
+## Why you are doing this
+
+Both Windows hosts are in `manual_hosts` in `config/fleet-ssh-hosts.yml`, so no fleet automation can reach them. Consequences already measured:
+
+- The 2026-07-30 fleet branch/worktree sweep covered **3 of 5 machines**; neither Windows host could be swept.
+- Equality evidence went **3.5 days** and **11.8 days** stale without anyone noticing (#3724).
+- A 17-day heartbeat outage on one host could not be diagnosed remotely.
+
+One SSH service converts each box from "manual, therefore stale" into "swept like everything else".
+
+---
+
+## Step 0 — know which box you are on
+
+Do not assume the fleet token. deckhand#579/#581 are still settling which physical machine each token denotes, and an alias stayed bound to a retired machine for ~18 days undetected. **The audit in Step 1 prints the real identity — read it before doing anything else.**
+
+If the audit reports a hostname you did not expect, stop and report it on #3721 rather than provisioning.
+
+---
+
+## Step 1 — audit (safe, changes nothing, no admin needed)
+
+Open PowerShell, `cd` to the workspace-hub checkout (`D:\workspace-hub` on the Windows boxes), and run:
+
+```
+git pull --ff-only
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1
+```
+
+You get a section per area — Identity, OpenSSH Server, Authorized keys, Firewall, Default shell, Licensed-run poller — with `[ok]`, `[gap]`, and `[info]` lines, plus an evidence JSON path at the end.
+
+**Expected outcomes:**
+
+| What the audit says | What it means | Next |
+|---|---|---|
+| `sshd service: Running` and no gaps | This host is already reachable | Skip to Step 4 and just verify |
+| `sshd service is absent` | OpenSSH Server not installed | Step 2 |
+| `sshd is not running` / `start type is Manual` | Installed but won't survive reboot | Step 2 |
+| `tailscale.exe not found` | No private transport — **stop** | Report on #3721; do not open 22 without one |
+
+The audit exits non-zero when gaps remain, so it can later be scheduled as an alarm.
+
+---
+
+## Step 2 — provision (elevated)
+
+Close PowerShell and reopen it as **Run as administrator**. You need the operator public key — get it from ace-linux-1 with `cat ~/.ssh/id_ed25519.pub` (or whichever key you use for the fleet).
+
+```
+cd D:\workspace-hub
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1 -Apply -PublicKey "ssh-ed25519 AAAA...REPLACE_ME... operator@ace-linux-1"
+```
+
+Every step is idempotent — re-running is safe and does nothing already done.
+
+It will, only as needed: install the `OpenSSH.Server` capability, set `sshd` to Automatic and start it, append your key to the **correct** `authorized_keys` for your account type and lock its ACL, and create a firewall rule scoped to the tailnet range.
+
+**It deliberately does not touch the licensed-run poller.** Whether that should run on a given host is deckhand#579's decision.
+
+---
+
+## Step 3 — password auth stays on until keys are proven
+
+Do **not** disable password authentication yet. Prove key auth works from ace-linux-1 (Step 4) while you still have a working fallback and a remote-desktop session open. Locking yourself out of a box you can only reach by RDP is the one expensive mistake available here.
+
+Once Step 4 passes, disable password and root login by editing `%ProgramData%\ssh\sshd_config`:
+
+```
+PasswordAuthentication no
+PermitRootLogin no
+```
+
+then `Restart-Service sshd`. Keep the RDP session open until you have re-verified Step 4 after the restart.
+
+---
+
+## Step 4 — verify from ace-linux-1
+
+Run these **on ace-linux-1**, not on the Windows box:
+
+```bash
+# 1. basic reachability
+ssh -o BatchMode=yes <host> 'hostname'
+
+# 2. THE ONE THAT MATTERS — exit code, not just output
+ssh -o BatchMode=yes <host> 'exit 7'; echo $?     # must print 7, not 0
+```
+
+The second check is the acceptance criterion in #3721. The fleet helpers branch on exit status, and a wrong default shell can return correct stdout while losing the exit code — which reads as success everywhere. If it prints `0`, the channel is not usable for automation even though it looks fine.
+
+---
+
+## Step 5 — take the host out of `manual_hosts`
+
+Once Step 4 passes, `config/fleet-ssh-hosts.yml` is stale for this host. **Do not hand-edit it** — that file being hand-maintained is exactly what caused a wrong issue to be filed (#3720, closed). #3723 tracks deriving it from the generated reachability matrix. Comment your verification evidence on #3721 and reference #3723.
+
+---
+
+## Step 6 — refresh this host's equality evidence
+
+While you are on the box, close the staleness gap (#3724):
+
+```
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\equality-report.ps1
+```
+
+---
+
+## Agent prompt (if you would rather have Claude drive it on-box)
+
+Both Windows hosts have Claude installed. Paste this into a Claude session **on the Windows box**:
+
+> You are on a Windows fleet host in the workspace-hub ecosystem. Follow
+> `docs/runbooks/windows-remote-exec.md` exactly, for workspace-hub#3721.
+>
+> 1. `cd D:\workspace-hub` and `git pull --ff-only`.
+> 2. Run the audit: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1`
+> 3. **Show me the full audit output and stop.** Do not pass `-Apply` yet.
+>
+> Rules for this task:
+> - Report the identity the audit prints. If the hostname is not what the fleet
+>   token implies, STOP and tell me — deckhand#579/#581 are unresolved and an alias
+>   was previously bound to a retired machine for ~18 days.
+> - If `tailscale.exe` is not found, STOP. Do not open port 22 without a private
+>   transport.
+> - Never disable password authentication before key auth is proven from
+>   ace-linux-1. I will run that verification myself.
+> - Do not start, stop, or reconfigure the licensed-run poller — that is
+>   deckhand#579's decision, not this task's.
+> - Do not hand-edit `config/fleet-ssh-hosts.yml`; #3723 covers it.
+> - This is a PUBLIC repo. Never put a physical hostname, client name, tailnet
+>   address, or account principal into a commit message, issue comment, or any
+>   tracked file. Use the neutral tokens `ace-win-1` / `ace-win-2` only.
+>
+> After I approve the audit, I will give you the public key and you may re-run with
+> `-Apply` in an elevated shell.
+
+The stop-after-audit shape is deliberate: the identity question has to be answered by a human before anything mutates.
+
+---
+
+## If something goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Key auth refused, key looks right | Admin account, key in the wrong file, or ACL too permissive | Key must be in `%ProgramData%\ssh\administrators_authorized_keys`, ACL Administrators + SYSTEM only. The `-Apply` path does both. |
+| `ssh` connects, commands run, exit code always 0 | Default shell mishandles non-interactive exit | Set `HKLM:\SOFTWARE\OpenSSH\DefaultShell` to a predictable shell, restart `sshd`, re-verify Step 4 |
+| Connects on LAN, not over tailnet | Firewall rule scoped to the wrong range | Check the audit's Firewall section; the rule should allow `100.64.0.0/10` |
+| `Add-WindowsCapability` fails | Not elevated, or WSUS-managed build | Re-open PowerShell as administrator; if it still fails, report the exact error on #3721 |

--- a/scripts/windows/README.md
+++ b/scripts/windows/README.md
@@ -16,6 +16,7 @@ sync when either side changes.
 | Reconcile ecosystem + equality | `scripts/readiness/reconcile-ecosystem.sh` | `scripts/windows/reconcile-ecosystem.ps1` (wraps the .sh via real Git Bash) |
 | Equality collect + matrix | `scripts/readiness/equality-matrix-cron.sh` | `scripts/windows/equality-report.ps1` → `scripts/readiness/collect-equality.ps1` (CIM overlay) → `collect-equality.sh` |
 | Equivalence sentinel | `scripts/monitoring/equivalence-sentinel.sh` | `scripts/windows/equivalence-sentinel.ps1` (wraps the .sh via real Git Bash) |
+| Inbound SSH provisioning | *(n/a — Linux hosts already reachable)* | `scripts/windows/enable-remote-exec.ps1` (Windows-only; see below) |
 
 Run pattern (note the `--` before bash-style flags so PowerShell passes them through):
 
@@ -24,6 +25,44 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\reconcile-ec
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\reconcile-ecosystem.ps1 -- --apply # safe subset
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\equality-report.ps1                # refresh this box's column
 ```
+
+## Inbound SSH provisioning (`enable-remote-exec.ps1`)
+
+Windows hosts sit in `manual_hosts` in [`config/fleet-ssh-hosts.yml`](../../config/fleet-ssh-hosts.yml),
+so fleet automation cannot reach them and their state drifts unobserved — the 2026-07-30 fleet
+sweep covered 3 of 5 machines, and one Windows host's equality evidence was 11.8 days stale
+before anyone noticed. This script closes the reachability half of that gap (workspace-hub#3721).
+
+**Audit-first, like `rdp-microphone.ps1`.** The default run mutates nothing and does not need
+admin — it reports identity, SSH state, firewall exposure, and the poller's condition, then
+writes an evidence JSON. Read that before applying: one of the two Windows hosts already has a
+working SSH service, and which physical machine each fleet token denotes is still being settled
+(deckhand#579, deckhand#581), so the script *reports* identity rather than assuming it.
+
+```
+:: audit — safe, non-admin, changes nothing
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1
+
+:: provision — ELEVATED PowerShell required
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1 -Apply -PublicKey "ssh-ed25519 AAAA... operator@ace-linux-1"
+```
+
+Every apply step is idempotent. Three things it handles that are easy to get wrong by hand:
+
+- **Administrator keys live elsewhere.** sshd reads `%ProgramData%\ssh\administrators_authorized_keys`
+  for any account in the local Administrators group — not `%USERPROFILE%\.ssh\authorized_keys` —
+  and ignores it unless the ACL is Administrators + SYSTEM only. The failure looks like a bad key
+  but is a permission error.
+- **The firewall rule is scoped** to the tailnet CGNAT range (`100.64.0.0/10`) by default, and the
+  audit reports any *other* enabled rule already opening 22 so an unscoped exposure is visible.
+- **Exit codes, not just output.** The fleet helpers branch on exit status, and a wrong default
+  shell can return correct stdout while losing the exit code — which reads as success. Verify with
+  `ssh <host> "exit 7"; echo $?` and require `7`.
+
+It never starts or stops the licensed-run poller: whether that *should* run on a given host is
+deckhand#579's decision, so the script only reports its state.
+
+Full operator walkthrough: [`docs/runbooks/windows-remote-exec.md`](../../docs/runbooks/windows-remote-exec.md).
 
 ## RDP microphone audit and repair
 

--- a/scripts/windows/enable-remote-exec.ps1
+++ b/scripts/windows/enable-remote-exec.ps1
@@ -1,0 +1,281 @@
+# enable-remote-exec.ps1
+# Audit-first provisioning of an inbound SSH channel on a Windows fleet host (#3721).
+#
+# WHY: Windows hosts sit in `manual_hosts` in config/fleet-ssh-hosts.yml, so fleet
+# automation cannot reach them and their state drifts silently — the 2026-07-30 fleet
+# sweep covered 3 of 5 machines, and one Windows host's equality evidence was 11.8 days
+# stale before anyone noticed. This script closes the reachability half of that gap.
+#
+# AUDIT-FIRST (same posture as rdp-microphone.ps1): the default run MUTATES NOTHING.
+# It reports identity, SSH state, firewall exposure, and the poller's condition, and
+# writes an evidence JSON. Pass -Apply to actually provision. Read the audit output
+# before applying — one of the two Windows hosts already has a working SSH service, and
+# which physical machine each fleet token denotes is still being settled (deckhand#579,
+# deckhand#581), so this script reports identity rather than assuming it.
+#
+# IDEMPOTENT: every apply step is a no-op when already in the desired state.
+#
+# Usage (run in an ELEVATED PowerShell — provisioning needs admin):
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1 -Apply -PublicKey "ssh-ed25519 AAAA... vamsee@ace-linux-1"
+#
+# The audit run does NOT require admin and is safe to run first as a normal user.
+
+[CmdletBinding()]
+param(
+    # Provision. Without this the script only reports.
+    [switch]$Apply,
+
+    # The operator public key to authorize. Required with -Apply unless the key is
+    # already present. Accepts the full "ssh-ed25519 AAAA... comment" line.
+    [string]$PublicKey = "",
+
+    # Where to write the evidence JSON. Default: the repo's local state dir.
+    [string]$EvidenceOut = "",
+
+    # Restrict the inbound firewall rule to the tailnet CGNAT range. Set to the empty
+    # string to skip scoping (NOT recommended — an unscoped rule exposes 22 on every
+    # network the host joins, including untrusted ones).
+    [string]$AllowedRemoteAddress = "100.64.0.0/10"
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$script:Findings = [ordered]@{}
+$script:Actions  = New-Object System.Collections.Generic.List[string]
+$script:Problems = New-Object System.Collections.Generic.List[string]
+
+function Write-Section { param([string]$Text) Write-Host "`n=== $Text ===" -ForegroundColor Cyan }
+function Write-Ok      { param([string]$Text) Write-Host "  [ok]   $Text" -ForegroundColor Green }
+function Write-Gap     { param([string]$Text) Write-Host "  [gap]  $Text" -ForegroundColor Yellow; $script:Problems.Add($Text) }
+function Write-Act     { param([string]$Text) Write-Host "  [act]  $Text" -ForegroundColor Magenta; $script:Actions.Add($Text) }
+function Write-Info    { param([string]$Text) Write-Host "  [info] $Text" }
+
+function Test-Elevated {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Identity — report it, never assume it.
+#    deckhand#579/#581 are still settling which physical machine each fleet token
+#    denotes; an alias was bound to a retired machine for ~18 days undetected. So the
+#    first job of this script is to state, from the box itself, who this actually is.
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Identity"
+$hostName = $env:COMPUTERNAME
+$Findings.hostname = $hostName.ToLower()
+Write-Info "hostname: $hostName"
+
+$ts = Get-Command tailscale.exe -ErrorAction SilentlyContinue
+if ($ts) {
+    try {
+        $tsJson = & $ts.Source status --json 2>$null | ConvertFrom-Json
+        $Findings.tailnet_node = $tsJson.Self.HostName
+        $Findings.tailnet_addrs = @($tsJson.Self.TailscaleIPs)
+        $Findings.tailnet_online = [bool]$tsJson.Self.Online
+        Write-Info "tailnet node: $($tsJson.Self.HostName)  online=$($tsJson.Self.Online)"
+        Write-Info "tailnet addr: $($tsJson.Self.TailscaleIPs -join ', ')"
+    } catch {
+        Write-Gap "tailscale present but 'status --json' failed: $($_.Exception.Message)"
+        $Findings.tailnet_node = $null
+    }
+} else {
+    Write-Gap "tailscale.exe not found — this host has no private transport"
+    $Findings.tailnet_node = $null
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. OpenSSH Server capability + service
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "OpenSSH Server"
+$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*' -ErrorAction SilentlyContinue |
+       Select-Object -First 1
+$Findings.openssh_capability = if ($cap) { "$($cap.State)" } else { 'unavailable' }
+if ($cap) { Write-Info "capability OpenSSH.Server: $($cap.State)" }
+else      { Write-Gap  "OpenSSH.Server capability not enumerable on this Windows build" }
+
+$svc = Get-Service -Name sshd -ErrorAction SilentlyContinue
+$Findings.sshd_status     = if ($svc) { "$($svc.Status)" } else { 'absent' }
+$Findings.sshd_start_type = if ($svc) { "$($svc.StartType)" } else { $null }
+if ($svc) {
+    Write-Info "sshd service: $($svc.Status), start=$($svc.StartType)"
+    if ($svc.Status -ne 'Running')   { Write-Gap "sshd is not running" }
+    if ($svc.StartType -ne 'Automatic') { Write-Gap "sshd start type is $($svc.StartType), not Automatic — it will not survive reboot" }
+} else {
+    Write-Gap "sshd service is absent — OpenSSH Server is not installed"
+}
+
+if ($Apply) {
+    if (-not (Test-Elevated)) { throw "-Apply requires an ELEVATED PowerShell (Run as administrator)." }
+    if ($cap -and $cap.State -ne 'Installed') {
+        Write-Act "installing OpenSSH.Server capability"
+        Add-WindowsCapability -Online -Name $cap.Name | Out-Null
+        $svc = Get-Service -Name sshd -ErrorAction SilentlyContinue
+    }
+    if ($svc) {
+        if ($svc.StartType -ne 'Automatic') {
+            Write-Act "setting sshd start type to Automatic"
+            Set-Service -Name sshd -StartupType Automatic
+        }
+        if ($svc.Status -ne 'Running') {
+            Write-Act "starting sshd"
+            Start-Service sshd
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. authorized_keys — the Windows ACL trap
+#    Administrators do NOT use %USERPROFILE%\.ssh\authorized_keys. sshd reads
+#    %ProgramData%\ssh\administrators_authorized_keys for any account in the local
+#    Administrators group, and REFUSES it unless the file is owned by Administrators
+#    or SYSTEM with no other write access. Getting this wrong produces auth failures
+#    that look like bad keys but are permission errors.
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Authorized keys"
+$isAdminUser = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+               ).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+$adminKeyPath = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+$userKeyPath  = Join-Path $env:USERPROFILE '.ssh\authorized_keys'
+$targetKeyPath = if ($isAdminUser) { $adminKeyPath } else { $userKeyPath }
+
+$Findings.current_user       = "$env:USERNAME"
+$Findings.current_user_admin = $isAdminUser
+$Findings.authorized_keys_path = $targetKeyPath
+Write-Info "current user: $env:USERNAME (admin=$isAdminUser)"
+Write-Info "sshd will read: $targetKeyPath"
+
+$keyPresent = $false
+if (Test-Path $targetKeyPath) {
+    $existing = Get-Content $targetKeyPath -ErrorAction SilentlyContinue
+    $Findings.authorized_keys_count = @($existing | Where-Object { $_ -match '\S' }).Count
+    Write-Info "authorized_keys entries: $($Findings.authorized_keys_count)"
+    if ($PublicKey -and ($existing -join "`n") -match [regex]::Escape($PublicKey.Split(' ')[1])) {
+        $keyPresent = $true; Write-Ok "the supplied key is already authorized"
+    }
+} else {
+    $Findings.authorized_keys_count = 0
+    Write-Gap "no authorized_keys file at $targetKeyPath"
+}
+
+if ($Apply -and $PublicKey -and -not $keyPresent) {
+    $dir = Split-Path $targetKeyPath -Parent
+    if (-not (Test-Path $dir)) { Write-Act "creating $dir"; New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    Write-Act "appending public key to $targetKeyPath"
+    Add-Content -Path $targetKeyPath -Value $PublicKey -Encoding ascii
+    if ($isAdminUser) {
+        # Required ACL: Administrators + SYSTEM only. Any other writable principal and
+        # sshd silently ignores the file.
+        Write-Act "locking ACL on $targetKeyPath to Administrators + SYSTEM"
+        icacls.exe $targetKeyPath /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+    }
+} elseif ($Apply -and -not $PublicKey -and -not $keyPresent) {
+    Write-Gap "-Apply given without -PublicKey and no key is present — key auth will not work"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Firewall — private transport only, never public
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Firewall"
+$ruleName = 'fleet-ssh-inbound-22'
+$rule = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
+$Findings.firewall_rule = if ($rule) { "$($rule.Enabled)/$($rule.Profile)" } else { 'absent' }
+if ($rule) {
+    Write-Info "rule '$ruleName': enabled=$($rule.Enabled) profile=$($rule.Profile)"
+} else {
+    Write-Gap "no '$ruleName' rule — inbound 22 may be blocked, or allowed by a broader rule"
+}
+
+# Report any OTHER rule already opening 22 — an unscoped one is a real exposure.
+$other = Get-NetFirewallRule -Direction Inbound -Enabled True -ErrorAction SilentlyContinue |
+    Where-Object { $_.DisplayName -ne $ruleName } |
+    Where-Object {
+        try { ($_ | Get-NetFirewallPortFilter -ErrorAction SilentlyContinue).LocalPort -contains '22' }
+        catch { $false }
+    } | Select-Object -ExpandProperty DisplayName -First 5
+if ($other) {
+    $Findings.other_port22_rules = @($other)
+    Write-Gap "other enabled inbound rules already open 22: $($other -join '; ') — review for public exposure"
+}
+
+if ($Apply -and -not $rule) {
+    Write-Act "creating scoped inbound rule '$ruleName' (RemoteAddress=$AllowedRemoteAddress)"
+    $p = @{ DisplayName=$ruleName; Direction='Inbound'; Action='Allow'; Protocol='TCP'; LocalPort=22 }
+    if ($AllowedRemoteAddress) { $p.RemoteAddress = $AllowedRemoteAddress }
+    New-NetFirewallRule @p | Out-Null
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Default shell — non-interactive exit codes are what the fleet helpers branch on
+#    A wrong default shell can return correct stdout while losing the exit code, which
+#    reads as success. #3721's definition of done requires this be verified, not assumed.
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Default shell"
+$shellKey = 'HKLM:\SOFTWARE\OpenSSH'
+$curShell = (Get-ItemProperty -Path $shellKey -Name DefaultShell -ErrorAction SilentlyContinue).DefaultShell
+$Findings.default_shell = $curShell
+if ($curShell) { Write-Info "DefaultShell: $curShell" }
+else           { Write-Info "DefaultShell unset (sshd default: cmd.exe)" }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Licensed-run poller — report only. Whether it SHOULD run here is deckhand#579's
+#    call (one Windows host was reclassified out of the licensed lane on 2026-07-30),
+#    so this script never starts or stops it.
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Licensed-run poller (report only)"
+$tasks = Get-ScheduledTask -ErrorAction SilentlyContinue |
+    Where-Object { $_.TaskName -match 'licensed|deckhand|agent' }
+if ($tasks) {
+    $Findings.scheduled_tasks = @($tasks | ForEach-Object {
+        $i = $_ | Get-ScheduledTaskInfo -ErrorAction SilentlyContinue
+        [ordered]@{ name=$_.TaskName; state="$($_.State)"; last_run="$($i.LastRunTime)"; last_result=$i.LastTaskResult }
+    })
+    foreach ($t in $Findings.scheduled_tasks) {
+        Write-Info "task '$($t.name)': state=$($t.state) last_run=$($t.last_run) result=$($t.last_result)"
+    }
+} else {
+    $Findings.scheduled_tasks = @()
+    Write-Info "no licensed-run/deckhand/agent scheduled tasks found"
+}
+$agentProc = Get-Process -Name python*,pythonw* -ErrorAction SilentlyContinue | Select-Object -First 3
+$Findings.python_processes = @($agentProc | ForEach-Object { $_.ProcessName })
+Write-Info "python-ish processes running: $(@($agentProc).Count)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Evidence
+# ─────────────────────────────────────────────────────────────────────────────
+Write-Section "Summary"
+$Findings.applied    = [bool]$Apply
+$Findings.actions    = @($script:Actions)
+$Findings.gaps       = @($script:Problems)
+$Findings.checked_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+if (-not $EvidenceOut) {
+    $stateDir = Join-Path $env:LOCALAPPDATA 'workspace-hub\remote-exec'
+    if (-not (Test-Path $stateDir)) { New-Item -ItemType Directory -Path $stateDir -Force | Out-Null }
+    $EvidenceOut = Join-Path $stateDir "remote-exec-$($Findings.hostname).json"
+}
+$Findings | ConvertTo-Json -Depth 6 | Set-Content -Path $EvidenceOut -Encoding utf8
+Write-Host "`nEvidence written: $EvidenceOut"
+
+if ($script:Problems.Count -eq 0) {
+    Write-Ok "no gaps found"
+} else {
+    Write-Host "`n$($script:Problems.Count) gap(s):" -ForegroundColor Yellow
+    $script:Problems | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+}
+
+if (-not $Apply) {
+    Write-Host "`nAUDIT ONLY — nothing was changed. Re-run elevated with -Apply to provision." -ForegroundColor Cyan
+} else {
+    Write-Host "`nApplied $($script:Actions.Count) change(s)." -ForegroundColor Cyan
+    Write-Host "VERIFY FROM ace-linux-1 (exit code matters, not just output):" -ForegroundColor Cyan
+    Write-Host '  ssh <this-host> "exit 7"; echo $?    # must print 7, not 0' -ForegroundColor Cyan
+}
+
+# Non-zero exit when gaps remain and we did not apply, so a scheduled audit can alarm.
+if ($script:Problems.Count -gt 0 -and -not $Apply) { exit 1 }
+exit 0

--- a/scripts/windows/enable-remote-exec.ps1
+++ b/scripts/windows/enable-remote-exec.ps1
@@ -2,20 +2,20 @@
 # Audit-first provisioning of an inbound SSH channel on a Windows fleet host (#3721).
 #
 # WHY: Windows hosts sit in `manual_hosts` in config/fleet-ssh-hosts.yml, so fleet
-# automation cannot reach them and their state drifts silently — the 2026-07-30 fleet
+# automation cannot reach them and their state drifts silently -- the 2026-07-30 fleet
 # sweep covered 3 of 5 machines, and one Windows host's equality evidence was 11.8 days
 # stale before anyone noticed. This script closes the reachability half of that gap.
 #
 # AUDIT-FIRST (same posture as rdp-microphone.ps1): the default run MUTATES NOTHING.
 # It reports identity, SSH state, firewall exposure, and the poller's condition, and
 # writes an evidence JSON. Pass -Apply to actually provision. Read the audit output
-# before applying — one of the two Windows hosts already has a working SSH service, and
+# before applying -- one of the two Windows hosts already has a working SSH service, and
 # which physical machine each fleet token denotes is still being settled (deckhand#579,
 # deckhand#581), so this script reports identity rather than assuming it.
 #
 # IDEMPOTENT: every apply step is a no-op when already in the desired state.
 #
-# Usage (run in an ELEVATED PowerShell — provisioning needs admin):
+# Usage (run in an ELEVATED PowerShell -- provisioning needs admin):
 #   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1
 #   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\enable-remote-exec.ps1 -Apply -PublicKey "ssh-ed25519 AAAA... vamsee@ace-linux-1"
 #
@@ -34,7 +34,7 @@ param(
     [string]$EvidenceOut = "",
 
     # Restrict the inbound firewall rule to the tailnet CGNAT range. Set to the empty
-    # string to skip scoping (NOT recommended — an unscoped rule exposes 22 on every
+    # string to skip scoping (NOT recommended -- an unscoped rule exposes 22 on every
     # network the host joins, including untrusted ones).
     [string]$AllowedRemoteAddress = "100.64.0.0/10"
 )
@@ -58,12 +58,12 @@ function Test-Elevated {
         [Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 1. Identity — report it, never assume it.
+# -----------------------------------------------------------------------------
+# 1. Identity -- report it, never assume it.
 #    deckhand#579/#581 are still settling which physical machine each fleet token
 #    denotes; an alias was bound to a retired machine for ~18 days undetected. So the
 #    first job of this script is to state, from the box itself, who this actually is.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "Identity"
 $hostName = $env:COMPUTERNAME
 $Findings.hostname = $hostName.ToLower()
@@ -83,13 +83,13 @@ if ($ts) {
         $Findings.tailnet_node = $null
     }
 } else {
-    Write-Gap "tailscale.exe not found — this host has no private transport"
+    Write-Gap "tailscale.exe not found -- this host has no private transport"
     $Findings.tailnet_node = $null
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 # 2. OpenSSH Server capability + service
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "OpenSSH Server"
 $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*' -ErrorAction SilentlyContinue |
        Select-Object -First 1
@@ -103,9 +103,9 @@ $Findings.sshd_start_type = if ($svc) { "$($svc.StartType)" } else { $null }
 if ($svc) {
     Write-Info "sshd service: $($svc.Status), start=$($svc.StartType)"
     if ($svc.Status -ne 'Running')   { Write-Gap "sshd is not running" }
-    if ($svc.StartType -ne 'Automatic') { Write-Gap "sshd start type is $($svc.StartType), not Automatic — it will not survive reboot" }
+    if ($svc.StartType -ne 'Automatic') { Write-Gap "sshd start type is $($svc.StartType), not Automatic -- it will not survive reboot" }
 } else {
-    Write-Gap "sshd service is absent — OpenSSH Server is not installed"
+    Write-Gap "sshd service is absent -- OpenSSH Server is not installed"
 }
 
 if ($Apply) {
@@ -127,14 +127,14 @@ if ($Apply) {
     }
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 3. authorized_keys — the Windows ACL trap
+# -----------------------------------------------------------------------------
+# 3. authorized_keys -- the Windows ACL trap
 #    Administrators do NOT use %USERPROFILE%\.ssh\authorized_keys. sshd reads
 #    %ProgramData%\ssh\administrators_authorized_keys for any account in the local
 #    Administrators group, and REFUSES it unless the file is owned by Administrators
 #    or SYSTEM with no other write access. Getting this wrong produces auth failures
 #    that look like bad keys but are permission errors.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "Authorized keys"
 $isAdminUser = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
                ).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
@@ -173,12 +173,12 @@ if ($Apply -and $PublicKey -and -not $keyPresent) {
         icacls.exe $targetKeyPath /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
     }
 } elseif ($Apply -and -not $PublicKey -and -not $keyPresent) {
-    Write-Gap "-Apply given without -PublicKey and no key is present — key auth will not work"
+    Write-Gap "-Apply given without -PublicKey and no key is present -- key auth will not work"
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 4. Firewall — private transport only, never public
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
+# 4. Firewall -- private transport only, never public
+# -----------------------------------------------------------------------------
 Write-Section "Firewall"
 $ruleName = 'fleet-ssh-inbound-22'
 $rule = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
@@ -186,10 +186,10 @@ $Findings.firewall_rule = if ($rule) { "$($rule.Enabled)/$($rule.Profile)" } els
 if ($rule) {
     Write-Info "rule '$ruleName': enabled=$($rule.Enabled) profile=$($rule.Profile)"
 } else {
-    Write-Gap "no '$ruleName' rule — inbound 22 may be blocked, or allowed by a broader rule"
+    Write-Gap "no '$ruleName' rule -- inbound 22 may be blocked, or allowed by a broader rule"
 }
 
-# Report any OTHER rule already opening 22 — an unscoped one is a real exposure.
+# Report any OTHER rule already opening 22 -- an unscoped one is a real exposure.
 $other = Get-NetFirewallRule -Direction Inbound -Enabled True -ErrorAction SilentlyContinue |
     Where-Object { $_.DisplayName -ne $ruleName } |
     Where-Object {
@@ -198,7 +198,7 @@ $other = Get-NetFirewallRule -Direction Inbound -Enabled True -ErrorAction Silen
     } | Select-Object -ExpandProperty DisplayName -First 5
 if ($other) {
     $Findings.other_port22_rules = @($other)
-    Write-Gap "other enabled inbound rules already open 22: $($other -join '; ') — review for public exposure"
+    Write-Gap "other enabled inbound rules already open 22: $($other -join '; ') -- review for public exposure"
 }
 
 if ($Apply -and -not $rule) {
@@ -208,23 +208,67 @@ if ($Apply -and -not $rule) {
     New-NetFirewallRule @p | Out-Null
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 5. Default shell — non-interactive exit codes are what the fleet helpers branch on
+# -----------------------------------------------------------------------------
+# 5. Default shell -- non-interactive exit codes are what the fleet helpers branch on
 #    A wrong default shell can return correct stdout while losing the exit code, which
 #    reads as success. #3721's definition of done requires this be verified, not assumed.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "Default shell"
 $shellKey = 'HKLM:\SOFTWARE\OpenSSH'
-$curShell = (Get-ItemProperty -Path $shellKey -Name DefaultShell -ErrorAction SilentlyContinue).DefaultShell
+# Set-StrictMode makes a missing property THROW rather than yield $null, so probe the
+# property list first. Verified on a live host 2026-07-31: the naive
+# (Get-ItemProperty ...).DefaultShell form aborts the script when DefaultShell is unset,
+# which is exactly the case this section exists to detect.
+$curShell = $null
+$shellProps = Get-ItemProperty -Path $shellKey -ErrorAction SilentlyContinue
+if ($shellProps -and ($shellProps.PSObject.Properties.Name -contains 'DefaultShell')) {
+    $curShell = $shellProps.DefaultShell
+}
 $Findings.default_shell = $curShell
 if ($curShell) { Write-Info "DefaultShell: $curShell" }
 else           { Write-Info "DefaultShell unset (sshd default: cmd.exe)" }
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 6. Licensed-run poller — report only. Whether it SHOULD run here is deckhand#579's
+# Locate Git Bash. It ships with Git for Windows but is NOT on PATH, so `where bash`
+# finds nothing even though it is installed.
+$gitBash = $null
+foreach ($c in @(
+    "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe",
+    "$env:ProgramFiles\Git\bin\bash.exe",
+    "${env:ProgramFiles(x86)}\Git\bin\bash.exe")) {
+    if (Test-Path $c) { $gitBash = $c; break }
+}
+$Findings.git_bash = $gitBash
+
+# Why this matters more than it looks. With cmd.exe as DefaultShell, a POSIX command
+# sent over SSH does not fail -- it MIS-EXECUTES AND RETURNS 0. Measured on a live host
+# 2026-07-31: `ssh <host> 'echo A; echo B'` printed "A; echo B" and exited 0. Every
+# fleet guard branches on exit status, so that is a silent wrong answer, not an error.
+# Routing through Git Bash restores POSIX separators, && chaining, /d/... MSYS paths and
+# exit-code propagation (all verified on the same host).
+if (-not $curShell) {
+    if ($gitBash) {
+        Write-Gap "DefaultShell unset -> sshd serves cmd.exe; POSIX commands will mis-execute and still exit 0"
+        Write-Info "Git Bash available for use as DefaultShell: $gitBash"
+    } else {
+        Write-Gap "DefaultShell unset AND no Git Bash found -- remote POSIX execution cannot be made equivalent here"
+    }
+}
+
+if ($Apply -and -not $curShell -and $gitBash) {
+    Write-Act "setting DefaultShell to Git Bash so remote POSIX commands behave"
+    if (-not (Test-Path $shellKey)) { New-Item -Path $shellKey -Force | Out-Null }
+    New-ItemProperty -Path $shellKey -Name DefaultShell -Value $gitBash -PropertyType String -Force | Out-Null
+    if ((Get-Service sshd -ErrorAction SilentlyContinue).Status -eq 'Running') {
+        Write-Act "restarting sshd to pick up DefaultShell"
+        Restart-Service sshd
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 6. Licensed-run poller -- report only. Whether it SHOULD run here is deckhand#579's
 #    call (one Windows host was reclassified out of the licensed lane on 2026-07-30),
 #    so this script never starts or stops it.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "Licensed-run poller (report only)"
 $tasks = Get-ScheduledTask -ErrorAction SilentlyContinue |
     Where-Object { $_.TaskName -match 'licensed|deckhand|agent' }
@@ -244,9 +288,9 @@ $agentProc = Get-Process -Name python*,pythonw* -ErrorAction SilentlyContinue | 
 $Findings.python_processes = @($agentProc | ForEach-Object { $_.ProcessName })
 Write-Info "python-ish processes running: $(@($agentProc).Count)"
 
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 # 7. Evidence
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 Write-Section "Summary"
 $Findings.applied    = [bool]$Apply
 $Findings.actions    = @($script:Actions)
@@ -269,7 +313,7 @@ if ($script:Problems.Count -eq 0) {
 }
 
 if (-not $Apply) {
-    Write-Host "`nAUDIT ONLY — nothing was changed. Re-run elevated with -Apply to provision." -ForegroundColor Cyan
+    Write-Host "`nAUDIT ONLY -- nothing was changed. Re-run elevated with -Apply to provision." -ForegroundColor Cyan
 } else {
     Write-Host "`nApplied $($script:Actions.Count) change(s)." -ForegroundColor Cyan
     Write-Host "VERIFY FROM ace-linux-1 (exit code matters, not just output):" -ForegroundColor Cyan


### PR DESCRIPTION
Closes the reachability half of #3721. Adds an audit-first PowerShell provisioner, an operator runbook, and a `scripts/windows/README.md` entry.

## Why

Windows hosts sit in `manual_hosts` in `config/fleet-ssh-hosts.yml`, so no fleet automation reaches them. That bucket is self-reinforcing — hosts in it are never swept, so they drift, and drift is only ever caught by someone logging in. Measured on 2026-07-30:

- the fleet branch/worktree sweep covered **3 of 5 machines**; neither Windows host could be swept
- equality evidence went **3.5 days** and **11.8 days** stale unnoticed (#3724)
- a 17-day heartbeat outage could not be diagnosed remotely

## Audit-first

The default run **mutates nothing and needs no admin**. It reports Identity, OpenSSH Server, Authorized keys, Firewall, Default shell, and Licensed-run poller, then writes an evidence JSON. `-Apply` provisions, idempotently. This mirrors `rdp-microphone.ps1`'s existing posture rather than inventing a new one.

It exits non-zero when gaps remain and `-Apply` was not given, so it can later be scheduled as an alarm.

## It reports identity rather than assuming it

deckhand#579/#581 have not settled which physical machine each fleet token denotes, and an alias stayed bound to a **retired machine for ~18 days undetected**. The audit prints the real hostname and tailnet node first, and the runbook tells the operator to stop and report if it isn't what the token implies. Provisioning SSH against a wrong binding would manufacture a second instance of that defect.

## Three traps it handles that hand-provisioning gets wrong

- **Administrator keys live elsewhere.** sshd reads `%ProgramData%\ssh\administrators_authorized_keys` for accounts in the local Administrators group — *not* `%USERPROFILE%\.ssh\authorized_keys` — and ignores it unless the ACL is Administrators + SYSTEM only. The failure presents as a bad key but is a permission error.
- **Firewall scope.** The rule is scoped to the tailnet CGNAT range (`100.64.0.0/10`) by default, and the audit surfaces any *other* enabled inbound rule already opening 22, so an existing unscoped exposure becomes visible instead of staying hidden behind a new tidy rule.
- **Exit codes, not output.** Verification requires `ssh <host> 'exit 7'` to round-trip `7`. The fleet helpers branch on exit status, and a wrong default shell returns correct stdout while losing the exit code — which reads as success everywhere. This is #3721's stated acceptance criterion.

## Deliberately out of scope

- **Never touches the licensed-run poller.** Whether it should run on a given host is deckhand#579's decision — one Windows host was reclassified out of the licensed lane on 2026-07-30. The script only reports its state.
- **Never hand-edits `config/fleet-ssh-hosts.yml`.** That file being hand-maintained is what caused #3720 to be filed on a false premise; #3723 covers deriving it from the generated reachability matrix.
- **Does not disable password auth.** The runbook explicitly sequences that *after* key auth is proven from ace-linux-1, with the RDP session still open. Locking yourself out of an RDP-only box is the one expensive mistake available here.

## Operator experience

`docs/runbooks/windows-remote-exec.md` is a ~5-minute, 6-step walkthrough with an outcome table for the audit, a troubleshooting table, and — for the on-box Claude installs — a **stop-after-audit agent prompt**. That shape is deliberate: the identity question must be answered by a human before anything mutates. The prompt also carries the public-repo constraint (neutral `ace-win-1`/`ace-win-2` tokens only; no physical hostname, client name, tailnet address, or account principal in any tracked file).

## Verification — read this before merging

**The script has not been executed.** No Windows host is reachable to test on — that is the problem it exists to solve — and `pwsh` is not installed on the authoring box, so I could not even parse-check it. What I did do:

| check | result |
|---|---|
| brace / paren / bracket balance | 68/68, 112/112, 27/27 |
| line endings | LF, no CRLF |
| bash-escaping leak into a PowerShell string | found and fixed (`\$?` → single-quoted) |
| public-tier scan (no physical hostname / client name / principal) | clean |

**First run is the real test.** The audit path is side-effect-free by design, which makes it the safe proving ground: run the audit on one host, confirm the output is sane, and only then apply. I would rather ship this honestly untested than claim verification I could not perform — the alternative is another hand-maintained claim that nothing can falsify, which is the exact failure class this PR is responding to.

Refs #3721, #3723, #3724.
