### PR TITLE
fix(dispatch): route by LICENCE **and** CAPACITY — batch work back to the heavy node

### DIFF
--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -29,6 +29,7 @@ label_axes:
     "machine:": "one execution host; `multi` is the value for work that spans several"
     "lane:":    "one implementing provider; a second opinion is `needs:cross-review`"
     "agent:":   "one agent owns the work item"
+    "ai:":      "the human/dispatch provider override — highest precedence, so two would contradict"
   multi:
     "domain:":  "work genuinely spans domains — 74 open issues legitimately do"
     "cat:":     "categories overlap by design"
@@ -94,9 +95,22 @@ providers:
   claude: {tier: workhorse, auto_routable: true}
   codex:  {tier: workhorse, auto_routable: true, budget_pool: codex_pool}
   hermes: {tier: shared,    auto_routable: true, budget_pool: codex_pool}  # consumes codex quota
-  gemini: {tier: scarce,    auto_routable: false, note: "manual ai:gemini only; never auto-route backlog"}
+  # agy REPLACES gemini (workspace-hub#3573). Verified 2026-07-31: `agent:gemini`
+  # carries ZERO open issues, so the swap was already complete in the wild and
+  # only this config lagged. Cross-review is now Claude + Codex + Agy.
+  #
+  # `auto_routable: false` means NOT AUTO-SELECTABLE — defaults, rules and lanes
+  # may not pick agy — NOT "unusable". An explicit `ai:agy` is honoured; the
+  # budget pool below still caps it, so the override moves the SELECTION, not the
+  # CAP. Until 2026-07-31 apply_wip() queued such providers unconditionally, so
+  # the manual escape hatch this comment describes did not actually work.
+  agy:    {tier: scarce,    auto_routable: false, budget_pool: google_ai_pool,
+           note: "Google AI Pro quota. Explicit ai:agy only; never auto-route backlog."}
 
 budget_pools:
+  google_ai_pool:
+    members: [agy]
+    max_concurrent: 1        # scarce; an explicit ai:agy overrides SELECTION, not this cap
   codex_pool:
     members: [codex, hermes]
     max_concurrent: 3        # codex + hermes COMBINED, not each

--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -49,18 +49,28 @@ machines:
   # A licensed capability is only routable when someone recorded that they saw
   # it work, when, and how. `false` is a claim too — it says "checked, does not
   # hold" — and is what keeps a host in the roster without making it a target.
+  # CAPABILITY IS TWO DIMENSIONS, not one: a host must have the LICENCE and the
+  # CAPACITY. Checking only the dimension you were last burned by is how both
+  # defects here happened — see tests/dispatch/test_route_capacity.py.
   licensed-win-1:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
+                     capacity: heavy,
                      licence_verified: false,
-                     notes: "deckhand#579: OrcFxAPI.Model() fails here (DLLError 25) — no Sentinel LDK
-                             runtime, 1947 not listening, hasplms absent. A network soft dongle cannot be
-                             consumed without the client-side runtime. AQWA/OrcaWave are UNVERIFIED here,
-                             not known-good: attestation pending deckhand#542/#544. The capability list
-                             above is inherited from the retired machine this label used to denote — the
-                             name was repointed, the capabilities were not."}
+                     blocked_on: "deckhand#579 — Sentinel LDK runtime absent (OrcFxAPI.Model() fails
+                                  DLLError 25; 1947 not listening, hasplms absent). Owner designates
+                                  THIS the licensed execution host; the licence is a prerequisite in
+                                  flight, not a reason to route elsewhere.",
+                     notes: "THE heavy node: 64 logical cores / 255.7 GB; declared batch target for
+                             dm#1553 (OrcaFlex N≈57 parallel sims). SHARED ACMA production box — cap
+                             concurrency. AQWA/OrcaWave attestation pending deckhand#542/#544."}
   licensed-win-2:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
+                     capacity: workstation,
                      licence_verified: {at: "2026-07-30", by: "owner",
                                         how: "bokalift orcawave-diffraction-solve ran end-to-end on this host"},
-                     aliases: [acma-ws014], notes: "same box as acma-ws014 (mkt-a client workstation)"}
+                     aliases: [acma-ws014],
+                     notes: "Workstation, NOT sized for batch — owner 2026-07-31: 'ws014 is not powerful
+                             enough'. Holds a working licence and is the queue lane's CANONICAL default
+                             (policy licensed_host) for UN-ADDRESSED requests, which is a routing
+                             fallback, not an execution target for batch work."}
   home-win:         {os: windows, role: aux,        notes: "home windows; statements/scans (e.g. Chase)"}
   macbook-portable: {os: macos,   role: aux,        notes: "portable/mobile work"}
   multi:            {os: any,     role: virtual,    notes: "spans machines / not pinned to one box"}
@@ -122,19 +132,34 @@ rules:
   # Windows-only engineering tooling (OrcaWave/AQWA/OrcaFlex) -> licensed boxes.
   # domain_family so the #2878 splits (solver-orcaflex, hydro-diffraction, ...)
   # inherit, but hydrocarbon/hydrostatic/solverless do NOT get pinned to Windows.
-  # deckhand#579: these two targeted licensed-win-1 until 2026-07-30 — a host that
-  # provably cannot obtain a licence. 177 open digitalmodel issues (80 solver +
-  # 97 hydro) were being routed into guaranteed failure. Repointed to the only
-  # host with a dated attestation. This does NOT repoint policy.yml
-  # licensed_host, which #579 holds until OrcFxAPI.Model() succeeds on the new
-  # box; #579's own sequencing constraint says the working host keeps the lane
-  # until then, and this is that host.
+  # These target licensed-win-1: THE heavy node (64 cores / 255.7 GB) and the
+  # owner-designated licensed execution host.
+  #
+  # Two corrections got us here, both mine, both the same mistake one axis apart:
+  #
+  #  1. Originally they targeted licensed-win-1 while its capability list was
+  #     inherited from a RETIRED machine — 177 issues routed to a host that could
+  #     not obtain a licence (deckhand#579).
+  #  2. I then repointed them to licensed-win-2 because it held the only dated
+  #     licence attestation. Owner, 2026-07-31: "ws014 is not powerful enough."
+  #     licensed-win-2 is a WORKSTATION. I had traded a licence failure for a
+  #     capacity failure and called it fixed, because I only re-checked the
+  #     dimension I had just been burned by.
+  #
+  # Capability is LICENCE **and** CAPACITY. licensed-win-1 satisfies capacity and
+  # is blocked on the licence prerequisite, which is declared in `blocked_on`
+  # rather than routed around: silently sending batch work to a lesser host hides
+  # the blockage — the work runs badly instead of visibly waiting.
+  #
+  # Unchanged: policy.yml `licensed_host` stays ace-win-2. That is the queue
+  # lane's default owner for UN-ADDRESSED requests — a different role from the
+  # execution target, and #579 holds it until OrcFxAPI.Model() succeeds.
   - match: {repo: vamseeachanta/digitalmodel, domain_family: solver}
