### PR TITLE
feat(windows): optional password logon for dispatch -- licensed solvers need it

### DIFF
--- a/scripts/windows/dispatch-run.ps1
+++ b/scripts/windows/dispatch-run.ps1
@@ -37,6 +37,12 @@ param(
     [string]$WorkDir = "",
     [ValidateSet('bash','cmd','powershell')]
     [string]$Shell = 'bash',
+
+    # Run the task under a PASSWORD logon as this user (e.g. 'DOMAIN\user' or '.\user').
+    # Required for licensed solvers whose FlexNet checkout an SSH key token cannot complete.
+    # The password comes from the machine-level DISPATCH_RUN_PASSWORD env var, never a
+    # parameter -- command-line values are readable from the process list.
+    [string]$RunAsUser = "",
     [int]$Tail = 50
 )
 
@@ -159,9 +165,45 @@ exit /b 0
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     try {
-        $create = & schtasks /create /tn "$task" /sc ONCE /st 00:00 /f /tr "`"$runnerFile`"" 2>&1
+        # Logon type decides whether licensed solvers work.
+        #
+        # Measured 2026-07-31: OrcaFlex checks out its FlexNet seat fine from an INTERACTIVE
+        # logon and fails over SSH with FlexNet Error 21, while AQWA succeeds on both. Env
+        # vars, ORCINA_LICENSE_FILE, the HKCU hive and TCP reach to every licence port were
+        # byte-identical between the two sessions, so it is not configuration. Session 0 is
+        # not the cause either -- the deckhand licensed-run agent runs in session 0 as the
+        # same user with LogonType=Password and completes OrcaFlex at rc 0.
+        #
+        # What differs is the TOKEN. An SSH public-key logon cannot complete the checkout.
+        # A task created without /ru inherits the caller's token, so an SSH-dispatched job
+        # inherits the broken one. Supplying /ru + /rp registers the task with a stored
+        # credential and it runs under a PASSWORD logon -- the configuration already proven
+        # to work by the deckhand agent.
+        #
+        # The password is read from the environment, never passed as a parameter: a value on
+        # the command line is visible to every other process on the box via the process list.
+        # Set it machine-level, on the box, once:
+        #   [Environment]::SetEnvironmentVariable('DISPATCH_RUN_PASSWORD','<pw>','Machine')
+        # AQWA and ordinary compute do NOT need this -- omit -RunAsUser and nothing changes.
+        $createArgs = @('/create','/tn',$task,'/sc','ONCE','/st','00:00','/f','/tr',"`"$runnerFile`"")
+        $logonMode = 'inherited-token'
+        if ($RunAsUser) {
+            $pw = [Environment]::GetEnvironmentVariable('DISPATCH_RUN_PASSWORD','Machine')
+            if (-not $pw) { $pw = $env:DISPATCH_RUN_PASSWORD }
+            if (-not $pw) {
+                throw "-RunAsUser given but DISPATCH_RUN_PASSWORD is not set (machine-level env var). Licensed-solver jobs need a password logon; see the comment at this line."
+            }
+            $createArgs += @('/ru',$RunAsUser,'/rp',$pw)
+            $logonMode = 'password'
+        }
+        $create = & schtasks @createArgs 2>&1
         $createRc = $LASTEXITCODE
-        if ($createRc -ne 0) { throw "schtasks /create failed (rc=$createRc): $create" }
+        # Never echo $create on the failure path once /rp is in play -- schtasks can reflect
+        # its own argv, which would put the password in the error text and any log capturing it.
+        if ($createRc -ne 0) {
+            if ($RunAsUser) { throw "schtasks /create failed (rc=$createRc) [password logon; output suppressed to avoid echoing the credential]" }
+            throw "schtasks /create failed (rc=$createRc): $create"
+        }
         $run = & schtasks /run /tn "$task" 2>&1
         $runRc = $LASTEXITCODE
         if ($runRc -ne 0) { throw "schtasks /run failed (rc=$runRc): $run" }
@@ -172,6 +214,7 @@ exit /b 0
     Emit ([ordered]@{
         ok = $true; action = 'submit'; job_id = $JobId; task = $task
         dir = $dir; stdout = $outLog; stderr = $errLog; shell = $Shell
+        logon = $logonMode; run_as = $(if ($RunAsUser) { $RunAsUser } else { $null })
     })
     exit 0
 }


