### PR TITLE
fix(harness): stop reporting OK when the install-doctor repaired nothing

### DIFF
--- a/scripts/agents/install-soul-runtime.sh
+++ b/scripts/agents/install-soul-runtime.sh
@@ -21,8 +21,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-TS="$(date +%Y%m%dT%H%M%SZ)"
+# Self-locating rather than cwd-derived (#3752): under cron / Task Scheduler the cwd
+# is not guaranteed, and `git rev-parse` would resolve whatever repo the shell landed
+# in — silently installing links that point at the wrong tree.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"   # -u: the filename suffix claims Z, so make it true
 created=0
 unchanged=0
 backed_up=0
@@ -49,7 +53,11 @@ create_link() {
         return 0
     fi
 
-    MSYS=winsymlinks:nativestrict ln -s "${resolved}" "${runtime_path}" 2>/dev/null || true
+    # Capture stderr rather than discarding it (#3752): an ACL denial, a missing
+    # parent dir, a cross-volume target and a path-length overflow all land here, and
+    # reporting every one of them as "enable Developer Mode" sends the operator down
+    # the wrong path.
+    LINK_ERR="$(MSYS=winsymlinks:nativestrict ln -s "${resolved}" "${runtime_path}" 2>&1)" || true
     [[ -L "${runtime_path}" ]] && return 0
 
     # Native symlink unavailable (no Developer Mode / not elevated). Remove only a
@@ -84,7 +92,16 @@ link_if_needed() {
 
     if [[ -e "${runtime_path}" || -L "${runtime_path}" ]]; then
         local backup="${runtime_path}.pre-install-backup.${TS}"
-        mv "${runtime_path}" "${backup}"
+        # Do not let one path abort the whole run (#3752). Under `set -e` a failed mv
+        # kills the installer outright and the remaining providers are never
+        # processed. Windows uses mandatory file locking, so a live Claude/Codex
+        # process holding this file makes that a routine event on a 6-hourly schedule.
+        if ! mv "${runtime_path}" "${backup}" 2>/dev/null; then
+            echo "NEEDS-ATTENTION ${runtime_path} — could not back up (file locked by a running provider?)"
+            echo "                Skipped so the remaining providers still get processed."
+            failed=$((failed + 1))
+            return 0
+        fi
         echo "BACKUP ${runtime_path} → ${backup}"
         backed_up=$((backed_up + 1))
     fi
@@ -93,9 +110,12 @@ link_if_needed() {
         echo "LINK   ${runtime_path} → ${resolved}"
         created=$((created + 1))
     else
-        echo "NEEDS-ATTENTION ${runtime_path} — native symlink unavailable on Windows."
-        echo "                Enable Developer Mode (or run elevated) and re-run. No copy was left behind:"
-        echo "                a copy would silently drift from ${repo_relative_target} and nothing checks it."
+        echo "NEEDS-ATTENTION ${runtime_path} — native symlink not created."
+        echo "                ln: ${LINK_ERR:-(no error text)}"
+        echo "                Common cause is no Developer Mode / not elevated, but check the error above"
+        echo "                first — ACL denial, missing parent dir and path-length also land here."
+        echo "                No copy was left behind: a copy would silently drift from"
+        echo "                ${repo_relative_target} and nothing checks it."
         failed=$((failed + 1))
     fi
 }

--- a/scripts/maintenance/harness-install-doctor.sh
+++ b/scripts/maintenance/harness-install-doctor.sh
@@ -43,7 +43,15 @@ set -uo pipefail
 # cryptic "unbound variable" before any report. Fail early and legibly instead.
 : "${HOME:?HOME must be set}"
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "${WORKSPACE_HUB:-/mnt/local-analysis/workspace-hub}")"
+# Self-locating, NOT cwd- or $WORKSPACE_HUB-derived (#3752). This runs from cron /
+# Task Scheduler with a non-login shell, which does not source ~/.bashrc — so
+# ${WORKSPACE_HUB} is often empty, the catalog's `cd $WORKSPACE_HUB` becomes a bare
+# `cd` to $HOME with rc 0, and `git rev-parse` then resolves whatever repo happens to
+# be there (or the hardcoded Linux fallback). Deriving the root from this script's own
+# path is the only form that cannot silently target the wrong tree. Precedent:
+# scripts/cron/harness-update-windows.sh:13-14.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DRY="${DOCTOR_DRY_RUN:-0}"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 
@@ -81,7 +89,27 @@ if [[ -x "${installer}" || -f "${installer}" ]]; then
     else
         if out="$(bash "${installer}" 2>&1)"; then
             summary="$(printf '%s\n' "${out}" | grep -i '^Summary:' || echo 'ran')"
-            record OK "soul-runtime-symlinks" "${summary}"
+            # Exit 0 is NOT sufficient evidence of a repair (#3752). The installer
+            # returns 0 for every SKIP — missing source artifact, absent provider
+            # dir, wrong repo root — and only `failed` reaches its exit gate. So a
+            # run that linked NOTHING previously reported OK, making a silently
+            # broken box indistinguishable from a healthy one. Inspect the summary
+            # we already captured: if nothing was created AND nothing was already
+            # correct, the repair arm did not repair.
+            created="$(printf '%s\n' "${summary}" | sed -n 's/.*Summary: \([0-9]\{1,\}\) created.*/\1/p')"
+            unchanged="$(printf '%s\n' "${summary}" | sed -n 's/.*, \([0-9]\{1,\}\) unchanged.*/\1/p')"
+            if [[ -z "${created}" || -z "${unchanged}" ]]; then
+                # Summary absent or in an unexpected shape — do not assume success.
+                record NEEDS-ATTENTION "soul-runtime-symlinks" \
+                    "installer exited 0 but its summary was unparseable: ${summary}"
+                printf '%s\n' "${out}" | sed 's/^/      /'
+            elif (( created + unchanged == 0 )); then
+                record NEEDS-ATTENTION "soul-runtime-symlinks" \
+                    "no-op run — 0 created, 0 unchanged (${summary})"
+                printf '%s\n' "${out}" | sed 's/^/      /'
+            else
+                record OK "soul-runtime-symlinks" "${summary}"
+            fi
         else
             record NEEDS-ATTENTION "soul-runtime-symlinks" "install-soul-runtime.sh failed — see output"
             printf '%s\n' "${out}" | sed 's/^/      /'

--- a/scripts/maintenance/tests/test_harness_install_doctor.sh
+++ b/scripts/maintenance/tests/test_harness_install_doctor.sh
@@ -240,6 +240,60 @@ assert_contains "$OUT5B" "healthy" "second run reports healthy"
 assert_contains "$OUT5B" "soul-runtime-symlinks" "second run still checks soul-runtime symlinks"
 echo ""
 
+# ── Test 6: a no-op installer run must NOT be reported OK (#3752) ─────────────
+# Regression guard. install-soul-runtime.sh returns 0 for every SKIP (missing source
+# artifact, absent provider dir, wrong repo root) and only `failed` reaches its exit
+# gate — so before #3752 the doctor recorded OK on exit status alone and a run that
+# linked NOTHING was indistinguishable from a healthy box.
+#
+# Simulate by pointing the doctor at a stub installer that exits 0 while reporting a
+# fully no-op summary. Asserting on the doctor's own parsing keeps this independent of
+# how the real installer happens to behave on the test host.
+echo "Test 6: installer exits 0 but linked nothing => NEEDS-ATTENTION, not OK"
+HOME6="$(make_sandbox_home)"
+FAKE_REPO="$TEST_DIR/fake-repo-$$"
+mkdir -p "$FAKE_REPO/scripts/agents" "$FAKE_REPO/scripts/maintenance"
+cp "$DOCTOR" "$FAKE_REPO/scripts/maintenance/harness-install-doctor.sh"
+cat > "$FAKE_REPO/scripts/agents/install-soul-runtime.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "SKIP   ~/.hermes/SOUL.md — source missing"
+echo ""
+echo "Summary: 0 created, 0 unchanged, 0 backed-up, 4 skipped, 0 needs-attention."
+exit 0
+STUB
+chmod +x "$FAKE_REPO/scripts/agents/install-soul-runtime.sh"
+
+OUT6="$( HOME="$HOME6" bash "$FAKE_REPO/scripts/maintenance/harness-install-doctor.sh" 2>&1 )"
+RC6=$?
+OUT6_PLAIN="$(printf '%s' "$OUT6" | strip_ansi)"
+
+if echo "$OUT6_PLAIN" | grep -E 'NEEDS-ATTENTION[[:space:]]+soul-runtime-symlinks' >/dev/null; then
+    pass "no-op installer run reported NEEDS-ATTENTION"
+else
+    fail "no-op installer run reported NEEDS-ATTENTION" "got:
+$(echo "$OUT6_PLAIN" | grep -i soul-runtime)"
+fi
+assert_not_contains "$OUT6_PLAIN" "OK               soul-runtime-symlinks" \
+    "no-op run is NOT reported OK"
+assert_eq "1" "$RC6" "doctor exits non-zero on a no-op repair"
+
+# Non-vacuity: the SAME harness with a stub that DID link must still report OK,
+# proving the assertion above discriminates rather than always failing.
+cat > "$FAKE_REPO/scripts/agents/install-soul-runtime.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "Summary: 2 created, 1 unchanged, 0 backed-up, 0 skipped, 0 needs-attention."
+exit 0
+STUB
+OUT6B="$( HOME="$(make_sandbox_home)" bash "$FAKE_REPO/scripts/maintenance/harness-install-doctor.sh" 2>&1 )"
+OUT6B_PLAIN="$(printf '%s' "$OUT6B" | strip_ansi)"
+if echo "$OUT6B_PLAIN" | grep -E 'OK[[:space:]]+soul-runtime-symlinks' >/dev/null; then
+    pass "non-vacuous: a run that DID link is still reported OK"
+else
+    fail "non-vacuous: a run that DID link is still reported OK" "got:
+$(echo "$OUT6B_PLAIN" | grep -i soul-runtime)"
+fi
+echo ""
+
 # ── Results ───────────────────────────────────────────────────────────────────
 echo "============================================"
 echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Closes #3752.

## The defect

`harness-install-doctor.sh` captured the installer's summary and then recorded `OK` **purely on exit status, never inspecting what it captured**. `install-soul-runtime.sh` returns 0 for every `SKIP` — missing source, absent provider dir, wrong repo root — and only `failed` reaches its exit gate.

So a run that linked **nothing** printed:

```
OK  soul-runtime-symlinks  Summary: 0 created, 0 unchanged, 0 backed-up, 4 skipped
```

…and exited 0. A silently broken box was indistinguishable from a healthy one. This is the repair arm for every provider's runtime symlinks, running 6-hourly across 6 machines — the failure could persist indefinitely. Same class as the R5 context-budget defect fixed in #3744, where a *missing* file scored greener than a large one.

## Changes

| Fix | Why |
|---|---|
| Doctor parses the summary it already captures | `NEEDS-ATTENTION` when `created + unchanged == 0`, **and** when the summary is absent/unparseable — an unexpected shape must not read as success |
| Both scripts self-locate `REPO_ROOT` from `${BASH_SOURCE[0]}` | Under cron/Task Scheduler the shell is non-login, so `$WORKSPACE_HUB` from `~/.bashrc` is unset; the catalog's `cd $WORKSPACE_HUB` becomes a bare `cd` to `$HOME` with rc 0 and the old code resolved whatever repo was there |
| Failed backup `mv` no longer aborts the run | Windows uses mandatory file locking; a live provider holding the target would kill the installer under `set -e` and leave later providers unprocessed |
| Windows `ln` stderr captured, not discarded | ACL denial, missing parent dir and path-length overflow all reported as "enable Developer Mode" |
| `date -u` for the backup suffix | The filename already claimed `Z` |

## Regression test — and proof it discriminates

Test 6 drives the doctor with a stub installer that exits 0 reporting a no-op summary, asserts `NEEDS-ATTENTION` + non-zero exit, then re-runs **the same harness** with a stub that *did* link and asserts `OK`. So the assertion discriminates rather than always failing.

```
Test 6: installer exits 0 but linked nothing => NEEDS-ATTENTION, not OK
  PASS: no-op installer run reported NEEDS-ATTENTION
  PASS: no-op run is NOT reported OK
  PASS: doctor exits non-zero on a no-op repair
  PASS: non-vacuous: a run that DID link is still reported OK

Results: 24/24 passed, 0 failed
```

**The two fixes are coupled**, which is worth knowing: the pre-fix doctor could not be pointed at a test repo at all. Invoking a copy from another directory still resolved the *real* repo via `git rev-parse` and ran the *real* installer — I demonstrated this accidentally while trying to prove the defect. A hermetic test was impossible until `REPO_ROOT` became self-locating.

## Scope

No scheduler-registry impact: neither script contains a scheduler primitive (`crontab`/`Register-ScheduledTask`/systemd), so no `mutation-surfaces.yaml` entry and no identity-digest re-affirmation are required. `check-scheduler-mutation-surfaces.py` exits 0.

Found while investigating #3750 (Windows parity), where this defect would have been far more reachable — but it affects **Linux today**.