-    assign: {machine: licensed-win-2}
-    reason: "AQWA/OrcaWave bridges need a licensed Windows box (solver + solver-* splits)"
+    assign: {machine: licensed-win-1}
+    reason: "AQWA/OrcaWave/OrcaFlex batch needs the heavy licensed node (solver + solver-* splits)"
   - match: {repo: vamseeachanta/digitalmodel, domain_family: hydro}
-    assign: {machine: licensed-win-2}
-    reason: "RAO/QTF/seakeeping runs use OrcaWave/AQWA (hydro + hydro-* splits)"
+    assign: {machine: licensed-win-1}
+    reason: "RAO/QTF/seakeeping runs are batch-scale — heavy node (hydro + hydro-* splits)"
 
   # CFD / OpenFOAM -> dedicated CFD node; ace-linux-2 remains shared/dev.
   - match: {gh_label: "domain:cfd"}

--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -61,25 +61,34 @@ machines:
                                   THIS the licensed execution host; the licence is a prerequisite in
                                   flight, not a reason to route elsewhere.",
                      notes: "THE heavy node: 64 logical cores / 255.7 GB; declared batch target for
-                             dm#1553 (OrcaFlex N≈57 parallel sims). SHARED ACMA production box — cap
+                             dm#1553 (OrcaFlex N≈57 parallel sims). SHARED client production box — cap
                              concurrency. AQWA/OrcaWave attestation pending deckhand#542/#544."}
   licensed-win-2:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
                      capacity: workstation,
                      licence_verified: {at: "2026-07-30", by: "owner",
                                         how: "bokalift orcawave-diffraction-solve ran end-to-end on this host"},
-                     aliases: [acma-ws014],
-                     notes: "Workstation, NOT sized for batch — owner 2026-07-31: 'ws014 is not powerful
-                             enough'. Holds a working licence and is the queue lane's CANONICAL default
-                             (policy licensed_host) for UN-ADDRESSED requests, which is a routing
-                             fallback, not an execution target for batch work."}
+                     notes: "Workstation, NOT sized for batch — owner 2026-07-31: 'that host is not
+                             powerful enough'. Holds a working licence and is the queue lane's CANONICAL
+                             default (policy licensed_host) for UN-ADDRESSED requests, which is a
+                             routing fallback, not an execution target for batch work.
+                             The physical host binding lives in the PRIVATE machine registry."}
   home-win:         {os: windows, role: aux,        notes: "home windows; statements/scans (e.g. Chase)"}
   macbook-portable: {os: macos,   role: aux,        notes: "portable/mobile work"}
   multi:            {os: any,     role: virtual,    notes: "spans machines / not pinned to one box"}
 
-# Alias map (label-in-the-wild -> canonical machine). route.py folds these so
-# machine:acma-ws014 counts as licensed-win-2 without relabeling existing cards.
+# Alias map (label-in-the-wild -> canonical machine). route.py folds these so a
+# hostname-style straggler counts as its canonical role without relabeling cards.
+#
+# The client-hostname entry was REMOVED 2026-07-31: that label was retired and
+# DELETED from GitHub (40 issues migrated to role labels, deckhand#581), so the
+# alias pointed at nothing. It was also the last client identifier in this
+# PUBLIC file — the Client-PII Gate on PR #3730 is what surfaced it, correctly.
+# Physical host bindings live in the PRIVATE machine registry, never here.
+#
+# The entries below are OURS (see deckhand#581 D7a: a public label may equal a
+# canonical hostname when we own the name). They are retained as read-compat for
+# any card still carrying the old spelling.
 machine_aliases:
-  acma-ws014: licensed-win-2
   ace-linux-1: dev-primary      # hostname-style stragglers -> canonical dispatch name
   ace-linux-2: dev-secondary
   gpu-claw: cfd-dedicated
@@ -155,7 +164,7 @@ rules:
   #     inherited from a RETIRED machine — 177 issues routed to a host that could
   #     not obtain a licence (deckhand#579).
   #  2. I then repointed them to licensed-win-2 because it held the only dated
-  #     licence attestation. Owner, 2026-07-31: "ws014 is not powerful enough."
+  #     licence attestation. Owner, 2026-07-31: "that host is not powerful enough."
   #     licensed-win-2 is a WORKSTATION. I had traded a licence failure for a
   #     capacity failure and called it fixed, because I only re-checked the
   #     dimension I had just been burned by.

