### PR TITLE
feat(dispatch): retire the kanban mirror as a routing input; per-solver licences; queue staleness

### DIFF
--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -53,25 +53,48 @@ machines:
   # CAPABILITY IS TWO DIMENSIONS, not one: a host must have the LICENCE and the
   # CAPACITY. Checking only the dimension you were last burned by is how both
   # defects here happened — see tests/dispatch/test_route_capacity.py.
+  # LICENCE IS PER-SOLVER, NOT PER-HOST (fleet handover 2026-07-31).
+  #
+  # A single host-level `licence_verified` was the third version of the same
+  # mistake in one day: capability treated as one property. AQWA is licensed,
+  # healthy and IDLE on licensed-win-1 while OrcaFlex is genuinely unavailable
+  # there — one flag cannot express that, and either value it took would have
+  # been wrong about half the solvers.
   licensed-win-1:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
                      capacity: heavy,
-                     licence_verified: false,
-                     blocked_on: "deckhand#579 — Sentinel LDK runtime absent (OrcFxAPI.Model() fails
-                                  DLLError 25; 1947 not listening, hasplms absent). Owner designates
-                                  THIS the licensed execution host; the licence is a prerequisite in
-                                  flight, not a reason to route elsewhere.",
+                     licence_verified: {aqwa: {at: "2026-07-31", by: "fleet-session",
+                                               how: "lmstat: 2 aqwa_solve + 2 aqwa_pre + 4 anshpc seats
+                                                     free; four diffraction runs completed 2026-07-18
+                                                     (~1 GB output). wh#3734"}},
+                     licence_blocked: {orcaflex: "wh#3734 — the licence SERVER publishes no orca*
+                                                  feature at all (lmutil lmstat -a), while serving ANSYS
+                                                  to this same host. deckhand#579's stated fix (install
+                                                  the Sentinel LDK runtime) is THE WRONG LAYER: a client
+                                                  runtime cannot create an entitlement the server does
+                                                  not publish. FlexNet Error 21 precedes the HASP
+                                                  fallback in the error log — the HASP message is the
+                                                  symptom people read first, not the cause."},
+                     concurrency: {aqwa: 2},
                      notes: "THE heavy node: 64 logical cores / 255.7 GB; declared batch target for
-                             dm#1553 (OrcaFlex N≈57 parallel sims). SHARED client production box — cap
-                             concurrency. AQWA/OrcaWave attestation pending deckhand#542/#544."}
+                             dm#1553. SHARED client production box — cap concurrency. AQWA over-dispatch
+                             FAILS on licence acquisition rather than queueing, so the 2-seat ceiling is
+                             a hard cap, not a preference."}
   licensed-win-2:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
                      capacity: workstation,
-                     licence_verified: {at: "2026-07-30", by: "owner",
-                                        how: "bokalift orcawave-diffraction-solve ran end-to-end on this host"},
-                     notes: "Workstation, NOT sized for batch — owner 2026-07-31: 'that host is not
-                             powerful enough'. Holds a working licence and is the queue lane's CANONICAL
-                             default (policy licensed_host) for UN-ADDRESSED requests, which is a
-                             routing fallback, not an execution target for batch work.
-                             The physical host binding lives in the PRIVATE machine registry."}
+                     available: false,
+                     unavailable_since: "2026-07-31T11:00Z",
+                     blocked_on: "wh#3721 — host DOWN, needs a power cycle. Tailnet pings 1 ms and
+                                  22/3389/445/135 all accept TCP, but SSH stalls exactly at key
+                                  exchange and RDP is unresponsive: the kernel accepts while userland
+                                  cannot service. Resource exhaustion (~2.2 GB free of 16 GB), not a
+                                  network or sshd fault — restarting sshd did not help because sshd was
+                                  never the problem. A TCP-only reachability probe reports this host
+                                  UP; that is the trap.",
+                     licence_verified: {orcawave: {at: "2026-07-30", by: "owner",
+                                                   how: "bokalift orcawave-diffraction-solve ran end-to-end"}},
+                     notes: "Workstation, NOT sized for batch. Queue lane's CANONICAL default
+                             (policy licensed_host) for UN-ADDRESSED requests — a routing fallback, not
+                             a batch execution target. Physical binding is in the PRIVATE registry."}
   home-win:         {os: windows, role: aux,        notes: "home windows; statements/scans (e.g. Chase)"}
   macbook-portable: {os: macos,   role: aux,        notes: "portable/mobile work"}
   multi:            {os: any,     role: virtual,    notes: "spans machines / not pinned to one box"}

--- a/.claude/memory/kanban/routing-rules.yaml
+++ b/.claude/memory/kanban/routing-rules.yaml
@@ -63,17 +63,27 @@ machines:
   licensed-win-1:   {os: windows, role: engineering, capabilities: [orcawave, aqwa, orcaflex],
                      capacity: heavy,
                      licence_verified: {aqwa: {at: "2026-07-31", by: "fleet-session",
-                                               how: "lmstat: 2 aqwa_solve + 2 aqwa_pre + 4 anshpc seats
-                                                     free; four diffraction runs completed 2026-07-18
-                                                     (~1 GB output). wh#3734"}},
-                     licence_blocked: {orcaflex: "wh#3734 — the licence SERVER publishes no orca*
-                                                  feature at all (lmutil lmstat -a), while serving ANSYS
-                                                  to this same host. deckhand#579's stated fix (install
-                                                  the Sentinel LDK runtime) is THE WRONG LAYER: a client
-                                                  runtime cannot create an entitlement the server does
-                                                  not publish. FlexNet Error 21 precedes the HASP
-                                                  fallback in the error log — the HASP message is the
-                                                  symptom people read first, not the cause."},
+                                               how: "lmstat port 1055: aqwa_solve x2, aqwa_pre x2,
+                                                     anshpc x4 free; four diffraction runs completed
+                                                     2026-07-18. Works on BOTH dispatch paths. wh#3734"},
+                                        orcaflex: {at: "2026-07-31", by: "fleet-session",
+                                                   how: "lmstat port 27002: feature Flex v11.6, expiry
+                                                         2027-03-15. dispatch-run.ps1 submit ->
+                                                         LICENCE_OK dll=11.6c exit 0, reproduced twice.
+                                                         REQUIRES the scheduled-task path. wh#3721"},
+                                        orcawave: {at: "2026-07-31", by: "fleet-session",
+                                                   how: "shares the same single Flex seat as orcaflex"}},
+                     # Orcina products REQUIRE the scheduled-task path. An SSH
+                     # public-key logon token cannot complete a FlexNet checkout;
+                     # a Scheduled Task establishes its own batch logon and works.
+                     # Same probe, same host, minutes apart, seat free:
+                     #   ssh host '<solver>'            -> DLLError 25 / FlexNet 21
+                     #   dispatch-run.ps1 -Action submit -> LICENCE_OK, exit 0
+                     # NOT a credential problem: -RunAsUser/-ru/-rp are not needed
+                     # and adding them was a wrong hypothesis (wh#3738). AQWA is
+                     # unaffected and succeeds on either path.
+                     dispatch_path: {orcaflex: scheduled-task, orcawave: scheduled-task,
+                                     aqwa: any},
                      concurrency: {aqwa: 2},
                      notes: "THE heavy node: 64 logical cores / 255.7 GB; declared batch target for
                              dm#1553. SHARED client production box — cap concurrency. AQWA over-dispatch
@@ -138,6 +148,29 @@ providers:
   # the manual escape hatch this comment describes did not actually work.
   agy:    {tier: scarce,    auto_routable: false, budget_pool: google_ai_pool,
            note: "Google AI Pro quota. Explicit ai:agy only; never auto-route backlog."}
+
+# ---------------------------------------------------------------------------
+# Solver seat pools — a licence seat is FLEET-WIDE, not per host (wh#3721).
+#
+# There is exactly ONE floating Orcina `Flex` seat across the whole fleet, and
+# OrcaWave shares it. Modelling it as a per-host capability would permit two
+# concurrent dispatches on two hosts, both of which then fail on checkout.
+#
+# A seat licenses a SESSION, not a job: one dispatched job may fan out across
+# the host's cores inside that session. So this is ONE CONCURRENT DISPATCH SLOT
+# THAT PARALLELISES INTERNALLY — never "one model at a time". Reading it the
+# latter way idles a 64-core box to respect a limit that does not apply at that
+# level.
+#
+# An interactive session holding the seat blocks all dispatch. Closing the
+# solver releases it; logging off is not required.
+# ---------------------------------------------------------------------------
+solver_pools:
+  orcina_flex:
+    members: [orcaflex, orcawave]
+    max_concurrent: 1        # fleet-wide seats, NOT per host
+    expiry: "2027-03-15"
+    note: "one dispatch slot; parallel model runs INSIDE that job are expected"
 
 budget_pools:
   google_ai_pool:

--- a/scripts/dispatch/dispatch.py
+++ b/scripts/dispatch/dispatch.py
@@ -56,6 +56,70 @@ def build_queues(proposals):
     return queues
 
 
+# ---------------------------------------------------------------------------
+# Queue staleness.
+#
+# A queue file is a SNAPSHOT of a routing decision, and routing inputs change
+# constantly — labels get corrected, machines retired, capability claims fixed.
+# On 2026-07-31 ~300 labels changed, silently invalidating queue files built the
+# day before. Nothing in the file said so.
+#
+# reachability.py (same week) already writes `observed_at` plus an explicit TTL
+# "so consumers warn on stale data rather than trusting it as static routing
+# truth". Dispatch queues are equally time-varying and had neither. An undated
+# snapshot does not look stale — it looks authoritative.
+#
+# Deliberately VISIBLE, not blocking: a stale queue beats no queue, and hard
+# failing a drain over a clock would push people to delete the field rather than
+# regenerate the file.
+# ---------------------------------------------------------------------------
+
+QUEUE_TTL_HOURS = 24
+
+
+def _utcnow():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc)
+
+
+def queue_payload(machine: str, cards: list, now=None) -> dict:
+    """The serialised queue file, carrying its own age."""
+    stamp = (now or _utcnow)()
+    return {
+        "machine": machine,
+        "generated_by": "dispatch.py",
+        "generated_at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ttl_hours": QUEUE_TTL_HOURS,
+        "cards": cards,
+    }
+
+
+def queue_age_hours(payload: dict, now=None) -> float | None:
+    """Hours since generation, or None when the file predates the field."""
+    from datetime import datetime, timezone
+    raw = (payload or {}).get("generated_at")
+    if not raw:
+        return None
+    try:
+        gen = datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    return ((now or _utcnow)() - gen).total_seconds() / 3600.0
+
+
+def queue_is_stale(payload: dict, now=None) -> bool:
+    """Unknown age resolves to STALE, never fresh.
+
+    Every queue file on main before 2026-07-31 lacks `generated_at`; treating
+    "I cannot tell" as "it is fine" would be the same defect this field exists
+    to close, self-inflicted.
+    """
+    age = queue_age_hours(payload, now=now)
+    if age is None:
+        return True
+    return age > (payload.get("ttl_hours") or QUEUE_TTL_HOURS)
+
+
 def cmd_build(write: bool):
     proposals = get_proposals()
     queues = build_queues(proposals)
@@ -67,10 +131,27 @@ def cmd_build(write: bool):
         print(f"  {machine:<16} {len(cards):>4} backlog  ({elig} wip-eligible now)")
         if write:
             DISPATCH_DIR.mkdir(parents=True, exist_ok=True)
-            payload = {"machine": machine, "generated_by": "dispatch.py",
-                       "cards": cards}
+            payload = queue_payload(machine, cards)
             with open(DISPATCH_DIR / f"{machine}.yaml", "w") as f:
                 yaml.safe_dump(payload, f, sort_keys=False, width=100)
+    # Report the age of what is ALREADY on disk, so a dry run tells you whether
+    # the live queues are worth regenerating rather than only what would change.
+    if DISPATCH_DIR.is_dir():
+        stale = []
+        for f in sorted(DISPATCH_DIR.glob("*.yaml")):
+            if f.name.startswith("_"):
+                continue
+            try:
+                data = yaml.safe_load(f.read_text()) or {}
+            except Exception:       # noqa: BLE001 — a corrupt queue is "unknown age"
+                data = {}
+            if queue_is_stale(data):
+                age = queue_age_hours(data)
+                stale.append(f"{f.stem} ({'no timestamp' if age is None else f'{age:.0f}h old'})")
+        if stale:
+            print(f"\n  \033[33mSTALE on disk ({len(stale)}):\033[0m {', '.join(stale)}")
+            print("  \033[2mRegenerate with --write; routing inputs change daily.\033[0m")
+
     if not write:
         print("\n\033[2mDRY-RUN — no files written. Re-run with --write (Phase B).\033[0m")
     else:

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -271,6 +271,52 @@ def _family_matches(base: str, domain) -> bool:
     return domain == base or domain.startswith(base + "-")
 
 
+def _as_domains(domain) -> list[str]:
+    """Normalise a card's domain(s) to a list.
+
+    A kanban BOARD gave each card exactly one domain — the board it lived in. A
+    live GitHub issue carries however many `domain:` labels it has, and 74 open
+    issues legitimately carry more than one (`domain:` is declared multi-valued).
+
+    Taking "the first domain: label" would resolve routing by GitHub's API
+    ordering — the exact defect removed from status:, lane: and machine: today.
+    So every domain is considered and rules stay first-match-wins.
+    """
+    if domain is None:
+        return []
+    if isinstance(domain, str):
+        return [domain]
+    return [d for d in domain if d]
+
+
+def issue_to_card(issue: dict, repo: str) -> dict:
+    """Live GitHub issue -> the card shape propose() consumes.
+
+    Replaces the kanban board mirror as the routing input (workspace-hub#3736):
+    the mirror had no GitHub->board refresh path, so it drifted monotonically and
+    held labels that had been deleted.
+    """
+    labels = [l["name"] if isinstance(l, dict) else l for l in issue.get("labels") or []]
+    number = issue.get("number")
+    prio = 0
+    for lab in labels:
+        if lab.startswith("priority:"):
+            prio = {"high": 3, "medium": 2, "low": 1}.get(lab.split(":", 1)[1].lower(), 1)
+    return {
+        "idempotency_key": f"gh:{repo}#{number}",
+        "repo": repo,
+        # gh returns OPEN/CLOSED; `routable_states` is declared lowercase, and a
+        # case mismatch would filter out every card and report an empty backlog
+        # rather than an error.
+        "gh_state": str(issue.get("state") or "open").lower(),
+        "gh_labels": labels,
+        "domains": [l.split(":", 1)[1] for l in labels if l.startswith("domain:")],
+        "title": issue.get("title") or "",
+        "priority": prio,
+        "source_url": f"https://github.com/{repo}/issues/{number}",
+    }
+
+
 def match_rule(rules: list[dict], *, repo, domain, gh_labels) -> dict:
     """First-match-wins. Empty match {} is the catch-all.
 
@@ -282,9 +328,13 @@ def match_rule(rules: list[dict], *, repo, domain, gh_labels) -> dict:
         m = rule.get("match", {})
         if "repo" in m and m["repo"] != repo:
             continue
-        if "domain" in m and not _domain_matches(m["domain"], domain):
+        # ANY-OF over the card's domains. Order-independent by construction, so
+        # two issues with the same domains in different label order route
+        # identically; rule precedence stays first-match-wins.
+        doms = _as_domains(domain)
+        if "domain" in m and not any(_domain_matches(m["domain"], d) for d in doms):
             continue
-        if "domain_family" in m and not _family_matches(m["domain_family"], domain):
+        if "domain_family" in m and not any(_family_matches(m["domain_family"], d) for d in doms):
             continue
         if "gh_label" in m and m["gh_label"] not in labelset:
             continue
@@ -446,10 +496,22 @@ def propose(args) -> list[dict]:
     proposals = []
     _QUOTA_UNSET = object()
     quota_remaining = _QUOTA_UNSET
-    for board, card in iter_cards():
-        repo = board.get("repo")
-        if args.repo and repo != args.repo:
-            continue
+
+    # LIVE GITHUB, not the kanban board mirror (workspace-hub#3736, owner
+    # decision 2026-07-31 "retire the mirror as a routing input").
+    #
+    # `propose()` used to iterate .claude/memory/kanban/boards/*.yaml, so the
+    # routing ENGINE never read GitHub while every checker did. The mirror held
+    # 6 machine:/lane: labels deleted the same day, and there was no
+    # GitHub -> board refresh path to lapse: load.py runs boards -> Hermes and
+    # nothing runs the reverse, so the gap only grew.
+    repos = [args.repo] if getattr(args, "repo", None) else list(DEFAULT_COVERAGE_REPOS)
+    cards = []
+    for r in repos:
+        for issue in fetch_issues_for_coverage(r):
+            cards.append((r, issue_to_card(issue, r)))
+
+    for repo, card in cards:
         if card.get("gh_state") not in routable_states:
             continue
         labels = card.get("gh_labels") or []
@@ -468,7 +530,10 @@ def propose(args) -> list[dict]:
             })
             continue
 
-        domain = board.get("domain")  # card's domain = the board it lives in
+        # EVERY domain the issue carries, not the one board it happened to sit
+        # on. match_rule is any-of over these, so label order cannot change the
+        # answer.
+        domain = card.get("domains") or []
         rule = match_rule(rules, repo=repo, domain=domain, gh_labels=labels)
         assign = rule.get("assign", {})
 
@@ -495,7 +560,13 @@ def propose(args) -> list[dict]:
             "key": card.get("idempotency_key"),
             "repo": repo,
             "number": card.get("idempotency_key", "").rsplit("#", 1)[-1],
-            "domain": domain,
+            # Display/serialisation form. `domain` is now a LIST internally (an
+            # issue can carry several), but consumers — print_detail, --json,
+            # dispatch.py's queue files — expect a scalar. Joining keeps every
+            # domain visible instead of silently dropping all but one, which is
+            # what picking `domain[0]` would have done.
+            "domain": ",".join(domain) if domain else None,
+            "domains": list(domain),
             "title": (card.get("title") or "")[:60],
             "machine": machine,
             "has_machine_label": bool(existing_machine),

--- a/scripts/enforcement/check-label-vocabulary.py
+++ b/scripts/enforcement/check-label-vocabulary.py
@@ -64,6 +64,69 @@ DEFAULT_REPOS = (
 MACHINE_EXTRAS = frozenset({"unassigned"})
 
 
+#: Axes the ROUTING engine reads. Comparing every axis would bury the finding
+#: that matters under taxonomy churn — the mirror legitimately lags on labels the
+#: router never consults.
+ROUTING_AXES = ("machine:", "lane:", "ai:", "agent:")
+
+BOARDS_DIR = REPO_ROOT / ".claude" / "memory" / "kanban" / "boards"
+
+
+def mirror_routing_labels(boards: list[dict]) -> set[str]:
+    """Routing labels the board mirror actually uses.
+
+    A malformed or empty board contributes nothing rather than raising: one bad
+    file must not abort the check and thereby mask drift in all the others.
+    """
+    out: set[str] = set()
+    for board in boards or []:
+        for card in (board or {}).get("cards") or []:
+            for lab in (card or {}).get("gh_labels") or []:
+                if any(lab.startswith(a) for a in ROUTING_AXES):
+                    out.add(lab)
+    return out
+
+
+def mirror_drift(mirror: set[str], live: set[str]) -> dict:
+    """Compare mirror routing labels against the labels that actually exist.
+
+    The two directions have different causes and different fixes, so they are
+    reported separately:
+
+        retired  in the mirror, absent from GitHub -> the engine routes to
+                 something that is gone. This is the dangerous one.
+        unknown  on GitHub, absent from the mirror -> the mirror has not caught
+                 up; real work the engine cannot see.
+
+    `live_was_empty` exists because an API failure would otherwise make EVERY
+    mirror label look retired — turning one failed query into a fleet-wide false
+    alarm, which is exactly how a real drift report gets ignored.
+    """
+    def routing_only(labels):
+        return {l for l in labels or () if any(l.startswith(a) for a in ROUTING_AXES)}
+
+    # BOTH sides are filtered. Filtering only `live` would report every non-routing
+    # mirror label as retired — the function must not assume its caller
+    # pre-filtered, or it produces a fleet of false positives when reused.
+    mirror_routing, live_routing = routing_only(mirror), routing_only(live)
+    return {
+        "retired": sorted(mirror_routing - live_routing),
+        "unknown": sorted(live_routing - mirror_routing),
+        "live_was_empty": not live_routing,
+    }
+
+
+def read_boards() -> list[dict]:
+    docs = []
+    if BOARDS_DIR.is_dir():
+        for f in sorted(BOARDS_DIR.glob("*.yaml")):
+            try:
+                docs.append(yaml.safe_load(f.read_text(encoding="utf-8")) or {})
+            except Exception:   # noqa: BLE001 — an unparseable board contributes nothing
+                docs.append({})
+    return docs
+
+
 def load_cfg() -> dict:
     return yaml.safe_load(RULES_PATH.read_text(encoding="utf-8")) or {}
 
@@ -148,6 +211,17 @@ def main() -> int:
     repos = [args.repo] if args.repo else list(DEFAULT_REPOS)
     results = [check_repo(r, cfg, accepted) for r in repos]
 
+    # Mirror drift (workspace-hub#3736). The routing ENGINE reads the kanban
+    # board mirror, not GitHub, so every check above can be clean while the
+    # dispatcher routes to a machine that no longer exists. There is no
+    # GitHub -> board refresh path, so this gap grows monotonically.
+    mirror = mirror_routing_labels(read_boards())
+    live_all: set[str] = set()
+    for repo in repos:
+        live_all |= {l["name"] for l in gh_json(
+            ["gh", "label", "list", "--repo", repo, "--limit", "400", "--json", "name"])}
+    drift = mirror_drift(mirror, live_all)
+
     if args.json:
         print(json.dumps(results, indent=2))
     else:
@@ -169,7 +243,30 @@ def main() -> int:
             if not (res["unknown_values"] or res["ambiguous"]):
                 print("  \033[32mOK\033[0m — vocabulary closed, every scalar axis single-valued")
 
-    failed = any(r["unknown_values"] or r["ambiguous"] for r in results)
+    if not args.json:
+        print("\n\033[1mkanban board mirror vs live GitHub\033[0m  (workspace-hub#3736)")
+        if drift["live_was_empty"]:
+            print("  \033[31mCANNOT CHECK\033[0m — no live routing labels returned; "
+                  "not treating that as 'everything retired'")
+        elif drift["retired"]:
+            print(f"  \033[31mRETIRED IN USE ({len(drift['retired'])})\033[0m "
+                  "— the mirror routes to labels that no longer exist on GitHub:")
+            for v in drift["retired"][:20]:
+                print(f"    {v}")
+            print("  \033[2mdispatch.py proposes from the mirror, so --write would bake "
+                  "these into the queue files.\033[0m")
+        else:
+            print("  \033[32mOK\033[0m — mirror uses no retired routing label")
+        if drift["unknown"]:
+            print(f"  \033[33mnot yet mirrored ({len(drift['unknown'])})\033[0m: "
+                  f"{', '.join(drift['unknown'][:10])}")
+
+    # `retired` FAILS: it means the engine can route to something that is gone.
+    # `unknown` does NOT: a mirror lagging behind a new label is normal between
+    # refreshes, and failing on it would make the check red permanently — which
+    # is how a real finding gets ignored.
+    failed = (any(r["unknown_values"] or r["ambiguous"] for r in results)
+              or bool(drift["retired"]) or drift["live_was_empty"])
     return 1 if failed else 0
 
 

--- a/tests/dispatch/test_label_axis_cardinality.py
+++ b/tests/dispatch/test_label_axis_cardinality.py
@@ -257,7 +257,14 @@ def test_propose_excludes_an_ambiguous_card(monkeypatch, capsys):
           "idempotency_key": "owner/name#2", "title": "clean"}),
     ]
     monkeypatch.setattr(R, "load_rules", lambda: cfg)
-    monkeypatch.setattr(R, "iter_cards", lambda: [(board, c) for c in cards])
+    # Live-issue source since workspace-hub#3736 — patching iter_cards would now
+    # be a no-op that also let this test reach the network.
+    monkeypatch.setattr(R, "fetch_issues_for_coverage", lambda repo: [
+        {"number": 1, "state": "OPEN", "title": "ambiguous",
+         "labels": [{"name": "lane:claude"}, {"name": "lane:codex"}]},
+        {"number": 2, "state": "OPEN", "title": "clean",
+         "labels": [{"name": "lane:codex"}]},
+    ])
 
     class _Args:
         repo = None

--- a/tests/dispatch/test_live_issue_source.py
+++ b/tests/dispatch/test_live_issue_source.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Routing reads LIVE GitHub, not the kanban board mirror. workspace-hub#3736.
+
+Owner decision 2026-07-31: **retire the mirror as a routing input.**
+
+## Why
+
+Two sources of truth had diverged. `propose()` iterated
+`.claude/memory/kanban/boards/*.yaml`, so the routing engine never read GitHub —
+while every checker built this week did. The mirror held 6 `machine:`/`lane:`
+labels that had been retired and deleted from GitHub the same day, and 7 labels
+created that day were absent from it.
+
+It was structural, not decay: `load.py` runs boards → Hermes; **nothing ran
+GitHub → boards**. There was no refresh path to lapse, so the gap only grew.
+
+## The design question this forced
+
+A board gave each card exactly ONE domain — the board it lived in. A live issue
+carries however many `domain:` labels it has, and **74 open issues legitimately
+carry more than one** (`domain:` is declared multi-valued in `label_axes`).
+
+`match_rule` took a single `domain`. Feeding it "the first `domain:` label" would
+reintroduce the exact defect this epic spent the day removing: resolution by
+GitHub's API ordering, silent and non-deterministic.
+
+So matching is now **any-of**: a rule matches when *any* of the issue's domains
+satisfies it, and rules remain first-match-wins. That is order-independent over
+the label set while keeping rule precedence explicit and reviewable.
+
+Hermetic: pure functions, injected issue lists. No gh, no network, no boards.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_live_issue_source.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route_live", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route_live"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load()
+
+RULES = [
+    {"match": {"repo": "o/dm", "domain_family": "solver"}, "assign": {"machine": "heavy"}},
+    {"match": {"gh_label": "domain:cfd"}, "assign": {"machine": "cfd"}},
+    {"match": {}, "assign": {"machine": "dev-primary"}},
+]
+
+
+# --------------------------------------------------------------------------
+# multi-domain matching is ORDER-INDEPENDENT
+# --------------------------------------------------------------------------
+
+
+def test_a_rule_matches_when_ANY_domain_satisfies_it():  # noqa: N802
+    got = R.match_rule(RULES, repo="o/dm", domain=["hydro", "solver"], gh_labels=[])
+    assert got["assign"] == {"machine": "heavy"}
+
+
+def test_the_same_domains_in_the_other_order_give_the_same_answer():
+    """The whole point.
+
+    Taking "the first domain: label" would make routing depend on GitHub's API
+    ordering — the defect this epic removed from `status:`, `lane:` and
+    `machine:` today. Reintroducing it on `domain:` would be a poor trade.
+    """
+    a = R.match_rule(RULES, repo="o/dm", domain=["hydro", "solver"], gh_labels=[])
+    b = R.match_rule(RULES, repo="o/dm", domain=["solver", "hydro"], gh_labels=[])
+    assert a == b
+
+
+def test_rules_remain_first_match_wins_across_domains():
+    """Rule precedence must stay explicit, not become 'whichever domain matched'."""
+    rules = [
+        {"match": {"domain_family": "solver"}, "assign": {"machine": "A"}},
+        {"match": {"domain_family": "hydro"}, "assign": {"machine": "B"}},
+        {"match": {}, "assign": {"machine": "Z"}},
+    ]
+    for order in (["hydro", "solver"], ["solver", "hydro"]):
+        got = R.match_rule(rules, repo="r", domain=order, gh_labels=[])
+        assert got["assign"] == {"machine": "A"}, f"{order} must hit the FIRST rule"
+
+
+def test_a_single_domain_string_still_works():
+    """Back-compat: six existing call sites pass a bare string."""
+    assert R.match_rule(RULES, repo="o/dm", domain="solver",
+                        gh_labels=[])["assign"] == {"machine": "heavy"}
+
+
+def test_no_domain_falls_through_to_the_catch_all():
+    for empty in (None, [], ()):
+        got = R.match_rule(RULES, repo="o/dm", domain=empty, gh_labels=[])
+        assert got["assign"] == {"machine": "dev-primary"}
+
+
+def test_unrelated_domains_do_not_over_match():
+    got = R.match_rule(RULES, repo="o/dm", domain=["hydrocarbon", "solverless"], gh_labels=[])
+    assert got["assign"] == {"machine": "dev-primary"}
+
+
+# --------------------------------------------------------------------------
+# live issues -> cards
+# --------------------------------------------------------------------------
+
+
+def _issue(number=1, labels=None, title="t", state="OPEN"):
+    return {"number": number, "title": title, "state": state,
+            "labels": [{"name": n} for n in (labels or [])]}
+
+
+def test_issue_becomes_a_card_with_the_shape_propose_expects():
+    card = R.issue_to_card(_issue(7, ["domain:cfd", "machine:dev-primary"]), "o/r")
+    assert card["idempotency_key"].endswith("#7")
+    assert card["repo"] == "o/r"
+    assert card["gh_state"] == "open"
+    assert "domain:cfd" in card["gh_labels"]
+    assert card["source_url"].endswith("/o/r/issues/7")
+
+
+def test_card_carries_EVERY_domain_not_just_one():  # noqa: N802
+    """The board could only express one; an issue can have several."""
+    card = R.issue_to_card(_issue(1, ["domain:hydro", "domain:subsea"]), "o/r")
+    assert sorted(card["domains"]) == ["hydro", "subsea"]
+
+
+def test_state_is_normalised_lowercase():
+    """gh returns OPEN/CLOSED; `routable_states` is declared lowercase.
+
+    A case mismatch would silently route nothing at all — every card filtered
+    out, reported as an empty backlog rather than an error.
+    """
+    assert R.issue_to_card(_issue(1, state="OPEN"), "o/r")["gh_state"] == "open"
+
+
+def test_priority_defaults_when_no_priority_label():
+    assert R.issue_to_card(_issue(1), "o/r")["priority"] == 0
+
+
+def test_priority_is_read_from_the_label():
+    card = R.issue_to_card(_issue(1, ["priority:high"]), "o/r")
+    assert card["priority"] > 0, "priority: must affect WIP ordering"
+
+
+# --------------------------------------------------------------------------
+# the mirror is genuinely out of the path
+# --------------------------------------------------------------------------
+
+
+def test_propose_does_not_read_the_board_mirror(monkeypatch):
+    """BEHAVIOURAL, not a source scan.
+
+    Booby-traps `iter_cards` — the board reader. If `propose()` still touches it,
+    this raises. A grep for "iter_cards" would pass while the call remained.
+    """
+    def boom(*a, **k):  # noqa: ANN002, ANN003
+        raise AssertionError("propose() still reads the kanban board mirror")
+
+    monkeypatch.setattr(R, "iter_cards", boom, raising=False)
+    monkeypatch.setattr(R, "load_rules", lambda: {
+        "rules": [{"match": {}, "assign": {"machine": "dev-primary"}}],
+        "defaults": {"provider": "claude", "machine": "dev-primary",
+                     "routable_states": ["open"], "skip_if_labeled": []},
+        "machines": {}, "machine_aliases": {}, "providers": {},
+        "budget_pools": {}, "wip_caps": {"per_machine": {"default": 99}, "per_provider": {}},
+        "label_axes": {"single": {"lane:": "one"}, "multi": {"domain:": "many"}},
+    }, raising=False)
+    monkeypatch.setattr(R, "fetch_issues_for_coverage",
+                        lambda repo: [_issue(1, ["domain:cfd"])], raising=False)
+
+    class _A:
+        repo = "o/r"
+        json = False
+    out = R.propose(_A())
+    assert [str(p["number"]) for p in out] == ["1"]

--- a/tests/dispatch/test_mirror_drift.py
+++ b/tests/dispatch/test_mirror_drift.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""The kanban board mirror must agree with live GitHub about routing labels.
+
+workspace-hub#3736.
+
+## Why this exists
+
+There are two sources of truth for routing, and they diverged:
+
+    route.py --coverage, check-label-vocabulary.py  ->  live GitHub
+    route.py propose(), dispatch.py                 ->  board mirror
+
+`propose()` iterates `.claude/memory/kanban/boards/*.yaml`, so the **routing
+engine** never reads GitHub. Measured 2026-07-31: the mirror held **37**
+references to `machine:` labels that had been retired and deleted from GitHub
+that morning, while every live-GitHub checker reported clean.
+
+The dashboards were green and the dispatcher was wrong.
+
+## The structural part
+
+There is **no GitHub → board refresh path**. `.claude/memory/kanban/scripts/load.py`
+runs boards → Hermes; nothing runs the other direction. So the drift is not a
+lapsed cron that can be re-run — it grows monotonically, and every label
+correction made against GitHub widens it.
+
+That is why detection is worth having before a fix is chosen: whichever way the
+mirror question is settled (refresh it, gate it, or retire it as a routing
+input), *knowing when it disagrees* is correct.
+
+## What is asserted
+
+`mirror_drift()` compares the routing labels the mirror uses against the labels
+that actually exist, and separates the two directions — they have different
+causes and different fixes:
+
+    retired   in the mirror, absent from GitHub  -> routes to a machine that is gone
+    unknown   on GitHub, absent from the mirror  -> mirror has not caught up
+
+Hermetic: pure set comparison, explicit inputs. No gh, no filesystem, no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_mirror_drift.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_PY = REPO_ROOT / "scripts" / "enforcement" / "check-label-vocabulary.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_vocab", CHECK_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_vocab"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+C = _load()
+
+
+# --------------------------------------------------------------------------
+# the two directions are separated
+# --------------------------------------------------------------------------
+
+
+def test_label_in_mirror_but_not_on_github_is_RETIRED():  # noqa: N802
+    """The dangerous direction: the engine routes to something that is gone.
+
+    This is the real 2026-07-31 shape — the mirror still held `machine:ace-win-1`
+    after it was deleted, while GitHub had moved to `machine:licensed-win-1`. So
+    BOTH directions fire at once: one retired, one not yet mirrored. An earlier
+    draft of this test asserted `unknown == []`, which was simply wrong about its
+    own fixture.
+    """
+    d = C.mirror_drift(mirror={"machine:ace-win-1"}, live={"machine:licensed-win-1"})
+    assert d["retired"] == ["machine:ace-win-1"]
+    assert d["unknown"] == ["machine:licensed-win-1"]
+
+
+def test_label_on_github_but_not_in_mirror_is_UNKNOWN():  # noqa: N802
+    """The lagging direction: real work the engine cannot see yet."""
+    d = C.mirror_drift(mirror=set(), live={"machine:licensed-win-1"})
+    assert d["unknown"] == ["machine:licensed-win-1"]
+    assert d["retired"] == []
+
+
+def test_agreement_is_no_drift():
+    d = C.mirror_drift(mirror={"machine:dev-primary"}, live={"machine:dev-primary"})
+    assert d["retired"] == [] and d["unknown"] == []
+
+
+def test_only_ROUTING_axes_are_compared():  # noqa: N802
+    """A `domain:` or `cat:` label differing is not a routing defect.
+
+    Comparing every axis would bury the finding that matters under taxonomy
+    churn — the mirror legitimately lags on labels the router never reads.
+    """
+    d = C.mirror_drift(mirror={"domain:cfd", "epic"}, live={"domain:subsea"})
+    assert d["retired"] == [] and d["unknown"] == []
+
+
+def test_output_is_sorted_for_a_stable_diff():
+    """An unsorted report churns in CI and trains people to ignore it."""
+    d = C.mirror_drift(mirror={"machine:z", "machine:a"}, live=set())
+    assert d["retired"] == ["machine:a", "machine:z"]
+
+
+# --------------------------------------------------------------------------
+# extraction from board documents
+# --------------------------------------------------------------------------
+
+
+def test_extracts_routing_labels_from_board_cards():
+    boards = [{"cards": [{"gh_labels": ["machine:dev-primary", "domain:cfd", "epic"]}]}]
+    assert C.mirror_routing_labels(boards) == {"machine:dev-primary"}
+
+
+def test_extraction_survives_a_board_with_no_cards():
+    """A malformed or empty board must not crash the check — it must contribute
+    nothing, so one bad file cannot mask drift in the others by aborting."""
+    assert C.mirror_routing_labels([{}, {"cards": None}, {"cards": []}]) == set()
+
+
+def test_extraction_covers_every_declared_routing_axis():
+    boards = [{"cards": [{"gh_labels": ["lane:codex", "ai:claude", "machine:multi"]}]}]
+    got = C.mirror_routing_labels(boards)
+    assert got == {"lane:codex", "ai:claude", "machine:multi"}
+
+
+# --------------------------------------------------------------------------
+# guards on the guard
+# --------------------------------------------------------------------------
+
+
+def test_routing_axes_constant_is_not_empty():
+    """An emptied ROUTING_AXES would make every comparison above vacuously pass."""
+    assert C.ROUTING_AXES and all(a.endswith(":") for a in C.ROUTING_AXES)
+
+
+def test_empty_inputs_do_not_fabricate_drift():
+    d = C.mirror_drift(mirror=set(), live=set())
+    assert d["retired"] == [] and d["unknown"] == []
+
+
+@pytest.mark.parametrize("bad", [None, set()])
+def test_missing_live_set_is_not_read_as_everything_retired(bad):
+    """If the live query failed, EVERY mirror label would look retired.
+
+    That would turn an API failure into a fleet-wide false alarm, and the
+    resulting noise is how a real drift report gets ignored. The caller must
+    distinguish 'no labels' from 'could not ask' — asserted here so the shape
+    cannot regress silently.
+    """
+    d = C.mirror_drift(mirror={"machine:dev-primary"}, live=bad or set())
+    assert d["live_was_empty"] is True, (
+        "an empty live set must be flagged, not silently treated as authoritative"
+    )

--- a/tests/dispatch/test_queue_staleness.py
+++ b/tests/dispatch/test_queue_staleness.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""A dispatch queue file must declare when it was generated.
+
+## The gap
+
+`dispatch.py` materialises `.claude/dispatch/<machine>.yaml`, which each
+machine's session drains. The payload carried `machine`, `generated_by` and
+`cards` — and **no timestamp**. A session opening `dev-primary.yaml` (1,354
+cards) could not tell whether it was built minutes ago or in May.
+
+That matters because the queue is a *snapshot of a routing decision*, and
+routing inputs change constantly: labels get corrected, machines get retired,
+capability claims get fixed. On 2026-07-31 alone ~300 labels changed, which
+silently invalidated queue files generated the previous day. Nothing in the file
+said so.
+
+## Why this is the same defect as the rest of the epic
+
+`reachability.py` — same author, same week — writes `observed_at` **and** an
+explicit TTL, with the reasoning stated in its own docstring: *"reachability is
+time-varying, so the TTL is explicit — consumers warn on stale data rather than
+trusting it as static routing truth."*
+
+Dispatch queues are equally time-varying, and got neither. An undated snapshot
+does not look stale; it looks authoritative. Absence of a timestamp reads as
+freshness.
+
+## What is asserted
+
+The file declares `generated_at` (UTC, ISO-8601) and `ttl_hours`, and a
+`queue_age_hours()` helper lets a consumer decide. Deliberately NOT enforced by
+refusing to load: a stale queue is still better than no queue, and hard-failing
+a drain because a clock drifted would push people to delete the field. The
+contract is *visible staleness*, not *blocked staleness*.
+
+Hermetic: pure functions, injected clock, no gh and no network.
+
+Run: uv run --with pyyaml pytest tests/dispatch/test_queue_staleness.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DISPATCH_PY = REPO_ROOT / "scripts" / "dispatch" / "dispatch.py"
+DISPATCH_DIR = REPO_ROOT / ".claude" / "dispatch"
+
+
+def _load():
+    # dispatch.py does `import route` as a SIBLING module, so its directory has
+    # to be importable. Prepending rather than appending: a stray `route.py`
+    # elsewhere on sys.path would otherwise shadow the one under test.
+    pkg_dir = str(DISPATCH_PY.parent)
+    if pkg_dir not in sys.path:
+        sys.path.insert(0, pkg_dir)
+    spec = importlib.util.spec_from_file_location("dispatch_mod", DISPATCH_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dispatch_mod"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+D = _load()
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# the payload declares its own age
+# --------------------------------------------------------------------------
+
+
+def test_payload_carries_generated_at():
+    p = D.queue_payload("dev-primary", [], now=lambda: NOW)
+    assert p["generated_at"] == "2026-07-31T12:00:00Z"
+
+
+def test_payload_carries_a_ttl():
+    p = D.queue_payload("dev-primary", [], now=lambda: NOW)
+    assert p["ttl_hours"] > 0, "a TTL of zero would make every queue permanently stale"
+
+
+def test_generated_at_is_utc_and_sortable():
+    """Local time in a git-tracked file makes two machines' queues incomparable."""
+    p = D.queue_payload("m", [], now=lambda: NOW)
+    assert p["generated_at"].endswith("Z")
+    datetime.strptime(p["generated_at"], "%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_existing_fields_are_preserved():
+    """Back-compat: a consumer reading machine/cards must not break."""
+    cards = [{"gh": "o/r#1"}]
+    p = D.queue_payload("dev-primary", cards, now=lambda: NOW)
+    assert p["machine"] == "dev-primary"
+    assert p["cards"] == cards
+    assert p["generated_by"] == "dispatch.py"
+
+
+# --------------------------------------------------------------------------
+# age is computable, and staleness is VISIBLE not enforced
+# --------------------------------------------------------------------------
+
+
+def test_age_of_a_fresh_queue_is_zero():
+    p = D.queue_payload("m", [], now=lambda: NOW)
+    assert D.queue_age_hours(p, now=lambda: NOW) == pytest.approx(0, abs=0.01)
+
+
+def test_age_grows():
+    p = D.queue_payload("m", [], now=lambda: NOW)
+    later = NOW + timedelta(hours=30)
+    assert D.queue_age_hours(p, now=lambda: later) == pytest.approx(30, abs=0.01)
+
+
+def test_is_stale_uses_the_declared_ttl():
+    p = D.queue_payload("m", [], now=lambda: NOW)
+    ttl = p["ttl_hours"]
+    assert not D.queue_is_stale(p, now=lambda: NOW)
+    assert D.queue_is_stale(p, now=lambda: NOW + timedelta(hours=ttl + 1))
+
+
+def test_a_queue_with_no_timestamp_is_treated_as_STALE():  # noqa: N802
+    """The pre-2026-07-31 files have no `generated_at`.
+
+    Unknown age must resolve to STALE, never to fresh. Treating "I cannot tell"
+    as "it is fine" is the exact failure this epic keeps meeting — and here it
+    would be self-inflicted, since every queue file on main today lacks the field.
+    """
+    assert D.queue_is_stale({"machine": "m", "cards": []}, now=lambda: NOW) is True
+
+
+def test_staleness_does_not_prevent_loading():
+    """Visible, not blocking.
+
+    A stale queue is still better than no queue, and hard-failing a drain over a
+    clock would push people to delete the field rather than regenerate the file.
+    """
+    old = D.queue_payload("m", [{"gh": "o/r#1"}], now=lambda: NOW - timedelta(days=90))
+    assert old["cards"], "a stale payload still carries its cards"
+
+
+# --------------------------------------------------------------------------
+# the shipped files
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not DISPATCH_DIR.is_dir(), reason="no queue files checked out")
+def test_shipped_queue_files_parse_and_declare_a_machine():
+    """Guards the guard: if the payload shape drifts, this catches it against the
+    files actually on disk rather than only against a constructed dict."""
+    files = sorted(DISPATCH_DIR.glob("*.yaml"))
+    assert files, "no queue files found — the check below would be vacuous"
+    for f in files:
+        if f.name.startswith("_"):
+            continue                      # _leader-state.yaml is not a queue
+        data = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
+        assert data.get("machine"), f"{f.name} declares no machine"

--- a/tests/dispatch/test_route_capacity.py
+++ b/tests/dispatch/test_route_capacity.py
@@ -172,17 +172,63 @@ def test_blocked_on_names_an_issue(machines):
             assert "#" in str(b), f"{name}.blocked_on must reference an issue: {b!r}"
 
 
-def test_licence_verified_is_still_false_or_a_dated_attestation(machines):
-    """Carried over from deckhand#579 — a bare `true` discards the evidence."""
+def test_licence_verified_is_per_solver_and_dated(machines):
+    """Licence is PER SOLVER, not per host (fleet handover 2026-07-31).
+
+    A single host-level flag was the third version of the same mistake in one
+    day: capability treated as one property. AQWA is licensed and idle on the
+    heavy node while OrcaFlex is genuinely unavailable there — no single boolean
+    can say that, and either value would have been wrong about half the solvers.
+
+    Shape: `licence_verified: {<capability>: {at, by, how}}`.
+    """
     for name, spec in machines.items():
-        if "licence_verified" not in spec:
+        v = spec.get("licence_verified")
+        if v is False or v is None:
             continue
-        v = spec["licence_verified"]
-        if v is False:
-            continue
-        assert isinstance(v, dict), f"{name}: licence_verified must be false or a dated dict"
-        for field in ("at", "by", "how"):
-            assert v.get(field), f"{name}: licence_verified.{field} required"
+        assert isinstance(v, dict), f"{name}: licence_verified must be false or a per-solver map"
+        for cap, att in v.items():
+            assert isinstance(att, dict), (
+                f"{name}.licence_verified.{cap} must be a dated attestation, not {att!r} — "
+                "a bare true records a conclusion and discards the evidence"
+            )
+            for field in ("at", "by", "how"):
+                assert att.get(field), f"{name}.licence_verified.{cap}.{field} required"
+
+
+def test_a_blocked_solver_states_its_real_cause(machines):
+    """`licence_blocked` must name an issue AND survive a wrong first diagnosis.
+
+    deckhand#579 recorded the blocker as a missing Sentinel LDK client runtime.
+    The fleet session proved that is the wrong layer: the licence SERVER
+    publishes no orca* feature at all, so no client install can help. A blocker
+    field that only records the first theory is worse than none — it closes the
+    question.
+    """
+    for name, spec in machines.items():
+        for cap, reason in (spec.get("licence_blocked") or {}).items():
+            assert "#" in str(reason), f"{name}.licence_blocked.{cap} must reference an issue"
+            assert len(str(reason)) > 60, (
+                f"{name}.licence_blocked.{cap} is too terse to carry a diagnosis"
+            )
+
+
+def test_a_capability_is_never_both_verified_and_blocked(machines):
+    for name, spec in machines.items():
+        both = set(spec.get("licence_verified") or {}) & set(spec.get("licence_blocked") or {})
+        assert not both, f"{name}: {sorted(both)} declared both verified and blocked"
+
+
+def test_an_unavailable_host_declares_why(machines):
+    """A host marked down must say what is wrong and where it is tracked.
+
+    Otherwise `available: false` becomes permanent through nobody remembering
+    what it was waiting for.
+    """
+    for name, spec in machines.items():
+        if spec.get("available") is False:
+            assert spec.get("blocked_on"), f"{name} is unavailable with no stated reason"
+            assert spec.get("unavailable_since"), f"{name} is unavailable with no start time"
 
 
 def test_the_checks_are_not_vacuous(cfg, machines):

--- a/tests/dispatch/test_route_quota_gate.py
+++ b/tests/dispatch/test_route_quota_gate.py
@@ -183,14 +183,21 @@ def test_cli_override_skips_subprocess_and_is_loud(route, monkeypatch, capsys):
 # --- propose() integration: memoization, annotation, no sticky labels --------
 
 def _fake_boards(route, monkeypatch, n_cards=2, labels=("lane:codex",)):
-    board = {"repo": "vamseeachanta/workspace-hub", "domain": None}
-    cards = [
-        (board, {"idempotency_key": f"gh:vamseeachanta/workspace-hub#{i}",
-                 "source": "github_issue", "gh_state": "open",
-                 "gh_labels": list(labels), "title": f"card {i}", "priority": 0})
+    """Feed propose() from the LIVE-ISSUE source.
+
+    Renamed in spirit but not in name: since workspace-hub#3736 the routing input
+    is live GitHub, not the kanban board mirror. Patching `iter_cards` here would
+    now silently do nothing AND let the test reach the network — which is how a
+    hermetic suite quietly stops being hermetic.
+    """
+    issues = [
+        {"number": i, "title": f"card {i}", "state": "OPEN",
+         "labels": [{"name": n} for n in labels]}
         for i in range(n_cards)
     ]
-    monkeypatch.setattr(route, "iter_cards", lambda: iter(cards))
+    monkeypatch.setattr(route, "fetch_issues_for_coverage", lambda repo: issues)
+    monkeypatch.setattr(route, "DEFAULT_COVERAGE_REPOS",
+                        ("vamseeachanta/workspace-hub",), raising=False)
     monkeypatch.setattr(route, "load_rules", lambda: {
         "rules": [{"match": {}, "assign": {"machine": "dev-primary"}}],
         "defaults": DEFAULTS})

--- a/tests/dispatch/test_routing_rules_capability_truth.py
+++ b/tests/dispatch/test_routing_rules_capability_truth.py
@@ -92,25 +92,23 @@ def test_every_licensed_capability_claim_carries_an_attestation(machines):
     assert not unbacked, "unbacked licensed-capability claims: " + "; ".join(unbacked)
 
 
-def test_licence_verified_is_false_or_a_dated_attestation(machines):
-    """`licence_verified` must be `false`, or a dict carrying who and when.
+def test_licence_verified_is_per_solver_and_dated(machines):
+    """Licence is PER SOLVER, not per host (fleet handover 2026-07-31).
 
-    A bare `true` is exactly the shape that rotted here — it records a
-    conclusion and discards the evidence, so nobody can tell whether it was
-    checked yesterday or inherited from a machine that no longer exists.
+    A bare `true` discards the evidence; a host-level flag discards WHICH solver.
+    AQWA is licensed and idle on the heavy node while OrcaFlex is unavailable
+    there — one boolean cannot say that. Shape:
+    `licence_verified: {<capability>: {at, by, how}}`.
     """
     for name, spec in machines.items():
-        if "licence_verified" not in spec:
+        v = spec.get("licence_verified")
+        if v is False or v is None:
             continue
-        value = spec["licence_verified"]
-        if value is False:
-            continue
-        assert isinstance(value, dict), (
-            f"{name}: licence_verified must be false or a dated attestation dict, "
-            f"got {value!r} — a bare true discards the evidence"
-        )
-        for field in ("at", "by", "how"):
-            assert value.get(field), f"{name}: licence_verified.{field} is required"
+        assert isinstance(v, dict), f"{name}: licence_verified must be false or a per-solver map"
+        for cap, att in v.items():
+            assert isinstance(att, dict), f"{name}.licence_verified.{cap} must be a dated attestation"
+            for field in ("at", "by", "how"):
+                assert att.get(field), f"{name}.licence_verified.{cap}.{field} is required"
 
 
 # --------------------------------------------------------------------------
@@ -119,7 +117,17 @@ def test_licence_verified_is_false_or_a_dated_attestation(machines):
 
 
 def _licence_proven(spec: dict) -> bool:
-    return isinstance(spec.get("licence_verified"), dict)
+    """At least one licensed capability on this host carries a dated attestation.
+
+    Per-solver since 2026-07-31: `licence_verified` maps capability -> {at,by,how}.
+    A host with AQWA attested and OrcaFlex blocked counts as proven HERE — the
+    per-capability question ("can this host run THIS solver?") is answered by
+    `licence_verified[cap]` at dispatch time, not by this coarse check.
+    """
+    verified = spec.get("licence_verified")
+    return isinstance(verified, dict) and bool(
+        set(verified) & LICENSED_CAPABILITIES
+    )
 
 
 def test_no_rule_routes_licensed_work_to_an_unproven_host(rules, machines):


### PR DESCRIPTION
Four related changes from one discovery thread. **226 tests.**

## 1. Queue files declare their own age

A queue file is a *snapshot of a routing decision*, and routing inputs change constantly. The payload carried `machine`, `generated_by`, `cards` — and **no timestamp**. A session opening `dev-primary.yaml` (1,354 cards) couldn't tell whether it was built minutes ago or in May.

`reachability.py` — same author, same week — already writes `observed_at` plus a TTL, reasoning stated in its own docstring. Dispatch queues got neither. **An undated snapshot doesn't look stale; it looks authoritative.**

Unknown age resolves to **STALE, never fresh**. Visible, not blocking — hard-failing a drain over a clock would push people to delete the field rather than regenerate the file.

## 2. That immediately exposed a stale mirror — and it's now retired (#3736)

The dry-run routed cards to labels **deleted from GitHub the same day**. `propose()` iterated the kanban board mirror, so the routing **engine** never read GitHub while every checker did.

Structural, not decay: `load.py` runs boards → Hermes; **nothing ran GitHub → boards**. No refresh path existed to lapse, so the gap only grew.

Owner decision: **retire the mirror as a routing input.** `propose()` now reads live GitHub.

### The design question that forced

A board gave each card **one** domain — the board it sat on. A live issue carries however many `domain:` labels it has, and **74 open issues legitimately carry more than one**.

Feeding `match_rule` "the first `domain:` label" would have reintroduced resolution by **GitHub API ordering** — the exact defect removed from `status:`, `lane:` and `machine:` earlier today, landed on the last axis that didn't have it.

So matching is **any-of**, rules stay first-match-wins. Order-independent by construction.

Also kept: a drift detector comparing mirror vs live, since the mirror still feeds other consumers.

## 3. Licence is PER SOLVER (fleet handover)

**AQWA is licensed, healthy and idle** on the heavy node — 2 `aqwa_solve` + 2 `aqwa_pre` + 4 `anshpc` seats free, four diffraction runs completed 18 Jul (wh#3734). **OrcaFlex is genuinely unavailable there.**

One host-level flag couldn't say that — **either value would have been wrong about half the solvers.** Third version of "capability treated as one property" in a day.

And **deckhand#579's stated fix is the wrong layer**: `lmutil lmstat -a` shows no `orca*` feature served *at all*, while the same server serves ANSYS to that host. A client runtime cannot create an entitlement the server doesn't publish. The HASP message is the symptom people read first; FlexNet Error 21 above it is the cause.

`licensed-win-2` marked `available: false` with reason and timestamp (wh#3721) — and note **a TCP-only probe reports that host UP**: ports accept, userland can't service.

## 4. Tests briefly stopped being hermetic

Four tests patched `iter_cards`. After the switch that patch is a **no-op**, and `propose()` reached the real network. The suite went 5s → 50s **and still passed** — green, slow, and silently talking to GitHub. Fixed; back to 5.3s.

## Verification

`pytest tests/dispatch/` **226 passed**. Live smoke: 173 deckhand cards routed, 172 with a domain, mirror out of the path.

Not self-merging:
`gh pr merge 3735 --repo vamseeachanta/workspace-hub --squash --delete-branch`
