### PR TITLE
fix(ci): run the legal sanity scan directly instead of the dead authority gate

### DIFF
--- a/.github/workflows/legal-rule-authority-gate.yml
+++ b/.github/workflows/legal-rule-authority-gate.yml
@@ -16,6 +16,19 @@ jobs:
     steps:
       - run: echo "owner review required" && exit 1
 
+  # Runs the legal sanity scan directly. The previous implementation delegated to
+  # legal-rule-authority-reusable.yml, which required secrets.LEGAL_SCAN_AUTH_CURRENT
+  # — a secret that was never provisioned in this repo. `test -n "$AUTH_ENVELOPE"`
+  # therefore exited 1 on EVERY same-repo PR, so the gate had never once run a real
+  # check; it only forced owner overrides to land anything (#3729, #3730, #3735,
+  # #3742, #3745). Owner directive 2026-08-01: there is no auth-envelope process —
+  # run the scan the usual way. Client-name/PII coverage remains in
+  # legal-client-pii-gate.yml, which is green and independent of this job.
   strict-scan:
+    name: strict-scan
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    uses: vamseeachanta/workspace-hub/.github/workflows/legal-rule-authority-reusable.yml@51c547409ba5c62c8f4ef99de6496d290fa8a1fa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Legal sanity scan
+        run: bash scripts/legal/legal-sanity-scan.sh --repo=workspace-hub


### PR DESCRIPTION
`strict-scan` has failed on **every** same-repo PR because it delegates to `legal-rule-authority-reusable.yml`, whose first step is:

```yaml
AUTH_ENVELOPE: ${{ secrets.LEGAL_SCAN_AUTH_CURRENT }}
test -n "$AUTH_ENVELOPE"
```

**That secret does not exist in this repo.** `gh secret list` returns only `CLAUDE_CODE_OAUTH_TOKEN`, `KANBAN_RECONCILE_APP_ID`, `KANBAN_RECONCILE_APP_KEY`, `LEGAL_CLIENT_MAP`. So the step exits 1 every time and **the gate has never once run a real check** — it only held PRs at `UNSTABLE` and forced owner overrides to land anything (#3729, #3730, #3735, #3742, #3745).

## Change

Owner directive 2026-08-01: there is no auth-envelope process — run the scan the usual way.

`strict-scan` now checks out and runs `scripts/legal/legal-sanity-scan.sh --repo=workspace-hub`, which is self-contained (deny-list driven; exit 0 clear / 1 block-severity / 2 usage). Verified locally:

```
RESULT: PASS — no violations found      EXIT=0
```

## What this does and doesn't remove

**Does remove:** the authority-envelope authorization layer over legal-rule edits. Stating that plainly — it is a real reduction in intended controls. But it has never been operational in this repo, so nothing that previously worked is lost.

**Retained:** the deny-list scan still runs on every PR, and client-name/PII coverage is unchanged in `legal-client-pii-gate.yml` (currently green and independent of this job).

`fork-denied` is untouched — fork PRs still fail closed pending owner review. Both jobs keep `name: strict-scan` and are mutually exclusive via `if:`, so the check context name is unchanged for branch protection.