### PR DESCRIPTION
Makes OrcaFlex dispatchable from the control surface. Adds an **optional** `-RunAsUser` so a dispatched job runs under a **password logon** instead of the caller's inherited token.

## Why

OrcaFlex cannot check out its FlexNet seat from an SSH-dispatched job. Measured 2026-07-31:

| path | OrcaFlex | AQWA |
|---|---|---|
| interactive session | **PASS** | PASS |
| over SSH | **FAIL — FlexNet Error 21** | PASS |

The usual suspects were ruled out by measuring both sessions: env vars, `ORCINA_LICENSE_FILE` (HKCU → `FlexNet.ini`, `SERVER <host> ANY`), HKCU hive identity, and TCP reach to all four licence ports (1055/27000/27001/27002 open) are **byte-identical**. Exporting the licence variable does not help.

**Session 0 is not the cause.** The deckhand licensed-run agent runs in session 0, as the same user, with `LogonType=Password`, and has a finished OrcaFlex run at rc 0.

What differs is the **token**. An SSH public-key logon cannot complete the checkout. A task created without `/ru` inherits the caller's token — so an SSH-dispatched job inherits the broken one. `/ru` + `/rp` registers the task with a stored credential and it runs under a password logon: the configuration the deckhand agent already proves works.

Note this is the same class as the `gh` failure found on both Windows hosts the same day — a credential valid for an interactive logon and unreachable from a **network** logon.

## Credential handling

**The password is never a parameter.** It is read from the machine-level `DISPATCH_RUN_PASSWORD` env var:

```powershell
[Environment]::SetEnvironmentVariable('DISPATCH_RUN_PASSWORD','<pw>','Machine')
```

A value on the command line is readable from the process list by every other process on the box. On the `/rp` failure path the `schtasks` output is **suppressed rather than echoed** — `schtasks` can reflect its own argv, which would put the credential into the error text and into any log capturing it.

## Backward compatibility

Omit `-RunAsUser` and behaviour is unchanged. Verified on a live host: a plain submit reports `"logon":"inherited-token","run_as":null`, runs detached, and returns the payload's exit code (`exit_code: 3` from a job that exits 3).

`submit` now also reports `logon` (`inherited-token` | `password`) and `run_as`, so a caller can **see** which token a job got rather than assuming — which matters given the failure it addresses is invisible from the outside.

## Not yet verified against OrcaFlex — read before merging

There is exactly **one floating Orcina seat, fleet-wide** (port 27002, feature `Flex` v11.6, expiry 2027-03-15). It has been checked out by an interactive session since 21:16, so a run now would fail on **seat exhaustion** and be indistinguishable from a token failure. I chose not to run a test whose result could not be interpreted.

To complete the verification, two preconditions:

1. `DISPATCH_RUN_PASSWORD` set machine-level on the target host
2. The single seat free — i.e. the interactive session **logged off**, not merely disconnected

Then:

```bash
ssh <host> "powershell -NoProfile -ExecutionPolicy Bypass -File '<path>/dispatch-run.ps1' \
  -Action submit -Shell bash -RunAsUser '<domain>\<user>' -JobId orca01 \
  -Command '<orcaflex licence probe>'"
```

Expect `"logon":"password"` in the submit result, and the probe to reach a licence rather than Error 21.

## Related constraint worth encoding elsewhere

OrcaFlex capacity is **1, fleet-wide** — not one per host. Any routing that can dispatch two OrcaFlex jobs concurrently will fail on checkout regardless of where they land. Relevant to #3730's licence-and-capacity work; it should be a capacity limit, not a boolean capability.

Refs #3721, deckhand#579.
