### PR TITLE
fix(ci): run the scheduled-task catalog schema validator in the enforcement gate

### DIFF
--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -32,6 +32,14 @@ jobs:
         run: uv run python scripts/cron/build-cron-identity-inventory.py --check
       - name: Verify scheduler mutation audit report
         run: uv run python scripts/enforcement/check-scheduler-mutation-surfaces.py --check-html docs/reports/2026-07-11-issue-3470-scheduler-mutation-safety.html
+      # The catalog SCHEMA validator ran in neither CI nor pre-commit until 2026-08-01.
+      # It enforces that every `machines:` value exists in config/workstations/registry.yaml,
+      # that `roles:`/`requires:` resolve, that cron expressions parse, and that ids are
+      # unique — none of which the three checks above look at. They validate the mutation
+      # REGISTRY and the identity digest, not the task definitions themselves. Wiring it in
+      # is non-breaking: it reports "OK: 66 tasks validated" on main today.
+      - name: Validate scheduled-task catalog schema
+        run: uv run python scripts/cron/validate-schedule.py
 
   stage-prompt-drift:
     name: Stage Prompt Drift Guard

--- a/docs/reports/2026-07-11-issue-3470-scheduler-mutation-safety.html
+++ b/docs/reports/2026-07-11-issue-3470-scheduler-mutation-safety.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en" data-input-digest="e0911a95388db79d1f6acb4da9b9c4692c9d5080c99aaf1b9bae49a9b881c807"><head><meta charset="utf-8">
+<html lang="en" data-input-digest="fcb93273a2033ec61c8e882db22c1bf694ed591bcf5dcc2878f80d7a66c1cbef"><head><meta charset="utf-8">
 <title>Scheduler Mutation Safety Audit</title>
 <style>body{font:16px system-ui;max-width:1200px;margin:2rem auto;padding:0 1rem}table{border-collapse:collapse;width:100%}th,td{border:1px solid #bbb;padding:.5rem;text-align:left}code{font-size:.9em}.warning{border-left:4px solid #b45309;padding:1rem;background:#fff7ed}</style></head>
 <body><h1>Scheduler Mutation Safety Audit</h1>
-<p><strong>Input digest:</strong> <code>e0911a95388db79d1f6acb4da9b9c4692c9d5080c99aaf1b9bae49a9b881c807</code></p>
+<p><strong>Input digest:</strong> <code>fcb93273a2033ec61c8e882db22c1bf694ed591bcf5dcc2878f80d7a66c1cbef</code></p>
 <p class="warning">Registry inclusion does not authorize live scheduler mutation.</p>
 <table><thead><tr><th>Surface</th><th>Kind</th><th>Derived status</th><th>Operations</th><th>Disposition</th></tr></thead><tbody>
 <tr data-surface="scripts/coordination/context/setup_cron.sh"><td><code>scripts/coordination/context/setup_cron.sh</code></td><td>direct-owner</td><td>migration-required</td><td><section class="operation" data-operation="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace" data-target-kind="current-user-cron" data-scheduler-identity="local-current-user-crontab" data-execution-host-binding="physical-local"><strong>marker-filtered-crontab-replace</strong><br>Target: current-user-cron; identity: local-current-user-crontab; binding: physical-local<br>Authority:<ul><li data-authority="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace::marker-filter" data-mechanism="command-substring" data-strength="substring">marker-filter:command-substring/substring</li></ul>Transaction gaps: <span class="transaction-gaps" data-transaction-for="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace">lock=false, baseline_snapshot=false, backup=false, pre_write_cas=false, post_write_preservation_verify=false, post_write_exact_state_verify=false, rollback_cas=false</span></section></td><td><a href="https://github.com/vamseeachanta/workspace-hub/issues/3476">#3476</a></td></tr>


### PR DESCRIPTION
`scripts/cron/validate-schedule.py` ran in **neither CI nor pre-commit** — verified by grep over `.github/workflows/` and `.pre-commit-config.yaml`, no hits in either.

## Why the existing checks don't cover it

| Existing check | What it actually validates |
|---|---|
| `check-scheduler-mutation-surfaces.py` | The mutation **registry** — derived by scanning *script bodies* for scheduler primitives, not from the catalog |
| `build-cron-identity-inventory.py --check` | The identity **digest** — hashes raw bytes, so it detects *that* the catalog changed, never *whether it is valid* |
| `--check-html` | The rendered audit artifact |

The catalog's own schema — every `machines:` value resolving against `config/workstations/registry.yaml`, `roles:`/`requires:` existing, cron expressions parsing, ids unique — was enforced **nowhere automatically**.

That gap is how five tasks came to carry a literal `/path/to/workspace-hub` and stay green indefinitely (#3750). To be clear: this does **not** fix those five — the validator's only command check is non-emptiness (`validate-schedule.py:244-245`). It closes the hole that let *schema* regressions land unnoticed.

**Non-breaking:** `validate-schedule.py` reports `OK: 66 tasks validated` (exit 0) on main today.

## Why the audit HTML is also in this PR

Not incidental — **required**. `scheduler_mutation_contract.py:169` puts `.github/workflows/enforcement-gate.yml` in `digest_record_union`, so editing that workflow changes the audit's `input_digest`.

That is deliberate and worth appreciating: the attestation covers the checker code, its tests, **and the CI workflows that invoke it** — so enforcement cannot be silently weakened by deleting a step. A PR that *adds* a check trips the same wire. Regenerating the audit is the correct response, not a workaround.

The first push failed `Scheduler Mutation Surface Guard` for exactly this reason. I reproduced it locally by building an index of `origin/main` plus only this workflow change: the sole diff in the rendered audit was the embedded `input_digest`.

## Verification

Against a reproduced merge tree (`origin/main` + this change):

```
check-scheduler-mutation-surfaces.py                EXIT=0
check-scheduler-mutation-surfaces.py --check-html   EXIT=0
build-cron-identity-inventory.py --check            EXIT=0
validate-schedule.py                                OK: 66 tasks
```

Identity inventory needs no re-affirmation — its union is 3 configs + 5 `scripts/cron/*.py`, none touched here, so `source_digest` is unchanged.

Found while investigating #3750.