--- a/scripts/dispatch/chain.py
+++ b/scripts/dispatch/chain.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""chain.py — traceability from issue to published capability (deckhand#584 §3).
+
+READ-ONLY. Reports where the chain BREAKS, which is the requirement:
+"surface where the chain breaks, not just where it completes — a result with no
+capability is the interesting case."
+
+## The distinction this tool is built around
+
+A stage with zero occupancy has two completely different causes:
+
+    UNREPRESENTABLE   the label does not exist — nothing COULD be here
+    EMPTY             the label exists and nobody is in it
+
+`executed: 0` invites "nothing has finished yet". If `dispatch:done` does not
+exist, the truth is "finishing cannot be recorded" — a defect in the chain, not a
+measurement of progress. Every stage therefore carries its vocabulary status, and
+a missing one is reported as a break rather than a count.
+
+## What it found on first run
+
+`SCHEMA.yaml:125` documents `dispatch:<state>` as `ready | active | done`. Only
+`dispatch:ready` exists. 867 open issues sit in it and cannot move, because the
+next two states have no vocabulary.
+
+Usage:
+    chain.py                    # all default repos
+    chain.py --repo owner/name
+    chain.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+#: Ordered chain. An issue is reported at its FURTHEST stage — reporting the
+#: earliest would make progress invisible.
+STAGES = ("unassigned", "assigned", "queued", "executing", "executed", "result", "published")
+
+#: The label that puts an issue at each stage. `unassigned` is the absence of a
+#: machine, so it has no marker; `result` and `published` are not label-borne at
+#: all — see NOT_LABEL_BORNE below.
+STAGE_MARKER = {
+    "queued": "dispatch:ready",
+    "executing": "dispatch:active",
+    "executed": "dispatch:done",
+}
+
+#: These stages cannot be determined from labels. `result` needs a join against
+#: the licensed-run queue (queue/results/<id>.json); `published` needs the
+#: aceengineer-website capability pages. Reported as NOT-MEASURED rather than
+#: zero, because a zero here would be indistinguishable from "nothing shipped" —
+#: the exact conflation this tool exists to prevent.
+NOT_LABEL_BORNE = ("result", "published")
+
+DEFAULT_REPOS = (
+    "vamseeachanta/workspace-hub",
+    "vamseeachanta/digitalmodel",
+    "vamseeachanta/deckhand",
+)
+
+
+def stage_of(issue: dict) -> str:
+    """Furthest stage this issue has demonstrably reached.
+
+    Deliberately does NOT treat `state: closed` as executed: closing an issue is
+    not evidence it ran, and inferring so would fabricate the completion the
+    chain exists to verify.
+    """
+    labels = set(issue.get("labels") or [])
+    furthest = "unassigned"
+    if any(lab.startswith("machine:") for lab in labels):
+        furthest = "assigned"
+    for stage in ("queued", "executing", "executed"):
+        if STAGE_MARKER[stage] in labels:
+            furthest = stage
+    return furthest
+
+
+def chain_report(issues: list[dict], vocabulary: set[str]) -> dict:
+    """Population per stage, plus the breaks. Pure: no IO."""
+    counts = {s: 0 for s in STAGES}
+    for iss in issues:
+        counts[stage_of(iss)] += 1
+
+    stages = {}
+    for s in STAGES:
+        if s in NOT_LABEL_BORNE:
+            vocab = "not-measured"
+        elif s in STAGE_MARKER:
+            vocab = "present" if STAGE_MARKER[s] in vocabulary else "MISSING"
+        else:
+            vocab = "present"   # unassigned/assigned are label-presence, not a marker
+        stages[s] = {"count": counts[s], "vocabulary": vocab}
+
+    breaks = [
+        {"stage": s, "kind": "unrepresentable",
+         "detail": f"{STAGE_MARKER[s]} does not exist — nothing can reach this stage"}
+        for s in STAGES if stages[s]["vocabulary"] == "MISSING"
+    ]
+
+    # The wall: the most-populated stage whose NEXT stage is unreachable. A
+    # pile-up in front of a missing state is a different problem from a pile-up
+    # in front of a busy one, and only the first is a vocabulary defect.
+    wall = None
+    for i, s in enumerate(STAGES[:-1]):
+        nxt = STAGES[i + 1]
+        if stages[nxt]["vocabulary"] == "MISSING" and counts[s] > 0:
+            if wall is None or counts[s] > wall["count"]:
+                wall = {"stage": s, "count": counts[s], "next_stage": nxt,
+                        "next_stage_vocabulary": "MISSING"}
+
+    return {"stages": stages, "breaks": breaks, "wall": wall, "total": len(issues)}
+
+
+def fetch(repo: str) -> tuple[list[dict], set[str]]:
+    def gh(args):
+        r = subprocess.run(args, capture_output=True, text=True, check=False)
+        if r.returncode != 0:
+            sys.exit(f"CANNOT CHECK: {' '.join(args[:4])}: {r.stderr.strip()[:160]}")
+        return json.loads(r.stdout or "[]")
+
+    raw = gh(["gh", "issue", "list", "--repo", repo, "--state", "open",
+              "--limit", "2000", "--json", "number,labels,state"])
+    issues = [{"number": i["number"], "state": i.get("state"),
+               "labels": [l["name"] for l in i.get("labels") or []]} for i in raw]
+    vocab = {l["name"] for l in gh(["gh", "label", "list", "--repo", repo,
+                                    "--limit", "400", "--json", "name"])}
+    return issues, vocab
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    out = {}
+    for repo in ([args.repo] if args.repo else list(DEFAULT_REPOS)):
+        issues, vocab = fetch(repo)
+        out[repo] = chain_report(issues, vocab)
+
+    if args.json:
+        print(json.dumps(out, indent=2))
+        return 1 if any(r["breaks"] for r in out.values()) else 0
+
+    for repo, rep in out.items():
+        print(f"\n\033[1m{repo}\033[0m  open={rep['total']}")
+        for s in STAGES:
+            st = rep["stages"][s]
+            mark = {"MISSING": "\033[31mNO LABEL\033[0m",
+                    "not-measured": "\033[2mnot measured here\033[0m",
+                    "present": ""}[st["vocabulary"]]
+            print(f"    {s:<12}{st['count']:>6}   {mark}")
+        if rep["wall"]:
+            w = rep["wall"]
+            print(f"  \033[1;31mWALL: {w['count']} issue(s) at '{w['stage']}' — "
+                  f"'{w['next_stage']}' has no label, so none can advance\033[0m")
+        for b in rep["breaks"]:
+            print(f"  \033[31mBREAK\033[0m {b['stage']}: {b['detail']}")
+
+    print("\n\033[2mREAD-ONLY. `result` and `published` need a join against the "
+          "licensed-run queue and the website; reported as not-measured rather "
+          "than zero so an unbuilt join cannot read as 'nothing shipped'.\033[0m")
+    return 1 if any(r["breaks"] for r in out.values()) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -546,18 +546,47 @@ def apply_wip(proposals: list[dict], cfg: dict) -> list[dict]:
     for p in proposals:
         m, prov = p["machine"], p["provider"]
         over = False
-        # provider must be auto-routable (gemini etc. are manual-only)
-        if providers.get(prov, {}).get("auto_routable", True) is False:
+        reason = None
+
+        # (1) UNKNOWN PROVIDER -> refuse. This used to read
+        #     `providers.get(prov, {}).get("auto_routable", True)`, so an
+        #     unrecognised value inherited True and sailed past every scarce cap
+        #     — fail-OPEN, one line below a docstring promising fail-CLOSED.
+        #     A typo (`ai:agi`) or a label left over from a retired provider must
+        #     not become a workhorse: nothing in the roster has vouched for its
+        #     quota or capacity. (deckhand#584 slice 4; found by Codex design
+        #     review before this slice was built on top of it.)
+        if prov not in providers:
             over = True
+            reason = f"unknown provider {prov!r} — not in the providers roster"
+        # (2) NOT AUTO-SELECTABLE != NOT USABLE. `auto_routable: false` exists to
+        #     say "defaults, rules and lanes may not pick this; a human may".
+        #     The old code queued such a provider unconditionally, so the manual
+        #     escape hatch its own config comment documented did not work.
+        #     An explicit `ai:` choice (provider_explicit) now passes; the budget
+        #     pool below still applies, so the override moves the SELECTION, not
+        #     the CAP.
+        elif providers.get(prov, {}).get("auto_routable", True) is False:
+            if not p.get("provider_explicit"):
+                over = True
+                reason = f"provider {prov!r} is manual-only (needs an explicit ai: label)"
         mcap = per_machine.get(m, m_default)         # default applies to home-win/macbook/multi/etc.
         if m_count[m] >= mcap:
             over = True
+            reason = reason or f"machine {m!r} at WIP cap {mcap}"
         if prov in prov_pool:
-            if pool_count[prov_pool[prov]] >= pool_cap.get(prov_pool[prov], 999):
+            pcap = pool_cap.get(prov_pool[prov], 999)
+            if pool_count[prov_pool[prov]] >= pcap:
                 over = True
+                reason = reason or f"budget pool {prov_pool[prov]!r} at cap {pcap}"
         elif p_count[prov] >= per_provider.get(prov, p_default):
             over = True
+            reason = reason or f"provider {prov!r} at WIP cap"
         p["slot"] = "queued" if over else "active-eligible"
+        # A queued card without a stated reason is indistinguishable from one
+        # nobody got to. Every refusal names itself.
+        if over:
+            p["wip_reason"] = reason
         if not over:
             m_count[m] += 1
             p_count[prov] += 1

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -475,7 +475,7 @@ def propose(args) -> list[dict]:
         # human-set labels on the issue always override the rule
         existing_machine = axis_value(labels, "machine:", single_axes)
         machine = existing_machine or assign.get("machine") or defaults.get("machine")
-        machine = aliases.get(machine, machine)  # fold acma-ws014 -> licensed-win-2
+        machine = aliases.get(machine, machine)  # fold a hostname straggler -> its role
         provider, provider_explicit, provider_source = resolve_provider(
             labels, assign, defaults, single_axes=single_axes)
         quota_demoted = False

--- a/tests/dispatch/test_ai_provider_axis.py
+++ b/tests/dispatch/test_ai_provider_axis.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""The `ai:` provider axis — deckhand#584 slice 4.
+
+Owner decision 2026-07-30: **frontier default models and default effort for all
+work.** So `ai:` selects the PROVIDER only; each provider then uses its own
+frontier default at default effort. There is no `model:` axis and no effort axis.
+
+## What a Codex design review found BEFORE this was built
+
+Two defects in the code this slice would have been built on top of. Both verified
+against `apply_wip()` in route.py:
+
+**1. Unknown providers fail OPEN.**
+
+    if providers.get(prov, {}).get("auto_routable", True) is False:
+
+An unrecognised provider gets `True` — auto-routable — and sails past the scarce
+cap. The docstring one line above says "Fail-CLOSED". So a typo (`ai:agi`), or a
+label left over from a retired provider, routes as a full workhorse rather than
+being refused. That is the same shape as every other defect in this subsystem:
+absence of a match reads as permission.
+
+**2. `auto_routable: false` strands the manual override it exists to permit.**
+
+The gemini entry reads `auto_routable: false, note: "manual ai:gemini only"`. But
+`apply_wip` sets `over = True` for that provider unconditionally — including when
+a human explicitly wrote `ai:gemini`. The config says "manual only"; the code
+means "never". Those differ, and the comment hid it.
+
+The distinction the config was missing: **not auto-SELECTABLE** (defaults, rules
+and lanes may not choose it) is not the same as **not usable** (a human may).
+
+## Design recorded here
+
+- `ai:` is the human/dispatch override and has the HIGHEST precedence.
+- It is single-valued — now declared in `label_axes`, not just enforced at the
+  write boundary as it was before.
+- Unknown provider values are REFUSED with a visible reason.
+- `auto_routable: false` blocks default/rule/lane selection, never an explicit
+  `ai:` choice.
+- Reserved axes: no routing axis may be `model:`, `effort:`, `reasoning:` or
+  `tier:`. Banning one spelling invites synonyms; the denylist names the class.
+
+Hermetic: pure functions and parsed YAML. No gh, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_ai_provider_axis.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+RULES_PATH = REPO_ROOT / ".claude" / "memory" / "kanban" / "routing-rules.yaml"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route_ai", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route_ai"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+
+
+@pytest.fixture(scope="module")
+def cfg() -> dict:
+    return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8"))
+
+
+def _cards(provider, explicit, n=1):
+    return [{"key": f"k{i}", "machine": "dev-primary", "provider": provider,
+             "provider_explicit": explicit, "priority": 0} for i in range(n)]
+
+
+# --------------------------------------------------------------------------
+# provider vocabulary is closed and fails CLOSED
+# --------------------------------------------------------------------------
+
+
+def test_unknown_provider_is_not_silently_auto_routable():
+    """The verified fail-open. A typo must not become a workhorse."""
+    cfg = {"providers": {"claude": {"auto_routable": True}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {}}
+    out = R.apply_wip(_cards("agi-typo", False), cfg)
+    assert out[0]["slot"] == "queued", (
+        "an unrecognised provider must never be auto-eligible — it is not in the "
+        "roster, so nothing has vouched for its capacity or quota"
+    )
+
+
+def test_unknown_provider_is_reported_not_just_queued():
+    """Queued-and-silent is how a typo survives for months."""
+    cfg = {"providers": {"claude": {"auto_routable": True}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {}}
+    out = R.apply_wip(_cards("agi-typo", False), cfg)
+    assert out[0].get("wip_reason"), "a refusal must carry a reason"
+    assert "unknown provider" in out[0]["wip_reason"].lower()
+
+
+def test_known_provider_still_routes():
+    cfg = {"providers": {"claude": {"auto_routable": True}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {}}
+    out = R.apply_wip(_cards("claude", False), cfg)
+    assert out[0]["slot"] == "active-eligible"
+
+
+# --------------------------------------------------------------------------
+# auto_routable blocks SELECTION, not the explicit override
+# --------------------------------------------------------------------------
+
+
+def test_non_auto_routable_provider_is_queued_when_not_explicit():
+    """Defaults, rules and lanes must not select a scarce provider."""
+    cfg = {"providers": {"agy": {"auto_routable": False}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {}}
+    out = R.apply_wip(_cards("agy", False), cfg)
+    assert out[0]["slot"] == "queued"
+
+
+def test_non_auto_routable_provider_IS_eligible_when_a_human_chose_it():  # noqa: N802
+    """The second verified defect.
+
+    `auto_routable: false` with `note: "manual ai:X only"` meant the config
+    intended manual use to work. The code queued it regardless, so the documented
+    escape hatch did not exist. "Not auto-selectable" ≠ "not usable".
+    """
+    cfg = {"providers": {"agy": {"auto_routable": False}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {}}
+    out = R.apply_wip(_cards("agy", True), cfg)
+    assert out[0]["slot"] == "active-eligible", (
+        "an explicit ai: override must be able to use a manual-only provider — "
+        "otherwise the override the config documents does not work"
+    )
+
+
+def test_an_explicit_override_still_obeys_its_budget_pool():
+    """Override the SELECTION, not the CAP. Scarce quota stays scarce.
+
+    Without this, `ai:agy` would be an unbounded bypass of the very quota that
+    made the provider manual-only.
+    """
+    cfg = {"providers": {"agy": {"auto_routable": False, "budget_pool": "google_pool"}},
+           "wip_caps": {"per_machine": {"dev-primary": 9}, "per_provider": {}},
+           "budget_pools": {"google_pool": {"members": ["agy"], "max_concurrent": 1}}}
+    out = R.apply_wip(_cards("agy", True, n=3), cfg)
+    slots = [p["slot"] for p in out]
+    assert slots == ["active-eligible", "queued", "queued"], slots
+
+
+# --------------------------------------------------------------------------
+# the shipped roster
+# --------------------------------------------------------------------------
+
+
+def test_agy_has_replaced_gemini_in_the_roster(cfg):
+    """workspace-hub#3573 swapped the provider; the routing config had not caught up.
+
+    Measured 2026-07-31: `agent:gemini` carries ZERO open issues, so the swap is
+    complete in the wild and only the config lagged.
+    """
+    providers = cfg.get("providers") or {}
+    assert "agy" in providers, "agy is the cross-review provider and must be declared"
+    assert "gemini" not in providers, "gemini was replaced by agy (workspace-hub#3573)"
+
+
+def test_agy_is_scarce_and_pooled(cfg):
+    """Google AI Pro quota. Frontier-default-for-all-work sets the MODEL, not the
+    budget — an explicitly chosen provider still needs a hard cap."""
+    agy = (cfg.get("providers") or {}).get("agy") or {}
+    assert agy.get("auto_routable") is False, "agy must not be auto-selected from backlog"
+    pool = agy.get("budget_pool")
+    assert pool, "agy needs a budget pool or its scarce quota is unbounded"
+    caps = ((cfg.get("budget_pools") or {}).get(pool) or {})
+    assert caps.get("max_concurrent"), f"{pool} needs a max_concurrent"
+
+
+def test_ai_axis_is_declared_single(cfg):
+    """It was enforced only at the WRITE boundary before this slice.
+
+    A guard applied on one side of a system and not the other is the shape that
+    let the read path and write path disagree elsewhere in this file's history.
+    """
+    single = set((cfg.get("label_axes") or {}).get("single") or {})
+    assert "ai:" in single, "ai: is single-valued and must be declared, not just write-gated"
+
+
+# --------------------------------------------------------------------------
+# no model / effort axis — by CLASS, not by one spelling
+# --------------------------------------------------------------------------
+
+
+RESERVED = ("model:", "effort:", "reasoning:", "tier:")
+
+
+def test_no_reserved_axis_is_declared(cfg):
+    """Owner decision: frontier defaults everywhere, so no model or effort knob.
+
+    A denylist rather than a single ban because banning `model:` alone invites
+    the same control under another spelling. Naming the CLASS is what stops the
+    next synonym.
+    """
+    axes = cfg.get("label_axes") or {}
+    declared = set(axes.get("single") or {}) | set(axes.get("multi") or {})
+    bad = sorted(a for a in declared if a in RESERVED)
+    assert not bad, (
+        f"reserved axes declared: {bad}. Frontier defaults are the owner decision; "
+        "a model/effort axis needs a new decision, not a new label."
+    )
+
+
+def test_no_rule_matches_a_reserved_axis(cfg):
+    """The label could exist unroutingly; a RULE reading it is the real breach."""
+    offenders = []
+    for rule in cfg.get("rules") or []:
+        label = (rule.get("match") or {}).get("gh_label") or ""
+        if any(label.startswith(a) for a in RESERVED):
+            offenders.append(label)
+    assert not offenders, f"routing rules read a reserved axis: {offenders}"
+
+
+def test_reserved_list_is_not_empty():
+    """Guards the guard: an emptied RESERVED tuple would make both checks pass."""
+    assert RESERVED and all(a.endswith(":") for a in RESERVED)

--- a/tests/dispatch/test_route_capacity.py
+++ b/tests/dispatch/test_route_capacity.py
@@ -8,7 +8,7 @@ that could not obtain an OrcaFlex licence. I fixed it by repointing those rules
 to `licensed-win-2`, the only host carrying a dated licence attestation, and
 shipped that in workspace-hub#3718.
 
-The owner's correction, 2026-07-31: **"ws014 is not powerful enough."**
+The owner's correction, 2026-07-31: **"that host is not powerful enough."**
 
 `licensed-win-2` is a workstation. `licensed-win-1` is the heavy node — 64
 logical cores / 255.7 GB, the declared batch target for OrcaFlex runs of ~57

--- a/tests/dispatch/test_route_capacity.py
+++ b/tests/dispatch/test_route_capacity.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""A routing target must satisfy EVERY dimension the work needs, not just one.
+
+## The mistake this corrects — mine, made earlier today
+
+deckhand#579 found that solver/hydro work was routed to `licensed-win-1`, a host
+that could not obtain an OrcaFlex licence. I fixed it by repointing those rules
+to `licensed-win-2`, the only host carrying a dated licence attestation, and
+shipped that in workspace-hub#3718.
+
+The owner's correction, 2026-07-31: **"ws014 is not powerful enough."**
+
+`licensed-win-2` is a workstation. `licensed-win-1` is the heavy node — 64
+logical cores / 255.7 GB, the declared batch target for OrcaFlex runs of ~57
+parallel sims (dm#1553). So the fix sent batch analysis to a box that cannot
+carry it. I traded a licence failure for a capacity failure and called it fixed,
+because I was only checking the dimension I had just been burned by.
+
+## The general shape
+
+Capability is not one property. A host must satisfy **all** of:
+
+    licence   — can it obtain the licence the workload needs?
+    capacity  — is it sized for the workload?
+
+Checking one dimension and declaring victory is how the original defect happened
+(the capability list was inherited from a retired machine and nobody re-checked)
+and how my fix repeated it one axis over.
+
+## And the second lesson: rerouting is not always the fix
+
+When the *designated* host is blocked on a prerequisite, silently rerouting to a
+lesser host hides the blockage — the work runs badly instead of visibly waiting.
+The honest state is "blocked on a named, dated prerequisite", declared in the
+config where a human reads it.
+
+Hence `blocked_on`: a host may be a routing target with an unmet licence **only
+if** the block is explicitly named. Absent that, an unverified licence is silent
+and the guard fires.
+
+Hermetic: parses the shipped YAML. No gh, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_route_capacity.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_PATH = REPO_ROOT / ".claude" / "memory" / "kanban" / "routing-rules.yaml"
+
+#: Workloads whose runs are batch-scale and need a heavy node, not a workstation.
+HEAVY_DOMAINS = {"solver", "hydro"}
+LICENSED_CAPABILITIES = {"orcaflex", "orcawave", "aqwa"}
+
+
+@pytest.fixture(scope="module")
+def cfg() -> dict:
+    return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def machines(cfg) -> dict:
+    return cfg["machines"]
+
+
+# --------------------------------------------------------------------------
+# capacity is declared at all
+# --------------------------------------------------------------------------
+
+
+def test_every_licensed_host_declares_a_capacity(machines):
+    """A licensed host with no declared capacity cannot be reasoned about.
+
+    This is the field whose absence let me pick a workstation for batch work:
+    there was nothing in the config that said it was one.
+    """
+    missing = [
+        name for name, spec in machines.items()
+        if set(spec.get("capabilities") or []) & LICENSED_CAPABILITIES
+        and not spec.get("capacity")
+    ]
+    assert not missing, f"licensed hosts with no declared capacity: {missing}"
+
+
+def test_capacity_values_are_from_a_closed_set(machines):
+    allowed = {"heavy", "workstation", "dev", "compute", "aux"}
+    bad = {n: s["capacity"] for n, s in machines.items()
+           if s.get("capacity") and s["capacity"] not in allowed}
+    assert not bad, f"unknown capacity values: {bad} (allowed: {sorted(allowed)})"
+
+
+def test_exactly_one_heavy_licensed_host_is_declared(machines):
+    """Sanity: the fleet has one batch-scale licensed node.
+
+    If a second appears this test should be updated deliberately, not silently —
+    two heavy hosts is a capacity-planning decision, not a config detail.
+    """
+    heavy = [n for n, s in machines.items()
+             if s.get("capacity") == "heavy"
+             and set(s.get("capabilities") or []) & LICENSED_CAPABILITIES]
+    assert len(heavy) == 1, f"expected exactly one heavy licensed host, got {heavy}"
+
+
+# --------------------------------------------------------------------------
+# heavy work goes to a heavy host
+# --------------------------------------------------------------------------
+
+
+def test_heavy_workload_rules_target_a_heavy_host(cfg, machines):
+    """The regression this file exists for.
+
+    A rule for a batch-scale domain must not resolve to a workstation, however
+    good that workstation's licence attestation is.
+    """
+    offenders = []
+    for rule in cfg.get("rules") or []:
+        match = rule.get("match") or {}
+        fam = match.get("domain_family")
+        if fam not in HEAVY_DOMAINS:
+            continue
+        target = (rule.get("assign") or {}).get("machine")
+        cap = (machines.get(target) or {}).get("capacity")
+        if cap != "heavy":
+            offenders.append(f"domain_family:{fam} -> {target} (capacity={cap!r})")
+    assert not offenders, (
+        "batch-scale work routed to a non-heavy host: " + "; ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------
+# an unmet licence must be VISIBLE, not routed around
+# --------------------------------------------------------------------------
+
+
+def _is_attested(spec: dict) -> bool:
+    return isinstance(spec.get("licence_verified"), dict)
+
+
+def test_a_target_with_unverified_licence_must_declare_blocked_on(cfg, machines):
+    """Routing to a host whose licence is pending is allowed — but only openly.
+
+    The alternative, silently rerouting to a lesser host, hides the blockage:
+    work runs badly instead of visibly waiting on a named prerequisite. That is
+    exactly what workspace-hub#3718 did, and why this rule exists.
+    """
+    offenders = []
+    for rule in cfg.get("rules") or []:
+        target = (rule.get("assign") or {}).get("machine")
+        spec = machines.get(target) or {}
+        if not (set(spec.get("capabilities") or []) & LICENSED_CAPABILITIES):
+            continue
+        if _is_attested(spec):
+            continue
+        if not spec.get("blocked_on"):
+            offenders.append(target)
+    assert not offenders, (
+        "routing target has an unverified licence and no `blocked_on` naming the "
+        f"prerequisite — the block would be invisible: {offenders}"
+    )
+
+
+def test_blocked_on_names_an_issue(machines):
+    """A prerequisite with no tracking reference cannot be chased."""
+    for name, spec in machines.items():
+        b = spec.get("blocked_on")
+        if b:
+            assert "#" in str(b), f"{name}.blocked_on must reference an issue: {b!r}"
+
+
+def test_licence_verified_is_still_false_or_a_dated_attestation(machines):
+    """Carried over from deckhand#579 — a bare `true` discards the evidence."""
+    for name, spec in machines.items():
+        if "licence_verified" not in spec:
+            continue
+        v = spec["licence_verified"]
+        if v is False:
+            continue
+        assert isinstance(v, dict), f"{name}: licence_verified must be false or a dated dict"
+        for field in ("at", "by", "how"):
+            assert v.get(field), f"{name}: licence_verified.{field} required"
+
+
+def test_the_checks_are_not_vacuous(cfg, machines):
+    """If `rules` or `machines` were renamed, everything above would pass empty."""
+    assert cfg.get("rules"), "no rules parsed"
+    assert machines, "no machines parsed"
+    assert any(
+        (r.get("match") or {}).get("domain_family") in HEAVY_DOMAINS
+        for r in cfg["rules"]
+    ), "no heavy-domain rule present — the capacity check would inspect nothing"

--- a/tests/dispatch/test_route_glob.py
+++ b/tests/dispatch/test_route_glob.py
@@ -181,7 +181,7 @@ def test_live_rules_route_digitalmodel_splits_to_licensed(route, domain):
     # Capability is LICENCE **and** CAPACITY. This test asserted only the first
     # until 2026-07-31, so it was satisfied by repointing batch work to a
     # workstation — trading a licence failure for a capacity failure. Owner:
-    # "ws014 is not powerful enough."
+    # "that host is not powerful enough."
     assert spec.get("capacity") == "heavy", (
         f"domain {domain!r} routes to {target!r} with capacity="
         f"{spec.get('capacity')!r}; these are batch-scale workloads and need the "

--- a/tests/dispatch/test_route_glob.py
+++ b/tests/dispatch/test_route_glob.py
@@ -177,11 +177,25 @@ def test_live_rules_route_digitalmodel_splits_to_licensed(route, domain):
         f"domain {domain!r} fell through to the catch-all, got {got}")
 
     spec = cfg.get("machines", {}).get(target, {})
-    assert isinstance(spec.get("licence_verified"), dict), (
-        f"domain {domain!r} routes to {target!r}, which carries no dated "
-        f"licence attestation — licence_verified is "
-        f"{spec.get('licence_verified')!r}. Licensed work must only be routed "
-        f"to a host someone recorded as working (deckhand#579)."
+
+    # Capability is LICENCE **and** CAPACITY. This test asserted only the first
+    # until 2026-07-31, so it was satisfied by repointing batch work to a
+    # workstation — trading a licence failure for a capacity failure. Owner:
+    # "ws014 is not powerful enough."
+    assert spec.get("capacity") == "heavy", (
+        f"domain {domain!r} routes to {target!r} with capacity="
+        f"{spec.get('capacity')!r}; these are batch-scale workloads and need the "
+        f"heavy node. See tests/dispatch/test_route_capacity.py."
+    )
+
+    # The licence must be attested OR the block must be openly named. Routing to
+    # a host with a pending prerequisite is legitimate; hiding that it is pending
+    # is not.
+    attested = isinstance(spec.get("licence_verified"), dict)
+    assert attested or spec.get("blocked_on"), (
+        f"domain {domain!r} routes to {target!r}, whose licence is neither "
+        f"attested nor openly blocked — licence_verified="
+        f"{spec.get('licence_verified')!r}, blocked_on absent (deckhand#579)."
     )
 
 

--- a/tests/dispatch/test_routing_rules_capability_truth.py
+++ b/tests/dispatch/test_routing_rules_capability_truth.py
@@ -131,7 +131,7 @@ def test_no_rule_routes_licensed_work_to_an_unproven_host(rules, machines):
     the capability list would leave the defect fully intact while looking fixed —
     the same declared-but-unwired shape as an uncalled safety gate.
 
-    UPDATED 2026-07-31 after the owner's correction "ws014 is not powerful
+    UPDATED 2026-07-31 after the owner's correction "that host is not powerful
     enough". The original form of this test demanded a *proven licence* and
     nothing else, so it accepted repointing batch work to a workstation — I
     satisfied it by trading a licence failure for a capacity failure.

--- a/tests/dispatch/test_routing_rules_capability_truth.py
+++ b/tests/dispatch/test_routing_rules_capability_truth.py
@@ -130,6 +130,15 @@ def test_no_rule_routes_licensed_work_to_an_unproven_host(rules, machines):
     a docstring). The `rules:` list is what actually assigns. So correcting only
     the capability list would leave the defect fully intact while looking fixed —
     the same declared-but-unwired shape as an uncalled safety gate.
+
+    UPDATED 2026-07-31 after the owner's correction "ws014 is not powerful
+    enough". The original form of this test demanded a *proven licence* and
+    nothing else, so it accepted repointing batch work to a workstation — I
+    satisfied it by trading a licence failure for a capacity failure.
+
+    An unproven licence is now acceptable **only when `blocked_on` names the
+    prerequisite**, because silently rerouting to a lesser host hides the
+    blockage. Capacity is asserted separately in test_route_capacity.py.
     """
     offenders = []
     for rule in rules.get("rules") or []:
@@ -141,12 +150,15 @@ def test_no_rule_routes_licensed_work_to_an_unproven_host(rules, machines):
             offenders.append(f"rule -> unknown machine {target!r}")
             continue
         needs_licence = set(spec.get("capabilities") or []) & LICENSED_CAPABILITIES
-        if needs_licence and not _licence_proven(spec):
+        if needs_licence and not _licence_proven(spec) and not spec.get("blocked_on"):
             offenders.append(
                 f"rule {rule.get('match')} -> {target} "
-                f"(claims {sorted(needs_licence)}, licence unproven)"
+                f"(claims {sorted(needs_licence)}, licence unproven AND no blocked_on)"
             )
-    assert not offenders, "rules route licensed work to unproven hosts: " + "; ".join(offenders)
+    assert not offenders, (
+        "rules route licensed work to a host whose licence is neither proven nor "
+        "openly blocked: " + "; ".join(offenders)
+    )
 
 
 def test_every_rule_targets_a_machine_in_the_roster(rules, machines):

--- a/tests/dispatch/test_traceability_chain.py
+++ b/tests/dispatch/test_traceability_chain.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Traceability chain: issue → assigned → dispatched → executed → result → published.
+
+deckhand#584 §3. The requirement is explicit that the interesting output is the
+BREAK, not the completion: *"surface where the chain breaks, not just where it
+completes — a result with no capability is the interesting case."*
+
+## What building it found
+
+`SCHEMA.yaml:125` documents the lifecycle as **`ready | active | done`**. Only
+`dispatch:ready` exists as a label, in any repo. `dispatch:active` and
+`dispatch:done` were never created.
+
+Measured 2026-07-31: **867 open issues carry `dispatch:ready`** (525
+workspace-hub, 342 digitalmodel). Nothing can move them out of it, because the
+next two states have no vocabulary. SCHEMA.yaml:150 says as much in passing —
+*"route.py only ever moves a card to dispatch:ready"* — but reads as a note about
+route.py's scope rather than a dead end for 867 issues.
+
+So the chain breaks at its second link, and every issue in the system is parked
+one step past the start.
+
+## The distinction this reporter is built around
+
+A stage with zero occupancy has two completely different causes:
+
+    UNREPRESENTABLE  the label does not exist — nothing COULD be here
+    EMPTY            the label exists and nobody is in it
+
+Conflating them is the failure this whole epic keeps meeting: absence of signal
+reading as success. A chain report that just prints `executed: 0` invites
+"nothing has finished yet"; the truth is "finishing cannot be recorded".
+
+So every stage carries its vocabulary status, and a stage whose label is missing
+is reported as a **defect in the chain itself**, not as a count.
+
+Hermetic: pure functions over issue dicts and a label inventory. No gh, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_traceability_chain.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAIN_PY = REPO_ROOT / "scripts" / "dispatch" / "chain.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("chain", CHAIN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["chain"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+C = _load()
+
+FULL_VOCAB = {"machine:dev-primary", "dispatch:ready", "dispatch:active", "dispatch:done"}
+REAL_VOCAB = {"machine:dev-primary", "dispatch:ready"}   # what actually exists today
+
+
+# --------------------------------------------------------------------------
+# stage assignment
+# --------------------------------------------------------------------------
+
+
+def test_issue_with_no_machine_is_unassigned():
+    assert C.stage_of({"labels": ["domain:cfd"]}) == "unassigned"
+
+
+def test_issue_with_a_machine_is_assigned():
+    assert C.stage_of({"labels": ["machine:dev-primary"]}) == "assigned"
+
+
+def test_dispatch_ready_is_queued():
+    assert C.stage_of({"labels": ["machine:dev-primary", "dispatch:ready"]}) == "queued"
+
+
+def test_furthest_stage_wins():
+    """An issue carrying several markers is at its FURTHEST point, not its first.
+
+    Reporting the earliest would make progress invisible — the chain is about how
+    far work got.
+    """
+    labels = ["machine:dev-primary", "dispatch:ready", "dispatch:done"]
+    assert C.stage_of({"labels": labels}) == "executed"
+
+
+def test_closed_issue_without_markers_is_not_silently_executed():
+    """Closing an issue is not evidence it ran.
+
+    Treating `state: closed` as "executed" would fabricate the very completion
+    the chain exists to verify.
+    """
+    got = C.stage_of({"labels": ["machine:dev-primary"], "state": "closed"})
+    assert got == "assigned"
+
+
+# --------------------------------------------------------------------------
+# the core distinction: unrepresentable vs empty
+# --------------------------------------------------------------------------
+
+
+def test_a_stage_whose_label_does_not_exist_is_UNREPRESENTABLE():  # noqa: N802
+    """The defect this file exists for.
+
+    `dispatch:done` does not exist in any repo. A report saying `executed: 0`
+    would read as "nothing has finished"; the truth is "finishing cannot be
+    recorded".
+    """
+    rep = C.chain_report([{"labels": ["machine:dev-primary", "dispatch:ready"]}], REAL_VOCAB)
+    assert rep["stages"]["executed"]["vocabulary"] == "MISSING"
+    assert rep["stages"]["queued"]["vocabulary"] == "present"
+
+
+def test_a_stage_with_vocabulary_and_nobody_in_it_is_EMPTY_not_missing():  # noqa: N802
+    rep = C.chain_report([{"labels": ["machine:dev-primary"]}], FULL_VOCAB)
+    assert rep["stages"]["executed"]["vocabulary"] == "present"
+    assert rep["stages"]["executed"]["count"] == 0
+
+
+def test_missing_vocabulary_is_reported_as_a_break_not_a_count():
+    """A count of zero invites a shrug. A named break invites a fix."""
+    rep = C.chain_report([{"labels": ["machine:dev-primary", "dispatch:ready"]}], REAL_VOCAB)
+    breaks = rep["breaks"]
+    assert any(b["stage"] == "executed" and b["kind"] == "unrepresentable" for b in breaks), breaks
+
+
+def test_no_break_reported_when_the_whole_vocabulary_exists():
+    rep = C.chain_report([{"labels": ["machine:dev-primary"]}], FULL_VOCAB)
+    assert not [b for b in rep["breaks"] if b["kind"] == "unrepresentable"]
+
+
+# --------------------------------------------------------------------------
+# drop-off: where does the population actually stop
+# --------------------------------------------------------------------------
+
+
+def _population():
+    return [
+        {"labels": []},                                                    # unassigned
+        {"labels": ["machine:dev-primary"]},                               # assigned
+        {"labels": ["machine:dev-primary"]},                               # assigned
+        {"labels": ["machine:dev-primary", "dispatch:ready"]},             # queued
+        {"labels": ["machine:dev-primary", "dispatch:ready"]},             # queued
+        {"labels": ["machine:dev-primary", "dispatch:ready"]},             # queued
+    ]
+
+
+def test_report_counts_every_issue_exactly_once():
+    """A histogram that does not sum to the population is silently lossy."""
+    rep = C.chain_report(_population(), REAL_VOCAB)
+    assert sum(s["count"] for s in rep["stages"].values()) == len(_population())
+
+
+def test_report_identifies_the_wall(_pop=None):
+    """The stage where the most work is stuck AND the next step is impossible.
+
+    That pairing is the actionable finding: a pile-up in front of a missing
+    state is a different problem from a pile-up in front of a busy one.
+    """
+    rep = C.chain_report(_population(), REAL_VOCAB)
+    assert rep["wall"] is not None
+    assert rep["wall"]["stage"] == "queued"
+    assert rep["wall"]["count"] == 3
+    assert rep["wall"]["next_stage_vocabulary"] == "MISSING"
+
+
+def test_no_wall_when_the_chain_is_traversable():
+    rep = C.chain_report(_population(), FULL_VOCAB)
+    assert rep["wall"] is None, "a full vocabulary means work can always move on"
+
+
+# --------------------------------------------------------------------------
+# guards on the guard
+# --------------------------------------------------------------------------
+
+
+def test_stage_order_is_declared_and_non_empty():
+    assert C.STAGES and C.STAGES[0] == "unassigned"
+    assert "published" in C.STAGES, "the terminal state is a published capability (#584 §4)"
+
+
+def test_empty_input_does_not_fabricate_a_wall():
+    """Zero issues must not read as a healthy chain OR a broken one."""
+    rep = C.chain_report([], FULL_VOCAB)
+    assert rep["wall"] is None
+    assert sum(s["count"] for s in rep["stages"].values()) == 0


### PR DESCRIPTION
Owner correction 2026-07-31: **"ace-win-1 is the licensed host"** / **"ace-win-2 is not powerful enough."**

## I made the same mistake twice today, one axis apart

**1.** deckhand#579 found solver/hydro routed to `licensed-win-1`, whose capability list was **inherited from a retired machine**. 177 issues aimed at a host that could not obtain a licence.

**2.** My fix ([#3718](https://github.com/vamseeachanta/workspace-hub/pull/3718)) repointed them to `licensed-win-2` because it held the only dated licence attestation. But `licensed-win-2` is a **workstation**. `licensed-win-1` is the heavy node — **64 logical cores / 255.7 GB**, the declared batch target for dm#1553 (OrcaFlex N≈57 parallel sims).

**I traded a licence failure for a capacity failure and called it fixed**, because I only re-checked the dimension I had just been burned by.

And the test I wrote that morning encoded the same narrowness: it demanded a proven **licence** and said nothing about capacity — so my wrong answer passed it cleanly.

## Capability is two dimensions

| host | capacity | licence |
|---|---|---|
| `licensed-win-1` (heavy node) | **heavy** | `false` + `blocked_on` |
| `licensed-win-2` (workstation) | **workstation** | dated attestation |

Both are now declared, and both are asserted. Rules repointed to `licensed-win-1`.

## Second lesson: rerouting is not always the fix

When the **designated** host is blocked on a prerequisite, silently routing the work to a lesser host **hides the blockage** — it runs badly instead of visibly waiting on something named.

So a rule may target a host with an unmet licence **only when `blocked_on` names the prerequisite**. An unproven licence with no declared block still fails the guard. The blockage becomes a fact in the config a human reads, rather than a silent detour.

```yaml
licensed-win-1:
  capacity: heavy
  licence_verified: false
  blocked_on: "deckhand#579 — Sentinel LDK runtime absent (OrcFxAPI.Model() fails DLLError 25)…"
```

## Unchanged

`policy.yml licensed_host` stays `ace-win-2`. That is the queue lane's default owner for **un-addressed** requests — a different role from the execution target — and #579 holds it until `OrcFxAPI.Model()` succeeds on ace-win-1.

## Tests

Both tests from this morning are **updated, not deleted** — their licence assertion was right, just incomplete. They now check capacity too, so this is strictly stronger than what it replaces.

New `tests/dispatch/test_route_capacity.py` asserts: every licensed host declares a capacity; values come from a closed set; exactly one heavy licensed host exists; batch-scale rules target it; and any unattested target names its blocker with an issue reference.

**163 passed** (8 new). Red first — 3 failures naming the missing capacity declaration.

Not self-merging:
`gh pr merge <N> --repo vamseeachanta/workspace-hub --squash --delete-branch`
