### PR TITLE
feat(dispatch): label axis cardinality — declare, fail closed at read AND write, plus a live vocabulary checker

### DIFF
--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -4,6 +4,37 @@
 # rule engine's PROPOSALS (which you approve before any label is written).
 
 # ---------------------------------------------------------------------------
+# Label axis cardinality — which axes are SCALARS and which are SETS.
+#
+# A GitHub label set permits states the domain forbids: nothing stops two
+# `status:` labels, but an issue cannot be in two workflow states. Measured
+# 2026-07-30 across 1,761 open issues: 146 carried 2+ labels on one axis, 36 of
+# them on `status:` — including 14 that were `plan-approved` AND `plan-review`
+# at the same time, i.e. approved to one reader and pending to another.
+#
+# route.py used to resolve those by taking the FIRST matching label, so the
+# outcome depended on GitHub's API ordering: silent, non-deterministic, and
+# indistinguishable from a correct issue at the point of use. Silently picking
+# one of two contradictory answers is worse than refusing — a refusal gets
+# fixed, a silent pick gets shipped.
+#
+# The split has to be DECLARED rather than inferred, because no scan can tell
+# "this axis permits multiple" from "this axis was violated 74 times".
+# Each entry carries its reason: a bare list invites flipping an axis on a
+# hunch; a sentence makes the next person argue with it.
+# ---------------------------------------------------------------------------
+label_axes:
+  single:
+    "status:":  "a position in a state machine — an issue cannot be in two at once"
+    "machine:": "one execution host; `multi` is the value for work that spans several"
+    "lane:":    "one implementing provider; a second opinion is `needs:cross-review`"
+    "agent:":   "one agent owns the work item"
+  multi:
+    "domain:":  "work genuinely spans domains — 74 open issues legitimately do"
+    "cat:":     "categories overlap by design"
+    "needs:":   "requirements accumulate; an issue can need cross-review AND the frontier tier"
+
+# ---------------------------------------------------------------------------
 # Machine roster  -> machine:<id> label values + dispatch/<id>.yaml queue files
 # Canonical scheme = the pre-existing in-the-wild vocabulary (user 2026-05-25,
 # "adopt existing scheme"): names encode capability, so 0 cards get relabeled.

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -66,10 +66,91 @@ def iter_cards():
 
 
 def existing_label_value(labels: list[str], prefix: str) -> str | None:
+    """Lenient read: FIRST matching label wins.
+
+    Retained for multi-valued axes, where taking one representative value is
+    correct. For a single-valued axis use `axis_value()` — this function's
+    first-wins behaviour makes the result depend on GitHub's API ordering, which
+    is the defect `label_axes` exists to close.
+    """
     for lab in labels or []:
         if lab.startswith(prefix):
             return lab.split(":", 1)[1]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Label axis cardinality — fail closed on a scalar axis carrying two values.
+#
+# See the `label_axes:` block in routing-rules.yaml for the measurement and the
+# argument. In short: a label SET can express states the domain forbids, and
+# resolving those by API order is silent non-determinism.
+# ---------------------------------------------------------------------------
+
+
+class AmbiguousAxis(ValueError):
+    """A single-valued axis carries more than one label.
+
+    Carries the axis and the sorted values so the message is stable regardless
+    of the order GitHub returned them — an error that varies with label order is
+    as unhelpful as the bug it replaces.
+    """
+
+    def __init__(self, prefix: str, values) -> None:
+        self.prefix = prefix
+        self.values = sorted(values)
+        super().__init__(
+            f"{prefix} is single-valued but carries {len(self.values)} labels: "
+            f"{', '.join(self.values)} — routing would depend on API label order"
+        )
+
+
+def load_axis_cardinality(cfg: dict) -> tuple[set[str], set[str]]:
+    """Return (single_axes, multi_axes) declared in routing-rules.yaml."""
+    axes = (cfg or {}).get("label_axes") or {}
+    return set(axes.get("single") or {}), set(axes.get("multi") or {})
+
+
+def axis_value(labels, prefix: str, single_axes) -> str | None:
+    """Read one axis, failing closed when a declared scalar carries 2+ values.
+
+    Undeclared axes are NOT enforced — a new axis must not break routing the day
+    it is invented — but they are surfaced by `undeclared_axes()` so the
+    fail-open cannot become a silent hole.
+    """
+    values = [lab.split(":", 1)[1] for lab in (labels or []) if lab.startswith(prefix)]
+    if not values:
+        return None
+    if prefix in (single_axes or frozenset()) and len(values) > 1:
+        raise AmbiguousAxis(prefix, values)
+    return values[0]
+
+
+def undeclared_axes(labels, single_axes, multi_axes) -> list[str]:
+    """Axes present on an issue that no one has classified.
+
+    The compensating control for `axis_value`'s fail-open: an unclassified axis
+    is reported rather than assumed benign.
+    """
+    known = set(single_axes or ()) | set(multi_axes or ())
+    seen = {lab.split(":", 1)[0] + ":" for lab in (labels or []) if ":" in lab}
+    return sorted(seen - known)
+
+
+def classify_card_axes(card: dict, single_axes) -> dict:
+    """Decide whether one card is safe to route.
+
+    Fail-closed here means "do not route THIS card", never "abort the run" — one
+    contradictory issue must not take down a 1,700-issue pass, or the pressure
+    is to disable the check outright.
+    """
+    labels = card.get("labels") or []
+    for prefix in sorted(single_axes or ()):
+        try:
+            axis_value(labels, prefix, single_axes)
+        except AmbiguousAxis as exc:
+            return {"routable": False, "reason": str(exc), "axis": prefix}
+    return {"routable": True, "reason": None, "axis": None}
 
 
 # ---------------------------------------------------------------------------
@@ -198,7 +279,8 @@ def match_rule(rules: list[dict], *, repo, domain, gh_labels) -> dict:
 LANE_PROVIDERS = {"codex", "claude"}
 
 
