### PR TITLE
fix(maintenance): update-model-ids.sh rewrote every other copy of itself into identity no-ops

### DIFF
--- a/scripts/maintenance/update-model-ids.sh
+++ b/scripts/maintenance/update-model-ids.sh
@@ -236,8 +236,24 @@ process_file() {
         return 0
     fi
 
-    # Safety: skip this script itself (contains stale IDs as mapping constants)
-    if [[ "$(realpath "$file")" == "$(realpath "${BASH_SOURCE[0]}")" ]]; then
+    # Safety: skip EVERY copy of this script, not only the one being executed.
+    #
+    # The realpath comparison this replaces compared absolute paths, so it protected the
+    # running copy and nothing else. But this script walks submodules and sibling
+    # worktrees, where the very same file exists at a DIFFERENT absolute path -- so the
+    # guard did not fire and the script rewrote its own mapping table in every other
+    # checkout, replacing each 'old|new' pair with 'new|new'.
+    #
+    # Measured on ace-linux-1 2026-07-30: 10 of 10 workspace-hub worktrees carried an
+    # identically corrupted copy (md5 bdd8c245... vs committed 9186a585...), four of them
+    # dirty from nothing else. Every mapping in those copies is an identity no-op, so the
+    # script still exits 0 while detecting no drift at all -- a silent no-op that reads
+    # exactly like a fleet with no stale model IDs.
+    #
+    # Match on basename: any file named like this script is skipped regardless of which
+    # checkout it lives in. Deliberately erring wide -- a false skip loses one file's
+    # rewrite, a false miss destroys the mapping table.
+    if [[ "$(basename "$file")" == "$(basename "${BASH_SOURCE[0]}")" ]]; then
         return 0
     fi
 

--- a/tests/maintenance/test_update_model_ids_self_exclusion.py
+++ b/tests/maintenance/test_update_model_ids_self_exclusion.py
@@ -1,0 +1,106 @@
+"""Regression test: update-model-ids.sh must not rewrite OTHER copies of itself.
+
+The script walks submodules and sibling worktrees, where the same file exists at a
+different absolute path. The original guard compared realpath against BASH_SOURCE, so it
+protected only the copy being executed and rewrote every other one -- turning each
+'old|new' mapping pair into 'new|new'.
+
+Measured on ace-linux-1 2026-07-30: 10 of 10 workspace-hub worktrees held an identically
+corrupted copy. Every mapping in them is an identity no-op, so the script still exits 0
+while detecting no drift -- indistinguishable from a fleet with no stale model IDs.
+"""
+import os
+import shutil
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SCRIPT = os.path.join(REPO, "scripts", "maintenance", "update-model-ids.sh")
+
+
+def _guard_form() -> str:
+    """Read which comparison the script's self-exclusion actually uses.
+
+    Deliberately DERIVED from source rather than restated. An earlier draft of this
+    test hardcoded the fixed condition, so the behavioural cases exercised the test
+    helper and passed against the buggy script -- they proved nothing. Deriving the
+    form means a revert to path-equality changes what the cases below observe.
+    """
+    for line in open(SCRIPT, encoding="utf-8").read().splitlines():
+        s = line.strip()
+        if s.startswith("if [[") and "BASH_SOURCE[0]" in s and '"$file"' in s:
+            if "basename" in s:
+                return "basename"
+            if "realpath" in s:
+                return "realpath"
+            raise AssertionError(f"unrecognised self-exclusion comparison: {s}")
+    raise AssertionError(
+        "self-exclusion guard not found in update-model-ids.sh -- the condition "
+        "moved or changed shape; update this detector rather than deleting the test"
+    )
+
+
+def _guard_skips(candidate: str) -> bool:
+    """Apply the semantics of whichever comparison the script currently uses."""
+    form = _guard_form()
+    if form == "basename":
+        return os.path.basename(candidate) == os.path.basename(SCRIPT)
+    return os.path.realpath(candidate) == os.path.realpath(SCRIPT)
+
+
+def test_guard_skips_the_executing_copy():
+    assert _guard_skips(SCRIPT)
+
+
+def test_guard_skips_a_copy_at_a_different_path(tmp_path):
+    """The actual defect: a copy in another worktree must NOT be rewritten."""
+    other = tmp_path / "worktree" / "scripts" / "maintenance"
+    other.mkdir(parents=True)
+    copy = other / "update-model-ids.sh"
+    shutil.copyfile(SCRIPT, copy)
+    assert _guard_skips(str(copy)), (
+        "a copy of the script at a different absolute path was NOT skipped -- "
+        "the script will rewrite its own mapping table into identity no-ops"
+    )
+
+
+def test_guard_does_not_skip_unrelated_files(tmp_path):
+    """The fix must not become a blanket skip that silently does nothing."""
+    ordinary = tmp_path / "some-doc.md"
+    ordinary.write_text("claude-sonnet-4-5\n")
+    assert not _guard_skips(str(ordinary))
+
+
+def test_script_source_does_not_use_realpath_self_comparison():
+    """Pin the fix at the source level.
+
+    basename equality is what makes the guard checkout-independent; a realpath
+    comparison against BASH_SOURCE reintroduces the defect while still looking
+    like a self-exclusion guard.
+    """
+    src = open(SCRIPT, encoding="utf-8").read()
+    assert 'realpath "${BASH_SOURCE[0]}"' not in src, (
+        "self-exclusion reverted to realpath comparison -- protects only the "
+        "executing copy, see this test's module docstring"
+    )
+    assert 'basename "${BASH_SOURCE[0]}"' in src
+
+
+def test_committed_mapping_table_is_not_all_identity():
+    """Detect the corrupted state directly.
+
+    If every pair is 'x|x' the script is a silent no-op: it runs, finds nothing to
+    replace, and exits 0 -- which reads exactly like a clean fleet.
+    """
+    src = open(SCRIPT, encoding="utf-8").read()
+    pairs = []
+    for line in src.splitlines():
+        line = line.strip()
+        if line.startswith("'") and "|" in line and line.endswith("'"):
+            body = line.strip("'")
+            if body.count("|") == 1:
+                pairs.append(tuple(body.split("|")))
+    assert pairs, "no mapping pairs found -- table shape changed, update this test"
+    non_identity = [p for p in pairs if p[0] != p[1]]
+    assert non_identity, (
+        f"all {len(pairs)} mappings are identity no-ops (x|x) -- the script has "
+        "rewritten its own table and can no longer detect any drift"
+    )


### PR DESCRIPTION
## The defect

`update-model-ids.sh` **rewrote its own mapping table in every checkout except the one being executed.**

The self-exclusion guard compared absolute paths:

```bash
if [[ "$(realpath "$file")" == "$(realpath "${BASH_SOURCE[0]}")" ]]; then
```

That protects the running copy and nothing else. But the script walks submodules and sibling worktrees, where this same file exists at a *different* absolute path — so the guard never fired there and the script replaced every `'old|new'` mapping pair with `'new|new'`:

```diff
- 'claude-sonnet-4-5-20250929|claude-sonnet-4-6'
+ 'claude-sonnet-4-6|claude-sonnet-4-6'
- 'claude-3-haiku-20240307|claude-haiku-4-5'
+ 'claude-haiku-4-5|claude-haiku-4-5'
```

It mangled the explanatory comments too — *"gpt-4.1-mini before gpt-4.1"* became *"gpt-5.4-mini before gpt-5.5"*, which is nonsense.

## Measured impact

**10 of 10 workspace-hub worktrees** on ace-linux-1 carry an identically corrupted copy — md5 `bdd8c245` against the committed `9186a585`. Four of them are dirty from **nothing else**, which is why this also blocks 5 stale worktrees from being cleaned up.

## Why it stayed invisible

Every mapping in a corrupted copy is an identity no-op. The script runs, finds nothing to replace, exits 0, and reports no drift — **which reads exactly like a fleet with no stale model IDs**. A model-ID drift guard that can no longer detect drift is indistinguishable from a clean fleet.

Same shape as #3600, where the nightly drift guard checks only `openai_primary` and leaves the Claude lane uncovered. Two independent ways of producing the same blind spot.

## The fix

Match on `basename`, so every copy is skipped regardless of which checkout it lives in. Erring wide deliberately: **a false skip loses one file's rewrite; a false miss destroys the mapping table.**

## Tests

Five cases in `tests/maintenance/`, pinning both behaviour and source form:

| test | pins |
|---|---|
| `guard_skips_the_executing_copy` | no regression on the original intent |
| `guard_skips_a_copy_at_a_different_path` | **the actual defect** |
| `guard_does_not_skip_unrelated_files` | the fix isn't a blanket skip that silently does nothing |
| `script_source_does_not_use_realpath_self_comparison` | source-level pin against reverting the form |
| `committed_mapping_table_is_not_all_identity` | detects the corrupted state directly |

**Verified red/green.** Against the pre-fix script exactly two fail — the copy-at-a-different-path case and the source-level pin. All five pass after.

One note on test construction, because it nearly went wrong: an earlier draft **hardcoded the fixed condition** in the helper, so the behavioural cases exercised the helper rather than the script and passed against the buggy version — they proved nothing. The helper now *derives* the comparison form from the script source, so reverting to `realpath` changes what the tests observe.

## Not addressed here

- **The committed mappings are themselves stale** — they target `claude-sonnet-4-6` / `claude-opus-4-8`, behind the current Claude 5 family. Separate decision, and it touches the Model-ID Sourcing Guard's canonical source.
- **The 10 corrupted worktree copies are not restored by this PR.** They are uncommitted modifications to tracked files; `git checkout --` in each worktree restores them once this lands. Left to the owner rather than done unilaterally.

Refs #3600.
