### PR TITLE
fix(harness): drop dangling .claude/rules/ references; make R5 fail on missing files

### DIFF
--- a/config/agents/SHARED_SOUL.md
+++ b/config/agents/SHARED_SOUL.md
@@ -40,8 +40,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 

--- a/config/agents/agy/SOUL.runtime.md
+++ b/config/agents/agy/SOUL.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 

--- a/config/agents/claude/SOUL.runtime.md
+++ b/config/agents/claude/SOUL.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 

--- a/config/agents/codex/AGENTS.runtime.md
+++ b/config/agents/codex/AGENTS.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 
@@ -181,7 +181,7 @@ Beyond the SHARED_SOUL.md Hard Gates, Codex sessions additionally enforce:
 1. **Every implementation task maps to a WRK-* in `.claude/work-queue/`** OR a GitHub issue per the broader workspace `feedback_no_reserved_wrk_ids` rule. Codex's `submit-to-codex.sh` Stage-5 gate validates WRK evidence when `--wrk-id` is supplied.
 2. **Workflow lifecycle skills are mandatory**: `.claude/skills/workspace-hub/work-queue-workflow/SKILL.md` + `.claude/skills/workspace-hub/workflow-gatepass/SKILL.md` for WRK-mode work.
 3. **Coding style guardrails**: max 400 lines/file, max 50 lines/function, snake_case Python, camelCase JS — see `.claude/rules/coding-style.md`.
-4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`) — see `.claude/rules/git-workflow.md`.
+4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`). Merges are governed by [`.claude/rules/merge-authorization.md`](../../../.claude/rules/merge-authorization.md) and [`merge-cleanup.md`](../../../.claude/rules/merge-cleanup.md).
 
 ## Bootstrap Hazard — `~/.codex/AGENTS.md` Untracked Generator
 