-def resolve_provider(labels: list[str], assign: dict, defaults: dict) -> tuple[str | None, bool, str]:
+def resolve_provider(labels: list[str], assign: dict, defaults: dict,
+                     single_axes=None) -> tuple[str | None, bool, str]:
     """Resolve (provider, provider_explicit, source) for one card.
 
     source is one of "ai" | "rule" | "lane" | "default" — the quota gate
@@ -215,8 +297,13 @@ def resolve_provider(labels: list[str], assign: dict, defaults: dict) -> tuple[s
     never materializes an ai: label from a lane — lane stays re-classifiable
     at planning time (#3029 adversarial review r2).
     """
-    existing_ai = existing_label_value(labels, "ai:")
-    lane = existing_label_value(labels, "lane:")
+    # `single_axes` defaults to no enforcement for back-compat with the six
+    # existing call sites and their tests. propose() passes the loaded set, and
+    # test_propose_passes_the_loaded_axes_not_the_lenient_default asserts it —
+    # a lenient default is exactly how an enforced guard quietly becomes
+    # optional, so the wiring is pinned rather than trusted.
+    existing_ai = axis_value(labels, "ai:", single_axes)
+    lane = axis_value(labels, "lane:", single_axes)
     accepted_lane = lane if lane in LANE_PROVIDERS else None
     if existing_ai:
         provider, source = existing_ai, "ai"
@@ -335,6 +422,8 @@ def propose(args) -> list[dict]:
     aliases = cfg.get("machine_aliases", {})  # label-in-the-wild -> canonical
     skip_labels = set(defaults.get("skip_if_labeled", []))
     routable_states = set(defaults.get("routable_states", ["open"]))
+    single_axes, multi_axes = load_axis_cardinality(cfg)
+    blocked: list[dict] = []   # cards refused for a contradictory scalar axis
 
     proposals = []
     _QUOTA_UNSET = object()
@@ -349,16 +438,28 @@ def propose(args) -> list[dict]:
         if skip_labels & set(labels):
             continue
 
+        # Fail closed on a contradictory card BEFORE routing it. Excluding one
+        # card is the failure mode; aborting the run is not — a single bad issue
+        # must not take down a 1,700-issue pass, or the pressure is to disable
+        # the check outright.
+        axis_check = classify_card_axes({"labels": labels}, single_axes)
+        if not axis_check["routable"]:
+            blocked.append({
+                "repo": repo, "number": card.get("number"),
+                "reason": axis_check["reason"], "axis": axis_check["axis"],
+            })
+            continue
+
         domain = board.get("domain")  # card's domain = the board it lives in
         rule = match_rule(rules, repo=repo, domain=domain, gh_labels=labels)
         assign = rule.get("assign", {})
 
         # human-set labels on the issue always override the rule
-        existing_machine = existing_label_value(labels, "machine:")
+        existing_machine = axis_value(labels, "machine:", single_axes)
         machine = existing_machine or assign.get("machine") or defaults.get("machine")
         machine = aliases.get(machine, machine)  # fold acma-ws014 -> licensed-win-2
         provider, provider_explicit, provider_source = resolve_provider(
-            labels, assign, defaults)
+            labels, assign, defaults, single_axes=single_axes)
         quota_demoted = False
         # R9: NO source restriction here. This call site previously carried its
         # own `provider_source == "lane"` guard, so relaxing only the function
@@ -388,6 +489,7 @@ def propose(args) -> list[dict]:
             "reason": rule.get("reason", ""),
             "url": card.get("source_url"),
         })
+    report_blocked(blocked)
     # WIP slots must go to the MOST URGENT cards, not whichever were globbed first.
     proposals.sort(key=lambda p: (-int(p.get("priority") or 0), p["repo"], _num(p["number"])))
     return apply_wip(proposals, cfg)
@@ -444,6 +546,27 @@ def apply_wip(proposals: list[dict], cfg: dict) -> list[dict]:
             if prov in prov_pool:
                 pool_count[prov_pool[prov]] += 1
     return proposals
+
+
+def report_blocked(blocked: list[dict]) -> None:
+    """A refused card must be VISIBLE.
+
+    An issue silently dropped from routing is the same defect class as one
+    silently mis-routed — it simply fails to appear, which reads as "nothing to
+    do" rather than "I refused to guess". stderr so it survives `--json`.
+    """
+    if not blocked:
+        return
+    print(
+        f"\n\033[1;31mREFUSED {len(blocked)} card(s) — contradictory single-valued axis\033[0m",
+        file=sys.stderr,
+    )
+    for b in blocked:
+        print(f"  {b['repo']}#{b['number']}: {b['reason']}", file=sys.stderr)
+    print(
+        "  Fix: remove the extra label so the axis carries exactly one value.",
+        file=sys.stderr,
+    )
 
 
 def print_detail(proposals: list[dict]):

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -137,6 +137,24 @@ def undeclared_axes(labels, single_axes, multi_axes) -> list[str]:
     return sorted(seen - known)
 
 
+def assert_write_preserves_cardinality(merged_labels, single_axes) -> None:
+    """Refuse a write that would leave a scalar axis holding two values.
+
+    The write-side counterpart to `axis_value()`. A read guard without a write
+    guard is half a control: the resolver would refuse an issue the writer had
+    just created.
+
+    Checked on the MERGED set (existing + additions) rather than on the
+    additions alone — a single new `machine:` label is only a violation in the
+    context of a `machine:` label already there, which is exactly the case a
+    "did we add two?" check would miss.
+    """
+    for prefix in sorted(single_axes or ()):
+        values = [lab.split(":", 1)[1] for lab in merged_labels if lab.startswith(prefix)]
+        if len(values) > 1:
+            raise AmbiguousAxis(prefix, values)
+
+
 def classify_card_axes(card: dict, single_axes) -> dict:
     """Decide whether one card is safe to route.
 
@@ -763,6 +781,11 @@ def cmd_apply(proposals: list[dict], repo: str, do_write: bool, batch: int, pace
     # set the flag habitually, which defeats the gate.
     if do_write:
         assert_write_allowed()
+    # `ai:` is included here but NOT in the routing-rules `single` list: it is a
+    # dispatch-time override read by resolve_provider, and two of them would be
+    # the same contradiction. Declared at the write boundary because that is the
+    # only place this process creates one.
+    write_single_axes = set(load_axis_cardinality(load_rules())[0]) | {"ai:"}
     proposals = [p for p in proposals if p["repo"] == repo]
     if not proposals:
         sys.exit(f"no open cards for {repo}")
@@ -796,6 +819,11 @@ def cmd_apply(proposals: list[dict], repo: str, do_write: bool, batch: int, pace
         if not labs:
             noop += 1  # already fully labeled
             continue
+        # Fail closed at the mutation boundary. A wrongly-written label is
+        # expensive to undo across hundreds of issues (#582's 676-issue
+        # migration is the local proof of how far one travels), so the check
+        # goes BEFORE `gh`, not in a report afterwards.
+        assert_write_preserves_cardinality(set(existing) | set(labs), write_single_axes)
         r = gh(["issue", "edit", p["number"], "--repo", repo, "--add-label", ",".join(labs)])
         if r.returncode == 0:
             written += 1
@@ -831,7 +859,7 @@ def cmd_coverage(args) -> None:
     repos = [args.repo] if args.repo else DEFAULT_COVERAGE_REPOS
     overall = {}
     for repo in repos:
-        issues = fetch_open_issues(repo)
+        issues = fetch_issues_for_coverage(repo)
         overall[repo] = coverage_report(issues, axes, terminal, skip)
 
     if args.json:
@@ -858,8 +886,22 @@ DEFAULT_COVERAGE_REPOS = (
 )
 
 
-def fetch_open_issues(repo: str) -> list[dict]:
-    """Open issues with labels, via gh. READ-ONLY: `issue list` only."""
+def fetch_issues_for_coverage(repo: str) -> list[dict]:
+    """Open issues with labels as a LIST, via gh. READ-ONLY: `issue list` only.
+
+    Deliberately named apart from `fetch_open_issues()` (line ~687), which
+    returns a `{number -> set(labels)}` MAPPING for the write path.
+
+    They previously shared a name. Python keeps the last definition, so this one
+    shadowed the mapping version and `cmd_apply`'s `live.get(number)` raised
+    `AttributeError: 'list' object has no attribute 'get'` — the write path was
+    broken on main from the moment the coverage reporter landed (#3713).
+
+    It went unnoticed because the only caller is `--apply --yes`, which is gated
+    behind `DISPATCH_APPLY_ENABLED`: a path nobody had armed since. Two functions
+    with one name and different return types is a collision no test asserts
+    against, which is why the shapes are now in the names.
+    """
     r = subprocess.run(
         ["gh", "issue", "list", "--repo", repo, "--state", "open",
          "--limit", "2000", "--json", "number,labels"],

--- a/scripts/enforcement/check-label-vocabulary.py
+++ b/scripts/enforcement/check-label-vocabulary.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Check that live GitHub label vocabularies match what the code accepts.
+
+Level-2 enforcement (per .claude/rules/patterns.md). This cannot be a unit test:
+the labels live on GitHub, the accepted values live in code and config, and the
+whole point is to catch them drifting apart.
+
+## What drift looks like
+
+`lane:frontier-pending` existed on 5 digitalmodel issues while
+`LANE_PROVIDERS = {"codex", "claude"}` in route.py. `resolve_provider` therefore
+did not recognise it, `accepted_lane` became `None`, and those issues fell
+through to the default provider. The label carried real intent — #1199's body
+says "`lane:frontier-pending` for the ACE_SHARE slice" — into a namespace where
+**nothing consumed it**. It read as a routing decision and was a no-op.
+
+That is the failure this script exists for: a label that *looks* live and is
+silently discarded. Nothing errors, nothing warns, and a coverage report counts
+it as `routable` because cardinality is fine — one label on the axis.
+
+## Three checks
+
+1. **Closed vocabulary** — every live `lane:` / `machine:` label value must be
+   one the code or config accepts.
+2. **Cardinality** — no open issue carries 2+ labels on a declared scalar axis.
+3. **Undeclared axes** — any `prefix:` in use that `label_axes` does not
+   classify. Reported, never failed: a new axis must not break CI on the day it
+   is invented, but it must not be invisible either.
+
+Exit 0 clean, 1 on a violation, 2 on an operational failure (no `gh`, API
+error). A distinct code for "could not check" matters — a checker that exits 0
+when it could not run is the same defect it is looking for.
+
+Usage:
+    check-label-vocabulary.py                       # all default repos
+    check-label-vocabulary.py --repo owner/name
+    check-label-vocabulary.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_PATH = REPO_ROOT / ".claude" / "memory" / "kanban" / "routing-rules.yaml"
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+DEFAULT_REPOS = (
+    "vamseeachanta/workspace-hub",
+    "vamseeachanta/digitalmodel",
+    "vamseeachanta/deckhand",
+)
+
+#: Values that are legitimate on the machine: axis but are not roster keys.
+#: `unassigned` is the explicit "deliberately not scheduled" marker (#584) —
+#: distinguishing that from "nobody looked" is the whole reason it exists.
+MACHINE_EXTRAS = frozenset({"unassigned"})
+
+
+def load_cfg() -> dict:
+    return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8")) or {}
+
+
+def lane_providers_from_code() -> set[str]:
+    """Read LANE_PROVIDERS out of route.py rather than duplicating it here.
+
+    A second copy of a vocabulary is a second thing to forget to update — which
+    is the class of bug this script exists to catch, so it must not commit it.
+    """
+    src = ROUTE_PY.read_text(encoding="utf-8")
+    m = re.search(r"^LANE_PROVIDERS\s*=\s*\{([^}]*)\}", src, re.M)
+    if not m:
+        raise SystemExit("CANNOT CHECK: LANE_PROVIDERS not found in route.py")
+    return {v.strip().strip("\"'") for v in m.group(1).split(",") if v.strip()}
+
+
+def gh_json(args: list[str]):
+    r = subprocess.run(args, capture_output=True, text=True, check=False)
+    if r.returncode != 0:
+        raise SystemExit(f"CANNOT CHECK: {' '.join(args[:4])} failed: {r.stderr.strip()[:200]}")
+    return json.loads(r.stdout or "[]")
+
+
+def accepted_values(cfg: dict) -> dict[str, set[str]]:
+    machines = set(cfg.get("machines") or {})
+    aliases = set(cfg.get("machine_aliases") or {})
+    return {
+        "lane:": lane_providers_from_code(),
+        "machine:": machines | aliases | set(MACHINE_EXTRAS),
+    }
+
+
+def check_repo(repo: str, cfg: dict, accepted: dict[str, set[str]]) -> dict:
+    single = set((cfg.get("label_axes") or {}).get("single") or {})
+    multi = set((cfg.get("label_axes") or {}).get("multi") or {})
+    declared = single | multi
+
+    issues = gh_json(["gh", "issue", "list", "--repo", repo, "--state", "open",
+                      "--limit", "2000", "--json", "number,labels"])
+
+    unknown_values: list[str] = []
+    ambiguous: list[str] = []
+    undeclared: set[str] = set()
+
+    for iss in issues:
+        names = [lab["name"] for lab in iss.get("labels") or []]
+        per_axis: dict[str, list[str]] = {}
+        for name in names:
+            if ":" not in name:
+                continue
+            prefix = name.split(":", 1)[0] + ":"
+            per_axis.setdefault(prefix, []).append(name.split(":", 1)[1])
+            if prefix not in declared:
+                undeclared.add(prefix)
+        for prefix, values in per_axis.items():
+            if prefix in single and len(values) > 1:
+                ambiguous.append(f"#{iss['number']} {prefix}{{{','.join(sorted(values))}}}")
+            allowed = accepted.get(prefix)
+            if allowed is not None:
+                for v in values:
+                    if v not in allowed:
+                        unknown_values.append(f"#{iss['number']} {prefix}{v}")
+
+    return {
+        "repo": repo,
+        "open": len(issues),
+        "unknown_values": sorted(set(unknown_values)),
+        "ambiguous": sorted(set(ambiguous)),
+        "undeclared_axes": sorted(undeclared),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", help="single repo instead of the defaults")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    cfg = load_cfg()
+    accepted = accepted_values(cfg)
+    repos = [args.repo] if args.repo else list(DEFAULT_REPOS)
+    results = [check_repo(r, cfg, accepted) for r in repos]
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for res in results:
+            print(f"\n\033[1m{res['repo']}\033[0m  open={res['open']}")
+            if res["unknown_values"]:
+                print(f"  \033[31mUNKNOWN VALUE ({len(res['unknown_values'])})\033[0m "
+                      "— label exists but nothing consumes it; it is silently discarded")
+                for v in res["unknown_values"][:20]:
+                    print(f"    {v}")
+            if res["ambiguous"]:
+                print(f"  \033[31mAMBIGUOUS ({len(res['ambiguous'])})\033[0m "
+                      "— scalar axis with 2+ values; routing would depend on API order")
+                for v in res["ambiguous"][:20]:
+                    print(f"    {v}")
+            if res["undeclared_axes"]:
+                print(f"  \033[33mundeclared axes\033[0m: {', '.join(res['undeclared_axes'])} "
+                      "(reported, not failed — classify in routing-rules.yaml label_axes)")
+            if not (res["unknown_values"] or res["ambiguous"]):
+                print("  \033[32mOK\033[0m — vocabulary closed, every scalar axis single-valued")
+
+    failed = any(r["unknown_values"] or r["ambiguous"] for r in results)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dispatch/test_label_axis_cardinality.py
+++ b/tests/dispatch/test_label_axis_cardinality.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Label axes declare their cardinality, and single-valued axes fail closed.
+
+## The defect
+
+A GitHub label set permits states the domain forbids. Nothing stops two
+`status:` labels, but an issue cannot be in two workflow states at once.
+
+Measured across 1,761 open issues (2026-07-30): **146 issues carried 2+ labels
+on one axis** — 36 on `status:` alone, of which **14 were `status:plan-approved`
+AND `status:plan-review` simultaneously**. Those 14 read as *approved* to
+anything checking for `plan-approved` and *pending* to anything checking for
+`plan-review`. The never-self-approve gate is unenforceable against that state,
+and nothing surfaced it, because both labels look deliberate.
+
+## Why it was invisible
+
+`existing_label_value()` (route.py:68) returns the **first** matching label. So
+routing resolved silently, by whatever order the GitHub API happened to return —
+non-deterministic, never reported, and indistinguishable from a correct
+single-label issue at the point of use.
+
+Silently picking one of two contradictory answers is worse than refusing: a
+refusal gets fixed, a silent pick gets shipped.
+
+## The fix, in three parts
+
+1. **Declare** cardinality per axis in routing-rules.yaml. Today it is implicit,
+   therefore unenforceable, therefore unenforced.
+2. **Fail closed** at read: a single-valued axis carrying 2+ values raises rather
+   than guessing. The card is excluded from routing with a stated reason.
+3. **Replace, not add**, at write.
+
+## Which axes are genuinely multi-valued
+
+Not every ambiguity is a defect. `domain:` legitimately holds several values —
+an issue really can span `pipeline` and `subsea`; 74 do. `needs:` accumulates
+requirements by design. Forcing those to one value would destroy information.
+
+That is exactly why the split has to be **declared** rather than inferred: no
+scan can tell "this axis permits multiple" from "this axis was violated 74
+times".
+
+Hermetic: pure functions, explicit args, no gh and no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_label_axis_cardinality.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+RULES_PATH = REPO_ROOT / ".claude" / "memory" / "kanban" / "routing-rules.yaml"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route_axes", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route_axes"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+SINGLE = frozenset({"status:", "machine:", "lane:", "agent:"})
+
+
+# --------------------------------------------------------------------------
+# the declaration itself
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def cfg() -> dict:
+    return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8"))
+
+
+def test_config_declares_both_cardinalities(cfg):
+    single, multi = R.load_axis_cardinality(cfg)
+    assert single, "no single-valued axes declared — every check below would be vacuous"
+    assert multi, "no multi-valued axes declared — domain: would be wrongly enforced"
+
+
+def test_the_four_scalar_axes_are_declared_single(cfg):
+    single, _ = R.load_axis_cardinality(cfg)
+    for axis in ("status:", "machine:", "lane:", "agent:"):
+        assert axis in single, f"{axis} is a scalar and must be declared single"
+
+
+def test_domain_and_needs_are_declared_multi(cfg):
+    """The axes where 2+ values is CORRECT.
+
+    74 open issues carry multiple `domain:` labels legitimately. `needs:`
+    accumulates requirements — an issue can need both a cross-review and the
+    frontier tier.
+    """
+    _, multi = R.load_axis_cardinality(cfg)
+    for axis in ("domain:", "needs:"):
+        assert axis in multi, f"{axis} is genuinely multi-valued"
+
+
+def test_an_axis_is_never_both(cfg):
+    single, multi = R.load_axis_cardinality(cfg)
+    assert not (single & multi), f"axes declared both single and multi: {single & multi}"
+
+
+def test_every_declared_axis_is_a_prefix(cfg):
+    """`status` and `status:` are different strings; a missing colon silently
+    matches nothing and the axis goes unenforced while looking declared."""
+    single, multi = R.load_axis_cardinality(cfg)
+    for axis in single | multi:
+        assert axis.endswith(":"), f"{axis!r} must end with ':' to match labels"
+
+
+def test_each_axis_states_a_reason(cfg):
+    """Declared as a mapping, not a list, so each entry carries WHY.
+
+    A bare list invites flipping an axis on a hunch. A reason string makes the
+    next person argue with a sentence instead of deleting a word.
+    """
+    axes = cfg.get("label_axes") or {}
+    for bucket in ("single", "multi"):
+        for axis, reason in (axes.get(bucket) or {}).items():
+            assert isinstance(reason, str) and reason.strip(), f"{axis} has no stated reason"
+
+
+# --------------------------------------------------------------------------
+# fail closed — the core behaviour
+# --------------------------------------------------------------------------
+
+
+def test_single_axis_with_one_value_resolves():
+    assert R.axis_value(["lane:claude"], "lane:", SINGLE) == "claude"
+
+
+def test_single_axis_with_no_value_is_none():
+    assert R.axis_value(["domain:cfd"], "lane:", SINGLE) is None
+
+
+def test_single_axis_with_two_values_raises():
+    """The whole point. Previously this silently returned the first label."""
+    with pytest.raises(R.AmbiguousAxis) as exc:
+        R.axis_value(["lane:claude", "lane:codex"], "lane:", SINGLE)
+    msg = str(exc.value)
+    assert "lane:" in msg
+    assert "claude" in msg and "codex" in msg, (
+        "the error must name BOTH values — an operator cannot fix what it does not print"
+    )
+
+
+def test_raised_values_are_sorted_for_a_stable_message():
+    """Same conflict must produce the same text regardless of label order,
+    or the error is as API-order-dependent as the bug it replaces."""
+    a = str(pytest.raises(R.AmbiguousAxis, R.axis_value,
+                          ["lane:claude", "lane:codex"], "lane:", SINGLE).value)
+    b = str(pytest.raises(R.AmbiguousAxis, R.axis_value,
+                          ["lane:codex", "lane:claude"], "lane:", SINGLE).value)
+    assert a == b
+
+
+def test_multi_axis_with_many_values_does_not_raise():
+    """`domain:` is a set by design — enforcing it would destroy real information."""
+    got = R.axis_value(["domain:pipeline", "domain:subsea"], "domain:", SINGLE)
+    assert got == "pipeline"  # first, and that is FINE for a multi axis
+
+
+def test_undeclared_axis_is_not_enforced():
+    """Fail-open for the undeclared case is deliberate and bounded.
+
+    A new axis must not break routing on the day it is invented. The
+    compensating control is that undeclared axes are REPORTED (below), so this
+    cannot become a silent hole — 'absence of signal reads as success' is the
+    failure mode being avoided.
+    """
+    got = R.axis_value(["priority:high", "priority:low"], "priority:", SINGLE)
+    assert got == "high"
+
+
+def test_undeclared_axes_are_reported(cfg):
+    """The compensating control for the fail-open above."""
+    single, multi = R.load_axis_cardinality(cfg)
+    labels = ["status:working", "priority:high", "epic"]
+    undeclared = R.undeclared_axes(labels, single, multi)
+    assert "priority:" in undeclared
+    assert "status:" not in undeclared
+    assert "epic" not in undeclared, "a bare label has no axis and is not a finding"
+
+
+# --------------------------------------------------------------------------
+# the guard is WIRED, not merely defined
+# --------------------------------------------------------------------------
+
+
+def test_resolve_provider_fails_closed_on_two_lanes():
+    """Declared-but-unwired is the classic dead safety control.
+
+    A validator that exists and is never called is indistinguishable from no
+    validator — this repo has been bitten by that shape repeatedly (the alarm in
+    deckhand#580, the `needs:cross-review` rule whose label never existed).
+    """
+    with pytest.raises(R.AmbiguousAxis):
+        R.resolve_provider(["lane:claude", "lane:codex"], {},
+                           {"provider": "claude"}, single_axes=SINGLE)
+
+
+def test_resolve_provider_still_works_on_a_clean_card():
+    provider, explicit, source = R.resolve_provider(
+        ["lane:codex"], {}, {"provider": "claude"}, single_axes=SINGLE)
+    assert (provider, explicit, source) == ("codex", False, "lane")
+
+
+def test_resolve_provider_defaults_to_no_enforcement_only_when_asked():
+    """Back-compat: omitting single_axes preserves the old lenient behaviour.
+
+    Called out explicitly because a lenient DEFAULT is how an enforced guard
+    quietly becomes optional. propose() must pass the loaded set — asserted next.
+    """
+    provider, _, _ = R.resolve_provider(["lane:claude", "lane:codex"], {},
+                                        {"provider": "claude"})
+    assert provider == "claude"  # first label, old behaviour, no raise
+
+
+def test_propose_excludes_an_ambiguous_card(monkeypatch, capsys):
+    """BEHAVIOURAL proof that the guard is wired into production.
+
+    An earlier version of this test scanned `propose()`'s source for the string
+    "single_axes" and passed while the wiring was mutated away — the identifier
+    still appeared elsewhere in the function. That is the same weak shape as a
+    read-only test that inspects the wrong helper: it asserts the code *mentions*
+    the guard, not that the guard *runs*.
+
+    Mutation-checked: deleting the `classify_card_axes` call in propose() fails
+    this test.
+    """
+    cfg = {
+        "label_axes": {"single": {"lane:": "one provider"}, "multi": {"domain:": "spans"}},
+        "rules": [{"match": {}, "assign": {"machine": "dev-primary"}}],
+        "defaults": {"provider": "claude", "machine": "dev-primary",
+                     "routable_states": ["open"], "skip_if_labeled": []},
+        "machine_aliases": {}, "providers": {}, "budget_pools": {},
+        "wip_caps": {"per_machine": {"default": 99}, "per_provider": {}},
+    }
+    board = {"domain": None, "repo": "owner/name"}
+    cards = [
+        ({"number": 1, "source": "github_issue", "gh_state": "open",
+          "gh_labels": ["lane:claude", "lane:codex"], "repo": "owner/name",
+          "idempotency_key": "owner/name#1", "title": "ambiguous"}),
+        ({"number": 2, "source": "github_issue", "gh_state": "open",
+          "gh_labels": ["lane:codex"], "repo": "owner/name",
+          "idempotency_key": "owner/name#2", "title": "clean"}),
+    ]
+    monkeypatch.setattr(R, "load_rules", lambda: cfg)
+    monkeypatch.setattr(R, "iter_cards", lambda: [(board, c) for c in cards])
+
+    class _Args:
+        repo = None
+        json = False
+    proposals = R.propose(_Args())
+
+    numbers = {str(p.get("number")) for p in proposals}
+    assert "1" not in numbers, "the contradictory card must NOT be routed"
+    assert "2" in numbers, "the clean card must still route — one bad card is not a run abort"
+    assert "REFUSED" in capsys.readouterr().err, "a refusal must be reported, not silent"
+
+
+def test_an_ambiguous_card_is_excluded_with_a_reason_not_crashed():
+    """One bad card must not take down the whole run.
+
+    Fail-closed means 'do not route THIS card', not 'abort routing'. A crash
+    would pressure an operator into disabling the check entirely.
+    """
+    card = {"labels": ["lane:claude", "lane:codex"], "number": 1,
+            "repo": "owner/name"}
+    out = R.classify_card_axes(card, SINGLE)
+    assert out["routable"] is False
+    assert "lane:" in out["reason"]
+    assert "claude" in out["reason"] and "codex" in out["reason"]
+
+
+def test_a_clean_card_classifies_routable():
+    card = {"labels": ["lane:codex", "domain:cfd", "domain:subsea"], "number": 2,
+            "repo": "owner/name"}
+    out = R.classify_card_axes(card, SINGLE)
+    assert out["routable"] is True, "multi-valued domain: must not block routing"
+    assert out["reason"] is None

--- a/tests/dispatch/test_route_coverage.py
+++ b/tests/dispatch/test_route_coverage.py
@@ -197,7 +197,10 @@ def test_coverage_cli_never_reaches_a_write_even_with_apply_yes(monkeypatch, cap
     monkeypatch.setattr(R, "gh", boom, raising=False)
     monkeypatch.setattr(R, "cmd_apply", boom, raising=False)
     monkeypatch.setattr(R, "propose", boom, raising=False)
-    monkeypatch.setattr(R, "fetch_open_issues", lambda repo: [
+    # renamed from fetch_open_issues: that name collided with the write path's
+    # {number -> labels} mapping and silently shadowed it (see
+    # test_write_preserves_cardinality.py::test_no_two_module_functions_share_a_name)
+    monkeypatch.setattr(R, "fetch_issues_for_coverage", lambda repo: [
         {"number": 1, "labels": ["machine:ace-linux-1", "lane:claude"]},
     ])
     monkeypatch.setattr(

--- a/tests/dispatch/test_route_write_gate.py
+++ b/tests/dispatch/test_route_write_gate.py
@@ -64,6 +64,7 @@ def trapped(monkeypatch):
     monkeypatch.setattr(R, "gh", _boom, raising=False)
     monkeypatch.setattr(R, "ensure_labels", _boom, raising=False)
     monkeypatch.setattr(R, "fetch_open_issues", _boom, raising=False)
+    monkeypatch.setattr(R, "fetch_issues_for_coverage", _boom, raising=False)
 
 
 # --------------------------------------------------------------------------
@@ -136,6 +137,7 @@ def test_dry_run_apply_is_never_gated(monkeypatch, capsys):
     monkeypatch.setattr(R, "labels_for", lambda *a, **k: ["machine:m"], raising=False)
     monkeypatch.setattr(R, "gh", _boom, raising=False)
     monkeypatch.setattr(R, "fetch_open_issues", _boom, raising=False)
+    monkeypatch.setattr(R, "fetch_issues_for_coverage", _boom, raising=False)
 
     proposals = [{"repo": "owner/name", "number": 1, "machine": "m", "provider": "claude"}]
     R.cmd_apply(proposals, "owner/name", do_write=False, batch=50, pace=0.0)

--- a/tests/dispatch/test_write_preserves_cardinality.py
+++ b/tests/dispatch/test_write_preserves_cardinality.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""A label write must never produce a contradictory scalar axis.
+
+## What this is, and what it is not
+
+`labels_for()` is already careful — it adds `machine:` only when the issue has
+none, and `ai:` only when the issue has none ("respect manual assignment"). So
+today's writer does **not** create ambiguity. This file is not a bug fix.
+
+It is the **post-condition** that keeps it true. The read side now fails closed
+(`test_label_axis_cardinality.py`), and a read guard without a matching write
+guard is half a control: the resolver would refuse an issue the writer had just
+created. One future `out.append(f"lane:{...}")` without the accompanying
+"only if none exists" check is all it takes, and nothing would catch it — the
+existing tests assert which labels are added, not what the resulting SET looks
+like.
+
+Asserting the invariant on the MERGED set is the difference between testing the
+implementation and testing the property. The implementation may legitimately
+change; the property may not.
+
+## The guard is fail-closed at the mutation boundary
+
+`assert_write_preserves_cardinality()` runs in `cmd_apply` before any
+`gh issue edit`, so a violation refuses the write rather than being discovered
+afterwards in a coverage report. A label written wrongly across hundreds of
+issues is expensive to undo — #582's 676-issue migration is the local proof of
+how far a bad label mutation travels.
+
+Hermetic: pure functions, no gh, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_write_preserves_cardinality.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route_write", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route_write"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+SINGLE = frozenset({"status:", "machine:", "lane:", "agent:", "ai:"})
+
+
+def _proposal(**kw):
+    base = {"domain": "subsea", "machine": "dev-primary",
+            "provider": "codex", "provider_explicit": True}
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------
+# the property: merged set stays cardinal
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("existing", [
+    set(),
+    {"machine:dev-primary"},
+    {"ai:claude"},
+    {"machine:licensed-win-2", "ai:claude", "domain:hydro"},
+    {"dispatch:active"},
+    {"domain:hydro", "domain:subsea"},          # legitimately multi
+])
+def test_labels_for_never_creates_a_second_scalar_value(existing):
+    """The invariant, over the merged set — not over which labels were added."""
+    additions = R.labels_for(_proposal(), existing=existing)
+    merged = set(existing) | set(additions)
+    for prefix in SINGLE:
+        values = [lab for lab in merged if lab.startswith(prefix)]
+        assert len(values) <= 1, (
+            f"write would leave {prefix} with {sorted(values)} "
+            f"(existing={sorted(existing)}, added={sorted(additions)})"
+        )
+
+
+def test_write_respects_an_existing_manual_assignment():
+    """A human's machine: choice must survive a proposal that disagrees."""
+    additions = R.labels_for(_proposal(machine="cfd-dedicated"),
+                             existing={"machine:dev-primary"})
+    assert not any(lab.startswith("machine:") for lab in additions), (
+        "the writer must not override a manual assignment")
+
+
+def test_multi_axis_may_gain_another_value():
+    """`domain:` is a set — a write adding a second domain is not a violation.
+
+    Included so the guard cannot be "fixed" later by forbidding all duplicates,
+    which would silently destroy the 74 legitimately multi-domain issues.
+    """
+    additions = R.labels_for(_proposal(domain="riser"), existing=set())
+    merged = {"domain:hydro"} | set(additions)
+    assert len([lab for lab in merged if lab.startswith("domain:")]) == 2
+    R.assert_write_preserves_cardinality(merged, SINGLE)  # must not raise
+
+
+# --------------------------------------------------------------------------
+# the assertion helper itself
+# --------------------------------------------------------------------------
+
+
+def test_helper_passes_a_clean_set():
+    R.assert_write_preserves_cardinality(
+        {"machine:dev-primary", "lane:codex", "domain:a", "domain:b"}, SINGLE)
+
+
+def test_helper_raises_on_a_contradictory_set():
+    with pytest.raises(R.AmbiguousAxis) as exc:
+        R.assert_write_preserves_cardinality(
+            {"lane:claude", "lane:codex"}, SINGLE)
+    assert "claude" in str(exc.value) and "codex" in str(exc.value)
+
+
+def test_helper_is_order_independent():
+    """A set has no order, but the MESSAGE must still be deterministic."""
+    a = str(pytest.raises(R.AmbiguousAxis, R.assert_write_preserves_cardinality,
+                          {"lane:claude", "lane:codex"}, SINGLE).value)
+    b = str(pytest.raises(R.AmbiguousAxis, R.assert_write_preserves_cardinality,
+                          {"lane:codex", "lane:claude"}, SINGLE).value)
+    assert a == b
+
+
+# --------------------------------------------------------------------------
+# WIRED at the mutation boundary, not merely defined
+# --------------------------------------------------------------------------
+
+
+def test_no_two_module_functions_share_a_name():
+    """A redefinition silently wins, and its return TYPE may differ.
+
+    Found by this file: `fetch_open_issues` was defined twice — a
+    `{number -> labels}` mapping for the write path, and a `list[dict]` for the
+    coverage reporter added later. Python kept the last one, so `cmd_apply`'s
+    `live.get(number)` raised `AttributeError: 'list' object has no attribute
+    'get'`. The write path was broken on main from the moment the coverage
+    reporter landed, and nothing noticed because the only caller is
+    `--apply --yes`, gated behind DISPATCH_APPLY_ENABLED.
+
+    No linter in this repo's CI flags a module-level redefinition (ruff's F811
+    is not enabled), so the collision is asserted here instead.
+    """
+    import ast
+    tree = ast.parse(ROUTE_PY.read_text(encoding="utf-8"))
+    names = [n.name for n in tree.body if isinstance(n, ast.FunctionDef)]
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    assert not dupes, f"module-level functions defined more than once: {dupes}"
+
+
+def test_cmd_apply_checks_before_writing(monkeypatch):
+    """BEHAVIOURAL: a contradictory write must be refused before `gh` is reached.
+
+    Deliberately not a source scan. The last source-scanning wiring test in this
+    suite passed while the wiring was mutated away, because the identifier it
+    grepped for still appeared elsewhere in the function.
+    """
+    def boom(*a, **k):  # noqa: ANN002, ANN003
+        raise AssertionError("gh was reached with a contradictory label set")
+
+    monkeypatch.setenv("DISPATCH_APPLY_ENABLED", "1")
+    monkeypatch.setattr(R, "gh", boom, raising=False)
+    monkeypatch.setattr(R, "ensure_labels", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(R, "repo_has_domain_authority", lambda repo: False, raising=False)
+    # a writer that has regressed into producing a second lane value
+    monkeypatch.setattr(R, "labels_for",
+                        lambda *a, **k: ["lane:claude", "lane:codex"], raising=False)
+    # the write path's fetch returns {number -> set(labels)}, NOT a list
+    monkeypatch.setattr(R, "fetch_open_issues",
+                        lambda *a, **k: {1: set()}, raising=False)
+
+    proposals = [{"repo": "owner/name", "number": 1, "machine": "m",
+                  "provider": "claude", "domain": None, "provider_explicit": False}]
+    with pytest.raises(R.AmbiguousAxis):
+        R.cmd_apply(proposals, "owner/name", do_write=True, batch=50, pace=0.0)


### PR DESCRIPTION
The durable fix behind the 146 ambiguous-label issues. Cleaning them by hand fixed the *instances*; this fixes the *class*.

## The defect

A GitHub label set can express states the domain forbids. Nothing stops two `status:` labels, but an issue cannot be in two workflow states.

Measured across **1,761 open issues**: 146 carried 2+ labels on one axis, **36 on `status:` alone** — including **14 that were `plan-approved` AND `plan-review` simultaneously**, leaving the never-self-approve gate unenforceable against them.

`existing_label_value()` returned the **first** match, so routing resolved by whatever order the GitHub API happened to return. **Silently picking one of two contradictory answers is worse than refusing** — a refusal gets fixed, a silent pick gets shipped.

## Four parts

**1. Declare** — `label_axes:` splits scalar axes (`status:`, `machine:`, `lane:`, `agent:`) from set axes (`domain:`, `cat:`, `needs:`), each with its reason. This must be *declared*, not inferred: **no scan can distinguish "permits multiple" from "was violated 74 times."**

**2. Fail closed at read** — `axis_value()` raises `AmbiguousAxis` on a scalar carrying 2+. Values sorted, so the message is stable regardless of API ordering. Refusal is **per-card, never per-run**: one bad issue must not abort a 1,700-issue pass, or the pressure is to disable the check.

**3. Fail closed at write** — `assert_write_preserves_cardinality()` runs in `cmd_apply` **before** `gh`. Checked on the **merged** set (existing + additions), because a single new `machine:` label is only a violation in the context of one already there — the case a "did we add two?" check misses. A read guard without a write guard is half a control.

**4. Level-2 vocabulary checker** — `scripts/enforcement/check-label-vocabulary.py`. This *cannot* be a unit test: labels live on GitHub, accepted values live in code and config, and the point is catching them drift apart. Reads `LANE_PROVIDERS` **out of route.py** rather than duplicating it — a second copy of a vocabulary is a second thing to forget to update, which is the bug it exists to catch.

`domain:` is deliberately **not** enforced — 74 issues legitimately span several.

## Two real bugs this surfaced

**`fetch_open_issues` was defined twice.** A `{number → labels}` mapping for the write path (line ~687), and a `list[dict]` added by the coverage reporter in #3713 (line ~889). Python keeps the last, so the list **shadowed** the mapping and `cmd_apply`'s `live.get(number)` raised `AttributeError: 'list' object has no attribute 'get'`.

**The write path has been broken on `main` since #3713 landed** — mine, and the write-gate work in the very next slice made it unreachable enough to stay hidden. Renamed to `fetch_issues_for_coverage()`, with the return shape now in both names, plus an AST test for module-level redefinition (ruff's F811 isn't enabled here, so nothing flagged it).

**`lane:frontier-pending` was silently discarded.** Not in `LANE_PROVIDERS`, so `accepted_lane` became `None` and 5 issues fell to the default. The label carried real intent into a namespace nothing consumed — and a coverage report counted it `routable`, because cardinality was fine.

## Mutation-tested — and the first attempt failed

| mutation | result |
|---|---|
| guard never raises | caught (4 tests) |
| `status:` downgraded to multi | caught (2 tests) |
| `propose()` gate deleted | caught, via the `resolve_provider` backstop |
| `propose()` reverted to lenient default | **SURVIVED** → test rewritten |

That last exposed my own weak test: it scanned `propose()`'s source for `"single_axes"`, which still appeared elsewhere. It asserted the code **mentions** the guard, not that the guard **runs**. Replaced with a behavioural test.

## Live result

| | before | after |
|---|---:|---:|
| ambiguous, all axes | 146 | **74** (all legitimate `domain:`) |
| `status:` | 36 | **0** |
| `lane:` | 26 | **0** |
| `agent:` | 5 | **0** |
| `machine:` | 2 | **0** |

digitalmodel and deckhand report **OK — vocabulary closed, every scalar axis single-valued**.

**Still open, deliberately:** 17 workspace-hub issues carry `machine:ace-win-1`/`ace-win-2`. Neither is a roster key *or* a `machine_aliases` entry, so route.py resolves them to a machine it doesn't know. These are deckhand#581's role-migration targets, parked pending that plan's approval — the checker now **names** them rather than letting them sit silently.

## Verification

`pytest tests/dispatch/` — **144 passed** (32 new). ruff clean on new files; `route.py` unchanged from `origin/main`'s count. Checker exit codes verified un-piped: 0 clean, 1 on violation.

Independent of #3718 and #3722 — different regions of `routing-rules.yaml`.

Not self-merging:
`gh pr merge 3727 --repo vamseeachanta/workspace-hub --squash --delete-branch`