@@ -198,7 +198,7 @@ The fix is `scripts/agents/install-soul-runtime.sh` (per [#2719](https://github.
 - **apple/** — 5 skill(s); `ls .claude/skills/apple/*/SKILL.md` to enumerate
 - **autonomous-ai-agents/** — 9 skill(s); `ls .claude/skills/autonomous-ai-agents/*/SKILL.md` to enumerate
 - **business/** — 74 skill(s); `ls .claude/skills/business/*/SKILL.md` to enumerate
-- **business_admin/** — 1 skill(s); `ls .claude/skills/business_admin/*/SKILL.md` to enumerate
+- **business_admin/** — 2 skill(s); `ls .claude/skills/business_admin/*/SKILL.md` to enumerate
 - **business-finance/** — 1 skill(s); `ls .claude/skills/business-finance/*/SKILL.md` to enumerate
 - **business-marketing/** — 2 skill(s); `ls .claude/skills/business-marketing/*/SKILL.md` to enumerate
 - **coordination/** — 59 skill(s); `ls .claude/skills/coordination/*/SKILL.md` to enumerate
@@ -229,6 +229,7 @@ The fix is `scripts/agents/install-soul-runtime.sh` (per [#2719](https://github.
 - **red-teaming/** — 1 skill(s); `ls .claude/skills/red-teaming/*/SKILL.md` to enumerate
 - **research/** — 15 skill(s); `ls .claude/skills/research/*/SKILL.md` to enumerate
 - **science/** — 6 skill(s); `ls .claude/skills/science/*/SKILL.md` to enumerate
+- **session-logs/** — 0 skill(s); `ls .claude/skills/session-logs/*/SKILL.md` to enumerate
 - **smart-home/** — 1 skill(s); `ls .claude/skills/smart-home/*/SKILL.md` to enumerate
 - **social-media/** — 2 skill(s); `ls .claude/skills/social-media/*/SKILL.md` to enumerate
 - **software-development/** — 35 skill(s); `ls .claude/skills/software-development/*/SKILL.md` to enumerate
@@ -253,7 +254,9 @@ The fix is `scripts/agents/install-soul-runtime.sh` (per [#2719](https://github.
 - Absolute paths permitted only when a tool call explicitly requires them (e.g., `file_path` parameter)
 
 ## Agent Harness Files
-CLAUDE.md, MEMORY.md, AGENTS.md, GEMINI.md must not exceed 20 lines. Migrate excess to a skill or doc. (enforced: `scripts/enforcement/check-harness-file-size.sh`)
+AGENTS.md is the canonical contract. It, MEMORY.md, and GEMINI.md must not exceed 20 lines. Migrate excess to a skill or doc. (enforced: `scripts/enforcement/check-harness-file-size.sh`)
+
+CLAUDE.md is retired in this repo (2026-08-01) — do not reintroduce one. The cap still applies to sibling repos that carry one.
 
 ### patterns
 # Design Patterns Rules — Universal

--- a/config/agents/codex/SOUL.delta.md
+++ b/config/agents/codex/SOUL.delta.md
@@ -60,7 +60,7 @@ Beyond the SHARED_SOUL.md Hard Gates, Codex sessions additionally enforce:
 1. **Every implementation task maps to a WRK-* in `.claude/work-queue/`** OR a GitHub issue per the broader workspace `feedback_no_reserved_wrk_ids` rule. Codex's `submit-to-codex.sh` Stage-5 gate validates WRK evidence when `--wrk-id` is supplied.
 2. **Workflow lifecycle skills are mandatory**: `.claude/skills/workspace-hub/work-queue-workflow/SKILL.md` + `.claude/skills/workspace-hub/workflow-gatepass/SKILL.md` for WRK-mode work.
 3. **Coding style guardrails**: max 400 lines/file, max 50 lines/function, snake_case Python, camelCase JS — see `.claude/rules/coding-style.md`.
-4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`) — see `.claude/rules/git-workflow.md`.
+4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`). Merges are governed by [`.claude/rules/merge-authorization.md`](../../../.claude/rules/merge-authorization.md) and [`merge-cleanup.md`](../../../.claude/rules/merge-cleanup.md).
 
 ## Bootstrap Hazard — `~/.codex/AGENTS.md` Untracked Generator
 

--- a/config/agents/codex/SOUL.runtime.md
+++ b/config/agents/codex/SOUL.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 
@@ -181,7 +181,7 @@ Beyond the SHARED_SOUL.md Hard Gates, Codex sessions additionally enforce:
 1. **Every implementation task maps to a WRK-* in `.claude/work-queue/`** OR a GitHub issue per the broader workspace `feedback_no_reserved_wrk_ids` rule. Codex's `submit-to-codex.sh` Stage-5 gate validates WRK evidence when `--wrk-id` is supplied.
 2. **Workflow lifecycle skills are mandatory**: `.claude/skills/workspace-hub/work-queue-workflow/SKILL.md` + `.claude/skills/workspace-hub/workflow-gatepass/SKILL.md` for WRK-mode work.
 3. **Coding style guardrails**: max 400 lines/file, max 50 lines/function, snake_case Python, camelCase JS — see `.claude/rules/coding-style.md`.
-4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`) — see `.claude/rules/git-workflow.md`.
+4. **Git workflow**: conventional commits, branch prefixes (`feature/`, `bugfix/`, `chore/`). Merges are governed by [`.claude/rules/merge-authorization.md`](../../../.claude/rules/merge-authorization.md) and [`merge-cleanup.md`](../../../.claude/rules/merge-cleanup.md).
 
 ## Bootstrap Hazard — `~/.codex/AGENTS.md` Untracked Generator
 

--- a/config/agents/gemini/SOUL.runtime.md
+++ b/config/agents/gemini/SOUL.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 

--- a/config/agents/hermes/SOUL.runtime.md
+++ b/config/agents/hermes/SOUL.runtime.md
@@ -43,8 +43,8 @@ These gates apply to **all meaningful work** on this repo. Provider runtimes inh
 3. **Gate order**: Issue → Plan → USER APPROVES → Implement → Cross-review → Close.
 4. **Adversarial review at BOTH stages**: plan AND code/artifact. Scale: T1 = 1 provider (simple, single-file), T2 = 2 providers (medium, multi-file or harness), T3 = 3 providers (large, cross-provider or systemic). Never skip; dial depth to scope.
 5. **Cross-review default 3-agent**: Claude + Codex + Agy (Antigravity, Gemini-backed; #3573) per AGENTS.md AI Review Policy (Claude orchestrates).
-6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see `.claude/rules/legal-compliance.md` and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
-7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets (see `.claude/rules/security.md`).
+6. **Legal/security scan**: code must pass `scripts/legal/legal-sanity-scan.sh`; no client identifiers in code (see [`.claude/docs/legal-scanning.md`](../../.claude/docs/legal-scanning.md) and `.legal-deny-list.yaml`); secrets via environment variables only; never hardcode API keys/tokens.
+7. **Security baseline**: input validation, parameterized queries, no hardcoded secrets.
 
 # Must-Fire Rules (per-message reinforcement)
 

--- a/scripts/enforcement/check-soul-runtime-drift.sh
+++ b/scripts/enforcement/check-soul-runtime-drift.sh
@@ -80,9 +80,12 @@ check_one codex  SOUL.delta.md AGENTS.runtime.md
 check_one gemini SOUL.delta.md SOUL.runtime.md
 
 # ── Auto-load wiring check (workspace-hub#2725) ──
-# CLAUDE.md and GEMINI.md must inline-import their per-provider runtime
-# artifacts via @file.md import syntax (Claude Code @file, Gemini CLI @file.md).
-# Without this, the 14+5 Must-Fire Rules don't reach Claude/Gemini sessions.
+# GEMINI.md must inline-import its per-provider runtime artifact via @file.md
+# import syntax (Gemini CLI @file.md). Without this, the Must-Fire Rules don't
+# reach Gemini sessions.
+#
+# CLAUDE.md was retired 2026-08-01 (#3743) — AGENTS.md is canonical and there is
+# no Claude auto-load surface to verify. Do NOT re-add a CLAUDE.md check here.
 check_autoload_wiring() {
     local file="$1" expected="$2"
     local full_path="${REPO_ROOT}/${file}"
@@ -99,7 +102,6 @@ check_autoload_wiring() {
     fi
 }
 
-check_autoload_wiring CLAUDE.md "@config/agents/claude/SOUL.runtime.md"
 check_autoload_wiring GEMINI.md "@config/agents/gemini/SOUL.runtime.md"
 
 if [[ "${drift_count}" -gt 0 ]]; then

--- a/scripts/readiness/nightly-readiness.sh
+++ b/scripts/readiness/nightly-readiness.sh
@@ -68,26 +68,32 @@ check_r1() {
 # ─────────────────────────────────────────────────────────────────────────────
 check_r5() {
   local total=0
+  local missing=()
+  # CLAUDE.md removed 2026-08-01 (harness surface retired; AGENTS.md is canonical).
   local candidates=(
-    "${WORKSPACE_HUB}/CLAUDE.md"
+    "${WORKSPACE_HUB}/AGENTS.md"
     "${WORKSPACE_HUB}/.claude/rules/coding-style.md"
-    "${WORKSPACE_HUB}/.claude/rules/git-workflow.md"
-    "${WORKSPACE_HUB}/.claude/rules/legal-compliance.md"
     "${WORKSPACE_HUB}/.claude/rules/patterns.md"
-    "${WORKSPACE_HUB}/.claude/rules/security.md"
-    "${WORKSPACE_HUB}/.claude/rules/testing.md"
   )
   for f in "${candidates[@]}"; do
-    [[ -f "$f" ]] || continue
+    # A missing candidate must FAIL, never be skipped: silently summing fewer files
+    # makes a deleted file score GREENER than a large one. Four rules files were
+    # deleted in 2fb3bdc7c and R5 kept reporting PASS while summing 3 of 7 (#3744).
+    if [[ ! -f "$f" ]]; then
+      missing+=("${f#"${WORKSPACE_HUB}/"}")
+      continue
+    fi
     local sz
     sz=$(wc -c < "$f" 2>/dev/null || echo 0)
     total=$((total + sz))
   done
   local kb=$(( total / 1024 ))
-  if [[ "$total" -le 16384 ]]; then
-    log_pass "R5: context budget ${kb}KB / 16KB"
+  if (( ${#missing[@]} > 0 )); then
+    log_fail "R5: ${#missing[@]} budgeted context file(s) missing: ${missing[*]} — update the candidate list or restore them"
+  elif [[ "$total" -le 16384 ]]; then
+    log_pass "R5: context budget ${kb}KB / 16KB (${#candidates[@]} files)"
   else
-    log_fail "R5: context budget ${kb}KB exceeds 16KB — trim rules or CLAUDE.md"
+    log_fail "R5: context budget ${kb}KB exceeds 16KB — trim rules or AGENTS.md"
   fi
 } ; check_r5 || true
 


### PR DESCRIPTION
Closes #3744.

Four rules files were deleted in `2fb3bdc7c` (WRK-1384 harness-context trim) but every reference survived. **Three of the four are dropped rather than restored** — the content is either generic or actively stale.

## Per-file decision

| File | Action | Rationale |
|---|---|---|
| `security.md` | **Drop citation** | Pure generic OWASP. Gate 7 already states the substance inline. |
| `legal-compliance.md` | **Re-point** → `.claude/docs/legal-scanning.md` | The only one with irreplaceable content (deny-list *extend* semantics, `block`/`warn` severities). That doc exists at 57 lines. |
| `git-workflow.md` | **Drop — deliberately not restored** | It mandated *"commit directly to `main`, push immediately"* and named `dev-primary`/`dev-secondary`/`licensed-win-1`. Both now wrong — branch protection forces PRs, and merges are governed by `merge-authorization.md`. Restoring it would reintroduce guidance that fights current rules. Re-pointed there instead. |
| `testing.md` | **Drop** | No citation existed (only R5 listed it). Its "Verified Test Data Sources" section is *not* salvaged — the dark-intelligence concept is retired; key data lives in private repos. |

Generated runtimes were rebuilt via `scripts/agents/build-soul-runtime.sh`, never hand-edited.

## The R5 silent-pass defect (the important part)

`nightly-readiness.sh` did `[[ -f \"\$f\" ]] || continue`, so it summed **3 of 7** files and reported `context budget 2KB / 16KB — PASS`. **A deleted file scored greener than a large one** — which is precisely why this rot survived unnoticed for the entire life of the reference.

A missing candidate now FAILS and names it. Verified non-vacuous by removing a candidate and confirming `PASS → FAIL`:

```
--- all 3 present ---   OK  R5: context budget 0KB / 16KB (3 files)
--- 1 deleted ---       FAIL R5: 1 budgeted context file(s) missing: .claude/rules/patterns.md
```

## Regression fixed from #3742

`check-soul-runtime-drift.sh` reported `DRIFT CLAUDE.md — file missing` after #3743 retired the file. There is no Claude auto-load surface left to verify, so that check is removed. This was a dependent the CLAUDE.md retirement missed.

## Verification

- `check-soul-runtime-drift.sh` → exit 0, all 6 artifacts in sync
- `nightly-readiness.sh` → `R5: context budget 4KB / 16KB (3 files)`
- No reference to the four deleted rules survives under `config/agents/`, `scripts/`, `.claude/rules/`, or `AGENTS.md`
- `bash -n` clean on both modified scripts