### PR TITLE
fix(dispatch): ready the dispatch surface — stale queues, empty card titles

### DIFF
--- a/.claude/dispatch/cfd-dedicated.yaml
+++ b/.claude/dispatch/cfd-dedicated.yaml
@@ -1,0 +1,149 @@
+machine: cfd-dedicated
+generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:54Z'
+ttl_hours: 24
+cards:
+- gh: vamseeachanta/digitalmodel#630
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(openfoam): assess HD ''T1 Suzuka Aero'' dataset for CFD f'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/630
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1166
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): laminar cylinder Re=100 \u2014 foundational vorte"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1166
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1167
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): laminar flat plate (Blasius) \u2014 foundational "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1167
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1168
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): turbulent flat plate ZPG (k-omega SST) \u2014 NAS"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1168
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1179
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(cfd): ephemeral remote-CFD lifecycle scripts over SSH ('
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1179
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1192
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'fix(cfd): validation cases generate non-runnable solver setu'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1192
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1173
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(openfoam): calm-water hull resistance (interFoam towing'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1173
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1174
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(openfoam): NACA0012 airfoil polar (simpleFoam k-omega S'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1174
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1175
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): backward-facing step (pitzDaily) \u2014 reattachm"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1175
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1176
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): square-cylinder bluff-body wind load \u2014 Lyn &"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1176
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1177
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "feat(openfoam): turbulent cylinder Re=3900 (LES) \u2014 Kravchenk"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1177
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1517
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'fix(cfd): harden attested snapshots and fail-closed solver e'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1517
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1528
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(cfd): coupled sloshing tank fill/drain over roll cycles'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1528
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1562
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: 'feat(cfd): dm#1528 anti-roll roll-reduction for a specific v'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1562
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1575
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: codex
+  title: 'OpenFOAM batch runner: preserve full case-definition contrac'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1575
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1576
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: codex
+  title: 'OpenFOAM MPI runner: emit post-processing and VTK artifacts'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1576
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual

--- a/.claude/dispatch/dev-primary.yaml
+++ b/.claude/dispatch/dev-primary.yaml
@@ -1,8115 +1,1232 @@
 machine: dev-primary
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:54Z'
+ttl_hours: 24
 cards:
-- gh: vamseeachanta/aceengineer-admin#25
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+- gh: vamseeachanta/deckhand#4
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: 'ops: download/archive all Google Drive data from AceEngineer'
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/25
+  title: 'Deckhand: wire + harden rate-limit / abuse controls (live en'
+  url: https://github.com/vamseeachanta/deckhand/issues/4
   dispatch_status: ready
   wip_eligible: true
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#23
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#22
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'Evaluate e-filing options for Form 1120: TaxAct vs paper vs '
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/23
+  title: 'Instrument demand signals: weekly asks-summary from gateway/'
+  url: https://github.com/vamseeachanta/deckhand/issues/22
   dispatch_status: ready
   wip_eligible: true
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#22
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#33
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: Locate 2023 filed Form 1120 and add to repo
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/22
+  title: '[P1] Runtime repairs: ParaView segfault on ace-linux-2, FAL '
+  url: https://github.com/vamseeachanta/deckhand/issues/33
   dispatch_status: ready
   wip_eligible: true
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#21
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#37
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: "Amend 2025 Form 1120 to claim NOL deduction \u2014 $4,864 refund"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/21
+  title: '[P1] Hermes upstream: operator-id propagation, no mid-task g'
+  url: https://github.com/vamseeachanta/deckhand/issues/37
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#20
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#81
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: Evaluate Form 1042-S requirement for foreign contractor paym
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/20
+  title: "Map outreach waves \u2192 Open Deck: installation-envelope prompt"
+  url: https://github.com/vamseeachanta/deckhand/issues/81
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#18
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#86
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: Verify SKEI/Sabitha loan documentation is complete (separate
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/18
+  title: "Onboard Baez Consulting LLC (baez) client scope \u2014 demo"
+  url: https://github.com/vamseeachanta/deckhand/issues/86
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#17
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#168
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: "2028: Evaluate AI R&D Productization \u2014 Licensing Revenue Mod"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/17
+  title: Verify Open Deck domain community-group wiring (identity / a
+  url: https://github.com/vamseeachanta/deckhand/issues/168
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#16
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#195
+  repo: vamseeachanta/deckhand
+  domain: routing,security
   provider: claude
-  title: "2027: Annual Tax Filing \u2014 2026 1120 + TX Franchise + R&D Cre"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/16
+  title: 'feat(family): add private family scope and data boundary'
+  url: https://github.com/vamseeachanta/deckhand/issues/195
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#15
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#197
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,routing,onboarding
   provider: claude
-  title: "2026 Q2: R&D Documentation System \u2014 Project Charters and QRE"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/15
+  title: 'feat(family): create and bind family-only Telegram channels '
+  url: https://github.com/vamseeachanta/deckhand/issues/197
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#14
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#198
+  repo: vamseeachanta/deckhand
+  domain: security,onboarding
   provider: claude
-  title: '2026 Q1: Officer W-2 Setup + Solo 401(k) for Vamsee'
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/14
+  title: 'feat(family): membership, invite hygiene, and revocation wor'
+  url: https://github.com/vamseeachanta/deckhand/issues/198
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#13
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#199
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,routing,security
   provider: claude
-  title: Set Up 2026 Estimated Tax Payments (Federal + TX)
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/13
+  title: 'test(family): end-to-end privacy canaries for family channel'
+  url: https://github.com/vamseeachanta/deckhand/issues/199
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#9
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#200
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,routing,security
   provider: claude
-  title: "Establish AI R&D Program \u2014 $200K/year Budget (2026-2030)"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/9
+  title: 'feat(family): support Telegram topic-bound routing in one pr'
+  url: https://github.com/vamseeachanta/deckhand/issues/200
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#6
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#202
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,security,onboarding
   provider: claude
-  title: 'Retrieve Chase Bank Statements (2025) from home-win for tax '
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/6
+  title: 'ops(family): live-create private Telegram family group/topic'
+  url: https://github.com/vamseeachanta/deckhand/issues/202
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#5
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#203
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,routing,security
   provider: claude
-  title: File 2025 Texas Franchise Tax by May 15, 2026
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/5
+  title: 'policy(family): high-sensitivity behavior for health and fin'
+  url: https://github.com/vamseeachanta/deckhand/issues/203
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#4
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#204
+  repo: vamseeachanta/deckhand
+  domain: routing,security
   provider: claude
-  title: File 2025 Form 1120 (Federal C-Corp) by April 15, 2026
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/4
+  title: 'feat(family): wire family scope config after repo and topic '
+  url: https://github.com/vamseeachanta/deckhand/issues/204
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-admin#3
-  repo: vamseeachanta/aceengineer-admin
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#206
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,security
   provider: claude
-  title: "BLOCKER: File 2024 Form 1120 (Federal) \u2014 unfiled prior year"
-  url: https://github.com/vamseeachanta/aceengineer-admin/issues/3
+  title: 'fix(security): redact operator Telegram invite links before '
+  url: https://github.com/vamseeachanta/deckhand/issues/206
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#22
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#214
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'Prepare Shell interventions outreach: Lou Daigle'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/22
+  title: 'Host-path audit: configured roots missing on ace-linux-2 (da'
+  url: https://github.com/vamseeachanta/deckhand/issues/214
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#21
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#390
+  repo: vamseeachanta/deckhand
+  domain: capability,onboarding
   provider: claude
-  title: 'Prepare Shell interventions outreach: Chris Gerace'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/21
+  title: "Tier A \u2014 Floating & Marine Systems: define + chat-eval 4 mar"
+  url: https://github.com/vamseeachanta/deckhand/issues/390
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#20
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#391
+  repo: vamseeachanta/deckhand
+  domain: capability,onboarding
   provider: claude
-  title: 'Plan Shell interventions outreach cluster: Mike Blackwell, C'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/20
+  title: "Tier A \u2014 Subsea, Pipelines & Integrity: define + chat-eval 4"
+  url: https://github.com/vamseeachanta/deckhand/issues/391
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#18
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#392
+  repo: vamseeachanta/deckhand
+  domain: capability,onboarding
   provider: claude
-  title: Plan Scott Sanantonio offshore intervention and riser automa
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/18
+  title: "Tier A \u2014 Wells & Subsurface: define + chat-eval 4 marketable"
+  url: https://github.com/vamseeachanta/deckhand/issues/392
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#17
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#393
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,onboarding
   provider: claude
-  title: Prepare GTM outreach pack for smaller installation vessel ow
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/17
+  title: "Tier B \u2014 Codes, Standards & Maritime Law: define + chat-eval"
+  url: https://github.com/vamseeachanta/deckhand/issues/393
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#15
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#394
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,onboarding
   provider: claude
-  title: 'governance(ace-drive): standardize external-drive ingest and'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/15
+  title: "Tier B \u2014 Power, Electrical & Controls: define + chat-eval ad"
+  url: https://github.com/vamseeachanta/deckhand/issues/394
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#14
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#395
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,onboarding
   provider: claude
-  title: '[P4] Replication harness: riser + field-development vertical'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/14
+  title: "Tier B \u2014 Design & CAD: define + chat-eval advisory workflows"
+  url: https://github.com/vamseeachanta/deckhand/issues/395
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#13
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#396
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,onboarding
   provider: claude
-  title: '[P3] Feedback-loop pipeline + public loop-closure log'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/13
+  title: "Tier B \u2014 Manufacturing & Fabrication: define + chat-eval adv"
+  url: https://github.com/vamseeachanta/deckhand/issues/396
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#12
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#397
+  repo: vamseeachanta/deckhand
+  domain: capability,onboarding
   provider: claude
-  title: "[P3] Real-time mooring monitoring copilot \u2014 pilot scope"
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/12
+  title: "Asset production \u2014 approved workflows \u2192 GIFs (Tier A) + prom"
+  url: https://github.com/vamseeachanta/deckhand/issues/397
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#11
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#407
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,security,onboarding
   provider: claude
-  title: '[P3] Anchor pilot client + telemetry-sharing agreement (defa'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/11
+  title: "Onboarding channel \u2014 new 'onboarding' scope + App token + 'D"
+  url: https://github.com/vamseeachanta/deckhand/issues/407
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#10
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#408
+  repo: vamseeachanta/deckhand
+  domain: routing,onboarding
   provider: claude
-  title: "[P2] Flywheel portfolio management \u2014 cadence, dashboards, go"
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/10
+  title: "Onboarding routing (greet\u2192classify\u2192route) + operator lead-ca"
+  url: https://github.com/vamseeachanta/deckhand/issues/408
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#9
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#431
+  repo: vamseeachanta/deckhand
+  domain: routing,onboarding
   provider: claude
-  title: '[P2] Pricing & licensing model: open-core, client-opt-out, f'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/9
+  title: "feat(routing): source-tag deep-link contract \u2014 canonical src"
+  url: https://github.com/vamseeachanta/deckhand/issues/431
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#8
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#432
+  repo: vamseeachanta/deckhand
+  domain: routing,onboarding
   provider: claude
-  title: "[P2] Mooring parametric atlas API \u2014 institutional integratio"
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/8
+  title: "feat(onboarding): front-door CTA handler \u2014 the 4 'Start Here"
+  url: https://github.com/vamseeachanta/deckhand/issues/432
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#7
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#557
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: '[P2] Mooring failure intelligence integration product (premi'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/7
+  title: Onboard gpu-claw as first Linux execution host (OpenFOAM CFD
+  url: https://github.com/vamseeachanta/deckhand/issues/557
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#6
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#558
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: "[P1] Public failure-case browser \u2014 full corpus, default-publ"
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/6
+  title: "ace-linux-2 \u2192 headless execution host; producer/control-plan"
+  url: https://github.com/vamseeachanta/deckhand/issues/558
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#5
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#579
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: '[P1] Public mooring quick-screen calculator'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/5
+  title: "Migrate licensed-run lane: ace-win-2 \u2192 acma-hou-rds02; ws014"
+  url: https://github.com/vamseeachanta/deckhand/issues/579
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#4
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#580
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: '[P0] Standards LLM-wiki industrialization (decide canonical '
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/4
+  title: 'licensed-run alarm fires but nobody is told: 1694 unheeded '''
+  url: https://github.com/vamseeachanta/deckhand/issues/580
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#3
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#581
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: '[P0] ICP confirmation: primary buyer segment for paid integr'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/3
+  title: 'Supersede #565: retire logical host aliases; route by canoni'
+  url: https://github.com/vamseeachanta/deckhand/issues/581
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#2
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#582
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: '[P0] Wedge confirmation: Approach C + mooring as first verti'
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/2
+  title: 'ace-linux-1 as the fleet''s single dispatch/control surface: '
+  url: https://github.com/vamseeachanta/deckhand/issues/582
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-strategy#1
-  repo: vamseeachanta/aceengineer-strategy
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#584
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: "[Epic] Cradle-to-Grave Engineering Flywheel \u2014 Strategic Init"
-  url: https://github.com/vamseeachanta/aceengineer-strategy/issues/1
+  title: 'EPIC: dispatch surface owns assignment, traceability and goa'
+  url: https://github.com/vamseeachanta/deckhand/issues/584
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-website#9
-  repo: vamseeachanta/aceengineer-website
-  domain: null
+  routed_by: manual
+- gh: vamseeachanta/deckhand#587
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: Canonical firm-copy home for reusable About/Services text
-  url: https://github.com/vamseeachanta/aceengineer-website/issues/9
+  title: "2026-09-01: host-local policy snapshots lack host_aliases \u2014 "
+  url: https://github.com/vamseeachanta/deckhand/issues/587
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-website#8
-  repo: vamseeachanta/aceengineer-website
-  domain: null
-  provider: claude
-  title: "engineering.html \u2014 rename capability headings for CAP parall"
-  url: https://github.com/vamseeachanta/aceengineer-website/issues/8
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-website#7
-  repo: vamseeachanta/aceengineer-website
-  domain: null
-  provider: claude
-  title: "About hero \u2014 add FPSO + panel-mesh imagery for diffraction-a"
-  url: https://github.com/vamseeachanta/aceengineer-website/issues/7
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-website#6
-  repo: vamseeachanta/aceengineer-website
-  domain: null
-  provider: claude
-  title: "About page \u2014 align services phrasing with llm-wiki (workspac"
-  url: https://github.com/vamseeachanta/aceengineer-website/issues/6
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/aceengineer-website#5
-  repo: vamseeachanta/aceengineer-website
-  domain: null
-  provider: claude
-  title: 'GTM Demo 4: Subsea Jumper Installation Analysis'
-  url: https://github.com/vamseeachanta/aceengineer-website/issues/5
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#92
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 devaKrishna tennis: serious-track execution decisio"
-  url: https://github.com/vamseeachanta/achantas-data/issues/92
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#89
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Video-evidence analysis: Swimming (devaKrishna)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/89
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#88
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Video-evidence analysis: Soccer (devaKrishna)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/88
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#87
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Video-evidence analysis: Tennis (devaKrishna)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/87
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#86
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Video-evidence analysis: Typing (devaKrishna)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/86
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#85
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Video-evidence analysis: Reading (devaKrishna)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/85
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#84
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 devaKrishna video-evidence analysis (umbrella works"
-  url: https://github.com/vamseeachanta/achantas-data/issues/84
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#83
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 devaKrishna activity planning (reading \xB7 typing \xB7 t"
-  url: https://github.com/vamseeachanta/achantas-data/issues/83
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#82
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Gate-1 (2030) prep checklist for devaKrishna IEP tr"
-  url: https://github.com/vamseeachanta/achantas-data/issues/82
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#81
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Risk-mitigation matrix (parental, devaKrishna, fina"
-  url: https://github.com/vamseeachanta/achantas-data/issues/81
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#80
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 Tooling: SNT corpus + term-life sizing calculator"
-  url: https://github.com/vamseeachanta/achantas-data/issues/80
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#78
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 devaKrishna Letter of Intent (drafting + incrementa"
-  url: https://github.com/vamseeachanta/achantas-data/issues/78
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#75
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 EA Phillips wills review (SNT pour-over + Plan-B fa"
-  url: https://github.com/vamseeachanta/achantas-data/issues/75
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#74
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 TX Medicaid waitlist enrollment for devaKrishna (MD"
-  url: https://github.com/vamseeachanta/achantas-data/issues/74
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#73
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: "Family \u2014 5/10/15/20/25/30-year goals (Vamsee/Sabitha/Krishna"
-  url: https://github.com/vamseeachanta/achantas-data/issues/73
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#11
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: DA | Cheatsheets
-  url: https://github.com/vamseeachanta/achantas-data/issues/11
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#10
-  repo: vamseeachanta/achantas-data
-  domain: devakrishna
-  provider: claude
-  title: DA | Activity Schedule
-  url: https://github.com/vamseeachanta/achantas-data/issues/10
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#79
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: "Family \u2014 Tooling: NW glidepath calculator (`scripts/family/g"
-  url: https://github.com/vamseeachanta/achantas-data/issues/79
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#77
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: "Family \u2014 Fidelity 2025 year-end NW lookup \u2192 #73 glidepath ba"
-  url: https://github.com/vamseeachanta/achantas-data/issues/77
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#76
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: "Family \u2014 Term-life + disability insurance audit (Vamsee 46 /"
-  url: https://github.com/vamseeachanta/achantas-data/issues/76
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#39
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: 'Sabitha: compare short- and long-term effects of hair-fall t'
-  url: https://github.com/vamseeachanta/achantas-data/issues/39
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#38
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: 'Sabitha: assess nutrient and supplement approaches for hair '
-  url: https://github.com/vamseeachanta/achantas-data/issues/38
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#37
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: 'Sabitha: assess PRP treatment for hair fall'
-  url: https://github.com/vamseeachanta/achantas-data/issues/37
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#36
-  repo: vamseeachanta/achantas-data
-  domain: family-planning
-  provider: claude
-  title: 'Sabitha: evaluate hair-fall treatment options'
-  url: https://github.com/vamseeachanta/achantas-data/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#40
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: "Evaluate electricity plan renewal \u2014 10.054\xA2/kWh \xD7 36 months"
-  url: https://github.com/vamseeachanta/achantas-data/issues/40
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#34
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: Download FreeTaxUSA 2025 tax return PDFs for archival
-  url: https://github.com/vamseeachanta/achantas-data/issues/34
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#33
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: Complete FreeTaxUSA final steps and submit 2025 return
-  url: https://github.com/vamseeachanta/achantas-data/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#31
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: "Pay 2025 federal taxes via IRS Direct Pay \u2014 $13,635 by April"
-  url: https://github.com/vamseeachanta/achantas-data/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#30
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: Review 2026 year-end tax strategy to reduce underpayment ris
-  url: https://github.com/vamseeachanta/achantas-data/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#29
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: 'Archive 2025 filed return, payment confirmations, and close '
-  url: https://github.com/vamseeachanta/achantas-data/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#28
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: Set up and track 2026 quarterly estimated federal tax paymen
-  url: https://github.com/vamseeachanta/achantas-data/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#27
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: 'Stock Portfolio: Performance Assessment & Daily Guidance Fra'
-  url: https://github.com/vamseeachanta/achantas-data/issues/27
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#23
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: Pay 2025 Federal Tax Balance Due (~$13,091) by April 15, 202
-  url: https://github.com/vamseeachanta/achantas-data/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#22
-  repo: vamseeachanta/achantas-data
-  domain: finance
-  provider: claude
-  title: File 2025 Personal Federal Tax Return (Form 1040 MFJ) by Apr
-  url: https://github.com/vamseeachanta/achantas-data/issues/22
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#72
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 'Hardware: Replace lost Jabra USB dongle (or migrate to Bluet'
-  url: https://github.com/vamseeachanta/achantas-data/issues/72
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#69
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 'Purchase Decision: Hacksaw blades for HDX saw (tree-cutting '
-  url: https://github.com/vamseeachanta/achantas-data/issues/69
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#24
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 'Repair partial .claude/skills migration and remove leftover '
-  url: https://github.com/vamseeachanta/achantas-data/issues/24
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#18
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: rp house builder
-  url: https://github.com/vamseeachanta/achantas-data/issues/18
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#17
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: Buy Hall Sofa and remove bed
-  url: https://github.com/vamseeachanta/achantas-data/issues/17
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#16
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: RK | Apology Letter
-  url: https://github.com/vamseeachanta/achantas-data/issues/16
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#15
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 11511 | Maid Research
-  url: https://github.com/vamseeachanta/achantas-data/issues/15
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#14
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 11511 Piping Rock
-  url: https://github.com/vamseeachanta/achantas-data/issues/14
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#13
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: ACH | Mobile Service
-  url: https://github.com/vamseeachanta/achantas-data/issues/13
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#12
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: 'SD | APSP House for Sale '
-  url: https://github.com/vamseeachanta/achantas-data/issues/12
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#9
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: SDEV | Physcology
-  url: https://github.com/vamseeachanta/achantas-data/issues/9
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#8
-  repo: vamseeachanta/achantas-data
-  domain: household
-  provider: claude
-  title: SDEV | Summary
-  url: https://github.com/vamseeachanta/achantas-data/issues/8
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#113
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Colombia Costco Travel deal res"
-  url: https://github.com/vamseeachanta/achantas-data/issues/113
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#112
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Brazil Costco Travel deal resea"
-  url: https://github.com/vamseeachanta/achantas-data/issues/112
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#111
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Chile Costco Travel deal resear"
-  url: https://github.com/vamseeachanta/achantas-data/issues/111
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#110
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Argentina Costco Travel deal re"
-  url: https://github.com/vamseeachanta/achantas-data/issues/110
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#109
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Ecuador / Galapagos Costco Trav"
-  url: https://github.com/vamseeachanta/achantas-data/issues/109
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#108
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: South America \u2014 Peru Costco Travel deal researc"
-  url: https://github.com/vamseeachanta/achantas-data/issues/108
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#107
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: South America Costco Travel comparison hub'
-  url: https://github.com/vamseeachanta/achantas-data/issues/107
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#106
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Petit Jean / Mount Magazine fallback cabin o'
-  url: https://github.com/vamseeachanta/achantas-data/issues/106
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#105
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Buffalo National River / Jasper cabin option'
-  url: https://github.com/vamseeachanta/achantas-data/issues/105
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#104
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Mena / Ouachita Mountains cabin option detai'
-  url: https://github.com/vamseeachanta/achantas-data/issues/104
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#103
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Lake Ouachita / Hot Springs cabin option det'
-  url: https://github.com/vamseeachanta/achantas-data/issues/103
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#102
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Eureka Springs / Beaver Lake cabin option de'
-  url: https://github.com/vamseeachanta/achantas-data/issues/102
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#101
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Arkansas Broken Bow-style cabin alternatives'
-  url: https://github.com/vamseeachanta/achantas-data/issues/101
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#100
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Caddo Lake / Uncertain stretch cabin option '
-  url: https://github.com/vamseeachanta/achantas-data/issues/100
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#99
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: New Braunfels / Gruene river-town option det'
-  url: https://github.com/vamseeachanta/achantas-data/issues/99
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#98
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Bastrop / Lost Pines cabin option details'
-  url: https://github.com/vamseeachanta/achantas-data/issues/98
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#97
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Lake Livingston / Sam Houston NF cabin optio'
-  url: https://github.com/vamseeachanta/achantas-data/issues/97
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#96
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Wimberley / Canyon Lake cabin option details'
-  url: https://github.com/vamseeachanta/achantas-data/issues/96
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#95
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Explore: Broken Bow-style cabin alternatives within 4'
-  url: https://github.com/vamseeachanta/achantas-data/issues/95
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#94
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Trip planning: Austin / Texas Hill Country options'
-  url: https://github.com/vamseeachanta/achantas-data/issues/94
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#93
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Booking shortlist: OK / Broken Bow cabin with kitchen + veri'
-  url: https://github.com/vamseeachanta/achantas-data/issues/93
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#91
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'trip: plan Broken Bow OK family road trip (Jun 6-9 2026 vs S'
-  url: https://github.com/vamseeachanta/achantas-data/issues/91
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#90
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'trip: plan Colorado road trip from Houston (4-day itinerary '
-  url: https://github.com/vamseeachanta/achantas-data/issues/90
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#71
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Feature: Travel apps shortlist \u2014 install/login checklist for"
-  url: https://github.com/vamseeachanta/achantas-data/issues/71
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#70
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Feature: Digitalize family IDs for domestic + international '
-  url: https://github.com/vamseeachanta/achantas-data/issues/70
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#68
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Switzerland 1-week train + scenic family trip'
-  url: https://github.com/vamseeachanta/achantas-data/issues/68
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#67
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Feature: Travel ranking matrix for family trip review'
-  url: https://github.com/vamseeachanta/achantas-data/issues/67
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#66
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination Base: Cottonwood Falls, Kansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/66
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#65
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination Base: Council Grove, Kansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/65
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#64
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Konza Prairie, Kansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/64
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#63
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Flint Hills Scenic Byway, Kansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/63
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#62
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Tallgrass Prairie National Preserve, Kansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/62
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#61
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Grayton Beach State Park, Florida'
-  url: https://github.com/vamseeachanta/achantas-data/issues/61
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#60
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Henderson Beach State Park, Florida'
-  url: https://github.com/vamseeachanta/achantas-data/issues/60
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#59
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: 30A and South Walton, Florida'
-  url: https://github.com/vamseeachanta/achantas-data/issues/59
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#58
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Pensacola Beach, Florida'
-  url: https://github.com/vamseeachanta/achantas-data/issues/58
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#57
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Gulf Islands National Seashore, Florida'
-  url: https://github.com/vamseeachanta/achantas-data/issues/57
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#56
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Destin, Florida Panhandle'
-  url: https://github.com/vamseeachanta/achantas-data/issues/56
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#55
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination Base: Lafayette and Breaux Bridge, Louisiana'
-  url: https://github.com/vamseeachanta/achantas-data/issues/55
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#54
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Atchafalaya Basin, Louisiana'
-  url: https://github.com/vamseeachanta/achantas-data/issues/54
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#53
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Kisatchie National Forest, Louisiana'
-  url: https://github.com/vamseeachanta/achantas-data/issues/53
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#52
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Jean Lafitte Barataria Preserve, Louisiana'
-  url: https://github.com/vamseeachanta/achantas-data/issues/52
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#51
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Devil''s Den State Park, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/51
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#50
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Buffalo National River, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/50
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#49
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Lake Ouachita State Park, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/49
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#48
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Mount Magazine State Park, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/48
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#47
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Petit Jean State Park, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/47
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#46
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Destination: Hot Springs National Park, Arkansas'
-  url: https://github.com/vamseeachanta/achantas-data/issues/46
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#45
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Houston to Kansas Flint Hills prairie scenic tr'
-  url: https://github.com/vamseeachanta/achantas-data/issues/45
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#44
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Houston to Florida Panhandle emerald coast scen'
-  url: https://github.com/vamseeachanta/achantas-data/issues/44
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#43
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Houston to Louisiana bayou and forest scenic tr'
-  url: https://github.com/vamseeachanta/achantas-data/issues/43
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#42
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Houston to Arkansas Ozarks and Hot Springs scen'
-  url: https://github.com/vamseeachanta/achantas-data/issues/42
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#41
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Travel Plan: Houston to Oklahoma Mountains and Lake to Houst'
-  url: https://github.com/vamseeachanta/achantas-data/issues/41
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#26
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Weekend Trip: Houston \u2192 New Orleans (Food, Music & Culture)"
-  url: https://github.com/vamseeachanta/achantas-data/issues/26
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#25
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Weekend Trip: Houston \u2192 Fredericksburg / Texas Hill Country"
-  url: https://github.com/vamseeachanta/achantas-data/issues/25
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#21
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Galveston trip \u2014 bicycle ride + ferry"
-  url: https://github.com/vamseeachanta/achantas-data/issues/21
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#20
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: 'Weekend Trip Ideas: Houston to Surrounding Areas (Nature/Sce'
-  url: https://github.com/vamseeachanta/achantas-data/issues/20
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/achantas-data#19
-  repo: vamseeachanta/achantas-data
-  domain: travel
-  provider: claude
-  title: "Travel Plan: Houston \u2192 Dallas Tulip Gardens \u2192 Oklahoma Mount"
-  url: https://github.com/vamseeachanta/achantas-data/issues/19
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#46
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: 'follow-up(ci): reconcile duplicate non-package reporting pat'
-  url: https://github.com/vamseeachanta/assethold/issues/46
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#45
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: 'follow-up(ci): clean or retire auxiliary agent-os Python fil'
-  url: https://github.com/vamseeachanta/assethold/issues/45
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#37
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: 'chore: update git origin to vamseeachanta/assethold canonica'
-  url: https://github.com/vamseeachanta/assethold/issues/37
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#33
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: "Architecture documentation \u2014 module diagram, MkDocs build, d"
-  url: https://github.com/vamseeachanta/assethold/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#31
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: "Enforce quality gates \u2014 test coverage, mypy, loguru initiali"
-  url: https://github.com/vamseeachanta/assethold/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#12
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: Running Task List
-  url: https://github.com/vamseeachanta/assethold/issues/12
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#11
-  repo: vamseeachanta/assethold
-  domain: infra
-  provider: claude
-  title: repo | guidelines
-  url: https://github.com/vamseeachanta/assethold/issues/11
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#43
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Wire insider_tracker into WatchlistRunner.insider_flags_prov
-  url: https://github.com/vamseeachanta/assethold/issues/43
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#42
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Wire settings.cache_ttl_hours through StockDataSource consum
-  url: https://github.com/vamseeachanta/assethold/issues/42
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#40
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: "Phase 1.5 \u2014 pre-market/after-hours support + configurable be"
-  url: https://github.com/vamseeachanta/assethold/issues/40
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#36
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: "Multifamily sensitivity and stress-test scenarios (TODOs a\u2013e"
-  url: https://github.com/vamseeachanta/assethold/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#34
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Assess and integrate real-time stock price feeds across modu
-  url: https://github.com/vamseeachanta/assethold/issues/34
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#32
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: "Complete skeletal modules \u2014 fixed_interest, multifamily, net"
-  url: https://github.com/vamseeachanta/assethold/issues/32
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#28
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: "Portfolio future outlook \u2014 probabilistic high/low projection"
-  url: https://github.com/vamseeachanta/assethold/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#27
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Portfolio performance benchmark vs SPY
-  url: https://github.com/vamseeachanta/assethold/issues/27
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#26
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Dividend reinvestment and ex-date calendar
-  url: https://github.com/vamseeachanta/assethold/issues/26
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#25
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: "Tax lot aging report \u2014 long-term capital gains optimizer"
-  url: https://github.com/vamseeachanta/assethold/issues/25
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#18
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: 'WRK-1199: Fama-French factor model'
-  url: https://github.com/vamseeachanta/assethold/issues/18
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#17
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: 'WRK-1198: Dividend yield forecasting'
-  url: https://github.com/vamseeachanta/assethold/issues/17
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#8
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Literature | Running Board
-  url: https://github.com/vamseeachanta/assethold/issues/8
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#5
-  repo: vamseeachanta/assethold
-  domain: models
-  provider: claude
-  title: Breakout | Trends | Backtesting
-  url: https://github.com/vamseeachanta/assethold/issues/5
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#44
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: Decide --render-charts default dir (fail-loud vs ./dashboard
-  url: https://github.com/vamseeachanta/assethold/issues/44
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#24
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: "Market disruption monitor \u2014 30-min cron during volatile sess"
-  url: https://github.com/vamseeachanta/assethold/issues/24
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#23
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: WhatsApp trade signals at market open and close
-  url: https://github.com/vamseeachanta/assethold/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#22
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: Daily portfolio report as PDF emailed to inbox
-  url: https://github.com/vamseeachanta/assethold/issues/22
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#21
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: 'Portfolio Dashboard: Automated Allocation Tracking & Daily R'
-  url: https://github.com/vamseeachanta/assethold/issues/21
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assethold#7
-  repo: vamseeachanta/assethold
-  domain: reports
-  provider: claude
-  title: 'Portfolio value '
-  url: https://github.com/vamseeachanta/assethold/issues/7
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#79
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: Client-deliverable templates binding to private llm-wiki cit
-  url: https://github.com/vamseeachanta/assetutilities/issues/79
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#60
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: repo | package development
-  url: https://github.com/vamseeachanta/assetutilities/issues/60
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#59
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: yaml_utilities | Variable Definition
-  url: https://github.com/vamseeachanta/assetutilities/issues/59
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#58
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: YAML Plotting
-  url: https://github.com/vamseeachanta/assetutilities/issues/58
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#56
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | Meetings
-  url: https://github.com/vamseeachanta/assetutilities/issues/56
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#52
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: YAML file split
-  url: https://github.com/vamseeachanta/assetutilities/issues/52
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#42
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | PB Hardware and Utility Readiness
-  url: https://github.com/vamseeachanta/assetutilities/issues/42
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#41
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | Clean code
-  url: https://github.com/vamseeachanta/assetutilities/issues/41
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#40
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: ' productivity | Marketing'
-  url: https://github.com/vamseeachanta/assetutilities/issues/40
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#39
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | email clean up
-  url: https://github.com/vamseeachanta/assetutilities/issues/39
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#38
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | Knowledge Management
-  url: https://github.com/vamseeachanta/assetutilities/issues/38
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#37
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: Scalability | Process, People
-  url: https://github.com/vamseeachanta/assetutilities/issues/37
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#36
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | Consolidate hardware
-  url: https://github.com/vamseeachanta/assetutilities/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#35
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | Consolidate repos
-  url: https://github.com/vamseeachanta/assetutilities/issues/35
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#33
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: productivity | Consolidate data
-  url: https://github.com/vamseeachanta/assetutilities/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#31
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | mkt-a | Source Files | Sync vs. Copy
-  url: https://github.com/vamseeachanta/assetutilities/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#30
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | AI agents
-  url: https://github.com/vamseeachanta/assetutilities/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#29
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | switch engine to registry design pattern
-  url: https://github.com/vamseeachanta/assetutilities/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#28
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | switch to loguru
-  url: https://github.com/vamseeachanta/assetutilities/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/assetutilities#19
-  repo: vamseeachanta/assetutilities
-  domain: null
-  provider: claude
-  title: tech debt | git | branch, computer and multiuser merge
-  url: https://github.com/vamseeachanta/assetutilities/issues/19
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#584
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#179
   repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "WRK-558: feat(digitalmodel/marine): Implement API RP 2SM \u2014 A"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/584
+  domain: subsea
+  provider: codex
+  title: 'WRK-481: feat(digitalmodel): integrate GEBCO_2025 Bathymetry'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/179
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#583
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "WRK-557: feat(digitalmodel/marine): Implement API RP 572 \u2014 A"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/583
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#582
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "WRK-556: feat(digitalmodel/marine): Implement API RP 2I \u2014 AP"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/582
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#581
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-539: feat(digitalmodel/structural): Implement API RP 2A '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/581
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#579
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-494: feat(digitalmodel/cathodic_protection): Implement D'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/579
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#574
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: Wiki standards-page family for FOWT (IEC 61400-3-2, DNV-ST-0
-  url: https://github.com/vamseeachanta/digitalmodel/issues/574
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#249
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "WRK-559: feat(digitalmodel/marine): Implement API RP 2P \u2014 AP"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/249
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#248
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "WRK-555: feat(digitalmodel/marine): Implement DNV E301 \u2014 DNV"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/248
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#188
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-492: feat(digitalmodel/cathodic_protection): Implement I'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/188
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#187
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-490: feat(digitalmodel/cathodic_protection): Implement I'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/187
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#186
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-489: feat(digitalmodel/cathodic_protection): Implement I'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/186
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
+  routed_by: manual
 - gh: vamseeachanta/digitalmodel#185
   repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
+  domain: standards
+  provider: codex
   title: 'WRK-488: feat(digitalmodel/cathodic_protection): Implement I'
   url: https://github.com/vamseeachanta/digitalmodel/issues/185
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#576
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#186
   repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'FOWT watch-circle envelope check vs dynamic-cable curvature '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/576
+  domain: standards
+  provider: codex
+  title: 'WRK-489: feat(digitalmodel/cathodic_protection): Implement I'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/186
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#575
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#187
   repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: FOWT coupled aero-hydro response Python facade (IEC 61400-3-
-  url: https://github.com/vamseeachanta/digitalmodel/issues/575
+  domain: standards
+  provider: codex
+  title: 'WRK-490: feat(digitalmodel/cathodic_protection): Implement I'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/187
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#272
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#188
   repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-662: analysis(digitalmodel): engineering standards citat'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/272
+  domain: standards
+  provider: codex
+  title: 'WRK-492: feat(digitalmodel/cathodic_protection): Implement I'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/188
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#162
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-1282: Drive-off research and analysis methodologies'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/162
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#147
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-1193: Geotechnical anchor holding capacity'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/147
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#142
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-1027: DNV-RP-B401 real-world benchmark validation: GOM j'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/142
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#618
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: Citation-resolver hardening follow-ons (symlink hygiene, log
-  url: https://github.com/vamseeachanta/digitalmodel/issues/618
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#578
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: W2W motion-compensated gangway operability module (DNV-ST-03
-  url: https://github.com/vamseeachanta/digitalmodel/issues/578
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#573
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'fix(marine_ops): DNV-RP-F103 calibration drift in test_catho'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/573
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#566
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: "fix(marine_ops): batched residue clusters R1+R5+R7+R8 \u2014 clea"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/566
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#565
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'fix(marine_ops): test_hydro_coefficients.py::TestIntegration'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/565
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#563
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'fix(marine_ops): test_marine_eng_performance.py::test_ocimf_'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/563
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#557
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'fix(marine_ops): test_ocimf.py::TestOCIMFDatabase::test_boun'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/557
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#556
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'fix(marine_ops): test_ocimf.py::TestOCIMFDatabase::test_get_'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/556
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#266
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: 'WRK-623: feat(geotechnical): scour prediction per DNV-RP-F10'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/266
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#20
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: code_dnvrph103 | If CoV is same as CoG, leave it null
-  url: https://github.com/vamseeachanta/digitalmodel/issues/20
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#17
-  repo: vamseeachanta/digitalmodel
-  domain: codes
-  provider: claude
-  title: code_dnvrph103 | discretized model at an angle
-  url: https://github.com/vamseeachanta/digitalmodel/issues/17
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#146
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: "WRK-1180: Prototype: USNA EN400 worked examples \u2192 pytest tes"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/146
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#171
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: "WRK-343: OpenFOAM technical debt and exploration \u2014 tutorials"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/171
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#163
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: "WRK-1283: Rudder types survey \u2014 video references and digital"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/163
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#154
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: "WRK-1250: OpenFOAM deep solver workflows \u2014 tutorial reproduc"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/154
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#152
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'WRK-1233: Add test coverage for platform and pipeline loader'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/152
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#590
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'fix(marine_ops): test_database_performance has flaky 1ms per'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/590
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#589
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'fix(marine_ops): test_weight_scales_with_diameter_squared qu'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/589
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#530
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'OrcaFlex tests: hoist class-scoped fixtures in test_orcaflex'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/530
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#514
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'Resolve or document the conftest ignore policy around async '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/514
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#512
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: Fix GTM Demo 2 --from-cache path and make GTM validation tes
-  url: https://github.com/vamseeachanta/digitalmodel/issues/512
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#475
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: Add pytest test suite for jumper_lift.py (81 tests)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/475
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#123
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: 'TASK 1.1: Configuration Framework Consolidation'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/123
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#65
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: optimization | shells | migrate to gitbash
-  url: https://github.com/vamseeachanta/digitalmodel/issues/65
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#63
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: engg debt | openFOAM
-  url: https://github.com/vamseeachanta/digitalmodel/issues/63
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#59
-  repo: vamseeachanta/digitalmodel
-  domain: qa
-  provider: claude
-  title: engg debt | Pipe Capacity | Documentation and Calculations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/59
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#597
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#189
   repo: vamseeachanta/digitalmodel
   domain: subsea
-  provider: claude
-  title: 'chore(repo-structure): classify and relocate B1528 generated'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/597
+  provider: codex
+  title: 'WRK-496: feat(digitalmodel/cathodic_protection): Implement D'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/189
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#580
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#191
   repo: vamseeachanta/digitalmodel
   domain: subsea
-  provider: claude
-  title: "WRK-5066: Production engineering study \u2014 literature, methods"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/580
+  provider: codex
+  title: 'WRK-499: feat(digitalmodel/pipeline): Implement API RP 1109 '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/191
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#195
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-501: feat(digitalmodel/pipeline): Implement ISO 16708 \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/195
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#197
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-503: feat(digitalmodel/pipeline): Implement ISO 13628 \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/197
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#201
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-505: feat(digitalmodel/pipeline): Implement ISO 13624-1 '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/201
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#204
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5063: VIV analysis study \u2014 literature, methods and imple"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/204
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#205
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5064: Asset integrity and fitness-for-service study \u2014 li"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/205
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#213
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-507: feat(digitalmodel/pipeline): Implement ISO 13628-7 '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/213
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#216
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-509: feat(digitalmodel/pipeline): Implement ISO 16389 \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/216
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#222
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-515: feat(digitalmodel/pipeline): Implement API RP 17G \u2014"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/222
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#224
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-517: feat(digitalmodel/pipeline): Implement DNV OSS 006 '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/224
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#228
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-521: feat(digitalmodel/pipeline): Implement DNV F110 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/228
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#230
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-523: feat(digitalmodel/pipeline): Implement DNV F108 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/230
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#232
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-525: feat(digitalmodel/pipeline): Implement DNV F203 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/232
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#236
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-529: feat(digitalmodel/pipeline): Implement DNV F102 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/236
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#238
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-531: feat(digitalmodel/pipeline): Implement DNV F202 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/238
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#240
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-533: feat(digitalmodel/pipeline): Implement DNV F206 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/240
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#242
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-535: feat(digitalmodel/pipeline): Implement DNV F109 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/242
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#244
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-537: feat(digitalmodel/pipeline): Implement DNV F116 \u2014 D"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/244
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#246
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: 'WRK-543: feat(digitalmodel/structural): Implement ASTM E1049'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/246
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#248
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: "WRK-555: feat(digitalmodel/marine): Implement DNV E301 \u2014 DNV"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/248
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#249
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: "WRK-559: feat(digitalmodel/marine): Implement API RP 2P \u2014 AP"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/249
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#254
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: "WRK-589: feat(orcaflex): dat-to-yaml pipeline \u2014 extract, leg"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/254
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#255
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: "WRK-595: feat(orcaflex): rewrite enrichment pipeline \u2014 world"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/255
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#261
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-618: feat(geotechnical): soil profile models, CPT correl'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/261
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/digitalmodel#279
   repo: vamseeachanta/digitalmodel
-  domain: subsea
+  domain: solver
   provider: claude
   title: 'WRK-129: Standardize analysis reporting for each OrcaFlex st'
   url: https://github.com/vamseeachanta/digitalmodel/issues/279
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#268
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-628: feat(client-a): client AI roadshow \u2014 phase"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/268
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#267
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-625: feat(client-a): engineering AI demo \u2014 syst"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/267
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#256
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-598: feat(product): build engineering chatbot for oil & '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/256
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#255
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-595: feat(orcaflex): rewrite enrichment pipeline \u2014 world"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/255
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#254
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-589: feat(orcaflex): dat-to-yaml pipeline \u2014 extract, leg"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/254
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#247
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-544: feat(OGManufacturing/structural): Implement ASTM E1'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/247
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#246
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-543: feat(digitalmodel/structural): Implement ASTM E1049'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/246
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#245
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-538: feat(lng-a/pipeline): Implement DNV F116 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/245
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#244
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-537: feat(digitalmodel/pipeline): Implement DNV F116 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/244
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#243
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-536: feat(lng-a/pipeline): Implement DNV F109 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/243
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#242
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-535: feat(digitalmodel/pipeline): Implement DNV F109 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/242
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#241
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-534: feat(lng-a/pipeline): Implement DNV F206 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/241
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#240
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-533: feat(digitalmodel/pipeline): Implement DNV F206 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/240
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#239
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-532: feat(lng-a/pipeline): Implement DNV F202 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/239
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#238
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-531: feat(digitalmodel/pipeline): Implement DNV F202 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/238
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#237
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-530: feat(lng-a/pipeline): Implement DNV F102 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/237
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#236
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-529: feat(digitalmodel/pipeline): Implement DNV F102 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/236
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#235
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-528: feat(lng-a/pipeline): Implement DNV F105 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/235
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#234
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-527: feat(digitalmodel/pipeline): Implement DNV F105 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/234
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#233
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-526: feat(lng-a/pipeline): Implement DNV F203 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/233
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#232
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-525: feat(digitalmodel/pipeline): Implement DNV F203 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/232
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#231
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-524: feat(lng-a/pipeline): Implement DNV F108 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/231
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#230
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-523: feat(digitalmodel/pipeline): Implement DNV F108 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/230
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#229
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-522: feat(lng-a/pipeline): Implement DNV F110 \u2014 DNV RP F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/229
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#228
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-521: feat(digitalmodel/pipeline): Implement DNV F110 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/228
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#227
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-520: feat(lng-a/pipeline): Implement DNV F201 \u2014 DNV OS F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/227
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#226
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-519: feat(digitalmodel/pipeline): Implement DNV F201 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/226
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#225
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-518: feat(lng-a/pipeline): Implement DNV OSS 006 \u2014 DNV O"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/225
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#224
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-517: feat(digitalmodel/pipeline): Implement DNV OSS 006 '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/224
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#223
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-516: feat(lng-a/pipeline): Implement API RP 17G \u2014 API RP"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/223
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#222
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-515: feat(digitalmodel/pipeline): Implement API RP 17G \u2014"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/222
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#221
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-514: feat(lng-a/pipeline): Implement DNV F101 \u2014 DNV OS F"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/221
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#220
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-513: feat(digitalmodel/pipeline): Implement DNV F101 \u2014 D"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/220
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#219
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-512: feat(lng-a/pipeline): Implement API STD 2RD \u2014 API S"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/219
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#218
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-511: feat(digitalmodel/pipeline): Implement API STD 2RD '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/218
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#217
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-510: feat(lng-a/pipeline): Implement ISO 16389 \u2014 ISO 163"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/217
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#216
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-509: feat(digitalmodel/pipeline): Implement ISO 16389 \u2014 "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/216
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#215
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-508: feat(lng-a/pipeline): Implement ISO 13628-7 \u2014 ISO 1"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/215
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#213
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-507: feat(digitalmodel/pipeline): Implement ISO 13628-7 '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/213
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#210
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-506: feat(lng-a/pipeline): Implement ISO 13624-1 \u2014 DIN E"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/210
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#205
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5064: Asset integrity and fitness-for-service study \u2014 li"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/205
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#204
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5063: VIV analysis study \u2014 literature, methods and imple"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/204
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#201
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-505: feat(digitalmodel/pipeline): Implement ISO 13624-1 '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/201
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#198
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-504: feat(lng-a/pipeline): Implement ISO 13628 \u2014 ISO 136"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/198
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#197
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-503: feat(digitalmodel/pipeline): Implement ISO 13628 \u2014 "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/197
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#196
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-502: feat(lng-a/pipeline): Implement ISO 16708 \u2014 ISO 167"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/196
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#195
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-501: feat(digitalmodel/pipeline): Implement ISO 16708 \u2014 "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/195
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#193
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-500: feat(lng-a/pipeline): Implement API RP 1109 \u2014 API R"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/193
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#191
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-499: feat(digitalmodel/pipeline): Implement API RP 1109 '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/191
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#190
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-498: feat(lng-a/pipeline): Implement API RP 1111 \u2014 API R"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/190
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#189
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-496: feat(digitalmodel/cathodic_protection): Implement D'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/189
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#179
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-481: feat(digitalmodel): integrate GEBCO_2025 Bathymetry'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/179
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#176
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-478: feat(subsea): create Cathodic Protection module (DN'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/176
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#165
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1320: Benchmark Docling on ace-linux-2 GPU (T400 4GB) an'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/165
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#145
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1179: 15-day ecosystem sprint \u2014 data completeness + calc"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/145
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#486
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement subsea connectors and jumpers module (API 17R)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/486
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#485
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement subsea manifold aggregation module (API 17P)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/485
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#484
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement subsea tree modeling module (API 17D)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/484
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#277
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1251: FreeCAD deep parametric engineering \u2014 hull generat"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/277
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#271
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-631: feat(client-a): Microsoft Teams chatbot in'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/271
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#264
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-621: feat(geotechnical): shallow foundation bearing capa'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/264
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#263
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-620: feat(geotechnical): pipeline on-bottom stability pe'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/263
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#262
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-619: feat(geotechnical): pile axial/lateral capacity, p-'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/262
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#260
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-616: chore(wrk-309): convert document-intelligence findi'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/260
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#259
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-609: chore(digitalmodel): catalog and port ANSYS .inp ri'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/259
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#258
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-608: chore(digitalmodel): catalog and port MATLAB riser/'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/258
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#250
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-571: feat(digitalmodel): port VIV MATLAB mode analysis s'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/250
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#214
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5082: Parachute frame force calculation \u2014 drag car parac"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/214
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#212
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5077: Data needs registry \u2014 fill gaps across all digital"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/212
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#211
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5070: Metocean and extreme value analysis study \u2014 litera"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/211
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#209
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5069: Subsea risers and flowlines study \u2014 literature, me"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/209
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#208
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5068: Cathodic protection study \u2014 literature, methods an"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/208
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#202
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5060: Pipeline engineering study \u2014 literature, methods a"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/202
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#200
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-5058: Drilling riser engineering study \u2014 literature, met"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/200
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#184
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-487: feat(digitalmodel/cathodic_protection): Implement A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/184
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#183
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-486: feat(digitalmodel/cathodic_protection): Implement A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/183
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#182
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-485: feat(digitalmodel/cathodic_protection): Implement A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/182
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#181
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-484: feat(digitalmodel/cathodic_protection): Implement A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/181
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#180
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-483: feat(digitalmodel/cathodic_protection): Implement A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/180
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#177
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-479: feat(worldenergydata): wire SODIR FactPages OData A'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/177
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#175
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-477: feat(worldenergydata): create Offshore Geohazard Fe'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/175
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#174
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-474: feat(subsea): integrate MoorDyn + MoorPy for moorin'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/174
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#172
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-416: untitled'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/172
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#167
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-162: untitled'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/167
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#164
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1304: Update pdf skill to recommend PyMuPDF4LLM over Cod'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/164
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#159
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1275: Add sensitivity, validation, verification to calc '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/159
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#158
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1274: Upgrade Gen 1 calc examples \u2014 add scope, design_ba"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/158
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#155
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1252: Full CAD-to-CFD pipeline \u2014 FreeCAD \u2192 gmsh \u2192 OpenFO"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/155
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#153
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1249: gmsh deep meshing workflows \u2014 parametric studies, "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/153
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#150
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1196: P10/P50/P90 resource estimation'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/150
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#149
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1195: Type curve matching (Blasingame/Fetkovich)'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/149
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#148
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1194: Geotechnical scour assessment'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/148
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#144
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1150: Python implementation \u2014 propeller-rudder interacti"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/144
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#143
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1147: Propeller-rudder hydrodynamic interaction study \u2014 "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/143
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#138
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-046: OrcaFlex drilling and completion riser parametric a'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/138
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#137
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-045: OrcaFlex rigid jumper analysis - stress and VIV for'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/137
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#133
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-032: Modular OrcaFlex pipeline installation input with p'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/133
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#615
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Riser-analysis results as stage-by-stage animated HTML deliv
-  url: https://github.com/vamseeachanta/digitalmodel/issues/615
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#591
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: GTM vessel suitability analysis for installation and pipelin
-  url: https://github.com/vamseeachanta/digitalmodel/issues/591
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#562
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'fix(marine_ops): test_marine_eng_performance.py::test_comple'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/562
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#523
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'Harvest #517 subprocess review into actionable implementatio'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/523
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#508
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'OrcaFlex spec upgrader v2: rewrite generic specs to domain-s'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/508
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#506
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Add PassingShipSpec and JumperInstallationSpec schemas for n
-  url: https://github.com/vamseeachanta/digitalmodel/issues/506
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#494
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "Enhance flexible pipe modeling \u2014 API 17B/17J compliance"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/494
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#493
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement river/shallow-water current profile modeling
-  url: https://github.com/vamseeachanta/digitalmodel/issues/493
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#491
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement ROV intervention modeling module (API 17H)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/491
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#490
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement capping stack analysis module (API 17W)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/490
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#489
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement HIPPS modeling module (API 17O)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/489
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#488
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement subsea umbilical and control systems module (API 1
-  url: https://github.com/vamseeachanta/digitalmodel/issues/488
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#481
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Convert PLET-PLEM workbook via Windows cowork
-  url: https://github.com/vamseeachanta/digitalmodel/issues/481
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#480
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'BUG: Verify PLET-PLEM jumper segment lengths from SZ_Ballymo'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/480
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#479
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: HTML/PDF report renderer for jumper installation analysis
-  url: https://github.com/vamseeachanta/digitalmodel/issues/479
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#478
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: OrcaFlex model generator integration - spec.yml to .dat pipe
-  url: https://github.com/vamseeachanta/digitalmodel/issues/478
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#472
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: Implement Go/No-Go decision logic per DNV-RP-H103
-  url: https://github.com/vamseeachanta/digitalmodel/issues/472
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
+  routed_by: manual
 - gh: vamseeachanta/digitalmodel#471
   repo: vamseeachanta/digitalmodel
   domain: subsea
-  provider: claude
+  provider: codex
   title: "STORY: Jumper Installation Analysis Pipeline \u2014 spec.yml to O"
   url: https://github.com/vamseeachanta/digitalmodel/issues/471
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#252
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#478
   repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-585: feat(worldenergydata): add IRENA offshore wind capa'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/252
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#251
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-583: research: verify ANP Brazil production data REST AP'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/251
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#166
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-137: Download and parse rig spec PDFs (102 PDFs from 4 o'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/166
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#160
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: "WRK-1276: Create audit-calc-methodology.py \u2014 auto-score exam"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/160
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#151
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-1197: Decline/NPV duplicate consolidation'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/151
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#132
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'WRK-023: Property GIS development timeline with future proje'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/132
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#125
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'TASK 1.3: Common Utilities Deduplication'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/125
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#124
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: 'TASK 1.2: Mathematical Solvers Migration'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/124
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#109
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: debt | Architecture Implementation
-  url: https://github.com/vamseeachanta/digitalmodel/issues/109
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#87
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: engg debt | Autodesk Autocad
-  url: https://github.com/vamseeachanta/digitalmodel/issues/87
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#23
-  repo: vamseeachanta/digitalmodel
-  domain: subsea
-  provider: claude
-  title: dnvrph103 | Create common functions from rectangular and cir
-  url: https://github.com/vamseeachanta/digitalmodel/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#261
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: 'WRK-618: feat(geotechnical): soil profile models, CPT correl'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/261
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#168
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: "WRK-171: Cost data calibration \u2014 sanctioned project benchmar"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/168
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#522
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: Codify ultra-constrained Claude subprocess prompt patterns f
-  url: https://github.com/vamseeachanta/digitalmodel/issues/522
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#469
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: Assess AI agent session artifact dirs across machines (.code
-  url: https://github.com/vamseeachanta/digitalmodel/issues/469
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#461
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: Recover ship-dimensions template artifact from WRK-1339 Chil
-  url: https://github.com/vamseeachanta/digitalmodel/issues/461
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#257
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: "WRK-604: chore(doc-index): remap legacy HDD records \u2014 va-hdd"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/257
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#127
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: 'TASK 1.5: Database Integration Layer'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/127
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#126
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: 'TASK 1.4: Shared Data Models Unification'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/126
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#95
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: Design Drawings
-  url: https://github.com/vamseeachanta/digitalmodel/issues/95
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#92
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | FreeCAD
-  url: https://github.com/vamseeachanta/digitalmodel/issues/92
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#89
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: PB | Task List
-  url: https://github.com/vamseeachanta/digitalmodel/issues/89
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#80
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: Project DRS | Tasks
-  url: https://github.com/vamseeachanta/digitalmodel/issues/80
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#60
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | Time Series | Filter in FFT and Get Timetrace Ba
-  url: https://github.com/vamseeachanta/digitalmodel/issues/60
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#54
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: SS |  Task List
-  url: https://github.com/vamseeachanta/digitalmodel/issues/54
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#47
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | Plate Buckling Calculations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/47
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#31
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | Ship design | strength checks
-  url: https://github.com/vamseeachanta/digitalmodel/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#30
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | Ship design | min scantling calculations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#12
-  repo: vamseeachanta/digitalmodel
-  domain: null
-  provider: claude
-  title: engg debt | Padeye Calculations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/12
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/kaggle-rogii-2026#7
-  repo: vamseeachanta/kaggle-rogii-2026
-  domain: null
-  provider: claude
-  title: "Phase 4 \u2014 Sequence model with regime auxiliary head"
-  url: https://github.com/vamseeachanta/kaggle-rogii-2026/issues/7
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/kaggle-rogii-2026#8
-  repo: vamseeachanta/kaggle-rogii-2026
-  domain: null
-  provider: claude
-  title: "Phase 5 \u2014 Ensembling + submission packaging"
-  url: https://github.com/vamseeachanta/kaggle-rogii-2026/issues/8
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/kaggle-rogii-2026#4
-  repo: vamseeachanta/kaggle-rogii-2026
-  domain: null
-  provider: claude
-  title: "Phase 3 \u2014 GBDT regressor over combined features"
-  url: https://github.com/vamseeachanta/kaggle-rogii-2026/issues/4
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/kaggle-rogii-2026#3
-  repo: vamseeachanta/kaggle-rogii-2026
-  domain: null
-  provider: claude
-  title: "Phase 0.5 \u2014 Linear extrapolation baseline"
-  url: https://github.com/vamseeachanta/kaggle-rogii-2026/issues/3
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#35
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: 'feat: engineering wiki cross-link discovery with domain wiki'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/35
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#33
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: 'WRK-1126: Add maritime law domain: skill, data, public cases'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#32
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: "feat: career-learnings seed migration \u2014 pipeline integrity, "
-  url: https://github.com/vamseeachanta/llm-wiki/issues/32
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#25
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: 'feat(knowledge): execute Batch Pack 1 to promote API/standar'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/25
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#24
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: 'Phase 2: Promote CSA Z276.1-20 + Z276.18 into marine-enginee'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/24
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#23
-  repo: vamseeachanta/llm-wiki
-  domain: content
-  provider: claude
-  title: 'feat(knowledge): update wiki CLAUDE.md files to declare doc_'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#36
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'feat: cross-wiki link discovery and infrastructure'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#31
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'feat(knowledge): promote design-code registry into standards'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#28
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'feat(knowledge): chunk and paginate the canonical marine-eng'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#27
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'docs(knowledge): add standard uplink/back-navigation block t'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/27
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#21
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'feat(llm-wiki): regenerate cross-links.md across 8 wikis aft'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/21
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#20
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'feat(llm-wiki): backfill engineering-wiki reverse cross-link'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/20
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#13
-  repo: vamseeachanta/llm-wiki
-  domain: governance
-  provider: claude
-  title: 'epic(knowledge): llm-wiki strengthening roadmap and executio'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/13
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#117
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] marine-engineering/sigtto \u2014 14-document inge"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/117
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#116
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] marine-engineering/dnv \u2014 OS-E301 citation-pi"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/116
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#115
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[specialist-corpus] vendor-contractor pdfs \u2014 2H, client-d, dor"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/115
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#113
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[specialist-corpus] offshore renewables \u2014 openfast, WEC-Sim"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/113
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#112
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[specialist-corpus] BEM hydrodynamics \u2014 capytaine"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/112
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#111
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[specialist-corpus] hydrodynamic-mooring OSS \u2014 HAMS, MoorDyn"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/111
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#110
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] specialty-and-international \u2014 AMSA, ADCI, IA"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/110
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#109
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] materials-and-mechanical \u2014 ASTM, SAE, ANSI m"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/109
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#108
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] electrical-instrumentation \u2014 IEC, IEEE"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/108
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#107
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] maritime-regulatory \u2014 USCG, BSEE, EPA, OSHA,"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/107
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#106
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] production-engineering \u2014 API production spec"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/106
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#105
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] drilling-engineering \u2014 API drilling spec fam"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/105
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#104
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] civil-structural-engineering \u2014 AISC, ASCE, A"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/104
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#103
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "[corpus-ingest] marine-engineering \u2014 class societies + IMO r"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/103
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#101
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: '[meta] Follow-on substance work from 2026-05-18 14-URL inges'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/101
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#72
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "feat(execution): dry-tree Lower Tertiary corpus ingestion \u2014 "
-  url: https://github.com/vamseeachanta/llm-wiki/issues/72
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#34
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "feat: engineering wiki \u2014 ingest remaining high-value sources"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/34
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#30
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'feat(knowledge): backfill promotion provenance on pre-existi'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#29
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'feat(knowledge): add canonical source-title aliasing for wik'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#26
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'feat(knowledge): execute Batch Pack 4 for non-mkt-a standards'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/26
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#14
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'feat(llm-wiki): plan curated SESA LNG corpus extraction from'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/14
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#12
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'WRK-280: ABS standards acquisition: create folder + download'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/12
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#11
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1299: OCR pipeline \u2014 ace-linux-1 scanned PDFs (53K docs)"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/11
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#10
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1298: OCR pipeline \u2014 ace-linux-2 scanned PDFs (39K docs,"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/10
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#9
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1297: Batch deep extraction \u2014 ace-linux-2 machine-readab"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/9
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#8
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1296: Batch deep extraction \u2014 ace-linux-1 machine-readab"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/8
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#7
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1295: Batch LLM summaries \u2014 ace_standards + workspace_sp"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/7
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#6
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'WRK-1292: Enrich research briefs with key equations and work'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/6
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#5
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1257: Chart image extraction \u2014 extract actual images fro"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/5
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#4
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1255: Batch deep extraction \u2014 large standards PDFs >1MB "
-  url: https://github.com/vamseeachanta/llm-wiki/issues/4
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#3
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1253: Batch deep extraction \u2014 XLS/XLSX files (11,741 doc"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/3
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#2
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: 'WRK-1246: Assess deep extraction yield across text-extractab'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/2
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#1
-  repo: vamseeachanta/llm-wiki
-  domain: ingest
-  provider: claude
-  title: "WRK-1245: Full corpus intelligence extraction \u2014 summaries, d"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/1
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#114
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: "[specialist-corpus] reservoir-simulation OSS + meshing \u2014 opm"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/114
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#102
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: 'Validator hardening: address cross-review findings before cl'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/102
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#80
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: 'arch(agent-access): plan CLI/MCP query surface for llm-wiki '
-  url: https://github.com/vamseeachanta/llm-wiki/issues/80
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#77
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: 'feat(retrieval): generate public-safe knowledge graph and li'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/77
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#39
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: "feat: engineering wiki \u2014 ingest skill metadata as wiki pages"
-  url: https://github.com/vamseeachanta/llm-wiki/issues/39
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#38
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: 'feat(knowledge): normalize WRK completions into structured s'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/38
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/llm-wiki#19
-  repo: vamseeachanta/llm-wiki
-  domain: tooling
-  provider: claude
-  title: 'feat(llm-wiki): plan offshore raw-source family wiki backfil'
-  url: https://github.com/vamseeachanta/llm-wiki/issues/19
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#33
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: admin-comms
-  provider: claude
-  title: Verify $340 FSR transfer fee not duplicated at 2025-09-22 cl
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#29
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: admin-comms
-  provider: claude
-  title: 'Security: remove plaintext credentials from admin/admin.md'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#28
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: admin-comms
-  provider: claude
-  title: "Update loan agreement: AceEngineer \u2192 Sabitha as lender"
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#19
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: admin-comms
-  provider: claude
-  title: '2026 Annual: Renew Property Insurance (Crown ABOP-TX-1000851'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/19
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#4
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: admin-comms
-  provider: claude
-  title: Send 2025 Tenant Reimbursement Request to Family Dollar ($39
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/4
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#37
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: hoa-vendors
-  provider: claude
-  title: 'Verify ACH debit on Middlesex statement: $1,145.66 ClickPay '
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/37
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#36
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: hoa-vendors
-  provider: claude
-  title: Send Kevin Straight maintenance follow-up email (Gmail draft
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#35
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: hoa-vendors
-  provider: claude
-  title: "Submit 2026 HOA reimbursement ($802.66) to Family Dollar \u2014 d"
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/35
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#34
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: hoa-vendors
-  provider: claude
-  title: Set up ClickPay AutoPay for 2027 Clayton Park POA annual ass
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/34
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#32
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: hoa-vendors
-  provider: claude
-  title: 'Reply to Zaykeah Johnson confirming HOA payment + reiterate '
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/32
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#31
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: 'Evaluate e-filing options for Form 1120: TaxAct vs paper vs '
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#30
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: 'Reconcile September rent: $10,141.67 on 1099 but not in bank'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#24
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: File Texas No Tax Due Report + PIR by May 15, 2026
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/24
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#23
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: File Form 7004 or Form 1120 by April 15, 2026
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#21
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: 'Annual Recurring: SKEstates Tax Calendar (Template)'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/21
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#20
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: '2026 Annual: Review Entity Structure (C-Corp vs S-Corp vs LL'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/20
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#18
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: '2026 Annual: File Form 1120 + TX Franchise Tax by April/May '
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/18
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#13
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: '2026 Annual: Send 2026 Property Tax Reimbursement Request to'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/13
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#10
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: Send 2025 Tax/Insurance Reimbursement Request to Family Doll
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/10
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#9
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: File 2025 Form 1120 (Federal) + TX Franchise Tax by April 15
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/9
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#5
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: Track 2025 Tenant Tax Reimbursement ($29,194.58) - Paid to S
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/5
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/sabithaandkrishnaestates#3
-  repo: vamseeachanta/sabithaandkrishnaestates
-  domain: tax-1099
-  provider: claude
-  title: '1099-MISC Reconciliation: $50,085.60 RESOLVED -- pass-throug'
-  url: https://github.com/vamseeachanta/sabithaandkrishnaestates/issues/3
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2754
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'throughput(workstations): activate ace-linux-1 provider/mach'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2754
+  domain: solver
+  provider: codex
+  title: OrcaFlex model generator integration - spec.yml to .dat pipe
+  url: https://github.com/vamseeachanta/digitalmodel/issues/478
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2733
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/digitalmodel#512
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: 'epic: make Hermes agent memory canonical across all AI provi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2733
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2730
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'fix(gemini): remove unsupported permissionMode keys from age'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2730
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2715
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'bug(infra): codex-cli 0.130.0 stdin-hang regression (recurre'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2715
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2700
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): "Memory-to-Surface" map maintenance '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2700
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2699
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(ai-tools): refresh agent-capability-scores.yaml from 2'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2699
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2698
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): migration plan for AI_ECOSYSTEM_DESI'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2698
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2650
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(knowledge): post-spinout cleanup for llm-wiki migratio'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2650
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2506
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): validate Lane E implementation hando'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2506
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2505
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): add golden-output contract for morni'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2505
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2504
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): define dispatch-ledger trust contrac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2504
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2503
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): standardize canonical approval-reque'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2503
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2502
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(ai-orchestration): harden plan-review artifact metadata'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2502
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2440
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'decision: visual DNA coherence across aceengineer.com + digi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2440
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2439
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(aceengineer-website): Bootstrap design-debt audit + to'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2439
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2436
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(aceengineer-website): redesign templated page chrome (c'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2436
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2435
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(aceengineer-website): establish design system in Claude'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2435
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2434
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "epic(aceengineer-website): Claude Design adoption \u2014 site-wid"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2434
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2432
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(claude-design): adoption trial protocol \u2014 measure cost/"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2432
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2430
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(skills): claude-design-handoff \u2014 post-handoff receiver "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2430
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2429
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(skills): claude-design-prep \u2014 CLI-side input-pack gener"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2429
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2428
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(claude-design): upstream enhancement feedback bundle \u2014 "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2428
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2426
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "epic: Claude Design (research preview) \u2014 ecosystem adoption "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2426
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2420
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'fix(skills): restore repo-portfolio-steering balance snapsho'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2420
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2419
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'fix(tests): reconcile skill markdown contract drift in dark-'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2419
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2418
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(automation): add compounding multi-iteration autoresear'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2418
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2341
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'bug(pre-push): ModuleNotFoundError: yaml in uv run --no-proj'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2341
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2335
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(cron): retro-refactor state-size-report.sh to use cade'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2335
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2294
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(skills): salvage #2290 follow-on learnings for regress'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2294
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2292
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'fix(queue-refresh): restore weekly queue refresh evidence an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2292
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2253
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(provider-routing): harden Gemini auto-label confidence '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2253
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2252
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(provider-routing): add explanatory comments for high-co'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2252
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2222
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Follow up Claude auth drift hardening with stronger observab
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2222
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2221
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(daily-report): refresh stale data sources and complete '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2221
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2143
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Track security remediation for archived simpledigitalmarketi
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2143
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2142
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Standardize tracked skill-link handling across repos to avoi
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2142
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2111
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(governance): Phase 4b inter-session continuity validati'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2111
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2110
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(governance): Phase 4a session-close structured report g'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2110
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2083
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(skills): reconcile duplicate session-corpus-audit (coo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2083
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2080
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'fix(tests): repair 14 pre-existing skill test failures in te'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2080
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2073
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Expose stage-prompt drift doctor/status in CI and operator s
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2073
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2061
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Session governance Phase 4: Hermes-orchestrated session life'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2061
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2052
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Queue refresh: auto-generate ''This Week''s Focus'' and depende'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2052
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2046
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Audit compliance of strict issue planning workflow after rol
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2046
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1977
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "chore(memory): remaining memory ecosystem work \u2014 backup/roll"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1977
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1917
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'memory: backup and rollback mechanism for .claude/memory/'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1917
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1899
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Claude: workflow governance sprint (#1839+#1855+#1856+#1782)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1899
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1837
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'MODULE: Pipeline CAPEX cost model (steel + coating + install'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1837
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1833
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'GTM Demo 2: Review findings -- pressure insensitivity at lar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1833
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1751
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(skills): auto-convert pipeline \u2014 detect new agents and "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1751
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1749
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "feat(skills): convert .claude/commands to SKILL.md \u2014 306 com"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1749
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1748
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'feat(skills): convert CAD-DEVELOPMENTS + aceengineer-admin a'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1748
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1736
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore: standardize cross-review verdict format across Codex '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1736
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1734
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore: add domain skills to assethold (tier-1 with 0 skills)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1734
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1733
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore: promote 5 domain-critical skills from CAD-DEVELOPMENT'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1733
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1732
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore: deduplicate 13 skills in achantas-data that are copie'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1732
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1726
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'chore(skills): resurrect 27 dead skills covering active doma'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1726
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1635
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "152 MODERATE docs approaching staleness \u2014 triage and priorit"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1635
+  title: Fix GTM Demo 2 --from-cache path and make GTM validation tes
+  url: https://github.com/vamseeachanta/digitalmodel/issues/512
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1632
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/digitalmodel#524
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: "Test coverage: field_development matplotlib tests \u2014 skipped "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1632
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1630
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "Test coverage: web package Flask integration tests \u2014 require"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1630
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1615
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Schedule download-and-catalog pipeline as recurring cron tas
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1615
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1545
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Agentic feature progression for repo ecosystem productivity '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1545
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1505
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Verify Claude Desktop install: ace-linux-1'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1505
+  title: Add OrcaWave value-level semantic roundtrip regression tests
+  url: https://github.com/vamseeachanta/digitalmodel/issues/524
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1476
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "GWS (Google Workspace CLI) integration \u2014 Gmail, Docs, Sheets"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1476
+- gh: vamseeachanta/digitalmodel#573
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'fix(marine_ops): DNV-RP-F103 calibration drift in test_catho'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/573
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1426
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/digitalmodel#574
+  repo: vamseeachanta/digitalmodel
+  domain: standards
   provider: claude
-  title: Accelerate correction-to-skill promotion pipeline (8% to 40%
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1426
+  title: Wiki standards-page family for FOWT (IEC 61400-3-2, DNV-ST-0
+  url: https://github.com/vamseeachanta/digitalmodel/issues/574
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1352
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'whats-next: targeted index refresh before display + parallel'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1352
+- gh: vamseeachanta/digitalmodel#580
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5066: Production engineering study \u2014 literature, methods"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/580
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1351
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/digitalmodel#581
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-539: feat(digitalmodel/structural): Implement API RP 2A '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/581
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#582
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: "WRK-556: feat(digitalmodel/marine): Implement API RP 2I \u2014 AP"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/582
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#583
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: "WRK-557: feat(digitalmodel/marine): Implement API RP 572 \u2014 A"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/583
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#584
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: "WRK-558: feat(digitalmodel/marine): Implement API RP 2SM \u2014 A"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/584
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#591
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,website
+  provider: codex
+  title: GTM vessel suitability analysis for installation and pipelin
+  url: https://github.com/vamseeachanta/digitalmodel/issues/591
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#597
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: 'chore(repo-structure): classify and relocate B1528 generated'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/597
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#632
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'feat(gtm/parametric): demo_01 DNV-RP-F105 free-span VIV para'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/632
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#635
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'feat(gtm/parametric): demo_04 shallow-water pipelay parametr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/635
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#636
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'feat(gtm/parametric): demo_05 deepwater rigid jumper install'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/636
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#644
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Doris GTM: cathodic protection analysis/requirements for str'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/644
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#645
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "demo_06: CP for offshore structures (jacket/monopile) \u2014 sacr"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/645
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#646
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "demo_07: CP for subsea pipelines \u2014 bracelet-anode design, IS"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/646
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#647
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "demo_08: ICCP design \u2014 rectifier & ground-bed sizing for pla"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/647
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#648
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'demo_09: CP retrofit & remaining-life assessment for aging s'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/648
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#653
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'bug(gtm): demo_01 calc_max_allowable_span silently saturates'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/653
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#689
+  repo: vamseeachanta/digitalmodel
+  domain: workflow
   provider: claude
-  title: Lifecycle HTML still referenced in stage prompts and micro-s
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1351
+  title: 'Epic: roll out output-driven pipeline pattern (Q&A+assumptio'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/689
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#700
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: codex
+  title: 'CI baseline: Quality Gates and broad domain shards fail on m'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/700
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#706
+  repo: vamseeachanta/digitalmodel
+  domain: ci-release
+  provider: codex
+  title: 'CI: split domain baseline diagnostics from touched-domain PR'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/706
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#716
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'fix(orcaflex): refresh spec-library audit and clear known ge'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/716
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#891
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: "UDW intervention-demand model (BSEE well inventory \u2192 rig-day"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/891
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#892
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: HP-MODU fleet supply & demand-crossover model (20K/15K/10K r
+  url: https://github.com/vamseeachanta/digitalmodel/issues/892
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#893
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: Dry-tree vs subsea recovery comparison (Mars Miocene vs Juli
+  url: https://github.com/vamseeachanta/digitalmodel/issues/893
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#899
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: Acquire external UDW rig-fleet & dayrate data (sourced) to b
+  url: https://github.com/vamseeachanta/digitalmodel/issues/899
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#903
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: 'Data-quality guardrail: WAR reporting-lag & OGOR partial-yea'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/903
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1200
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "D2 \u2014 Establish the mooring database"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1200
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1201
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: "D3 \u2014 Establish the pipeline-subsea database"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1201
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1202
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "D4 \u2014 Establish the structural-ffs reference database"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1202
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1203
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: "D5 \u2014 Establish the naval-arch-hydro database"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1203
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1204
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: "D7 \u2014 Establish the materials-standards database"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1204
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1205
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "D9 \u2014 Establish the geotech database (soil profiles, CPT, p-y"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1205
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1206
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: "D12 \u2014 Establish the cad-simulation database (geometry + solv"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1206
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1247
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: "#1199c \u2014 orcaflex riser citation surface (net-new)"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1247
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1248
+  repo: vamseeachanta/digitalmodel
+  domain: knowledge
+  provider: claude
+  title: "#1199d \u2014 result_precedent from ACE_SHARE (T3, frontier)"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1248
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1505
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: 'feature: publish a public synthetic algorithm-run pilot to H'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1505
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1524
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'bug(ansys): detect versioned ansysNNN launchers and require '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1524
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1525
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'feat(ansys): register canonical licensed workflow and integr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1525
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1603
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Define normalized riser analysis cases and public source reg
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1603
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1604
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Build fail-closed riser result release and Hugging Face publ
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1604
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1811
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Catenary solver canonicalization: 8 implementations, 4 numer'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1811
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1819
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(solver-queue): add AQWA runner adapter and schema exten'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1819
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1821
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "infra: live AQWA env access on licensed Windows host \u2014 prere"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1821
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1822
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: 'revise(naval-arch): B1528 SIROCCO force calculation review u'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1822
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1864
+  repo: vamseeachanta/digitalmodel
+  domain: artificial-lift
+  provider: claude
+  title: 'dynacard: classifier has never been scored against a labelle'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1864
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1872
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: Request the UFRN/Nascimento labelled dynacard dataset (50,01
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1872
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1889
+  repo: vamseeachanta/digitalmodel
+  domain: ci-release
+  provider: claude
+  title: 'fix(ci): sustained-load variance assertion is nondeterminist'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1889
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1891
+  repo: vamseeachanta/digitalmodel
+  domain: artificial-lift
+  provider: claude
+  title: 'fix(dynacard): NORMAL/TUBING_MOVEMENT/PLUNGER_UNDERTRAVEL dr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1891
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1894
+  repo: vamseeachanta/digitalmodel
+  domain: artificial-lift
+  provider: claude
+  title: "fix(dynacard): deviation machinery is inert \u2014 survey parsed "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1894
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1923
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: "test: 139 tests hidden by collect_ignore/norecursedirs \u2014 113"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1923
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#113
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "WRK-235: ROADMAP: Repo ecosystem 3-6 month horizon \u2014 plan an"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/113
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#202
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'WRK-687: arch(comp-learning): per-workstation analysis with '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/202
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#209
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-664: feat(work-queue): multi-agent and multi-workstation'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/209
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1019
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "WRK-1272: Enforce 200-line skill limit \u2014 split 293 oversized"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1019
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1276
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: "WRK-5120: Calc report generator \u2014 chart JS validation tests"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1276
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#1297
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: naval-architecture
   provider: claude
   title: "WRK-1382: Naval architect expert skill \u2014 engineering + legal"
   url: https://github.com/vamseeachanta/workspace-hub/issues/1297
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1296
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1525
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: repo
   provider: claude
-  title: "WRK-1379: Naval architecture expert skill \u2014 knowledge synthe"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1296
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#375
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "WRK-306: feat: AI agent readiness check \u2014 claude/codex/gemin"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/375
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#121
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "WRK-5002: Task complexity tier \u2192 model routing (extend task_"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/121
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#92
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "WRK-1288: Review article (trq212 thread) \u2014 identify skill ga"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/92
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#80
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1243: Standardize WRK file structure anatomy across all '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/80
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#76
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1208: [script]: Missing back-link: workspace-hub/workflo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/76
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#74
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1206: fix: recurring correction correction pattern on Ed'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/74
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#73
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1205: fix: recurring correction correction pattern on Wr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/73
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#72
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1201: Create calculation-implementation-workflow orchest'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/72
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#66
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: "WRK-1176: Two-agent pattern \u2014 initializer vs coder session r"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/66
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#65
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1175: Structured progress log for cross-session WRK cont'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/65
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#46
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1116: Extract + integrate website-building skill pattern'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/46
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#31
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'WRK-1001: Workspace cleanup: .claude/, root artifacts, data '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/31
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2626
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'fix(security): narrow #2552 external-contributor runbook tes'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2626
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2557
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(productivity): weekly work-pattern review and flow hac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2557
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2553
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'docs(repo-portfolio): reconcile repository overview docs aft'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2553
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2552
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'docs(security): external contributor and unsolicited paid-he'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2552
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2549
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(business-brain): periodically assess repo work and ref'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2549
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2547
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(client-f): extract useful client information and arch'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2547
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2545
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(client-d): extract useful installation-project informati'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2545
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2539
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(client-b): sanity-check and migrate useful code/'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2539
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2537
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(investments): sanity-check and migrate files to asseth'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2537
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2533
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(repo-portfolio): review and revise mission/objective st'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2533
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2512
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(career): build semiconductor CAD/FEM portfolio and job-'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2512
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2497
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(memory): handoff-doc cross-row SHA transcription hazar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2497
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2483
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(knowledge): populate freshness-cadence matrix with per'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2483
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2379
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(knowledge): generate task and asset explorer views from'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2379
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2351
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "feat(gtm): Day-7/14/21/30 checkpoint dashboard \u2014 surface pla"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2351
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2350
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "verify: #2043 mooring animation render outputs \u2014 confirm pub"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2350
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2349
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "docs(gtm): refresh 30-day plan \u2014 #1809 closed, update depend"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2349
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2347
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'chore(gtm): reconcile stale tracker bodies for #2016, #1669,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2347
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2296
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK: 2026 tax projections \u2014 SKEstates and AceEngineer income"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2296
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2295
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK: 2025 TX franchise No Tax Due + PIR \u2014 SKEstates and AceE"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2295
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2286
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(wiki): promote SIGTTO LNG and mooring publications as b'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2286
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2285
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(wiki): promote API RP 2SK 3rd ed. to mooring wiki domai'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2285
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2284
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(wiki): promote OCIMF MEG3 and MEG4 to mooring wiki doma'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2284
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2283
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(wiki): promote CSA Z276.2-19 to LNG wiki domain'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2283
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2214
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'docs(ai): split current architecture guidance from legacy wr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2214
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2117
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(gtm): resume + cover letter generator for Rigzone appli'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2117
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2038
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(gtm): manim installation sequence / operability envelop'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2038
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2037
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(gtm): manim mooring layout / force explainer animation'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2037
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2035
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(gtm): manim-based engineering explainer pipeline'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2035
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2016
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'feat(gtm): client conversion pipeline -- turn repo capabilit'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2016
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1994
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: '[WRK] Register for GLG, AlphaSights, Guidepoint expert netwo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1994
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1993
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "[WRK] Rigzone job application pipeline \u2014 resume tailoring an"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1993
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1669
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: '[WRK] GTM: Vessel Installation Contractor Email Outreach Cam'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1669
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1610
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: Add opm-common to open-source-engineering-catalog.yaml (rese
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1610
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#207
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-006: Upload videos from iPhone to YouTube'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/207
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#206
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-5093: 2025 SKEstates Inc tax preparation \u2014 C-Corp (Form "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/206
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#205
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-5084: 2025 personal tax preparation \u2014 Vamsee & Sabitha A"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/205
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#204
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-1318: 2025 AceEngineer Inc tax preparation \u2014 C-Corp (For"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/204
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#203
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-TEST-ENSEMBLE: Smoke test for ensemble planning'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/203
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#197
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-665: docs(narada): capture OpenClaw/WhatsApp AI agent se'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/197
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#191
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-632: feat(client-a): chatbot fundamentals \u2014 sha"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/191
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#190
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-626: feat(client-a): engineering AI demo \u2014 calc"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/190
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#184
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-581: feat(worldenergydata): evaluate IEA Methane Tracker'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/184
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#183
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-580: feat(worldenergydata): map open-access journal port'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/183
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#167
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-5094: Real estate tax skill \u2014 CRE tax preparation, depre"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/167
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#166
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-5092: sabithaandkrishnaestates repo \u2014 document indexing "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/166
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#119
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-476: feat(worldenergydata): create ESG/Carbon Emissions '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/119
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#118
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-475: feat(marine_ops): wire Open-Meteo Marine API into w'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/118
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#117
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-470: feat(gtm): oil-and-gas practitioner persona + 1-mon'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/117
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#108
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-148: ACE-GTM: A&CE Go-to-Market strategy stream'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/108
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#98
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-1319: Self-prepared cost segregation study \u2014 15645 Westp"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/98
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#70
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: "WRK-1184: Establish ecosystem theme \u2014 tethering timeless eng"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/70
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#62
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1166: Generator fuel system CP design'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/62
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#61
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1165: Droop control simulator'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/61
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#60
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1164: Power flow / load flow calculator'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/60
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#59
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1163: IEC 61850 GOOSE messaging model'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/59
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#58
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1162: Protection relay coordination module'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/58
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#41
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1096: Add HydroComp NavCad electric-motor resources to w'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/41
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#35
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-1048: CV gap analysis + repo project alignment for Power'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/35
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#17
-  repo: vamseeachanta/workspace-hub
-  domain: business
-  provider: claude
-  title: 'WRK-021: Stock analysis for drastic trend changes, technical'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/17
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2778
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(architecture): lock data/knowledge/result search routin'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2778
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2744
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'epic(mkt-a): client project data-cycle readiness and private '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2744
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2732
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(data-governance): canonical first/second-level mount an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2732
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2731
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(data-governance): inventory and normalize canonical dat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2731
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2714
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'research: Gulf of Mexico production progress + Lower Tertiar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2714
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2691
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "R4 \u2014 Subsea Pipelines: LinkedIn expert mapping (marketing su"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2691
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2680
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "R4 \u2014 Mooring: LinkedIn expert mapping (marketing surface)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2680
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2672
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "R4 \u2014 Hydrodynamics: LinkedIn expert mapping (marketing surfa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2672
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2667
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "Feature: Domain Knowledge Sweep \u2014 systematic multi-source re"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2667
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2651
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: Convert ROGII task brief PPTX to PDF on ace-linux-2 (LibreOf
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2651
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2538
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'ace2: generate lifetime property imagery timelapse for 11511'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2538
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2534
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'chore(ace-drive): retention-gated cleanup for Elements stagi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2534
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2470
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(mkt-a-codes): produce readable source-grounded summaries'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2470
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2402
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(doc-intel): build embeddings index L2+L3 + query CLI (s'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2402
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2403
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "feat(doc-intel): embeddings model-selection spike \u2014 BGE-M3 /"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2403
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2392
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "feat(knowledge): wiki coverage-gap detector \u2014 inventory \xD7 wi"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2392
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2382
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(conformance): add promotion audit-trail checker for L5/'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2382
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2374
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(knowledge): build transient-promotion candidate queue f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2374
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2370
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(knowledge): build closed-issue promotion ledger for eng'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2370
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2363
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(doc-intel): materialize wiki_refs reverse lookup from d'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2363
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2362
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "feat(data): Phase E back-population \u2014 populate doc_key on pr"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2362
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2361
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "refactor(data): rename discovered \u2192 merged_at in scripts/dat"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2361
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2336
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "chore(cron): cadence-report retention policy \u2014 auto-archive "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2336
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2279
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'chore(mkt-a-codes): codify support-artifact defer/reject poli'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2279
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2278
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'chore(mkt-a-codes): reconcile OCIMF MEG fragments misfiled un'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2278
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2277
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(doc-intel): add summary-aware bounded classification wr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2277
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2276
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'chore(doc-intel): reconcile legacy Phase B summary artifacts'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2276
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2133
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'fix(today): research-highlights extraction returns empty for'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2133
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2125
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(llm-wiki): auto-refresh ingestion on new Orcina release'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2125
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2124
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(llm-wiki): extend ingestion to Orcina resources, exampl'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2124
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2103
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'feat(llm-wiki): extend ingestion to AQWA and BEMRosetta docu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2103
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2086
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "feat(subseaiq): normalize year field validation \u2014 reject non"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2086
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2024
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "build: gmail-extract-and-act pipeline \u2014 rewrite gmail-archiv"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2024
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1988
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "feat: Map Google Drive data to git repos \u2014 O&G public, perso"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1988
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1956
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'Phase 2: Deep scan 3,879 .xls binary workbooks with xlrd lib'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1956
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1928
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "Extract 419 marine Excel calculation references \u2192 digitalmod"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1928
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1927
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: Extract SNAME naval architecture knowledge into digitalmodel
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1927
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1926
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: Classify remaining 10K marine docs via PDF content extractio
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1926
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1925
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: Curate 3,683 extracted CSVs into TDD test fixtures for digit
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1925
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1924
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "Execute Phase B summarization \u2014 batch process 394K unsummari"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1924
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1923
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: Build CAD metadata extraction pipeline for 195K marine DWG/D
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1923
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1666
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'Test health dashboard: add historical trend tracking and cov'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1666
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1604
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'Architecture scanner: detect API surface and import dependen'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1604
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1578
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "Automated download-and-catalog pipeline \u2014 discover, download"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1578
+  title: Define canonical repo control-plane contract across workspac
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1525
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1498
+- gh: vamseeachanta/workspace-hub#1681
   repo: vamseeachanta/workspace-hub
-  domain: data
+  domain: ci-release
   provider: claude
-  title: Production sectionproperties module in digitalmodel
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1498
+  title: Supply chain hardening for AI harness updates (#1668 follow-
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1681
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1485
+- gh: vamseeachanta/workspace-hub#1805
   repo: vamseeachanta/workspace-hub
-  domain: data
+  domain: ai
   provider: claude
-  title: Retrofit existing calculation module to use Pint units
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1485
+  title: "Security hardening for AI agent workflows \u2014 skill scanning, "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1805
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1301
+- gh: vamseeachanta/workspace-hub#1962
   repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "WRK-261: BSEE field economics case study \u2014 rebuild on calibr"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1301
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#179
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-554: feat(OGManufacturing/structural): Implement ASTM A3'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/179
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#178
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: "WRK-553: feat(digitalmodel/structural): Implement ASTM A36 \u2014"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/178
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#177
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-552: feat(OGManufacturing/structural): Implement ASTM E7'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/177
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#176
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-551: feat(digitalmodel/structural): Implement ASTM E739 '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/176
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#175
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-550: feat(OGManufacturing/structural): Implement ASTM E4'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/175
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#174
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-549: feat(digitalmodel/structural): Implement ASTM E466 '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/174
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#173
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-548: feat(OGManufacturing/structural): Implement ASTM E6'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/173
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#172
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-547: feat(digitalmodel/structural): Implement ASTM E647 '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/172
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#171
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-546: feat(OGManufacturing/structural): Implement ASTM E6'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/171
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#170
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-545: feat(digitalmodel/structural): Implement ASTM E606 '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/170
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#169
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-542: feat(OGManufacturing/structural): Implement ASTM A1'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/169
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#168
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-541: feat(digitalmodel/structural): Implement ASTM A131 '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/168
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#57
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-1152: Collect and download electrical engineering resour'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/57
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2774
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Private llm-wiki corpus-ingest program (post-2026-05-20 priv
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2774
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2768
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'epic(ocimf): close out MEG3/MEG4 coefficient ingestion and r'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2768
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2760
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'revise(naval-arch): B1528 proj-a force calculation review u'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2760
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2736
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'design: migration plan from per-provider memory stores (Clau'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2736
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2735
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'design: memory write/read API for non-Hermes providers (Clau'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2735
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2711
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(provider-data): service-provider data library \u2014 Helix 1"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2711
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2694
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Epic: Cross-domain duplicate-implementation cleanup (catenar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2694
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2693
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R6 \u2014 Subsea Pipelines: Coverage map synthesis + gap subissue"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2693
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2692
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R5 \u2014 Subsea Pipelines: Comprehensive code coverage audit (di"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2692
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2690
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R3 \u2014 Subsea Pipelines: Industry practice (OMAE/ISOPE/OPT, Su"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2690
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2689
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R2 \u2014 Subsea Pipelines: Academic sources sweep (Bai & Bai, Pa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2689
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2688
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R1 \u2014 Subsea Pipelines: Standards & Codes inventory (DNV-OS-F"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2688
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2687
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Domain Sweep: Subsea Pipelines (design, installation, integr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2687
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2686
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Catenary solver canonicalization: 8 implementations, 4 numer'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2686
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2682
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R6 \u2014 Mooring: Coverage map synthesis + gap subissue spawning"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2682
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2681
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R5 \u2014 Mooring: Code coverage audit (digitalmodel + citation p"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2681
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2679
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R3 \u2014 Mooring: Industry practice (Vryhof, Bridon, MIRP, OMAE "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2679
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2678
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R2 \u2014 Mooring: Academic sources (Vryhof, OSIG, Aubeny, anchor"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2678
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2677
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R1 \u2014 Mooring: Standards & Codes inventory (DNV-OS-E301, API "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2677
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2676
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Domain Sweep: Mooring Design (catenary, taut, DP-assist, sta'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2676
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2674
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R6 \u2014 Hydrodynamics: Coverage map synthesis + gap subissue sp"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2674
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2673
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R5 \u2014 Hydrodynamics: Comprehensive code coverage audit (digit"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2673
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2671
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R3 \u2014 Hydrodynamics: Industry practice (conferences, journals"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2671
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2670
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R2 \u2014 Hydrodynamics: Academic sources sweep (Journ\xE9e, Faltins"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2670
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2669
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "R1 \u2014 Hydrodynamics: Standards & Codes inventory (API, DNV, I"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2669
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2668
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Domain Sweep: Offshore Hydrodynamics (RAOs, motion analysis,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2668
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2640
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(gtm): worldenergydata production decline forecast \u2014 sha"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2640
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2625
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "investigate(digitalmodel-tests): Cluster E \u2014 marine-engineer"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2625
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2624
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "policy(digitalmodel-tests): Cluster D \u2014 decide whether redis"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2624
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2623
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "fix(digitalmodel-tests): Cluster A \u2014 sys.modules pollution l"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2623
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2609
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'tracker(digitalmodel-tests): post-#543 main has 244+ broken '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2609
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2585
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'tracker(digitalmodel-tests): 26 collect_ignore entries from '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2585
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2558
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'data(field-dev): primary-source GoM equipment/cost source pa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2558
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2516
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(digitalmodel): flexible pipe and dynamic riser cross-se'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2516
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2513
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(knowledge): catalogue offshore wind and oil gas subsea '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2513
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2510
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(cad): build Python layout/CAD automation demo for chip/'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2510
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2509
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(eda): create reproducible OpenLane/OpenROAD RTL-to-GDS '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2509
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2507
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Feature: semiconductor chip-design CAD/FEM career lane'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2507
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2491
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Extend pyramid-conformance-check.py DT1_REQUIRED_FIELDS to i
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2491
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2474
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(canonical-spec): add OrcaFlex native reverse-parser equ'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2474
+  domain: repo
+  provider: codex
+  title: "FEATURE: Tier-1 Repo Ecosystem Refactoring \u2014 audit, plan, ex"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1962
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2473
+- gh: vamseeachanta/workspace-hub#1989
   repo: vamseeachanta/workspace-hub
-  domain: engineering
+  domain: ai
   provider: claude
-  title: 'feat(canonical-spec): prove OrcaWave-to-OrcaFlex hydrodynami'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2473
+  title: "insight: GitGuardian alert \u2014 secret exposed in workspace-hub"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1989
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2472
+- gh: vamseeachanta/workspace-hub#2067
   repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(canonical-spec): validate CALM/SPM buoy OrcaFlex semant'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2472
+  domain: knowledge
+  provider: codex
+  title: 'feat(knowledge): wire .planning/research into engineering wi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2067
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2454
+- gh: vamseeachanta/workspace-hub#2143
   repo: vamseeachanta/workspace-hub
-  domain: engineering
+  domain: ai
   provider: claude
-  title: 'feat(canonical-spec): validate flagship generic-track OrcaFl'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2454
+  title: Track security remediation for archived simpledigitalmarketi
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2143
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2355
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'chore(website): pin Node engines in aceengineer-website pack'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2355
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2329
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Engineering methodology: code-first vs GUI CAD for offshore '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2329
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2328
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "CAD-DEVELOPMENTS: comparison \u2014 CadQuery vs build123d vs Repl"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2328
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2327
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'digitalmodel: CadQuery spike for parametric offshore geometr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2327
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2325
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Design conference-corpus enrichment (successor to #2305 defe'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2325
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2287
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(architecture): assess LR and Noble Denton corpus for do'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2287
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2267
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'chore(sync): add regression coverage for stale gitlink and m'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2267
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2265
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'chore(rebase): audit skipped hardening commits from backup/p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2265
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2220
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "chore(repos): clean up dirty repo state \u2014 gitignore fixes + "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2220
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2219
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "chore(sync): resolve main branch divergence \u2014 9 local vs 134"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2219
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2114
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(gtm): VIV demo notebook \u2014 freespan walkthrough for pipe"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2114
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2112
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'data(field-dev): backfill SubseaIQ equipment counts to unblo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2112
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2085
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'fix(field-dev): timeline._stats() type annotation and empty-'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2085
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2084
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(field-dev): add regional segmentation to architecture p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2084
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2082
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'test(field-dev): add sparse/edge-case coverage to architectu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2082
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2081
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): add decline_sensitivity() sweep \u2014 NPV vs de"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2081
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2079
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(field-dev): make recovery_factor configurable on Econom'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2079
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2076
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'bug(field-dev): string decline_type bypasses EUR auto-derive'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2076
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2055
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(field-dev): subsea cost benchmarking from SubseaIQ equi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2055
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2041
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'chore: add LaTeX to manim-env for MathTex rendering'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2041
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2032
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'TASK: Write HLV and pipelay vessel spec JSON files from rese'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2032
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2029
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'TASK: Run YML + Excel inventory script locally to produce ca'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2029
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2006
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "audit(worldenergydata): 14000+ orphan modules \u2014 triage for a"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2006
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2005
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'audit(digitalmodel): worldenergydata test collection timeout'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2005
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2003
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Fix 5 failing tests in worldenergydata \u2014 test suite cleanup "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2003
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1972
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Test coverage uplift: integration tests for overnight module'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1972
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1960
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Implement seakeeping module \u2014 6-DOF motion analysis"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1960
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1959
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Implement OpenTURNS fatigue reliability analysis module
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1959
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1958
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Build slim-hole well engineering module \u2014 casing program com"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1958
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1957
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Implement DWG/DXF parser for CAD text extraction (ezdxf + OD
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1957
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1955
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Phase B: Summarize 27,735 extracted conference documents at '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1955
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1954
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Full text extraction of 27,735 conference files using fixed '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1954
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1953
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Batch 2: Convert FDAS Riser Engineering workbooks via Window'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1953
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1940
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 6: Shell Perdido + VMCast + Production Eng Library \u2014 7"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1940
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1939
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 5: Talos Venice Umbilical Installation \u2014 31 workbooks"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1939
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1938
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 4: SCR Design DNV F201 + Wall Thickness \u2014 18 workbooks"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1938
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1937
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 3: Installation Engineering References \u2014 18 workbooks"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1937
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1936
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 2: FDAS Riser Engineering \u2014 20+ workbooks"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1936
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1935
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Batch 1: Ballymore Jumper Lift + Mudmat Analysis \u2014 10 workbo"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1935
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1934
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "FEATURE: Excel-to-Code Conversion Pipeline \u2014 100 workbooks v"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1934
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1933
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "INVENTORY: Excel Workbook Conversion Registry \u2014 50 workbooks"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1933
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1932
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'INVENTORY: Complete OrcaFlex/OrcaWave model catalog (3,524 Y'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1932
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1929
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'PHASE 2: Deep scan 3,879 .xls workbooks with xlrd library'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1929
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1913
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Codex: test coverage + bounded implementation sprint \u2014 4 pri"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1913
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1912
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Claude: implementation sprint \u2014 field dev, naval arch, dark-"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1912
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1908
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Codex: test coverage + bounded implementation sprint (#1824+'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1908
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1905
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'DATA: Rigid jumper OrcaFlex model + input workbook for model'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1905
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1904
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'INVENTORY: Complete OrcaFlex/OrcaWave model and Excel workbo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1904
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1898
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Claude: naval architecture expansion sprint (#1850+#1851+#18'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1898
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1897
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Claude: field development system implementation sprint (#184'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1897
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1891
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "data: index 5,655 migrated DDE literature PDFs \u2014 Phase A ext"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1891
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1889
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: uplift digitalmodel test coverage 20% -> 50% \u2014 d"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1889
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1888
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "data: run doc-intelligence Phase B \u2014 summarize OTC/OMAE/DOT "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1888
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1887
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "data: Phase A conference indexing \u2014 ISOPE, SPE, and remainin"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1887
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1877
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Back-test engineering commits for workflow compliance
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1877
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1866
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(field-dev): worldenergydata unified production client a'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1866
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1861
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "data: build SubseaIQ-to-field-development bridge \u2014 concept s"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1861
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1859
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(naval-arch): integrate worldenergydata vessel fleet + h'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1859
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1854
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(naval-arch): tonnage and regulatory calculations \u2014 GT/N"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1854
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1853
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(naval-arch): complete curves_of_form.py \u2014 hydrostatic t"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1853
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1852
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(naval-arch): trim and ballast optimization \u2014 minimize f"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1852
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1851
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(naval-arch): gyradius calculator \u2014 mass distribution, r"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1851
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1850
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(naval-arch): floating platform stability \u2014 FPSO, semi-s"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1850
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1849
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "epic: naval architecture expansion \u2014 floating platforms, cla"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1849
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1848
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(field-dev): wire existing scattered modules into integr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1848
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1847
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): subsea architecture optimizer \u2014 tieback dis"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1847
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1846
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): facility sizing \u2014 separator, compressor, wa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1846
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1845
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): production profile generator \u2014 decline curv"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1845
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1844
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): CAPEX/OPEX estimation models \u2014 parametric c"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1844
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1843
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(field-dev): concept selection framework \u2014 hub vs standa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1843
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1842
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "epic: field development analysis system \u2014 concept selection,"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1842
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1841
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(geotechnical): offshore gaps \u2014 lateral piles, mudmats, "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1841
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1840
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(geotechnical): onshore foundations \u2014 shallow foundation"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1840
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1836
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'MODULE: Shore approach analysis (HDD, trenching, pull-in)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1836
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1835
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'MODULE: On-bottom stability analysis (DNV-RP-F109)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1835
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1834
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'SKILL: Field Development Pipeline Engineering -- pipe sizing'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1834
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1830
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'review and close solver queue bug fixes #1703-#1706'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1830
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1829
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: RAO comparison plots for L02 OC4 semi-sub (multi-column geom
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1829
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1828
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: populate RAODatabase from all existing .xlsx fixtures (5 geo
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1828
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1826
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'dark-intel: rebuild stale specs/module-registry.yaml as cano'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1826
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1824
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: uplift digitalmodel test coverage 2.95% \u2192 20% us"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1824
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1818
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'dark-intel: extract riser engineering priority files from /m'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1818
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1815
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: promote flowback calculator extraction \u2192 digital"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1815
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1814
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: promote API RP 2GEO alpha method archive \u2192 digit"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1814
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1813
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: promote surface wellhead SITP calculation \u2192 digi"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1813
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1812
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: promote conductor length assessment \u2192 digitalmod"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1812
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1811
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "dark-intel: promote SN curve POC v2 output \u2192 digitalmodel/fa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1811
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1810
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "epic: dark intelligence Excel-to-code promotion \u2014 extract 3,"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1810
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1799
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'DATA: Collect public pipelay barge/vessel specs for shallow '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1799
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1798
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'DATA: Collect public construction/heavy-lift vessel specs fo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1798
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1797
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(freespan): link to OrcaFlex rigid jumper VIV workflow ('
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1797
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1796
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(freespan): strake and SCF corrections for VIV fatigue d'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1796
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1795
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(freespan): trench depth correction for CF onset velocit'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1795
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1794
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(freespan): turbulence intensity and wave spreading redu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1794
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1793
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(freespan): wire wave_velocity into facade \u2014 auto-comput"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1793
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1792
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "feat(freespan): GTM demo notebook \u2014 free-span VIV assessment"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1792
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1788
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'OrcaFlex .sim snapshot testing: HTML report from minimal_tes'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1788
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1702
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'cathodic_protection: consolidate marine_cp.py and marine_str'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1702
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1701
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "ANSYS package: Calculation examples \u2014 pressure vessel, flang"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1701
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1700
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'cathodic_protection: ICCP vs SACP comparison tool and cost o'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1700
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1699
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'cathodic_protection: cross-module integration tests and edge'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1699
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1698
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "ANSYS package: Solver queue integration \u2014 dispatch FEA jobs "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1698
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1696
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'cathodic_protection: integration examples and YAML-driven CP'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1696
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1695
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "ANSYS package: YAML-based pipeline spec \u2014 define full FEA wo"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1695
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1694
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Fatigue post-processor: OrcaFlex time-history \u2192 rainflow \u2192 S"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1694
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1691
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Fatigue TDD Phase 2: test coverage for plotting, multiaxial,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1691
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1689
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "ANSYS package: Promote to PRODUCTION maturity \u2014 docstring au"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1689
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1687
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Docstring uplift wave 3 \u2014 complete infrastructure/ coverage "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1687
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1686
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "ANSYS package: Integration test suite \u2014 end-to-end pressure "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1686
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1667
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Reservoir package: add well correlation and facies analysis '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1667
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1662
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Module status matrix: PRODUCTION promotion campaign \u2014 16 DEV"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1662
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1657
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Resolve 179 cross-package API name collisions \u2014 top 20 worst"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1657
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1646
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Docstring uplift wave 3 \u2014 solvers, hydrodynamics, specialize"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1646
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1645
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Docstring uplift wave 2 \u2014 web, reservoir, infrastructure, ma"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1645
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1637
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Parametric spec generator: multi-dimensional sweep combinati'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1637
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1636
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'OrcaWave reporting: section-level unit tests for all 7 secti'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1636
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1620
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Clone and pip-install BEMRosetta, pyHAMS, OCEANLYZ, wavespec
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1620
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1613
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Cross-reference resource registry with standards transfer le
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1613
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1611
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Fill domain gaps in resource registry \u2014 orcawave, fatigue, s"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1611
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1609
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Automated resource download pipeline \u2014 execute top-priority "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1609
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1602
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Promote DEVELOPMENT packages toward PRODUCTION maturity \u2014 do"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1602
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1601
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Add tests for parametric_hull_analysis: forward_speed, shall'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1601
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1600
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Cross-tool structural comparison framework \u2014 2D solver vs Or"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1600
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1594
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Design Load Case (DLC) matrix generator for OrcaFlex mooring
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1594
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1593
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Automated WAMIT validation runner for L00 test cases
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1593
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1591
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Seed hull registry with standard hull forms (barge, tanker, '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1591
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1587
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Promote near-PRODUCTION packages: add docstrings to asset_in'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1587
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1579
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Audit /mnt/ace for undiscovered resources not in any index
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1579
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1572
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Domain-specific capability roadmaps \u2014 OrcaWave/OrcaFlex, str"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1572
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1567
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "Feature: Continuous Repo Architecture Intelligence \u2014 automat"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1567
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1478
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: FFmpeg skill for simulation output and media processing
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1478
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1465
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: '[Template] Prospect - [Company Name] - [Contact Name]'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1465
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1326
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5138: Fix Gemini cross-review NO_OUTPUT \u2014 CLI returns ex"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1326
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1322
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1392: 3D interactive frame viewer (HTML/three.js)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1322
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1320
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-1378: Regulatory compliance engine \u2014 IMO/ABS/DNV automat"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1320
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1310
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5121: FEM visualization skill \u2014 automate ccx results to "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1310
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1308
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-5115: Custom GitHub CLI bash tools for session-cycle eff'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1308
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1300
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1392: 3D interactive frame viewer (HTML/three.js)'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1300
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1282
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-5124: INP writer: validate beam element/section compatib'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1282
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1279
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5123: CalculiX plate-with-hole test fix \u2014 2 pre-existing"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1279
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1278
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5122: Calc report generator \u2014 auto-embed images as base6"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1278
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1276
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5120: Calc report generator \u2014 chart JS validation tests"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1276
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1275
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5119: CalculiX beam cross-section tests \u2014 CIRC and PIPE "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1275
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1274
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-5118: CalculiX B32 quadratic beam integration test with '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1274
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1267
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1368: Pipeline and engineering report'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1267
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1266
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1367: Member and connection checks'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1266
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1265
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1366: 2D vs 3D comparison'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1265
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1262
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1363: 2D frame analysis'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1262
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1260
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1361: 2D engineering drawing'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1260
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1242
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-5082: Parachute frame force calculation \u2014 drag car parac"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1242
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#604
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-560: docs(digitalmodel): add calc_examples mapping \u2014 pip"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/604
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#601
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-460: feat(assetutilities/calculations): implement Allen,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/601
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#569
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-444: feat(assetutilities/calculations): implement Vandiv'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/569
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#192
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-634: feat(workspace-hub): client roadshow brochures \u2014 cl"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/192
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#91
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-1287: Document extraction pipeline \u2014 index repo ecosyste"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/91
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#33
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1027: DNV-RP-B401 real-world benchmark validation: GOM j'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/33
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#29
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-099: Run 3-way benchmark on Unit Box hull'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#28
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-075: OFFPIPE Integration Module \u2014 pipelay cross-val'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#27
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-050: Hardware consolidation \u2014 inventory, assess, re'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/27
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#24
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-046: OrcaFlex drilling and completion riser parametric a'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/24
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#23
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-045: OrcaFlex rigid jumper analysis - stress and VIV for'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/23
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#22
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-043: Parametric hull form analysis with RAO generation a'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/22
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#21
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-039: SPM project benchmarking - AQWA vs OrcaFlex'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/21
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#20
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-036: OrcaFlex structure deployment analysis - supply boa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/20
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#19
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-032: Modular OrcaFlex pipeline installation input with p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/19
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#18
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-023: Property GIS development timeline with future proje'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/18
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#14
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-1251: FreeCAD deep parametric engineering \u2014 hull generat"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/14
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#13
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-1149: Method assessment and selection \u2014 propeller-rudder"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/13
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2776
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Cross-wiki linking discipline \u2014 supersede stale governance +"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2776
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2765
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(operations): add scheduler parity report for system cro'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2765
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2764
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'fix(operations): harden Hermes session exporter for undated '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2764
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2763
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'plan(operations): migrate gsd-researcher scheduled AI work t'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2763
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2762
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'plan(operations): define Hermes-vs-system cron scheduler rou'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2762
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2750
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Hermes: integrate pre-completion-cleanup-audit into sub-agen'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2750
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2749
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Compliance alert: W21 \u2014 50% (medium)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2749
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2741
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'test(hermes): validate Telegram dispatch smoke tests and des'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2741
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2723
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(enforcement): clean up dead code in .git/hooks/pre-com'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2723
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2721
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'fix(review-tools): submit-to-codex.sh silently degrades in n'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2721
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2718
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "audit(hermes): kanban-worker dispatch hazards \u2014 parallel-spa"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2718
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2713
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'infra: gemini 0.42.0 headless mode reports run_shell_command'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2713
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2710
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "feat(solver-queue): conversational submit UX \u2014 /solver-submi"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2710
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2707
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "chore(skills): curation judgments \u2014 single-skill stragglers,"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2707
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2704
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "spike(doc-intel): cloud embeddings comparison \u2014 Voyage + Ope"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2704
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2701
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'audit(harness): 17 status:plan-approved issues missing .plan'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2701
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2695
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(harness): /goal use-case catalog for repo ecosystem (cl'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2695
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2665
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(kanban): provider-credit approval dashboard and dispatc'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2665
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2664
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "feat(workflow): HTML PR explainer artifact (author-side) \u2014 d"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2664
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2660
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Compliance alert: W20 \u2014 0% (critical)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2660
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2657
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(provider-session): remediate Hermes llm-wiki spinout p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2657
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2656
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(repo-structure): normalize workspace-hub folder/file s'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2656
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2652
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Daily repo readiness tracker
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2652
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2647
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'ANNOUNCE: llm-wiki spinout in progress (parallel-session hea'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2647
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2634
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Compliance alert: W19 \u2014 35% (high)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2634
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2628
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'epic(digitalmodel-ci): domain-divided CI architecture replac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2628
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2572
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Routine: /repo-sync + /mnt/local-analysis cleanup audit (eve'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2572
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
 - gh: vamseeachanta/workspace-hub#2563
   repo: vamseeachanta/workspace-hub
   domain: harness
@@ -8118,2020 +1235,3253 @@ cards:
   url: https://github.com/vamseeachanta/workspace-hub/issues/2563
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2525
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2628
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: testing
   provider: claude
-  title: 'feat(provider-usage): codex expiring-credit burn-down contro'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2525
+  title: 'epic(digitalmodel-ci): domain-divided CI architecture replac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2628
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2524
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2694
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(orchestration): add machine-aware dispatch ledger and r'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2524
+  domain: repo
+  provider: codex
+  title: 'Epic: Cross-domain duplicate-implementation cleanup (catenar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2694
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2520
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2733
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: knowledge
   provider: claude
-  title: 'fix(workstations): repair and gate ace-linux-2 GitHub auth b'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2520
+  title: 'epic: make Hermes agent memory canonical across all AI provi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2733
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2519
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2737
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: 'feat(hermes): orchestrate AI provider usage and workstation '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2519
+  title: 'feat(hermes): enable Telegram/Hermes control-surface dispatc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2737
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2517
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2738
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: "Compliance alert: W18 \u2014 42% (high)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2517
+  title: 'feat(hermes): harden ace-linux-1 Telegram gateway as dispatc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2738
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2501
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2751
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: "chore(planning): #2105 governance-lock \u2014 handoff vs live-sta"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2501
+  title: 'Cross-platform harness setup: integrate AI-provider bootstra'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2751
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2500
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2754
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: 'chore(harness): #2476 non-standard approval pattern (no plan'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2500
+  title: 'throughput(workstations): activate ace-linux-1 provider/mach'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2754
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2499
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2778
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: repo
   provider: claude
-  title: 'chore(harness): #2368 missing revision-bound approval marker'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2499
+  title: 'feat(architecture): codify retrieval-time wiki-sibling routi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2778
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2498
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2779
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: testing
   provider: claude
-  title: 'chore(harness): #2364 plan branch drift recovery decision ne'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2498
+  title: 'Security: shell=True + f-string injection in git_manager.py '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2779
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2496
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2780
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: testing
   provider: claude
-  title: 'chore(routines): use $(date -u) substitution in execution-ag'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2496
+  title: 'Bug: gate_pass_review.sh subshell counter always REJECTS (2 '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2780
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2485
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2781
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "feat(enforcement): mechanical linter + ledger for llm-wiki \u2192"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2485
+  domain: testing
+  provider: codex
+  title: 'Security: workspace-wide yaml.Loader/pickle/eval/exec + SQLi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2781
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2484
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2783
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: testing
   provider: claude
-  title: 'feat(knowledge): extend staleness-scanner to cover yaml regi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2484
+  title: 'Review remediation: workspace-hub repo-specific findings (20'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2783
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2447
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2816
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: "Residual #2045 gaps \u2014 CODEX.md legacy WRK ref + GEMINI.md de"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2447
+  title: "feat(workstations): collect-equality.ps1 \u2014 accurate Windows "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2816
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2445
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2852
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: Implement bypass-rollback advisor and post-commit observer p
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2445
+  title: 'feat(workstations): real solver license probe on licensed-wi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2852
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2431
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2878
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: "Compliance alert: W17 \u2014 20% (critical)"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2431
+  title: "Kanban: reorganize boards by domain \u2192 subdomain (right-size "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2878
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2427
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2933
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'bug(ci): baseline-check.yml references deleted shell tests, '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2427
+  title: 'Deckhand gateway availability: keep Hermes gateway always-on'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2933
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2425
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2975
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: knowledge,governance
   provider: claude
-  title: 'meta(ai-orchestration): Claude Code CLI integration rollout '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2425
+  title: 'standard: ecosystem wiki flywheel manifest, provenance, and '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2975
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2421
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3013
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: knowledge,governance
   provider: claude
-  title: 'chore(control-plane): normalize workspace-hub provider entry'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2421
+  title: 'standard: ecosystem wiki flywheel validator and public-egres'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3013
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2416
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3026
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: 'fix(ecosystem-sync): use annotated tagger date for release f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2416
+  title: 'ace-linux-2: gnome-shell crash recovery (2026-06-10) + /dev/'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3026
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2415
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3063
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'fix(ecosystem-sync): ignore fenced code blocks when extracti'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2415
+  title: 'uv-workflow(assetutilities): register all 17 routed transfor'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3063
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2414
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3064
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'test(ecosystem-sync): autobuild or skip missing local git fi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2414
+  title: 'uv-workflow(worldenergydata): clean-clone verify all 9 + off'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3064
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2412
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3065
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'feat(release-readiness): deterministic follow-up issue creat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2412
+  title: 'uv-workflow(digitalmodel): register dm#711 backlog lanes + w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3065
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2410
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3282
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'feat(release-readiness): smoke-battery schema and runner con'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2410
+  title: 'wf-api(assetutilities): ResultEnvelope + run_workflow() + re'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3282
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2409
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3283
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(release-readiness): fixture-backed golden-task corpus f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2409
+  domain: workflow
+  provider: codex
+  title: "wf-api(ecosystem): determinism harness \u2014 provenance stamp + "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3283
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2404
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3285
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(doc-intel): MCP server audit log + hardened allowlist +'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2404
+  domain: workflow
+  provider: codex
+  title: 'wf-api(digitalmodel): adopt ResultEnvelope + schemas + golde'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3285
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2401
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3291
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ci-release
   provider: claude
-  title: "feat(doc-intel): MCP server multi-agent registration \u2014 Claud"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2401
+  title: 'seamless(ci): uv caching across assetutilities / assethold /'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3291
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2400
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3294
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ai
   provider: claude
-  title: "feat(doc-intel): MCP server core \u2014 doc_key_lookup, wiki_sear"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2400
+  title: 'seamless(review): make adversarial-review dispatchers run he'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3294
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2399
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3295
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'feat(ai-orchestration): define next-model-release readiness '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2399
+  title: 'seamless(contract): reconcile registry schema_version into a'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3295
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2397
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3297
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'epic(repo-organization): canonical folder structure and refa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2397
+  domain: workflow
+  provider: codex
+  title: "wf-api(assetutilities): make the engine embeddable \u2014 injecte"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3297
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2387
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3307
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(governance): cross-ref cleanup for 4 predecessor issue'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2387
+  domain: workflow
+  provider: codex
+  title: "wf-api(digitalmodel): engine embed-port \u2014 mirror #3297 for d"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3307
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2386
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3372
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workspace-backup
   provider: claude
-  title: 'chore(tests): move session-analysis fixtures out of gitignor'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2386
+  title: 'feat(backup): redundancy & backup policy for critical data ('
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3372
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2385
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3373
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workspace-backup
   provider: claude
-  title: "chore(harness): consolidate dual session-signals stores \u2014 .c"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2385
+  title: 'feat(gdrive): cloud-sunset (~6mo) with verified local-of-rec'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3373
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2384
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3416
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: repo
   provider: claude
-  title: 'feat(governance): add promotion-aware recurring-run output p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2384
+  title: 'chore(landman-desk): establish the private application repos'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3416
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2383
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3417
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: security
   provider: claude
-  title: 'feat(conformance): implement GUARD-1 invented-layer detector'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2383
+  title: 'security(landman-desk): enforce private records, role access'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3417
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2381
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3418
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(governance): add computable expiration metadata to ses'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2381
+  domain: workflow
+  provider: codex
+  title: 'feat(landman-desk): turn project intake into an assigned tra'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3418
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2377
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3419
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(harness): add missing session-signal event emitters to '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2377
+  domain: governance
+  provider: codex
+  title: 'feat(landman-desk): build the tract evidence ledger and exce'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3419
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2376
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3420
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "feat(harness): provider assessment \u2014 corpus-honest subset (d"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2376
+  domain: testing
+  provider: codex
+  title: 'feat(landman-desk): add reviewer QA, exception disposition, '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3420
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2359
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3421
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(plugins): remove or fix failing semantic-scholar-mcp i'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2359
+  domain: content
+  provider: codex
+  title: 'feat(landman-desk): export a broker-ready reviewed diligence'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3421
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2356
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3422
   repo: vamseeachanta/workspace-hub
   domain: harness
-  provider: claude
-  title: 'feat(ci): add GH Actions workflow to run npm test on aceengi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2356
+  provider: codex
+  title: 'feat(landman-desk): connect pilot county and federal-acreage'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3422
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2353
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3424
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(enforcement): port queue-git-tracked rule to solver que'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2353
+  domain: skills
+  provider: codex
+  title: '[skills] Add transactional metadata-only folder-note publica'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3424
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2345
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3426
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: "feat(gtm): wire GTM demos into unified smoke runner \u2014 preven"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2345
+  title: 'feat(governance): deploy completeness closeout contract to w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3426
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2339
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3428
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: 'Ecosystem: canonical .gitignore fragment + propagation for C'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2339
+  title: 'standard: deterministic run identity and algorithm version c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3428
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2332
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3429
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: 'chore(harness): drive provider-audit bare-python3 debt to ca'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2332
+  title: 'standard: content-addressed artifact and Hugging Face reside'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3429
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2331
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3430
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: Review and clean up stale .gemini/gsd-local-patches/ directo
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2331
+  title: 'standard: replayable public input and source snapshot contra'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3430
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2330
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3431
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: Verify first run of daily-repo-readiness cron (trig_019GWtRo
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2330
+  title: 'standard: curated output and rolling algorithm report contra'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3431
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2312
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3432
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: 'chore(harness): replace legacy local lifecycle-script guidan'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2312
+  title: 'standard: algorithm-specific metric definition and observati'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3432
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2310
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3433
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'analysis(harness): rank Claude stale-read migration-debt bac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2310
+  domain: governance
+  provider: codex
+  title: 'feature: per-repository Hugging Face projection and staged p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3433
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2301
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3434
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: governance
   provider: claude
-  title: 'bug(hermes): classify and recover from openai-codex transpor'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2301
+  title: 'feature: algorithm-scoped cross-run insights and decision br'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3434
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2300
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3439
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: security
   provider: claude
-  title: 'feat(governance): reconcile GitHub labels, approval markers,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2300
+  title: Audit descriptor-relative readers for FIFO blocking before f
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3439
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2299
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3442
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: testing
   provider: claude
-  title: 'chore(plans): make retention metadata a required planning ar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2299
+  title: Track Codex CLI 0.144 stdin regression in cross-review harne
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3442
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2298
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3443
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workflow
   provider: claude
-  title: 'feat(portability): phase-2 unified smoke runner expansion fo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2298
+  title: 'governance(legal): define repo-posture scanner profiles and '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3443
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2297
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3453
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'feat(portability): schedule unified smoke drift detection af'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2297
+  title: 'bug(cleanup): daily cleanup assumes nested repos and purges '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3453
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2293
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3456
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: security
   provider: claude
-  title: 'fix(wiki-ingest): make nightly ingest idempotent and push-st'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2293
+  title: 'security(local-analysis): make parent runtime-config permiss'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3456
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2291
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3458
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'fix(cron-health): harden failure detection and align task ev'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2291
+  title: 'bug(cleanup): make archive manifests safe for tabs, newlines'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3458
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2258
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3461
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'feat(parity): track Claude plugin inventory in ai-tools-stat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2258
+  title: 'bug(validation): make staged evidence handshakes resumable a'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3461
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2256
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3467
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ai
   provider: claude
-  title: 'feat(operations): automate session-exit handoff generation f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2256
+  title: Build an independent retained-input bootstrap for structured
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3467
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2255
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3498
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: 'feat(governance): reconcile GitHub plan-approval labels with'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2255
+  title: "Machine-ecosystem map: roles, data-source access, services \u2014"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3498
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2254
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3499
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: 'fix(provider-telemetry): improve Claude and Gemini quota obs'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2254
+  title: Zero-touch repo hygiene on all headless nodes (generalized f
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3499
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2238
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3500
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: repo
   provider: claude
-  title: 'feat(conformance): add closed-issue citation guardrail so du'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2238
+  title: 'bug(pre-push): equivalence-state publish loops full tier-1 s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3500
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2237
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3549
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations,security
   provider: claude
-  title: 'feat(automation): build transient-artifact cleanup and archi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2237
+  title: 'feat(ops): registry-driven Linux connection helpers with TDD'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3549
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2236
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3560
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(workflow): add post-closure promotion step to issue-pl'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2236
+  domain: ai
+  provider: codex
+  title: 'fix(review): isolate in-progress provider sinks and fail clo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3560
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2235
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3610
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: structural
   provider: claude
-  title: 'chore(plans): add retention metadata section to issue plan t'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2235
+  title: "WRK-634: feat(workspace-hub): client roadshow brochures \u2014 cl"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3610
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2234
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3673
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(workflow): update session-start-routine to treat hando'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2234
+  domain: pipeline
+  provider: codex
+  title: 'WRK-1368: Pipeline and engineering report'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3673
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2233
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3674
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(knowledge): add  frontmatter field to wiki schema and v'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2233
+  domain: pipeline
+  provider: codex
+  title: 'WRK-1367: Member and connection checks'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3674
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2232
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3675
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(memory-health): surface stale or missing session-log po'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2232
+  domain: structural
+  provider: codex
+  title: 'WRK-1366: 2D vs 3D comparison'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3675
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2231
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3676
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'test(memory): add regression coverage for session-log portab'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2231
+  domain: marine
+  provider: codex
+  title: 'WRK-1365: OrcaFlex frame analysis'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3676
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2230
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3677
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(claude-config): formalize managed-template vs active-s'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2230
+  domain: structural
+  provider: codex
+  title: 'WRK-1363: 2D frame analysis'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3677
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2224
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3678
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Codex: reduce stale warning churn in provider-health after l'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2224
+  domain: structural
+  provider: codex
+  title: 'WRK-1361: 2D engineering drawing'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3678
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2223
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3682
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: subsea
   provider: claude
-  title: Plan and execute safe origin/main integration for blocked wo
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2223
+  title: 'WRK-598: feat(product): build engineering chatbot for oil & '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3682
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2218
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3685
   repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'fix(harness): reduce false positives in issue-hygiene duplic'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2218
+  domain: repo
+  provider: codex
+  title: 'WRK-1320: Benchmark Docling on ace-linux-2 GPU (T400 4GB) an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3685
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2217
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3694
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: repo-cleanup
   provider: claude
-  title: 'fix(harness): harden issue-hygiene repo-reality path extract'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2217
+  title: "chore(repo): reconcile llm-wiki-mkt-a \u2192 llm-wiki-acma rename"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3694
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2215
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3728
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ci-release
   provider: claude
-  title: 'feat(analysis): add migration-debt trend snapshots to provid'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2215
+  title: 'CI: stale command-identity inventory red-lights every PR, in'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3728
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2213
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3736
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: routing
   provider: claude
-  title: 'test(docs): expand strict stale-reference enforcement across'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2213
+  title: 'Two sources of truth for routing have diverged: kanban board'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3736
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2212
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3740
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: routing
   provider: claude
-  title: 'chore(harness): add invalid-update atomicity regression cove'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2212
+  title: "867 issues cannot leave dispatch:ready \u2014 nothing advances di"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3740
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2211
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3762
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: null
   provider: claude
-  title: 'chore(harness): add dry-run existing-target regression cover'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2211
+  title: 'fix(harness): both context guards are name-based and miss th'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3762
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2210
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3763
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: routing
   provider: claude
-  title: 'chore(harness): add ws_hub fallback regression coverage for '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2210
+  title: "bug(dispatch): every routed card has an empty title \u2014 live-G"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3763
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2204
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#3
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(knowledge): add anchored repo-root rewrite mode to shar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2204
+  title: 'Deckhand: seamless member-onboarding guide (per connected pl'
+  url: https://github.com/vamseeachanta/deckhand/issues/3
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2203
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#5
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'fix(harness): make pre-push tier-1 repo checks worktree-awar'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2203
+  title: "Deckhand: connect WhatsApp platform \u2014 channels + user onboar"
+  url: https://github.com/vamseeachanta/deckhand/issues/5
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2202
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#6
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'feat(operations): extend readiness bundle schema for additio'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2202
+  title: 'Deckhand: migrate WhatsApp off personal number to a dedicate'
+  url: https://github.com/vamseeachanta/deckhand/issues/6
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2201
-  repo: vamseeachanta/workspace-hub
+  routed_by: manual
+- gh: vamseeachanta/deckhand#8
+  repo: vamseeachanta/deckhand
   domain: harness
   provider: claude
-  title: 'feat(gemini): normalize remaining interactive tool semantics'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2201
+  title: 'Deckhand: install-hermes-b2.sh should symlink the deckhand-s'
+  url: https://github.com/vamseeachanta/deckhand/issues/8
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2200
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#9
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: 'test(operations): add wrapper-level subprocess smoke coverag'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2200
+  title: 'Deckhand: encrypt scoped PATs at rest (keyring / age / syste'
+  url: https://github.com/vamseeachanta/deckhand/issues/9
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2199
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#10
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(claude): validate hook wiring and backfill session_id p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2199
+  title: 'Deckhand: aggressively document all work + build a fresh-ses'
+  url: https://github.com/vamseeachanta/deckhand/issues/10
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2198
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#11
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(validation): derive suppression auto-clear candidates a'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2198
+  title: 'Deckhand: create a dedicated PRIVATE repo (engine + operatio'
+  url: https://github.com/vamseeachanta/deckhand/issues/11
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2197
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#12
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'report(weekly-review): publish provider-specific repeated-of'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2197
+  title: 'Deckhand: product introduction + onboarding instructions (us'
+  url: https://github.com/vamseeachanta/deckhand/issues/12
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2196
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#14
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'test(reporting): cover failed-gate to fix/resume/finalize pu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2196
+  title: "Deckhand Open Deck \u2014 open-tier Telegram group + open/demo sc"
+  url: https://github.com/vamseeachanta/deckhand/issues/14
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2195
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#15
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'test(reporting): add publication recovery state-machine tran'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2195
+  title: "Open Deck \u2014 product introduction one-pager (sendable to indu"
+  url: https://github.com/vamseeachanta/deckhand/issues/15
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2194
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#16
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(reporting): emit cross-tool reporter delta artifacts ag'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2194
+  title: "Open Deck \u2014 onboarding flow for known industry contacts"
+  url: https://github.com/vamseeachanta/deckhand/issues/16
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2193
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#18
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(reporting): generate weekly Windows licensed-tool summa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2193
+  title: Refine Deckhand example prompts (pamphlet 'good prompts')
+  url: https://github.com/vamseeachanta/deckhand/issues/18
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2192
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#19
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(validation): establish historical raw-vs-canonical unre'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2192
+  title: Curate Deckhand supported workflows (the domains the agent r
+  url: https://github.com/vamseeachanta/deckhand/issues/19
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2191
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#31
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'report(weekly-review): generate unresolved-read suppression '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2191
+  title: '[P2] Private-scope channels: redirect general traffic to Ope'
+  url: https://github.com/vamseeachanta/deckhand/issues/31
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2190
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#35
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'feat(reporting): add manifest-indexed pruning for orphaned s'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2190
+  title: '[P2] Deliverables go to deckhand-sandbox PRs, never the work'
+  url: https://github.com/vamseeachanta/deckhand/issues/35
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2189
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#36
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'test(reporting): lock deterministic shared-asset canonical p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2189
+  title: '[P2] digitalmodel-first answer routing + example-harvesting '
+  url: https://github.com/vamseeachanta/deckhand/issues/36
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2188
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#39
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'test(reporting): add mixed-state golden fixture bundles for '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2188
+  title: "Path A \u2014 first-principles chat delivery (baseline + QA guard"
+  url: https://github.com/vamseeachanta/deckhand/issues/39
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2187
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(reporting): build cross-tool normalized Windows license'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2187
+  routed_by: manual
+- gh: vamseeachanta/deckhand#40
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: "Path B \u2014 host execution of digitalmodel GTM demos (execute_c"
+  url: https://github.com/vamseeachanta/deckhand/issues/40
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2186
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#41
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(validation): enforce suppression expiry and reviewer si'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2186
+  title: "Path C \u2014 add digitalmodel as read-only reference repo to ope"
+  url: https://github.com/vamseeachanta/deckhand/issues/41
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2185
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#42
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'feat(validation): implement unresolved session-read bucket c'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2185
+  title: "Path D \u2014 pre-baked GTM demo artifacts committed to deckhand-"
+  url: https://github.com/vamseeachanta/deckhand/issues/42
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2184
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#79
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'feat(reporting): enforce manifest-driven pre-promotion gate '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2184
+  title: "Conversation-quality rating harness: corpus extraction + 1\u20131"
+  url: https://github.com/vamseeachanta/deckhand/issues/79
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2183
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#88
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(reporting): add publication rollback journal and recove'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2183
+  title: 'Telegram group map + super-admin dispatch channel: any-clien'
+  url: https://github.com/vamseeachanta/deckhand/issues/88
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2182
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#107
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(operations): add OrcaWave L02 OC4 semi-sub manifest ass'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2182
+  title: 'Group-session write path: natural ''save/submit for review'' s'
+  url: https://github.com/vamseeachanta/deckhand/issues/107
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2181
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#108
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'test(operations): add AQWA zero-exit runtime-failure fixture'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2181
+  title: 'Chat quality: internal monologue leaked to client channel du'
+  url: https://github.com/vamseeachanta/deckhand/issues/108
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2180
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#109
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: 'feat(validation): add registry lineage/provenance report and'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2180
+  title: 'Containment review: client-group session read deckhand repo '
+  url: https://github.com/vamseeachanta/deckhand/issues/109
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2179
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#119
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'feat(validation): add weekly unresolved session-read regress'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2179
+  title: Per-group/per-user preference & communication-style profiles
+  url: https://github.com/vamseeachanta/deckhand/issues/119
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2178
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#129
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(reporting): add bundle checksum manifest and tree-diff '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2178
+  title: "Add Deckhand route: drilling (drilling-engineering) \u2014 #84"
+  url: https://github.com/vamseeachanta/deckhand/issues/129
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2177
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#130
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(reporting): implement atomic weekly publication promoti'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2177
+  title: "Add Deckhand route: cfd (CFD / OpenFOAM) \u2014 #84"
+  url: https://github.com/vamseeachanta/deckhand/issues/130
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2176
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#131
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(operations): add OrcaWave diffraction smoke fixtures an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2176
+  title: "Add Deckhand route: reservoir (reservoir-engineering) \u2014 #84"
+  url: https://github.com/vamseeachanta/deckhand/issues/131
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2175
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#132
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(operations): add fixture-backed OrcaFlex Windows probe '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2175
+  title: "Add Deckhand route: vessel-motions (naval-architecture) \u2014 #8"
+  url: https://github.com/vamseeachanta/deckhand/issues/132
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2174
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#133
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(knowledge): generate unresolved session-read triage rep'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2174
+  title: 'Add Deckhand route: offshore-renewables (offshore-renewables'
+  url: https://github.com/vamseeachanta/deckhand/issues/133
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2173
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#134
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(knowledge): wire provider-session ecosystem audit into '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2173
+  title: 'Add Deckhand route: production-engineering (production-engin'
+  url: https://github.com/vamseeachanta/deckhand/issues/134
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2172
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#135
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(reporting): verify rerun and idempotence behavior for w'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2172
+  title: "Add Deckhand route: maritime-law (maritime-law) \u2014 #84"
+  url: https://github.com/vamseeachanta/deckhand/issues/135
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2171
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#136
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'test(reporting): add end-to-end weekly publication smoke sce'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2171
+  title: "Open Deck \u2192 communities of practice: group public engineerin"
+  url: https://github.com/vamseeachanta/deckhand/issues/136
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2170
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#137
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(operations): implement OrcaFlex, OrcaWave, and ANSYS/AQ'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2170
+  title: 'Open Deck community: Floating & Marine Systems'
+  url: https://github.com/vamseeachanta/deckhand/issues/137
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2169
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#138
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(operations): define Windows licensed-tool probe adapter'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2169
+  title: 'Open Deck community: Subsea, Pipelines & Integrity'
+  url: https://github.com/vamseeachanta/deckhand/issues/138
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2168
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#139
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(validation): add cross-registry coverage and drift repo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2168
+  title: 'Open Deck community: Wells & Subsurface'
+  url: https://github.com/vamseeachanta/deckhand/issues/139
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2167
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#140
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(knowledge): build session-read coherence golden fixture'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2167
+  title: "Open Deck communities \u2014 mechanics: Telegram structure + per-"
+  url: https://github.com/vamseeachanta/deckhand/issues/140
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2166
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#144
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'test(reporting): add fixture-derived Markdown/HTML golden sn'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2166
+  title: Operator/admin Telegram group for the software SME + onboard
+  url: https://github.com/vamseeachanta/deckhand/issues/144
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2165
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#159
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(reporting): validate publication asset/path integrity f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2165
+  title: 'Finish RoutingTables consolidation: channel_prompts + escala'
+  url: https://github.com/vamseeachanta/deckhand/issues/159
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2164
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#163
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'test(operations): build cygpath/native-path fixture suite fo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2164
+  title: 'New-member welcome email: personal greeting + proactive star'
+  url: https://github.com/vamseeachanta/deckhand/issues/163
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2163
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#174
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(operations): add Windows Task Scheduler invocation harn'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2163
+  title: 'Consistency tests: bound domains have packs, demo-allowlist '
+  url: https://github.com/vamseeachanta/deckhand/issues/174
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2162
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#175
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(schema): define machine/path alias schema for seeded ac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2162
+  title: 'Fan out domain channel: floating-marine (pack + demo + canar'
+  url: https://github.com/vamseeachanta/deckhand/issues/175
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2161
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#177
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(knowledge): ingest provider-session ecosystem audit rea'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2161
+  title: 'Fan out domain channel: electrical (pack + demo + canary)'
+  url: https://github.com/vamseeachanta/deckhand/issues/177
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2160
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#179
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'test(reporting): validate latest/history navigation and rela'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2160
+  title: Wire venue send-path to the workspace-hub Telegram-venue con
+  url: https://github.com/vamseeachanta/deckhand/issues/179
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2159
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#183
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'feat(reporting): build publication bundle assembler for week'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2159
+  title: Domain-expert subagents the channel orchestrator delegates t
+  url: https://github.com/vamseeachanta/deckhand/issues/183
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2158
-  repo: vamseeachanta/workspace-hub
+  routed_by: manual
+- gh: vamseeachanta/deckhand#184
+  repo: vamseeachanta/deckhand
   domain: harness
   provider: claude
-  title: 'feat(operations): add Git Bash launcher and path-normalizati'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2158
+  title: Make all repos' skills accessible from workspace-hub via a s
+  url: https://github.com/vamseeachanta/deckhand/issues/184
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2157
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#196
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,knowledge,routing
   provider: claude
-  title: 'feat(operations): implement native PowerShell probe collecto'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2157
+  title: 'feat(family): scaffold private domain lanes for development,'
+  url: https://github.com/vamseeachanta/deckhand/issues/196
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2156
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#213
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(knowledge): add registry coherence validator for access'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2156
+  title: 'Super-admin dispatch lane: per-target-scope App-token mint +'
+  url: https://github.com/vamseeachanta/deckhand/issues/213
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2154
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#247
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(reporting): implement Markdown/HTML publication layout '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2154
+  title: 'Super-admin response curation loop: rate public replies, cap'
+  url: https://github.com/vamseeachanta/deckhand/issues/247
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2153
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#345
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'feat(reporting): implement weekly review history index and l'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2153
+  title: Make config-invariants a required status check (plan-gated)
+  url: https://github.com/vamseeachanta/deckhand/issues/345
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2152
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#346
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,capability
   provider: claude
-  title: 'test(reporting): add golden fixture corpus for weekly review'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2152
+  title: "Score the produce\u2192promote path with the next ~10-workflow on"
+  url: https://github.com/vamseeachanta/deckhand/issues/346
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2150
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#347
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'feat(operations): implement Windows no-SSH readiness evidenc'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2150
+  title: "Guard against guidance\u2194gate manifest-schema drift for future"
+  url: https://github.com/vamseeachanta/deckhand/issues/347
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2149
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#360
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(knowledge): generate seeded intelligence accessibility '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2149
+  title: "review(knowledge): use Deckhand to strengthen llm-wiki \u2014 bot"
+  url: https://github.com/vamseeachanta/deckhand/issues/360
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2148
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#363
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,routing
   provider: claude
-  title: 'feat(operations): implement Linux readiness evidence bundle '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2148
+  title: 'feat(escalation): first-pass workflow presentation on the ES'
+  url: https://github.com/vamseeachanta/deckhand/issues/363
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2147
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#366
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'feat(reporting): add validator CLI and CI checks for weekly '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2147
+  title: 'feat(qa): recurring read-only Open Deck workflow-QA pass (mi'
+  url: https://github.com/vamseeachanta/deckhand/issues/366
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2146
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#367
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: 'feat(reporting): add versioned schema spec for weekly ecosys'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2146
+  title: "design(security): client-audit mode \u2014 read-only client trace"
+  url: https://github.com/vamseeachanta/deckhand/issues/367
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2145
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#403
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'chore(automation): register weekly ecosystem review in sched'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2145
+  title: 'feat(capability): cathodic-protection demo set across struct'
+  url: https://github.com/vamseeachanta/deckhand/issues/403
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2144
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#404
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'feat(automation): implement weekly ecosystem review runner w'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2144
+  title: "design(routing): multi-domain problem handling \u2014 explicit-to"
+  url: https://github.com/vamseeachanta/deckhand/issues/404
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2141
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#409
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: Add fixture-backed tests for llm-wiki ingest and search scri
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2141
+  title: Wire demo-GIF CTAs to onboarding source-tagged deep link (#4
+  url: https://github.com/vamseeachanta/deckhand/issues/409
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2139
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#417
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'feat(reporting): define weekly review artifact schema and ca'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2139
+  title: 'feat(capability): marketing GIFs for the 4 CP structure demo'
+  url: https://github.com/vamseeachanta/deckhand/issues/417
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2138
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#419
+  repo: vamseeachanta/deckhand
+  domain: chat-quality,onboarding
   provider: claude
-  title: 'feat(automation): add scheduled weekly ecosystem review runn'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2138
+  title: "review(marketing): improve Open Deck demo videos \u2014 quality p"
+  url: https://github.com/vamseeachanta/deckhand/issues/419
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2137
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#420
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'docs(knowledge): create canonical Intelligence Entry Points '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2137
+  title: 'design(marketing): unified demo hosting + distribution acros'
+  url: https://github.com/vamseeachanta/deckhand/issues/420
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2135
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#421
+  repo: vamseeachanta/deckhand
+  domain: routing,capability
   provider: claude
-  title: 'feat(operations): emit per-machine readiness evidence bundle'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2135
+  title: 'feat(routing): composite multi-subdomain workflows (Option B'
+  url: https://github.com/vamseeachanta/deckhand/issues/421
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2134
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#424
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,security
   provider: claude
-  title: 'feat(operations): define machine readiness matrix schema and'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2134
+  title: '[P2] Gateway must fail closed (not leak) on patch drift afte'
+  url: https://github.com/vamseeachanta/deckhand/issues/424
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2132
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#426
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'fix(health-check): cron job counter shows 0 scheduled despit'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2132
+  title: "feat(factory): repeatable demo pipeline \u2014 one run per <repo>"
+  url: https://github.com/vamseeachanta/deckhand/issues/426
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2131
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#427
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: "chore(reflect): regenerate reflect-state.yaml \u2014 47 days stal"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2131
+  title: 'feat(reports): generate + cache real agent-composed report.h'
+  url: https://github.com/vamseeachanta/deckhand/issues/427
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2130
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#428
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'fix(bridge): memory bridge auto-commit fails to re-stage aft'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2130
+  title: "feat(renderer): exact-UX flow \u2014 full-bleed real-report scrol"
+  url: https://github.com/vamseeachanta/deckhand/issues/428
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2123
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#429
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(llm-wiki): add llm-wiki search to OrcaFlex/OrcaWave age'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2123
+  title: "feat(marketing): ecosystem-advert framing \u2014 aceengineer.com "
+  url: https://github.com/vamseeachanta/deckhand/issues/429
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2122
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#430
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(reporting): add weekly ecosystem scorecard with trend d'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2122
+  title: 'chore(render): backfill the current 17 via the factory + pub'
+  url: https://github.com/vamseeachanta/deckhand/issues/430
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2121
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#433
+  repo: vamseeachanta/deckhand
+  domain: security,onboarding
   provider: claude
-  title: 'feat(knowledge): add weekly-review query packs and verificat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2121
+  title: "feat(onboarding): lead attribution \u2014 src tag \u2192 PII-free lead"
+  url: https://github.com/vamseeachanta/deckhand/issues/433
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2120
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#434
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(operations): add fleet heartbeat and last-seen evidence'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2120
+  title: 'feat(renderer): vertical 9:16 mobile cut (#425)'
+  url: https://github.com/vamseeachanta/deckhand/issues/434
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2119
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#435
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(operations): define machine dispatch policy and workloa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2119
+  title: 'feat(renderer): real Telegram-client chat shell (#425)'
+  url: https://github.com/vamseeachanta/deckhand/issues/435
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2113
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#436
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'feat(orchestrator-worker): fresh repo bootstrap for governan'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2113
+  title: "feat(process): QA feedback loop \u2014 hybrid run captures hiccup"
+  url: https://github.com/vamseeachanta/deckhand/issues/436
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2109
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'test(hermes): add test coverage for codex_quota reset-time r'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2109
+  routed_by: manual
+- gh: vamseeachanta/deckhand#540
+  repo: vamseeachanta/deckhand
+  domain: workstations
+  provider: codex
+  title: 'bug(licensed-run): align watch leak checks with allowed resu'
+  url: https://github.com/vamseeachanta/deckhand/issues/540
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2108
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#541
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'chore(harness): add cron job to scrub stale quota cache entr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2108
+  title: 'licensed-run: onboard the canonical ANSYS/MAPDL workflow aft'
+  url: https://github.com/vamseeachanta/deckhand/issues/541
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2107
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#542
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'fix(hermes): auto-clear stale Codex exhaustion state on cred'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2107
+  title: 'ops(ace-win-1): attest ANSYS/AQWA, GHS, and CAD; stage neutr'
+  url: https://github.com/vamseeachanta/deckhand/issues/542
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2106
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#543
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'chore(reporting): define canonical artifact model for weekly'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2106
+  title: 'licensed-run: choose a neutral scope for manifest-bound ANSY'
+  url: https://github.com/vamseeachanta/deckhand/issues/543
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2097
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#544
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'chore(automation): establish recurring execution path for we'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2097
+  title: 'ops(ace-win-1): read-only inventory of ANSYS/AQWA, GHS, and '
+  url: https://github.com/vamseeachanta/deckhand/issues/544
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2094
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(operations): multi-machine readiness matrix for weekly '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2094
+  routed_by: manual
+- gh: vamseeachanta/deckhand#550
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: 'feat(licensed-run): onboard orcaflex-run-batch + per-workflo'
+  url: https://github.com/vamseeachanta/deckhand/issues/550
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2092
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#551
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: 'chore(harness): define weekly ecosystem review checklist and'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2092
+  title: 'design(licensed-run): standing approval for continuous sweep'
+  url: https://github.com/vamseeachanta/deckhand/issues/551
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2078
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/deckhand#585
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'test(governance): harden block assertion and error-tracker s'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2078
+  title: 'Self-contained issues: an issue carries everything needed to'
+  url: https://github.com/vamseeachanta/deckhand/issues/585
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2071
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Batch remediate historical stage-prompt drift with evidence '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2071
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#59
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: codex
+  title: engg debt | Pipe Capacity | Documentation and Calculations
+  url: https://github.com/vamseeachanta/digitalmodel/issues/59
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2068
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(knowledge): add cross-link JSONL package for wiki-to-st'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2068
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#63
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: codex
+  title: engg debt | openFOAM
+  url: https://github.com/vamseeachanta/digitalmodel/issues/63
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2067
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(knowledge): wire .planning/research into engineering wi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2067
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#133
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-032: Modular OrcaFlex pipeline installation input with p'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/133
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2065
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'chore(governance): derive FAST_PATH_CEILING dynamically from'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2065
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#137
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-045: OrcaFlex rigid jumper analysis - stress and VIV for'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/137
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2040
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat: cronize engineering wiki incremental ingest'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2040
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#138
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-046: OrcaFlex drilling and completion riser parametric a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/138
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2031
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'build: automated compliance monitoring -- daily cron, alerts'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2031
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#142
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-1027: DNV-RP-B401 real-world benchmark validation: GOM j'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/142
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2028
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat: review gate strict mode + GitHub Actions CI enforcemen'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2028
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#143
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-1147: Propeller-rudder hydrodynamic interaction study \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/143
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2012
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Review backlog: 22 unreviewed commits from 2026-04-07'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2012
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#144
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-1150: Python implementation \u2014 propeller-rudder interacti"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/144
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1962
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "FEATURE: Tier-1 Repo Ecosystem Refactoring \u2014 audit, plan, ex"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1962
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#147
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-1193: Geotechnical anchor holding capacity'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/147
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1922
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'infra: Ollama ecosystem rollout -- GPU audit (ace-linux-2 ha'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1922
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#148
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-1194: Geotechnical scour assessment'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/148
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1921
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'infra: Ollama local LLM runtime -- feasibility assessment an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1921
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#149
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-1195: Type curve matching (Blasingame/Fetkovich)'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/149
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1919
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'docs: create memory ecosystem quick-reference card'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1919
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#153
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: "WRK-1249: gmsh deep meshing workflows \u2014 parametric studies, "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/153
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1918
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'memory: Claude Code auto-memory sync from Windows back to re'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1918
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#154
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: codex
+  title: "WRK-1250: OpenFOAM deep solver workflows \u2014 tutorial reproduc"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/154
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1903
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'memory: new-machine onboarding documentation'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1903
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#155
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: "WRK-1252: Full CAD-to-CFD pipeline \u2014 FreeCAD \u2192 gmsh \u2192 OpenFO"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/155
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1902
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'memory: automate memory quality before bridge commit'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1902
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#162
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-1282: Drive-off research and analysis methodologies'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/162
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1901
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#163
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: 'memory: propagate bridge to digitalmodel/ and aceengineer-st'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1901
+  title: "WRK-1283: Rudder types survey \u2014 video references and digital"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/163
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1900
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'memory: test cron job 8c797470d7d3 in isolated Hermes sessio'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1900
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#174
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-474: feat(subsea): integrate MoorDyn + MoorPy for moorin'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/174
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1884
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Cross-review enforcement: nightly audit cron for unreviewed '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1884
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#182
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-485: feat(digitalmodel/cathodic_protection): Implement A'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/182
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1883
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Tool-call ceiling: reduce from 500 to 200 with auto-pause an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1883
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#183
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-486: feat(digitalmodel/cathodic_protection): Implement A'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/183
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1882
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'Enable cross-review strict mode -- gate defaults to WARNING '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1882
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#184
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-487: feat(digitalmodel/cathodic_protection): Implement A'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/184
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1881
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Install Hermes gateway as systemd service for cron job firin
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1881
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#200
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5058: Drilling riser engineering study \u2014 literature, met"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/200
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1880
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Create session-corpus-audit skill -- analyze session quality
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1880
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#202
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5060: Pipeline engineering study \u2014 literature, methods a"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/202
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1879
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "rebuild session-start-routine skill \u2014 lost during GSD migrat"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1879
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#208
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5068: Cathodic protection study \u2014 literature, methods an"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/208
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1876
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Enforce engineering workflow via Hermes prefill + Claude Cod
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1876
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#209
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5069: Subsea risers and flowlines study \u2014 literature, me"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/209
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1870
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Upstream deepseek CLI provider fix to OpenClaw/Hermes
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1870
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#211
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-5070: Metocean and extreme value analysis study \u2014 litera"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/211
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1869
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#212
+  repo: vamseeachanta/digitalmodel
+  domain: repo
   provider: claude
-  title: "Add HuggingFace, OpenRouter, Z.AI free providers to Hermes \u2014"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1869
+  title: "WRK-5077: Data needs registry \u2014 fill gaps across all digital"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/212
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1868
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Wire Google AI Studio API into Hermes \u2014 use $20/mo Gemini su"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1868
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#214
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-5082: Parachute frame force calculation \u2014 drag car parac"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/214
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1867
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Hermes provider config maintenance \u2014 deepseek CLI patch, ali"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1867
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#250
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-571: feat(digitalmodel): port VIV MATLAB mode analysis s'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/250
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1839
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Workflow hard-stops and session governance \u2014 Hermes-orchestr"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1839
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#258
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-608: chore(digitalmodel): catalog and port MATLAB riser/'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/258
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1838
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "AI credit utilization governance \u2014 horses-for-courses routin"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1838
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#259
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-609: chore(digitalmodel): catalog and port ANSYS .inp ri'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/259
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1806
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Document autonomous loop patterns \u2014 6 architectures from seq"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1806
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#260
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: 'WRK-616: chore(wrk-309): convert document-intelligence findi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/260
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1805
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Security hardening for AI agent workflows \u2014 skill scanning, "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1805
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#262
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-619: feat(geotechnical): pile axial/lateral capacity, p-'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/262
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1803
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Add context-budget audit skill \u2014 measure token overhead acro"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1803
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#264
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-621: feat(geotechnical): shallow foundation bearing capa'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/264
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1802
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#272
+  repo: vamseeachanta/digitalmodel
+  domain: standards
   provider: claude
-  title: "Implement batch-at-Stop pattern \u2014 defer format+typecheck to "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1802
+  title: 'WRK-662: analysis(digitalmodel): engineering standards citat'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/272
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1801
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Adopt pre:config-protection hook \u2014 prevent agents from weake"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1801
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#277
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: codex
+  title: "WRK-1251: FreeCAD deep parametric engineering \u2014 hull generat"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/277
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1775
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#461
+  repo: vamseeachanta/digitalmodel
+  domain: repo
   provider: claude
-  title: 'feat(harness): weekly Claude Code best-practice adoption cad'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1775
+  title: Recover ship-dimensions template artifact from WRK-1339 Chil
+  url: https://github.com/vamseeachanta/digitalmodel/issues/461
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1760
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'feat(self-improvement): operationalize /powerup, /insights, '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1760
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#472
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement Go/No-Go decision logic per DNV-RP-H103
+  url: https://github.com/vamseeachanta/digitalmodel/issues/472
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1745
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#475
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: codex
+  title: Add pytest test suite for jumper_lift.py (81 tests)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/475
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#479
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: 'feat(hermes): enable correction tracking in Hermes orchestra'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1745
+  title: HTML/PDF report renderer for jumper installation analysis
+  url: https://github.com/vamseeachanta/digitalmodel/issues/479
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1744
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#480
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'BUG: Verify PLET-PLEM jumper segment lengths from SZ_Ballymo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/480
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#481
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Convert PLET-PLEM workbook via Windows cowork
+  url: https://github.com/vamseeachanta/digitalmodel/issues/481
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#484
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement subsea tree modeling module (API 17D)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/484
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#485
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement subsea manifold aggregation module (API 17P)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/485
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#486
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement subsea connectors and jumpers module (API 17R)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/486
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#508
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'OrcaFlex spec upgrader v2: rewrite generic specs to domain-s'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/508
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#556
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'fix(marine_ops): test_ocimf.py::TestOCIMFDatabase::test_get_'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/556
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#557
+  repo: vamseeachanta/digitalmodel
+  domain: standards
   provider: claude
-  title: "refactor: stabilize work-queue subsystem \u2014 55% of all 8965 c"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1744
+  title: 'fix(marine_ops): test_ocimf.py::TestOCIMFDatabase::test_boun'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/557
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1743
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#562
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: 'test: add coverage for top 20 Python correction hotspot file'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1743
+  title: 'fix(marine_ops): test_marine_eng_performance.py::test_comple'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/562
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1738
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#563
+  repo: vamseeachanta/digitalmodel
+  domain: standards
   provider: claude
-  title: 'chore: triage 54 pending work queue items in CAD-DEVELOPMENT'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1738
+  title: 'fix(marine_ops): test_marine_eng_performance.py::test_ocimf_'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/563
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1720
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#565
+  repo: vamseeachanta/digitalmodel
+  domain: standards
   provider: claude
-  title: "analysis: cross-agent session corpus audit \u2014 mine 1M+ tool c"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1720
+  title: 'fix(marine_ops): test_hydro_coefficients.py::TestIntegration'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/565
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1717
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#566
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: 'chore(policy): resolve work-queue vs GitHub-issues contradic'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1717
+  title: "fix(marine_ops): batched residue clusters R1+R5+R7+R8 \u2014 clea"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/566
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1697
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#575
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: FOWT coupled aero-hydro response Python facade (IEC 61400-3-
+  url: https://github.com/vamseeachanta/digitalmodel/issues/575
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#576
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'FOWT watch-circle envelope check vs dynamic-cable curvature '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/576
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#589
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: 'Solver queue: close completed issues #1654, #1650, #1648 aft'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1697
+  title: 'fix(marine_ops): test_weight_scales_with_diameter_squared qu'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/589
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1693
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#615
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Riser-analysis results as stage-by-stage animated HTML deliv
+  url: https://github.com/vamseeachanta/digitalmodel/issues/615
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#619
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'Ship-class structural stress gaps: sloshing (rule-based), ra'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/619
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#620
+  repo: vamseeachanta/digitalmodel
+  domain: repo
   provider: claude
-  title: 'Solver queue: notification alerts on repeated failures + ret'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1693
+  title: 'Review remediation: SQLi/.format, pickle, yaml.Loader, dup m'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/620
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1688
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#690
+  repo: vamseeachanta/digitalmodel
+  domain: repo
   provider: claude
-  title: 'Solver queue: deploy cron entries for watch-results + dashbo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1688
+  title: 'bug(tracker): legacy issue bodies overwritten with unrelated'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/690
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1685
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#717
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'fix(orcaflex): close post-validator reference gaps (constrai'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/717
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#722
+  repo: vamseeachanta/digitalmodel
+  domain: solver
   provider: claude
-  title: 'Solver queue: integrate validate_manifest into submit-batch.'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1685
+  title: 'feat(orcaflex): M-shaped rigid jumper library entries from p'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/722
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1683
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#894
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
   provider: claude
-  title: 'Solver queue: integrate retry_handler into process-queue.py '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1683
+  title: Aggregate deferred/stranded-barrels estimate across the Lowe
+  url: https://github.com/vamseeachanta/digitalmodel/issues/894
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1681
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#895
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
   provider: claude
-  title: Supply chain hardening for AI harness updates (#1668 follow-
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1681
+  title: TLP/Spar/FrPS water-depth workability boundary map
+  url: https://github.com/vamseeachanta/digitalmodel/issues/895
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1680
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#914
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
   provider: claude
-  title: Validate harness-update rollback with simulated tool breakag
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1680
+  title: Re-run FrPS/APS-vs-20K-subsea economics at a current price d
+  url: https://github.com/vamseeachanta/digitalmodel/issues/914
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1679
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1535
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: Active push notifications for harness-update failures (#1668
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1679
+  title: 'Flaky CI: test_sustained_load response-time variance fails o'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1535
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1654
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1642
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Port ModesFind.m Shear7 VIV parser to Python
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1642
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1643
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Extract API RP 2A structural code check from 3824-CAL-2118 t
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1643
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1644
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Extract SCR Flexcom Model Creator (2H-CAL-0060) to Python
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1644
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1645
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Extract subsea jumper property calculators to Python
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1645
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1654
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-039: SPM project benchmarking - AQWA vs OrcaFlex'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1654
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1657
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-046: OrcaFlex drilling and completion riser parametric a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1657
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1659
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-099: Run 3-way benchmark on Unit Box hull'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1659
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1661
+  repo: vamseeachanta/digitalmodel
+  domain: marine
   provider: claude
-  title: 'Solver queue: retry logic for failed jobs + exponential back'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1654
+  title: 'WRK-475: feat(marine_ops): wire Open-Meteo Marine API into w'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1661
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1650
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1666
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "WRK-5082: Parachute frame force calculation \u2014 drag car parac"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1666
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1673
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'WRK-5118: CalculiX B32 quadratic beam integration test with '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1673
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1674
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "WRK-5119: CalculiX beam cross-section tests \u2014 CIRC and PIPE "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1674
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1675
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "WRK-5123: CalculiX plate-with-hole test fix \u2014 2 pre-existing"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1675
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1676
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'WRK-5124: INP writer: validate beam element/section compatib'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1676
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1695
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Production sectionproperties module in digitalmodel
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1695
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1697
+  repo: vamseeachanta/digitalmodel
+  domain: marine
   provider: claude
-  title: 'Solver queue: batch manifest validation CLI + schema enforce'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1650
+  title: "Domain-specific capability roadmaps \u2014 OrcaWave/OrcaFlex, str"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1697
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1648
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1698
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
   provider: claude
-  title: 'Solver queue: integrate watch-results.sh into cron schedule '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1648
+  title: "Automated download-and-catalog pipeline \u2014 discover, download"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1698
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1628
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1699
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Harden solver queue: batch submission, result watcher, auto '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1699
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1700
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Seed hull registry with standard hull forms (barge, tanker, '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1700
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1703
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "Cross-tool structural comparison framework \u2014 2D solver vs Or"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1703
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1704
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Add tests for parametric_hull_analysis: forward_speed, shall'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1704
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1708
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Clone and pip-install BEMRosetta, pyHAMS, OCEANLYZ, wavespec
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1708
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1709
+  repo: vamseeachanta/digitalmodel
+  domain: marine
   provider: claude
   title: "Sprint plan: OrcaWave/OrcaFlex Phase 1 \u2014 solver queue harden"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1628
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1563
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "Feature: Data & Resource Intelligence \u2014 consolidated plan (4"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1563
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1539
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Install codex-plugin-cc across all machines
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1539
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1538
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Verify cross-review adversarial enforcement across sessions
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1538
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1525
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Define canonical repo control-plane contract across workspac
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1525
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1511
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Migrate cron jobs to Claude Desktop scheduled agents for sel
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1511
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1709
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1404
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1404: Organize /mnt/ace/docs/ subfolders and deduplicate'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1404
+- gh: vamseeachanta/digitalmodel#1710
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'OrcaWave reporting: section-level unit tests for all 7 secti'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1710
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1350
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1350: Fix set-active-wrk.sh regex for repo-prefixed WRK '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1350
+- gh: vamseeachanta/digitalmodel#1711
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Parametric spec generator: multi-dimensional sweep combinati'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1711
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1349
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1349: Fix update-stage-evidence.py for repo-prefixed WRK'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1349
+- gh: vamseeachanta/digitalmodel#1714
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'OrcaFlex reporting: integration test with real .sim fixture '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1714
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1348
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+- gh: vamseeachanta/digitalmodel#1716
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
   provider: claude
-  title: 'WRK-1348: Update /work add skill to call capture-wrk.sh'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1348
+  title: 'Solver queue: integrate retry_handler into process-queue.py '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1716
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1341
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "WRK-1341: slim down large repos \u2014 relocate PDFs, reduce .git"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1341
+- gh: vamseeachanta/digitalmodel#1717
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'Solver queue: integrate validate_manifest into submit-batch.'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1717
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1331
+- gh: vamseeachanta/digitalmodel#1718
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'Solver queue: deploy cron entries for watch-results + dashbo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1718
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1719
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'Fatigue TDD Phase 2: test coverage for plotting, multiaxial,'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1719
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1721
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "Fatigue post-processor: OrcaFlex time-history \u2192 rainflow \u2192 S"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1721
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1722
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "ANSYS package: YAML-based pipeline spec \u2014 define full FEA wo"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1722
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1723
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'cathodic_protection: integration examples and YAML-driven CP'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1723
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1724
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "ANSYS package: Solver queue integration \u2014 dispatch FEA jobs "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1724
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1725
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'cathodic_protection: cross-module integration tests and edge'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1725
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1726
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'cathodic_protection: ICCP vs SACP comparison tool and cost o'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1726
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1727
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "ANSYS package: Calculation examples \u2014 pressure vessel, flang"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1727
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1728
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'OrcaFlex .sim snapshot testing: HTML report from minimal_tes'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1728
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1733
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'feat(freespan): link to OrcaFlex rigid jumper VIV workflow ('
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1733
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1734
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'dark-intel: rebuild stale specs/module-registry.yaml as cano'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1734
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1735
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'licensed-win-1: extract .sim model metadata to JSON for snap'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1735
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1739
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'MODULE: Shore approach analysis (HDD, trenching, pull-in)'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1739
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1740
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'MODULE: Pipeline CAPEX cost model (steel + coating + install'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1740
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1741
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "epic: field development analysis system \u2014 concept selection,"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1741
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1742
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "feat(field-dev): CAPEX/OPEX estimation models \u2014 parametric c"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1742
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1743
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "feat(field-dev): production profile generator \u2014 decline curv"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1743
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1744
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "feat(field-dev): facility sizing \u2014 separator, compressor, wa"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1744
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1745
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "feat(field-dev): subsea architecture optimizer \u2014 tieback dis"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1745
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1746
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'feat(field-dev): wire existing scattered modules into integr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1746
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1747
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "epic: naval architecture expansion \u2014 floating platforms, cla"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1747
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1748
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "feat(naval-arch): floating platform stability \u2014 FPSO, semi-s"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1748
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1749
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "feat(naval-arch): gyradius calculator \u2014 mass distribution, r"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1749
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1750
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "feat(naval-arch): trim and ballast optimization \u2014 minimize f"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1750
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1751
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "feat(naval-arch): complete curves_of_form.py \u2014 hydrostatic t"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1751
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1753
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "data: build SubseaIQ-to-field-development bridge \u2014 concept s"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1753
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1754
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'feat(field-dev): worldenergydata unified production client a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1754
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1756
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: 'Claude: naval architecture expansion sprint (#1850+#1851+#18'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1756
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1757
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'INVENTORY: Complete OrcaFlex/OrcaWave model and Excel workbo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1757
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1758
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'DATA: Rigid jumper OrcaFlex model + input workbook for model'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1758
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1760
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: Extract SNAME naval architecture knowledge into digitalmodel
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1760
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1761
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "Extract 419 marine Excel calculation references \u2192 digitalmod"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1761
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1763
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "Batch 1: Ballymore Jumper Lift + Mudmat Analysis \u2014 10 workbo"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1763
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1764
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Batch 2: FDAS Riser Engineering \u2014 20+ workbooks"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1764
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1770
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Implement OpenTURNS fatigue reliability analysis module
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1770
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1771
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "Implement seakeeping module \u2014 6-DOF motion analysis"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1771
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1772
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'TASK: Run YML + Excel inventory script locally to produce ca'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1772
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1773
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'TASK: Write HLV and pipelay vessel spec JSON files from rese'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1773
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1774
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'feat(field-dev): subsea cost benchmarking from SubseaIQ equi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1774
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1775
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'bug(field-dev): string decline_type bypasses EUR auto-derive'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1775
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1782
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'data(field-dev): backfill SubseaIQ equipment counts to unblo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1782
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1783
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'chore(acma-codes): reconcile OCIMF MEG fragments misfiled un'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1783
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1784
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'chore(acma-codes): codify support-artifact defer/reject poli'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1784
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1788
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(canonical-spec): validate flagship generic-track OrcaFl'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1788
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1792
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'feat(knowledge): catalogue offshore wind and oil gas subsea '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1792
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1793
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'feat(digitalmodel): flexible pipe and dynamic riser cross-se'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1793
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1794
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'data(field-dev): primary-source GoM equipment/cost source pa'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1794
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1795
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "investigate(digitalmodel-tests): Cluster E \u2014 marine-engineer"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1795
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1796
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(solver-queue): hands-off multi-machine inbox ingestion '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1796
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1797
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,knowledge
+  provider: codex
+  title: 'Domain Sweep: Offshore Hydrodynamics (RAOs, motion analysis,'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1797
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1798
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "R1 \u2014 Hydrodynamics: Standards & Codes inventory (API, DNV, I"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1798
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1799
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "R2 \u2014 Hydrodynamics: Academic sources sweep (Journ\xE9e, Faltins"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1799
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1800
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "R3 \u2014 Hydrodynamics: Industry practice (conferences, journals"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1800
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1802
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "R5 \u2014 Hydrodynamics: Comprehensive code coverage audit (digit"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1802
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1803
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "R6 \u2014 Hydrodynamics: Coverage map synthesis + gap subissue sp"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1803
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1804
+  repo: vamseeachanta/digitalmodel
+  domain: knowledge,marine
+  provider: codex
+  title: 'Domain Sweep: Mooring Design (catenary, taut, DP-assist, sta'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1804
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1805
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "R1 \u2014 Mooring: Standards & Codes inventory (DNV-OS-E301, API "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1805
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1806
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "R2 \u2014 Mooring: Academic sources (Vryhof, OSIG, Aubeny, anchor"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1806
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1807
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "R3 \u2014 Mooring: Industry practice (Vryhof, Bridon, MIRP, OMAE "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1807
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1809
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "R5 \u2014 Mooring: Code coverage audit (digitalmodel + citation p"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1809
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1810
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "R6 \u2014 Mooring: Coverage map synthesis + gap subissue spawning"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1810
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1812
+  repo: vamseeachanta/digitalmodel
+  domain: knowledge,pipeline
+  provider: codex
+  title: 'Domain Sweep: Subsea Pipelines (design, installation, integr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1812
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1813
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "R1 \u2014 Subsea Pipelines: Standards & Codes inventory (DNV-OS-F"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1813
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1814
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "R2 \u2014 Subsea Pipelines: Academic sources sweep (Bai & Bai, Pa"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1814
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1815
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "R3 \u2014 Subsea Pipelines: Industry practice (OMAE/ISOPE/OPT, Su"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1815
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1817
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "R5 \u2014 Subsea Pipelines: Comprehensive code coverage audit (di"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1817
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1818
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "R6 \u2014 Subsea Pipelines: Coverage map synthesis + gap subissue"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1818
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1820
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "feat(provider-data): service-provider data library \u2014 Helix 1"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1820
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1823
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'epic(ocimf): close out MEG3/MEG4 coefficient ingestion and r'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1823
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1824
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'arch(digitalmodel): deepen engineering workflow modules arou'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1824
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1852
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-1027: DNV-RP-B401 real-world benchmark validation: GOM j'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1852
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1854
+  repo: vamseeachanta/digitalmodel
+  domain: skills
+  provider: claude
+  title: "WRK-597: feat(digitalmodel): geotechnical module \u2014 umbrella "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1854
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1888
+  repo: vamseeachanta/digitalmodel
+  domain: content
+  provider: claude
+  title: 'fix(docs): brand migration edited generated pages, not their'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1888
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1900
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: 'chore(imports): 37 module-level imports in shipped code reso'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1900
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1919
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'bug(dashboard): six more scipy calls unguarded against const'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1919
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1925
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'bug(results_analysis): file_monitor start() races its own ev'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1925
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1927
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'test(cli): no CI check that installed console scripts actual'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1927
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#12
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-1331: Fix cross-review.sh Codex dispatch crash \u2014 unguard"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1331
+  title: 'WRK-1022: Consistent terminal experience across Linux CLI an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/12
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#27
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-050: Hardware consolidation \u2014 inventory, assess, re'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/27
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#30
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'WRK-1000: fix(work-queue): restore /work skill compatibility'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/30
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#31
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'WRK-1001: Workspace cleanup: .claude/, root artifacts, data '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/31
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#32
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1024: chore(harness): increase context window limits for'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/32
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#37
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1051: chore(harness): verify Codex config on ace-win-1 ('
+  url: https://github.com/vamseeachanta/workspace-hub/issues/37
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#38
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: "WRK-1088: feat(harness): data pipeline framework \u2014 consisten"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/38
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#40
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'WRK-1089: Split check-all.sh by responsibility (400L hard li'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/40
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#42
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'WRK-1103: learn(harness): complete Anthropic''s official Clau'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/42
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#45
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'WRK-1110: enhance(workstations): extend skill with hardware '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/45
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#46
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: 'WRK-1116: Extract + integrate website-building skill pattern'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/46
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#47
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'WRK-1117: Windows/Git Bash: fix comprehensive-learning push '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/47
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#48
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: codex
+  title: "WRK-1118: Cross-platform bash sweep \u2014 replace bc/python3/npr"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/48
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#54
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'WRK-1136: Improve repo-sync skill: comprehensive origin stat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/54
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#65
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-1175: Structured progress log for cross-session WRK cont'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/65
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#69
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-1182: Work-queue-workflow interactive stage menu'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/69
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#72
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-1201: Create calculation-implementation-workflow orchest'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/72
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#73
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1205: fix: recurring correction correction pattern on Wr'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/73
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#74
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1206: fix: recurring correction correction pattern on Ed'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/74
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#80
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-1243: Standardize WRK file structure anatomy across all '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/80
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#87
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1278: setup-cron.sh --replace mode + deploy canonical cr'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/87
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#88
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'WRK-1284: Evaluate Zellij terminal multiplexer for cross-wor'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/88
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#92
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "WRK-1288: Review article (trq212 thread) \u2014 identify skill ga"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/92
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#112
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "WRK-227: Evaluate cowork relevance \u2014 repo ecosystem fit vs a"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/112
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#121
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "WRK-5002: Task complexity tier \u2192 model routing (extend task_"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/121
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#131
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'WRK-5013: Fix session-analysis.sh Windows arithmetic bug (wc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/131
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#167
+  repo: vamseeachanta/workspace-hub
+  domain: skills,finance
+  provider: claude
+  title: "WRK-5094: Real estate tax skill \u2014 CRE tax preparation, depre"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/167
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#193
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "WRK-635: feat(memory): session scanner \u2014 extract learnings f"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/193
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#201
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'WRK-685: feat(skills): update /today to highlight availabili'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/201
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1249
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'WRK-1388: Propagate canonical AGENTS.md format to child repo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1249
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1258
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'WRK-5109: fix(work-queue): GitHub issue workflow discrepanci'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1258
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1299
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "WRK-1391: FreeCAD skill improvement \u2014 bend arcs + coordinate"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1299
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1300
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: codex
+  title: 'WRK-1392: 3D interactive frame viewer (HTML/three.js)'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1300
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1308
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'WRK-5115: Custom GitHub CLI bash tools for session-cycle eff'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1308
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
@@ -10144,231 +4494,3741 @@ cards:
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1309
+- gh: vamseeachanta/workspace-hub#1326
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "WRK-5138: Fix Gemini cross-review NO_OUTPUT \u2014 CLI returns ex"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1326
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1331
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "WRK-1331: Fix cross-review.sh Codex dispatch crash \u2014 unguard"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1331
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1352
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-5117: Add VC funding of 1MM to market brochures'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1309
+  title: 'whats-next: targeted index refresh before display + parallel'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1352
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1299
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1408
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-1391: FreeCAD skill improvement \u2014 bend arcs + coordinate"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1299
+  title: "WRK-1408: Wire notification consumer \u2014 surface logs/notifica"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1408
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1287
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1426
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: Accelerate correction-to-skill promotion pipeline (8% to 40%
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1426
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1432
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1432: Settings cleanup: auto mode, deduplicate config ac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1432
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1545
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Agentic feature progression for repo ecosystem productivity '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1545
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1563
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "Feature: Data & Resource Intelligence \u2014 consolidated plan (4"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1563
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1567
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "Feature: Continuous Repo Architecture Intelligence \u2014 automat"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1567
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1611
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "Fill domain gaps in resource registry \u2014 orcawave, fatigue, s"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1611
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1613
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: Cross-reference resource registry with standards transfer le
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1613
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1615
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: Schedule download-and-catalog pipeline as recurring cron tas
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1615
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1647
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "Fix broken test dependencies \u2014 pint, plotly, deepdiff missin"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1647
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1657
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "Resolve 179 cross-package API name collisions \u2014 top 20 worst"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1657
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1662
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "Module status matrix: PRODUCTION promotion campaign \u2014 16 DEV"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1662
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1679
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1287: Phase 4 cleanup: remove deprecated machine-ranges '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1287
+  title: Active push notifications for harness-update failures (#1668
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1679
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1258
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1680
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: Validate harness-update rollback with simulated tool breakag
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1680
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1682
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "Upgrade pytest-asyncio from 0.21.1 to >=0.23.0 \u2014 fix hypothe"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1682
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1686
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: "ANSYS package: Integration test suite \u2014 end-to-end pressure "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1686
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1689
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "ANSYS package: Promote to PRODUCTION maturity \u2014 docstring au"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1689
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1717
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'chore(policy): resolve work-queue vs GitHub-issues contradic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1717
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1720
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "analysis: cross-agent session corpus audit \u2014 mine 1M+ tool c"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1720
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1733
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore: promote 5 domain-critical skills from CAD-DEVELOPMENT'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1733
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1734
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore: add domain skills to assethold (tier-1 with 0 skills)'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1734
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1743
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test: add coverage for top 20 Python correction hotspot file'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1743
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1748
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'feat(skills): convert CAD-DEVELOPMENTS + aceengineer-admin a'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1748
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1760
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'feat(self-improvement): operationalize /powerup, /insights, '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1760
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1775
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'feat(harness): weekly Claude Code best-practice adoption cad'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1775
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1801
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "Adopt pre:config-protection hook \u2014 prevent agents from weake"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1801
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1802
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "Implement batch-at-Stop pattern \u2014 defer format+typecheck to "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1802
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1803
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "Add context-budget audit skill \u2014 measure token overhead acro"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1803
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1810
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "epic: dark intelligence Excel-to-code promotion \u2014 extract 3,"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1810
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1811
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "dark-intel: promote SN curve POC v2 output \u2192 digitalmodel/fa"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1811
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1812
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "dark-intel: promote conductor length assessment \u2192 digitalmod"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1812
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1813
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "dark-intel: promote surface wellhead SITP calculation \u2192 digi"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1813
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1814
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "dark-intel: promote API RP 2GEO alpha method archive \u2192 digit"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1814
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1815
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "dark-intel: promote flowback calculator extraction \u2192 digital"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1815
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1824
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: "dark-intel: uplift digitalmodel test coverage 2.95% \u2192 20% us"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1824
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1834
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'SKILL: Field Development Pipeline Engineering -- pipe sizing'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1834
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1838
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "AI credit utilization governance \u2014 horses-for-courses routin"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1838
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1839
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "Workflow hard-stops and session governance \u2014 Hermes-orchestr"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1839
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1840
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "feat(geotechnical): onshore foundations \u2014 shallow foundation"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1840
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1841
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "feat(geotechnical): offshore gaps \u2014 lateral piles, mudmats, "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1841
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1843
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "feat(field-dev): concept selection framework \u2014 hub vs standa"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1843
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1859
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'feat(naval-arch): integrate worldenergydata vessel fleet + h'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1859
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1867
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Hermes provider config maintenance \u2014 deepseek CLI patch, ali"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1867
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1868
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Wire Google AI Studio API into Hermes \u2014 use $20/mo Gemini su"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1868
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1876
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: Enforce engineering workflow via Hermes prefill + Claude Cod
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1876
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1877
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: Back-test engineering commits for workflow compliance
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1877
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1880
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: Create session-corpus-audit skill -- analyze session quality
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1880
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1882
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'Enable cross-review strict mode -- gate defaults to WARNING '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1882
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1883
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Tool-call ceiling: reduce from 500 to 200 with auto-pause an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1883
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1884
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'Cross-review enforcement: nightly audit cron for unreviewed '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1884
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1889
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: "dark-intel: uplift digitalmodel test coverage 20% -> 50% \u2014 d"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1889
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1903
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-5109: fix(work-queue): GitHub issue workflow discrepanci'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1258
+  title: 'memory: new-machine onboarding documentation'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1903
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1249
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1913
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: "Codex: test coverage + bounded implementation sprint \u2014 4 pri"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1913
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1918
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1388: Propagate canonical AGENTS.md format to child repo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1249
+  title: 'memory: Claude Code auto-memory sync from Windows back to re'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1918
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#209
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1921
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'infra: Ollama local LLM runtime -- feasibility assessment an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1921
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1925
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: Curate 3,683 extracted CSVs into TDD test fixtures for digit
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1925
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1958
+  repo: vamseeachanta/workspace-hub
+  domain: udw-well-access
+  provider: codex
+  title: "Build slim-hole well engineering module \u2014 casing program com"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1958
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1972
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'Test coverage uplift: integration tests for overnight module'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1972
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1977
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-664: feat(work-queue): multi-agent and multi-workstation'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/209
+  title: "chore(memory): remaining memory ecosystem work \u2014 backup/roll"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1977
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#201
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1988
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "feat: Map Google Drive data to git repos \u2014 O&G public, perso"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1988
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2005
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'audit(digitalmodel): worldenergydata test collection timeout'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2005
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2024
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "build: gmail-extract-and-act pipeline \u2014 rewrite gmail-archiv"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2024
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2028
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat: review gate strict mode + GitHub Actions CI enforcemen'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2028
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2031
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'build: automated compliance monitoring -- daily cron, alerts'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2031
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2046
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: Audit compliance of strict issue planning workflow after rol
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2046
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2052
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'Queue refresh: auto-generate ''This Week''s Focus'' and depende'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2052
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2064
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-685: feat(skills): update /today to highlight availabili'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/201
+  title: 'fix(governance): plan-approval-gate safe-path and marker tes'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2064
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#193
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2068
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): add cross-link JSONL package for wiki-to-st'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2068
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2073
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-635: feat(memory): session scanner \u2014 extract learnings f"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/193
+  title: Expose stage-prompt drift doctor/status in CI and operator s
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2073
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#188
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2077
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-597: feat(digitalmodel): geotechnical module \u2014 umbrella "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/188
+  title: 'fix(governance): narrow tests/* safe-path pattern in plan-ap'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2077
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#186
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2092
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore(harness): define weekly ecosystem review checklist and'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2092
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2094
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): multi-machine readiness matrix for weekly '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2094
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2097
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-586: feat(skills): auto-fetch IACS Blue Book UR updates'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/186
+  title: 'chore(automation): establish recurring execution path for we'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2097
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#137
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2103
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(llm-wiki): extend ingestion to AQWA and BEMRosetta docu'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2103
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2106
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'chore(reporting): define canonical artifact model for weekly'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2106
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2107
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(hermes): auto-clear stale Codex exhaustion state on cred'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2107
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2108
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore(harness): add cron job to scrub stale quota cache entr'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2108
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2109
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'test(hermes): add test coverage for codex_quota reset-time r'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2109
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2110
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-5026: chore(onboarding): add inotify watch limit fix to '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/137
+  title: 'feat(governance): Phase 4a session-close structured report g'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2110
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#113
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2113
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(orchestrator-worker): fresh repo bootstrap for governan'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2113
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2119
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): define machine dispatch policy and workloa'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2119
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2120
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): add fleet heartbeat and last-seen evidence'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2120
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2121
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): add weekly-review query packs and verificat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2121
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2122
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): add weekly ecosystem scorecard with trend d'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2122
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2124
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(llm-wiki): extend ingestion to Orcina resources, exampl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2124
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2125
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'feat(llm-wiki): auto-refresh ingestion on new Orcina release'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2125
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2130
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-235: ROADMAP: Repo ecosystem 3-6 month horizon \u2014 plan an"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/113
+  title: 'fix(bridge): memory bridge auto-commit fails to re-stage aft'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2130
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#111
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2134
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): define machine readiness matrix schema and'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2134
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2135
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): emit per-machine readiness evidence bundle'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2135
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2137
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'docs(knowledge): create canonical Intelligence Entry Points '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2137
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2139
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): define weekly review artifact schema and ca'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2139
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2141
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: Add fixture-backed tests for llm-wiki ingest and search scri
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2141
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2142
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: Standardize tracked skill-link handling across repos to avoi
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2142
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2144
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-182: Predictive Session Planning'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/111
+  title: 'feat(automation): implement weekly ecosystem review runner w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2144
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#110
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2145
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-181: Session Replay & Time Travel'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/110
+  title: 'chore(automation): register weekly ecosystem review in sched'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2145
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#109
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2146
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): add versioned schema spec for weekly ecosys'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2146
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2147
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(reporting): add validator CLI and CI checks for weekly '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2147
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2148
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): implement Linux readiness evidence bundle '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2148
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2149
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): generate seeded intelligence accessibility '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2149
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2150
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): implement Windows no-SSH readiness evidenc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2150
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2152
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): add golden fixture corpus for weekly review'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2152
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2153
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): implement weekly review history index and l'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2153
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2154
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: 'feat(reporting): implement Markdown/HTML publication layout '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2154
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2156
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): add registry coherence validator for access'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2156
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2161
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): ingest provider-session ecosystem audit rea'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2161
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2162
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(schema): define machine/path alias schema for seeded ac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2162
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2199
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(claude): validate hook wiring and backfill session_id p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2199
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2200
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(operations): add wrapper-level subprocess smoke coverag'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2200
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2201
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(gemini): normalize remaining interactive tool semantics'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2201
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2202
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-180: ''Stop Hook: Cross-Agent Learning Sync'''
-  url: https://github.com/vamseeachanta/workspace-hub/issues/109
+  title: 'feat(operations): extend readiness bundle schema for additio'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2202
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#107
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2203
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(harness): make pre-push tier-1 repo checks worktree-awar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2203
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2204
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): add anchored repo-root rewrite mode to shar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2204
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2213
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(docs): expand strict stale-reference enforcement across'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2213
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2214
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'docs(ai): split current architecture guidance from legacy wr'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2214
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2215
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(analysis): add migration-debt trend snapshots to provid'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2215
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2217
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(harness): harden issue-hygiene repo-reality path extract'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2217
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2218
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(harness): reduce false positives in issue-hygiene duplic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2218
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2220
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "chore(repos): clean up dirty repo state \u2014 gitignore fixes + "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2220
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2221
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1336: Bulk review 38 existing open issues + roadmap upda'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/107
+  title: 'feat(daily-report): refresh stale data sources and complete '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2221
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#106
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2222
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: Follow up Claude auth drift hardening with stronger observab
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2222
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2230
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore(claude-config): formalize managed-template vs active-s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2230
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2231
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(memory): add regression coverage for session-log portab'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2231
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2232
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1335: Patch archive-item.sh for ongoing GitHub Issue cre'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/106
+  title: 'feat(memory-health): surface stale or missing session-log po'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2232
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#105
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2233
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): add  frontmatter field to wiki schema and v'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2233
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2234
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'chore(workflow): update session-start-routine to treat hando'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2234
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2235
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'chore(plans): add retention metadata section to issue plan t'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2235
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2236
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'chore(workflow): add post-closure promotion step to issue-pl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2236
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2237
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1334: Delete HTML infrastructure (generator, sub-skills,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/105
+  title: 'feat(automation): build transient-artifact cleanup and archi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2237
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#104
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2238
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(conformance): add closed-issue citation guardrail so du'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2238
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2252
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(provider-routing): add explanatory comments for high-co'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2252
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2253
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(provider-routing): harden Gemini auto-label confidence '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2253
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2254
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(provider-telemetry): improve Claude and Gemini quota obs'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2254
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2255
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1333: Wire Issue updater into stage lifecycle (replace H'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/104
+  title: 'feat(governance): reconcile GitHub plan-approval labels with'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2255
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#103
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2256
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1332: Archive synthesis + knowledge backfill (synthesize'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/103
+  title: 'feat(operations): automate session-exit handoff generation f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2256
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#102
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2258
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(parity): track Claude plugin inventory in ai-tools-stat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2258
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2265
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(rebase): audit skipped hardening commits from backup/p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2265
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2266
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(ops): reconcile provider-health artifact contract after '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2266
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2267
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'chore(sync): add regression coverage for stale gitlink and m'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2267
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2283
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(wiki): promote CSA Z276.2-19 to LNG wiki domain'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2283
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2284
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(wiki): promote OCIMF MEG3 and MEG4 to mooring wiki doma'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2284
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2285
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(wiki): promote API RP 2SK 3rd ed. to mooring wiki domai'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2285
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2291
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1331: GitHub Issue body template renderer (update-github'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/102
+  title: 'fix(cron-health): harden failure detection and align task ev'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2291
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#101
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2292
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: "WRK-1327: Codex /work adapter drift \u2014 documented subcommands"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/101
+  title: 'fix(queue-refresh): restore weekly queue refresh evidence an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2292
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#86
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2293
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'fix(wiki-ingest): make nightly ingest idempotent and push-st'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2293
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2294
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore(skills): salvage #2290 follow-on learnings for regress'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2294
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2297
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(portability): schedule unified smoke drift detection af'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2297
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2298
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'feat(portability): phase-2 unified smoke runner expansion fo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2298
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2299
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'chore(plans): make retention metadata a required planning ar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2299
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2300
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1271: Enforce 200-line hard limit on all SKILL.md files'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/86
+  title: 'feat(governance): reconcile GitHub labels, approval markers,'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2300
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#79
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2301
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'bug(hermes): classify and recover from openai-codex transpor'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2301
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2310
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'analysis(harness): rank Claude stale-read migration-debt bac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2310
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2312
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore(harness): replace legacy local lifecycle-script guidan'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2312
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2332
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore(harness): drive provider-audit bare-python3 debt to ca'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2332
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2341
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'bug(pre-push): ModuleNotFoundError: yaml in uv run --no-proj'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2341
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2359
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore(plugins): remove or fix failing semantic-scholar-mcp i'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2359
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2370
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'feat(knowledge): build closed-issue promotion ledger for eng'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2370
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2374
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): build transient-promotion candidate queue f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2374
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2376
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1227: [script]: Missing back-link: workspace-hub/work-qu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/79
+  title: "feat(harness): provider assessment \u2014 corpus-honest subset (d"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2376
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#77
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2377
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: 'WRK-1209: [script]: Missing back-link: workspace-hub/wrk-lif'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/77
+  title: 'feat(harness): add missing session-signal event emitters to '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2377
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2381
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(governance): add computable expiration metadata to ses'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2381
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2382
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(conformance): add promotion audit-trail checker for L5/'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2382
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2383
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(conformance): implement GUARD-1 invented-layer detector'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2383
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2384
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(governance): add promotion-aware recurring-run output p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2384
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2385
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "chore(harness): consolidate dual session-signals stores \u2014 .c"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2385
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2397
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'epic(repo-organization): canonical folder structure and refa'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2397
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2399
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(ai-orchestration): define next-model-release readiness '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2399
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2400
+  repo: vamseeachanta/workspace-hub
+  domain: document-intelligence
+  provider: claude
+  title: "feat(doc-intel): MCP server core \u2014 doc_key_lookup, wiki_sear"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2400
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2401
+  repo: vamseeachanta/workspace-hub
+  domain: document-intelligence
+  provider: claude
+  title: "feat(doc-intel): MCP server multi-agent registration \u2014 Claud"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2401
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2404
+  repo: vamseeachanta/workspace-hub
+  domain: document-intelligence
+  provider: claude
+  title: 'feat(doc-intel): MCP server audit log + hardened allowlist +'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2404
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2409
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(release-readiness): fixture-backed golden-task corpus f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2409
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2410
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(release-readiness): smoke-battery schema and runner con'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2410
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2412
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(release-readiness): deterministic follow-up issue creat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2412
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2414
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(ecosystem-sync): autobuild or skip missing local git fi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2414
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2415
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(ecosystem-sync): ignore fenced code blocks when extracti'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2415
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2416
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(ecosystem-sync): use annotated tagger date for release f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2416
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2419
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(tests): reconcile skill markdown contract drift in dark-'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2419
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2420
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'fix(skills): restore repo-portfolio-steering balance snapsho'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2420
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2421
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'chore(control-plane): normalize workspace-hub provider entry'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2421
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2423
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat: automated Gmail-side delete/archive for email-as-queue'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2423
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2425
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'meta(ai-orchestration): Claude Code CLI integration rollout '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2425
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2426
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "epic: Claude Design (research preview) \u2014 ecosystem adoption "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2426
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2428
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "feat(claude-design): upstream enhancement feedback bundle \u2014 "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2428
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2429
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "feat(skills): claude-design-prep \u2014 CLI-side input-pack gener"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2429
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2430
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "feat(skills): claude-design-handoff \u2014 post-handoff receiver "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2430
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2432
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "feat(claude-design): adoption trial protocol \u2014 measure cost/"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2432
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2434
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: "epic(aceengineer-website): Claude Design adoption \u2014 site-wid"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2434
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2435
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: 'feat(aceengineer-website): establish design system in Claude'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2435
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2439
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: 'chore(aceengineer-website): Bootstrap design-debt audit + to'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2439
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2440
+  repo: vamseeachanta/workspace-hub
+  domain: content
+  provider: claude
+  title: 'decision: visual DNA coherence across aceengineer.com + digi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2440
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2445
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: Implement bypass-rollback advisor and post-commit observer p
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2445
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2470
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(acma-codes): produce readable source-grounded summaries'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2470
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2478
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'follow-up(ci): worldenergydata Python test matrix fails afte'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2478
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2483
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'chore(knowledge): populate freshness-cadence matrix with per'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2483
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2484
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): extend staleness-scanner to cover yaml regi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2484
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2485
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "feat(enforcement): mechanical linter + ledger for llm-wiki \u2192"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2485
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2497
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(memory): handoff-doc cross-row SHA transcription hazar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2497
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2498
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(harness): #2364 plan branch drift recovery decision ne'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2498
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2499
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(harness): #2368 missing revision-bound approval marker'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2499
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2500
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(harness): #2476 non-standard approval pattern (no plan'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2500
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2501
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "chore(planning): #2105 governance-lock \u2014 handoff vs live-sta"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2501
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2502
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat(ai-orchestration): harden plan-review artifact metadata'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2502
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2503
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat(ai-orchestration): standardize canonical approval-reque'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2503
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2504
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat(ai-orchestration): define dispatch-ledger trust contrac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2504
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2505
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat(ai-orchestration): add golden-output contract for morni'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2505
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2506
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'feat(ai-orchestration): validate Lane E implementation hando'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2506
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2524
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(orchestration): add machine-aware dispatch ledger and r'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2524
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2525
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(provider-usage): codex expiring-credit burn-down contro'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2525
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2527
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'infra(gmail): re-authorize claude_ai_Gmail MCP with gmail.mo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2527
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2529
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "[Daily] Inbox manageability tracker \u2014 auto-comment thread fr"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2529
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2533
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'feat(repo-portfolio): review and revise mission/objective st'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2533
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2534
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(ace-drive): retention-gated cleanup for Elements stagi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2534
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2537
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(investments): sanity-check and migrate files to asseth'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2537
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2538
+  repo: vamseeachanta/workspace-hub
+  domain: gis
+  provider: claude
+  title: 'ace2: generate lifetime property imagery timelapse for 11511'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2538
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2539
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(rock-oil-field): sanity-check and migrate useful code/'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2539
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2545
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(saipem): extract useful installation-project informati'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2545
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2547
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(seanation): extract useful client information and arch'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2547
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2549
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(business-brain): periodically assess repo work and ref'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2549
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2550
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'chore(security): codify public repo interaction-limit renewa'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2550
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2551
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'audit(security): verify branch/ruleset protections across pu'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2551
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2552
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'docs(security): external contributor and unsolicited paid-he'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2552
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2553
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'docs(repo-portfolio): reconcile repository overview docs aft'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2553
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2557
+  repo: vamseeachanta/workspace-hub
+  domain: gtm
+  provider: claude
+  title: 'chore(productivity): weekly work-pattern review and flow hac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2557
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2572
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'Routine: /repo-sync + /mnt/local-analysis cleanup audit (eve'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2572
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2585
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'tracker(digitalmodel-tests): 26 collect_ignore entries from '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2585
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2609
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'tracker(digitalmodel-tests): post-#543 main has 244+ broken '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2609
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2623
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "fix(digitalmodel-tests): Cluster A \u2014 sys.modules pollution l"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2623
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2624
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "policy(digitalmodel-tests): Cluster D \u2014 decide whether redis"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2624
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2626
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'fix(security): narrow #2552 external-contributor runbook tes'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2626
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2650
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'chore(knowledge): post-spinout cleanup for llm-wiki migratio'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2650
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2652
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: Daily repo readiness tracker
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2652
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2656
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(repo-structure): normalize workspace-hub folder/file s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2656
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2657
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(provider-session): remediate Hermes llm-wiki spinout p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2657
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2658
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'O&G-Standards consolidator: 8 catalog-classification defects'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2658
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2662
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "GTM client-artifact layout inconsistent across repos \u2014 no sh"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2662
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2663
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: "chore(harness): adopt HTML as default artifact format \u2014 .cla"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2663
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2665
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(kanban): provider-credit approval dashboard and dispatc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2665
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2667
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: "Feature: Domain Knowledge Sweep \u2014 systematic multi-source re"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2667
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2695
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(harness): /goal use-case catalog for repo ecosystem (cl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2695
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2698
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(ai-orchestration): migration plan for AI_ECOSYSTEM_DESI'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2698
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2699
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore(ai-tools): refresh agent-capability-scores.yaml from 2'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2699
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2700
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(ai-orchestration): "Memory-to-Surface" map maintenance '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2700
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2701
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'audit(harness): 17 status:plan-approved issues missing .plan'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2701
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2707
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "chore(skills): curation judgments \u2014 single-skill stragglers,"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2707
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2710
+  repo: vamseeachanta/workspace-hub
+  domain: solver
+  provider: claude
+  title: "feat(solver-queue): conversational submit UX \u2014 /solver-submi"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2710
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2715
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'bug(infra): codex-cli 0.130.0 stdin-hang regression (recurre'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2715
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2716
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'cleanup(paths): fix 4 hardcoded /mnt/workspace-hub callsites'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2716
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2718
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "audit(hermes): kanban-worker dispatch hazards \u2014 parallel-spa"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2718
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2721
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'fix(review-tools): submit-to-codex.sh silently degrades in n'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2721
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2732
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'feat(data-governance): canonical first/second-level mount an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2732
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2735
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'design: memory write/read API for non-Hermes providers (Clau'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2735
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2736
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'design: migration plan from per-provider memory stores (Clau'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2736
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2741
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(deckhand): validate Telegram dispatch smoke tests and d'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2741
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2750
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Hermes: integrate pre-completion-cleanup-audit into sub-agen'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2750
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2758
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: Clarify agent/runtime folder architecture to reduce human an
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2758
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2762
+  repo: vamseeachanta/workspace-hub
+  domain: gateway-ops
+  provider: claude
+  title: 'plan(operations): define Hermes-vs-system cron scheduler rou'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2762
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2763
+  repo: vamseeachanta/workspace-hub
+  domain: gateway-ops
+  provider: claude
+  title: 'plan(operations): migrate gsd-researcher scheduled AI work t'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2763
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2764
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(operations): harden Hermes session exporter for undated '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2764
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2765
+  repo: vamseeachanta/workspace-hub
+  domain: gateway-ops
+  provider: claude
+  title: 'feat(operations): add scheduler parity report for system cro'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2765
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2776
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "Cross-wiki linking discipline \u2014 supersede stale governance +"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2776
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2782
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'Bug: hardcoded /mnt/github paths silently no-op (env-var ref'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2782
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2785
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(ecosystem): deepen workspace-hub repo routing and sync '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2785
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2786
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(ecosystem): put duplicated agent infrastructure behind '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2786
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2787
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(worldenergydata): deepen ingestion around source-specif'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2787
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2788
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(assetutilities): deepen shared calculation and config u'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2788
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2790
+  repo: vamseeachanta/workspace-hub
+  domain: website,repo
+  provider: claude
+  title: 'arch(aceengineer-website): consolidate static-site delivery '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2790
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2791
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(ecosystem): split admin/document stores from executable'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2791
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2792
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'arch(llm-wiki): treat wiki repos as Knowledge Index modules'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2792
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2797
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Refine dispatch assignments as machine capabilities + worklo
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2797
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2854
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: "gap(memory): Hermes read-back leg missing \u2014 consolidated mem"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2854
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2900
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Plan Deckhand multi-platform notification fanout for Telegra
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2900
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2901
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Plan Deckhand Telegram/Signal/WhatsApp/Teams platform parity
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2901
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2902
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Plan Deckhand shared delivery group and fanout contract
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2902
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2903
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Plan Deckhand conversation reply policy guardrails for multi
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2903
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2904
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Plan Deckhand send_message multi-target text fanout
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2904
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2905
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Plan Deckhand operator docs for Telegram, Signal, WhatsApp, '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2905
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2906
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Apply Deckhand product name across the multi-platform bot pl
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2906
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2920
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Roll out update-harness-tools.sh across machine ecosystem
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2920
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2963
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: codex
+  title: Bulk-relabel command + execute the 5 alias renames from rout
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2963
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2964
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'routing-rules.yaml entries for the 34 new domain: labels (av'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2964
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3031
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'triage: backfill placeholder bodies on gh-next-id.sh / backf'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3031
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3032
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "triage: close-out sweep \u2014 migrated WRK issues open on GitHub"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3032
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3033
+  repo: vamseeachanta/workspace-hub
+  domain: skills,harness
+  provider: claude
+  title: 'triage: incorporate Claude session learnings from 2026-05-20'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3033
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3067
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'uv-workflow(workspace-hub): write the canonical UV workflow '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3067
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3284
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "wf-api(ecosystem): discovery manifest \u2014 aggregate callable w"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3284
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3286
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: codex
+  title: 'wf-api(worldenergydata): adopt envelope + generalize typed-q'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3286
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3288
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'wf-api(deckhand): EXECUTE leg consumes run_workflow + render'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3288
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3292
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'seamless(ci): digitalmodel touched-domain-only on push + cle'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3292
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3296
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'seamless(governance): evidence-threshold approval evolution '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3296
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3308
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: codex
+  title: "wf-api(assethold): engine embed-port \u2014 mirror #3297 for asse"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3308
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3349
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Perf: ecosystem-data-nudge.sh UserPromptSubmit hook runs 270'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3349
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3371
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(data): critical-data inventory & retention tiering (fin'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3371
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3374
+  repo: vamseeachanta/workspace-hub
+  domain: capability
+  provider: claude
+  title: 'spike(capability): prognostics/RUL from public benchmark dat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3374
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3385
+  repo: vamseeachanta/workspace-hub
+  domain: website
+  provider: claude
+  title: 'Ecosystem: dedicated SME-verification section on digitalmode'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3385
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3403
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: codex
+  title: Repair Linux voice dictation rollout and VNC consistency con
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3403
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3404
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Explore direct SSH path to gpu-claw without WireGuard depend
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3404
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3423
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(landman-desk): route work to landmen or trainees and cl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3423
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3435
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: 'bug: make hook installation worktree-aware'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3435
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3436
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: 'bug: make new-branch pre-push checks worktree-aware'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3436
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3437
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: codex
+  title: 'standard: require SHA-pinned cross-repository plan evidence'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3437
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3440
+  repo: vamseeachanta/workspace-hub
+  domain: security,workflow
+  provider: claude
+  title: Harden generated HTML against JSON script-tag breakout
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3440
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3444
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: 'infra: route Python environments off fuseblk worktrees'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3444
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3445
+  repo: vamseeachanta/workspace-hub
+  domain: testing,ci-release
+  provider: claude
+  title: Require status and readiness checks to validate the same sou
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3445
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3447
+  repo: vamseeachanta/workspace-hub
+  domain: testing,harness
+  provider: claude
+  title: Add cross-format CLI behavior parity tests for option-bearin
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3447
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3454
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'chore(local-analysis): publish sanitized interactive cleanup'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3454
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3457
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'fix(worktrees): fail closed on an absent sparse-worktree ind'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3457
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3472
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'feat(operations): add pressure-aware daily OS maintenance cl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3472
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3482
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'design(repo-health): safe worktree lifecycle with leases and'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3482
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3525
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: '[WRK] Investigate safe remote Claude job dispatch to ace-win'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3525
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3537
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: '[WRK] Make plan-review fanout artifacts atomic and revision-'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3537
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3545
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Plan bounded same-account Claude Remote Control pilot on Win
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3545
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3547
+  repo: vamseeachanta/workspace-hub
+  domain: workstations,security
+  provider: claude
+  title: 'feat(ops): secure remote Linux access architecture and stage'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3547
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3551
+  repo: vamseeachanta/workspace-hub
+  domain: workstations,security
+  provider: claude
+  title: 'ops(dev-primary): roll out and verify Tailscale plus hardene'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3551
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3572
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: Harden agent workflows for idempotent external mutations and
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3572
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3584
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'phone-media: USB-pull remaining family phones into the archi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3584
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3585
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'phone-media: EXIF-date organizer + cross-phone dedupe'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3585
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3586
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'phone-media: off-site backup capacity plan + periodic rclone'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3586
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3672
+  repo: vamseeachanta/workspace-hub
+  domain: marine
+  provider: claude
+  title: "WRK-5121: FEM visualization skill \u2014 automate ccx results to "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3672
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3686
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'WRK-1304: Update pdf skill to recommend PyMuPDF4LLM over Cod'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3686
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3688
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: 'WRK-1275: Add sensitivity, validation, verification to calc '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3688
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3689
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "WRK-1274: Upgrade Gen 1 calc examples \u2014 add scope, design_ba"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3689
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3690
+  repo: vamseeachanta/workspace-hub
+  domain: naval-architecture
+  provider: claude
+  title: 'WRK-1096: Add HydroComp NavCad electric-motor resources to w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3690
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3695
+  repo: vamseeachanta/workspace-hub
+  domain: repo-cleanup
+  provider: claude
+  title: "chore(llm-wiki): resolve two empty client-wiki stubs \u2014 llm-w"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3695
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3696
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'chore(machines): 6 unpushed commits stranded in secondary wo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3696
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3731
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'chore(scheduler): register dispatch-run.ps1 as a mutation su'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3731
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3737
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): Windows scheduler probe never runs - MSYS man'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3737
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#1
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: claude
+  title: Plan Deckhand named repository scopes and scope policy
+  url: https://github.com/vamseeachanta/deckhand/issues/1
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#2
+  repo: vamseeachanta/deckhand
+  domain: security
+  provider: claude
+  title: Rotate Deckhand PATs by 2026-06-08 (transcript exposure)
+  url: https://github.com/vamseeachanta/deckhand/issues/2
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#7
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
+  provider: claude
+  title: "Deckhand: connect Microsoft Teams platform \u2014 channels + user"
+  url: https://github.com/vamseeachanta/deckhand/issues/7
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#13
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: claude
+  title: 'Deckhand v2: multi-channel delivery groups + fanout (BLOCKED'
+  url: https://github.com/vamseeachanta/deckhand/issues/13
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#72
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
+  provider: claude
+  title: "Investigate operator-side Telegram automation \u2014 computer-use"
+  url: https://github.com/vamseeachanta/deckhand/issues/72
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#83
+  repo: vamseeachanta/deckhand
+  domain: security
+  provider: claude
+  title: 'skill: mint scope tokens via GitHub App (replace manual fine'
+  url: https://github.com/vamseeachanta/deckhand/issues/83
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#423
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops,security
+  provider: claude
+  title: "[P0] Live gateway UNPATCHED \u2014 redeploy client-protection gat"
+  url: https://github.com/vamseeachanta/deckhand/issues/423
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#559
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: claude
+  title: "L3 design: minimal per-node agent (bounded LLM work) \u2014 evolu"
+  url: https://github.com/vamseeachanta/deckhand/issues/559
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#12
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: engg debt | Padeye Calculations
+  url: https://github.com/vamseeachanta/digitalmodel/issues/12
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#17
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: code_dnvrph103 | discretized model at an angle
+  url: https://github.com/vamseeachanta/digitalmodel/issues/17
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#20
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: code_dnvrph103 | If CoV is same as CoG, leave it null
+  url: https://github.com/vamseeachanta/digitalmodel/issues/20
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#23
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: dnvrph103 | Create common functions from rectangular and cir
+  url: https://github.com/vamseeachanta/digitalmodel/issues/23
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#30
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: engg debt | Ship design | min scantling calculations
+  url: https://github.com/vamseeachanta/digitalmodel/issues/30
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#31
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: engg debt | Ship design | strength checks
+  url: https://github.com/vamseeachanta/digitalmodel/issues/31
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#54
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: SS |  Task List
+  url: https://github.com/vamseeachanta/digitalmodel/issues/54
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#60
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: engg debt | Time Series | Filter in FFT and Get Timetrace Ba
+  url: https://github.com/vamseeachanta/digitalmodel/issues/60
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#65
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: optimization | shells | migrate to gitbash
+  url: https://github.com/vamseeachanta/digitalmodel/issues/65
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#80
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: Project DRS | Tasks
+  url: https://github.com/vamseeachanta/digitalmodel/issues/80
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#87
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: engg debt | Autodesk Autocad
+  url: https://github.com/vamseeachanta/digitalmodel/issues/87
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#89
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: PB | Task List
+  url: https://github.com/vamseeachanta/digitalmodel/issues/89
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#92
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: engg debt | FreeCAD
+  url: https://github.com/vamseeachanta/digitalmodel/issues/92
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#95
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: Design Drawings
+  url: https://github.com/vamseeachanta/digitalmodel/issues/95
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#109
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: debt | Architecture Implementation
+  url: https://github.com/vamseeachanta/digitalmodel/issues/109
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#132
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: 'WRK-023: Property GIS development timeline with future proje'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/132
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#266
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: 'WRK-623: feat(geotechnical): scour prediction per DNV-RP-F10'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/266
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#469
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: Assess AI agent session artifact dirs across machines (.code
+  url: https://github.com/vamseeachanta/digitalmodel/issues/469
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#488
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement subsea umbilical and control systems module (API 1
+  url: https://github.com/vamseeachanta/digitalmodel/issues/488
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#489
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement HIPPS modeling module (API 17O)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/489
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#490
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement capping stack analysis module (API 17W)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/490
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#491
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Implement ROV intervention modeling module (API 17H)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/491
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#493
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Implement river/shallow-water current profile modeling
+  url: https://github.com/vamseeachanta/digitalmodel/issues/493
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#494
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Enhance flexible pipe modeling \u2014 API 17B/17J compliance"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/494
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#514
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'Resolve or document the conftest ignore policy around async '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/514
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#522
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: Codify ultra-constrained Claude subprocess prompt patterns f
+  url: https://github.com/vamseeachanta/digitalmodel/issues/522
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#523
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: 'Harvest #517 subprocess review into actionable implementatio'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/523
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#578
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: codex
+  title: W2W motion-compensated gangway operability module (DNV-ST-03
+  url: https://github.com/vamseeachanta/digitalmodel/issues/578
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#590
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'fix(marine_ops): test_database_performance has flaky 1ms per'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/590
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#618
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: Citation-resolver hardening follow-ons (symlink hygiene, log
+  url: https://github.com/vamseeachanta/digitalmodel/issues/618
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1184
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'seismic: code design spectra (ASCE 7 / Eurocode 8) + spectra'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1184
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1185
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'seismic: 1D site-response / ground-motion propagation (SHAKE'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1185
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1186
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'seismic: multi-component / HVSR microtremor array + instrume'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1186
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1187
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'seismic: multi-DOF / full-FEA seismic time-history (route vi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1187
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1188
+  repo: vamseeachanta/digitalmodel
+  domain: website
+  provider: claude
+  title: 'seismic: interactive browser front-end for strong-motion ana'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1188
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1634
+  repo: vamseeachanta/digitalmodel
+  domain: governance
+  provider: claude
+  title: 'ci(governance): protect-main has no required_status_checks a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1634
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1648
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-1149: Method assessment and selection \u2014 propeller-rudder"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1648
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1650
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "WRK-1251: FreeCAD deep parametric engineering \u2014 hull generat"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1650
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1655
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-043: Parametric hull form analysis with RAO generation a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1655
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1658
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-075: OFFPIPE Integration Module \u2014 pipelay cross-val'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1658
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1677
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "WRK-1342: OrcaFlex parachute deployment template \u2014 time-doma"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1677
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1682
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "WRK-1376: Resistance prediction \u2014 Holtrop-Mennen method impl"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1682
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1684
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'WRK-1392: 3D interactive frame viewer (HTML/three.js)'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1684
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1694
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Add AISC shapes database lookup for sectionproperties
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1694
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1696
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Composite/multi-material section analysis PoC with sectionpr
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1696
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1701
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Automated WAMIT validation runner for L00 test cases
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1701
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1702
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Design Load Case (DLC) matrix generator for OrcaFlex mooring
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1702
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1707
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: "Registry freshness checker \u2014 periodic URL validation and dea"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1707
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1720
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'Solver queue: notification alerts on repeated failures + ret'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1720
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1729
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "feat(freespan): wire wave_velocity into facade \u2014 auto-comput"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1729
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1730
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(freespan): turbulence intensity and wave spreading redu'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1730
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1731
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(freespan): trench depth correction for CF onset velocit'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1731
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1732
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(freespan): strake and SCF corrections for VIV fatigue d'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1732
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1736
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: populate RAODatabase from all existing .xlsx fixtures (5 geo
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1736
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1737
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: RAO comparison plots for L02 OC4 semi-sub (multi-column geom
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1737
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1752
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: "feat(naval-arch): tonnage and regulatory calculations \u2014 GT/N"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1752
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1765
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "Batch 3: Installation Engineering References \u2014 18 workbooks"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1765
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1766
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Batch 4: SCR Design DNV F201 + Wall Thickness \u2014 18 workbooks"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1766
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1767
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Batch 5: Talos Venice Umbilical Installation \u2014 31 workbooks"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1767
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1768
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "Batch 6: Shell Perdido + VMCast + Production Eng Library \u2014 7"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1768
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1769
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Batch 2: Convert FDAS Riser Engineering workbooks via Window'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1769
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1776
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'feat(field-dev): make recovery_factor configurable on Econom'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1776
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1777
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: "feat(field-dev): add decline_sensitivity() sweep \u2014 NPV vs de"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1777
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1778
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'test(field-dev): add sparse/edge-case coverage to architectu'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1778
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1779
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: codex
+  title: 'feat(field-dev): add regional segmentation to architecture p'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1779
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1780
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'fix(field-dev): timeline._stats() type annotation and empty-'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1780
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1781
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: "feat(subseaiq): normalize year field validation \u2014 reject non"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1781
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1785
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'digitalmodel: CadQuery spike for parametric offshore geometr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1785
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1786
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "CAD-DEVELOPMENTS: comparison \u2014 CadQuery vs build123d vs Repl"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1786
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1787
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'Engineering methodology: code-first vs GUI CAD for offshore '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1787
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1789
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(canonical-spec): validate CALM/SPM buoy OrcaFlex semant'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1789
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1790
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(canonical-spec): prove OrcaWave-to-OrcaFlex hydrodynami'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1790
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1791
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: 'feat(canonical-spec): add OrcaFlex native reverse-parser equ'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1791
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1801
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "R4 \u2014 Hydrodynamics: LinkedIn expert mapping (marketing surfa"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1801
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1808
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: "R4 \u2014 Mooring: LinkedIn expert mapping (marketing surface)"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1808
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1816
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: "R4 \u2014 Subsea Pipelines: LinkedIn expert mapping (marketing su"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1816
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1853
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: 'WRK-575: Clean digitalmodel docs/modules/ stale content'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1853
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1885
+  repo: vamseeachanta/digitalmodel
+  domain: artificial-lift
+  provider: claude
+  title: "fix(dynacard): solver round trip collapses 8 of 20 labels \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1885
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#44
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'WRK-1109: Set up WhatsApp MCP for Claude CLI on ace-linux-1'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/44
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/workspace-hub#63
   repo: vamseeachanta/workspace-hub
   domain: harness
@@ -10377,1813 +8237,3847 @@ cards:
   url: https://github.com/vamseeachanta/workspace-hub/issues/63
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#45
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#66
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ai
   provider: claude
-  title: 'WRK-1110: enhance(workstations): extend skill with hardware '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/45
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#44
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1109: Set up WhatsApp MCP for Claude CLI on ace-linux-1'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/44
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#42
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1103: learn(harness): complete Anthropic''s official Clau'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/42
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#38
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: "WRK-1088: feat(harness): data pipeline framework \u2014 consisten"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/38
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#37
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1051: chore(harness): verify Codex config on ace-win-1'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/37
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#32
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1024: chore(harness): increase context window limits for'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/32
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#30
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1000: fix(work-queue): restore /work skill compatibility'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/30
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#12
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK-1022: Consistent terminal experience across Linux CLI an'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/12
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2769
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'chore(data-disposition): plan disposition of /mnt/ace/mkt-a-p'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2769
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2758
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: Clarify agent/runtime folder architecture to reduce human an
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2758
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2753
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "Operational tracker: fresh-machine setup runs (evergreen \u2014 d"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2753
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2751
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'Cross-platform harness setup: integrate AI-provider bootstra'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2751
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2742
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'plan(hermes): Windows and macOS Telegram/Hermes dispatch par'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2742
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2738
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'feat(hermes): harden ace-linux-1 Telegram gateway as dispatc'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2738
+  title: "WRK-1176: Two-agent pattern \u2014 initializer vs coder session r"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/66
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2737
+- gh: vamseeachanta/workspace-hub#109
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: ai
   provider: claude
-  title: 'feat(hermes): enable Telegram/Hermes control-surface dispatc'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2737
+  title: 'WRK-180: ''Stop Hook: Cross-Agent Learning Sync'''
+  url: https://github.com/vamseeachanta/workspace-hub/issues/109
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2716
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#110
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: harness
   provider: claude
-  title: 'cleanup(paths): fix 4 hardcoded /mnt/workspace-hub callsites'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2716
+  title: 'WRK-181: Session Replay & Time Travel'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/110
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2666
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#111
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: harness
   provider: claude
-  title: "Multi-repo codex-burn-20260511 batch \u2014 2 unmerged branches r"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2666
+  title: 'WRK-182: Predictive Session Planning'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/111
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2662
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#137
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: workstations
   provider: claude
-  title: "GTM client-artifact layout inconsistent across repos \u2014 no sh"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2662
+  title: 'WRK-5026: chore(onboarding): add inotify watch limit fix to '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/137
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2658
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#164
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: uncategorised
   provider: claude
-  title: 'O&G-Standards consolidator: 8 catalog-classification defects'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2658
+  title: 'WRK-5089: Update pdf skill to recommend PyMuPDF4LLM over Cod'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/164
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2551
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#183
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: content
   provider: claude
-  title: 'audit(security): verify branch/ruleset protections across pu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2551
+  title: 'WRK-580: feat(worldenergydata): map open-access journal port'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/183
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2550
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#186
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: skills
   provider: claude
-  title: 'chore(security): codify public repo interaction-limit renewa'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2550
+  title: 'WRK-586: feat(skills): auto-fetch IACS Blue Book UR updates'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/186
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2529
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#189
   repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "[Daily] Inbox manageability tracker \u2014 auto-comment thread fr"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2529
+  domain: workstations
+  provider: codex
+  title: 'WRK-603: chore(doc-index): review disciplines/knowledge_skil'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/189
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2527
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1320
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: standards
   provider: claude
-  title: 'infra(gmail): re-authorize claude_ai_Gmail MCP with gmail.mo'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2527
+  title: "WRK-1378: Regulatory compliance engine \u2014 IMO/ABS/DNV automat"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1320
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2494
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1404
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: "chore(cleanup): aceengineer-admin \u2014 remove legacy src/aceeng"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2494
+  title: 'WRK-1404: Organize /mnt/ace/docs/ subfolders and deduplicate'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1404
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2478
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1476
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: workflow
   provider: claude
-  title: 'follow-up(ci): worldenergydata Python test matrix fails afte'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2478
+  title: "GWS (Google Workspace CLI) integration \u2014 Gmail, Docs, Sheets"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1476
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2450
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1478
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: skills
   provider: claude
-  title: "chore(ci-health): triage tests/work-queue/ \u2014 port to GSD or "
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2450
+  title: FFmpeg skill for simulation output and media processing
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1478
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2449
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1485
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: 'chore(ci-health): audit .planning/templates/ orphan refs fro'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2449
+  title: Retrofit existing calculation module to use Pint units
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1485
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2423
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1505
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: workstations
   provider: claude
-  title: 'feat: automated Gmail-side delete/archive for email-as-queue'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2423
+  title: 'Verify Claude Desktop install: ace-linux-1'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1505
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2338
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1511
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: harness
   provider: claude
-  title: "chore(cron): cadence-lib smoke test \u2014 pre-commit --smoke dry"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2338
+  title: Migrate cron jobs to Claude Desktop scheduled agents for sel
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1511
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2337
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1538
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: testing
   provider: claude
-  title: 'chore(cron): cadence-schedule index generator + pre-commit g'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2337
+  title: Verify cross-review adversarial enforcement across sessions
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1538
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2266
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1539
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: ai
   provider: claude
-  title: 'fix(ops): reconcile provider-health artifact contract after '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2266
+  title: Install codex-plugin-cc across all machines
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1539
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2259
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1587
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: 'chore(pyproject-starter): triage archived remote sync except'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2259
+  title: 'Promote near-PRODUCTION packages: add docstrings to asset_in'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1587
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2064
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1602
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: 'fix(governance): plan-approval-gate safe-path and marker tes'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2064
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2033
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'session-log: 2026-04-07 -- executed enforcement, self-improv'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2033
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2026
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "build: Email state tracking system \u2014 Gmail labels + local st"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2026
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2023
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'session-log: 2026-04-07 future-work-structuring -- random th'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2023
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1992
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'TODO: File taxes using 1099 payment analysis, then close iss'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1992
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1989
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "insight: GitGuardian alert \u2014 secret exposed in workspace-hub"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1989
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1985
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'Daily system health review 2026-04-06: 4 real cron failures,'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1985
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1885
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'Configure Telegram messaging platform for Hermes gateway on '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1885
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1804
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'Evaluate MCP servers: evalview, insaits, token-optimizer, om'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1804
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1682
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "Upgrade pytest-asyncio from 0.21.1 to >=0.23.0 \u2014 fix hypothe"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1682
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1664
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: Schedule test health dashboard as weekly cron task (Sunday 0
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1664
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1647
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "Fix broken test dependencies \u2014 pint, plotly, deepdiff missin"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1647
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1614
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "Registry freshness checker \u2014 periodic URL validation and dea"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1614
+  title: "Promote DEVELOPMENT packages toward PRODUCTION maturity \u2014 do"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1602
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#1603
   repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
+  domain: repo
+  provider: codex
   title: "Multi-repo architecture scan \u2014 expand scanner to all tier-1 "
   url: https://github.com/vamseeachanta/workspace-hub/issues/1603
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1411
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1604
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: "WRK-1411: fix: archive blocker from WRK-workspace-hub-1398 \u2014"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1411
+  title: 'Architecture scanner: detect API surface and import dependen'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1604
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1409
+- gh: vamseeachanta/workspace-hub#1630
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: testing
   provider: claude
-  title: "WRK-1409: fix: archive blocker from WRK-workspace-hub-1398 \u2014"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1409
+  title: "Test coverage: web package Flask integration tests \u2014 require"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1630
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1324
+- gh: vamseeachanta/workspace-hub#1632
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: testing
   provider: claude
-  title: 'WRK-1324: Fix archive hook deadlock: enforce-stage-machinery'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1324
+  title: "Test coverage: field_development matplotlib tests \u2014 skipped "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1632
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1313
+- gh: vamseeachanta/workspace-hub#1645
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: 'WRK-5130: WRK-5130'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1313
+  title: "Docstring uplift wave 2 \u2014 web, reservoir, infrastructure, ma"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1645
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1305
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1646
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: repo
   provider: claude
-  title: 'WRK-5101: WRK-5101'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1305
+  title: "Docstring uplift wave 3 \u2014 solvers, hydrodynamics, specialize"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1646
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1304
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5098: WRK-5098'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1304
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1303
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5096: WRK-5096'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1303
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1298
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1383: WRK-1383'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1298
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1290
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1338: WRK-1338'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1290
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1289
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1329: WRK-1329'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1289
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1119
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "WRK-300: workstations skill \u2014 evolve from registry to multi-"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1119
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#202
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-687: arch(comp-learning): per-workstation analysis with '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/202
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#196
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-661: analysis(worldenergydata): dead code identification'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/196
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#189
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-603: chore(doc-index): review disciplines/knowledge_skil'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/189
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#181
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-575: Clean digitalmodel docs/modules/ stale content'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/181
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#180
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-574: Remove digitalmodel setup.py (superseded by pyproje'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/180
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#165
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5090: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/165
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#164
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5089: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/164
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#163
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5083: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/163
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#162
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5081: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/162
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#161
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5080: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/161
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#160
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5079: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/160
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#159
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5078: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/159
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#158
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5076: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/158
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#157
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5075: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/157
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#156
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5074: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/156
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#155
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5073: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/155
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#154
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5061: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/154
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#151
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5053: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/151
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#150
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5052: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/150
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#149
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5051: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/149
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#148
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5050: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/148
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#147
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5049: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/147
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#146
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5045: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/146
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#145
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5043: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/145
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#144
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5034: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/144
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#143
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5033: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/143
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#142
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5032: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/142
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#141
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5031: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/141
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#139
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5029: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/139
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#138
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5028: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/138
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#136
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5025: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/136
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#135
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5024: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/135
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#134
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5017: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/134
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#133
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5015: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/133
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#132
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5014: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/132
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#131
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5013: Fix session-analysis.sh Windows arithmetic bug (wc'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/131
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#130
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5012: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/130
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#129
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5011: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/129
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#128
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5010: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/128
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#127
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5009: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/127
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#126
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5008: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/126
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#125
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5007: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/125
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#124
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5006: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/124
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#123
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5005: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/123
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#122
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-5004: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/122
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#112
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "WRK-227: Evaluate cowork relevance \u2014 repo ecosystem fit vs a"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/112
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#100
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1326: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/100
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#97
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1315: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/97
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#90
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1286: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/90
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#89
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1285: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/89
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#88
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1284: Evaluate Zellij terminal multiplexer for cross-wor'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/88
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#87
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1278: setup-cron.sh --replace mode + deploy canonical cr'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/87
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#84
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "WRK-1262: aceengineer-admin repo restructure \u2014 canonical doc"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/84
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#82
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1258: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/82
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#78
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1226: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/78
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#75
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1207: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/75
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#69
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1182: Work-queue-workflow interactive stage menu'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/69
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#54
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1136: Improve repo-sync skill: comprehensive origin stat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/54
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#53
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "WRK-1134: Audit empty submodule dirs in workspace-hub \u2014 init"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/53
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#52
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1133: Add ace-win-2 to workstations documentation and r'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/52
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#50
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1122: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/50
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#49
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1121: untitled'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/49
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#48
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: "WRK-1118: Cross-platform bash sweep \u2014 replace bc/python3/npr"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/48
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#47
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1117: Windows/Git Bash: fix comprehensive-learning push '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/47
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#40
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'WRK-1089: Split check-all.sh by responsibility (400L hard li'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/40
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2761
-  repo: vamseeachanta/workspace-hub
-  domain: null
-  provider: claude
-  title: Explore 3-night Broken Bow-style family getaway alternatives
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2761
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2077
-  repo: vamseeachanta/workspace-hub
-  domain: null
-  provider: claude
-  title: 'fix(governance): narrow tests/* safe-path pattern in plan-ap'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2077
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1663
-  repo: vamseeachanta/workspace-hub
-  domain: null
-  provider: claude
-  title: "Quality score trend dashboard \u2014 track maturity trajectory ov"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1663
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1661
-  repo: vamseeachanta/workspace-hub
-  domain: null
-  provider: claude
-  title: 'Architecture scanner: dependency cycle detection and layerin'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1661
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
+  routed_by: manual
 - gh: vamseeachanta/workspace-hub#1659
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: repo
   provider: claude
   title: "Promote data_models from SKELETON to DEVELOPMENT \u2014 add tests"
   url: https://github.com/vamseeachanta/workspace-hub/issues/1659
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#1499
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1661
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: repo
   provider: claude
-  title: Composite/multi-material section analysis PoC with sectionpr
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1499
+  title: 'Architecture scanner: dependency cycle detection and layerin'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1661
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1497
+- gh: vamseeachanta/workspace-hub#1663
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: testing
   provider: claude
-  title: Add AISC shapes database lookup for sectionproperties
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1497
+  title: "Quality score trend dashboard \u2014 track maturity trajectory ov"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1663
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1432
+- gh: vamseeachanta/workspace-hub#1664
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: testing
   provider: claude
-  title: 'WRK-1432: Settings cleanup: auto mode, deduplicate config ac'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1432
+  title: Schedule test health dashboard as weekly cron task (Sunday 0
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1664
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1408
+- gh: vamseeachanta/workspace-hub#1666
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: testing
   provider: claude
-  title: "WRK-1408: Wire notification consumer \u2014 surface logs/notifica"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1408
+  title: 'Test health dashboard: add historical trend tracking and cov'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1666
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1327
+- gh: vamseeachanta/workspace-hub#1667
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: udw-well-access
   provider: claude
-  title: 'WRK-1327: Remove deprecated next-id.sh and enforce gh-next-i'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1327
+  title: 'Reservoir package: add well correlation and facies analysis '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1667
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1319
+- gh: vamseeachanta/workspace-hub#1687
   repo: vamseeachanta/workspace-hub
-  domain: null
-  provider: claude
-  title: "WRK-1377: Hull form parametric design \u2014 coefficients and Ser"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1319
+  domain: repo
+  provider: codex
+  title: "Docstring uplift wave 3 \u2014 complete infrastructure/ coverage "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1687
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1318
+- gh: vamseeachanta/workspace-hub#1702
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: repo
   provider: claude
-  title: "WRK-1376: Resistance prediction \u2014 Holtrop-Mennen method impl"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1318
+  title: 'cathodic_protection: consolidate marine_cp.py and marine_str'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1702
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1317
+- gh: vamseeachanta/workspace-hub#1726
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: skills
   provider: claude
-  title: "WRK-1375: Maneuverability module \u2014 rudder forces and turning"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1317
+  title: 'chore(skills): resurrect 27 dead skills covering active doma'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1726
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1316
+- gh: vamseeachanta/workspace-hub#1732
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: skills
   provider: claude
-  title: "WRK-1374: Advanced stability \u2014 damage stability and IMO comp"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1316
+  title: 'chore: deduplicate 13 skills in achantas-data that are copie'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1732
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1314
+- gh: vamseeachanta/workspace-hub#1736
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: testing
   provider: claude
-  title: 'WRK-1372: Ship-specific hydrostatic data tables (DDG-51, FFG'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1314
+  title: 'chore: standardize cross-review verdict format across Codex '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1736
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1006
+- gh: vamseeachanta/workspace-hub#1738
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: cad
   provider: claude
-  title: 'TEST-FINAL3: delete me'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1006
+  title: 'chore: triage 54 pending work queue items in CAD-DEVELOPMENT'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1738
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#720
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1745
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: ai
   provider: claude
-  title: 'TEST-RATELIMIT7: delete me'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/720
+  title: 'feat(hermes): enable correction tracking in Hermes orchestra'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1745
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#425
-  repo: vamseeachanta/worldenergydata
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1749
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "feat(skills): convert .claude/commands to SKILL.md \u2014 306 com"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1749
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1751
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: "feat(skills): auto-convert pipeline \u2014 detect new agents and "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1751
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1804
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Evaluate MCP servers: evalview, insaits, token-optimizer, om'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1804
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1806
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Document autonomous loop patterns \u2014 6 architectures from seq"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1806
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1869
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Add HuggingFace, OpenRouter, Z.AI free providers to Hermes \u2014"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1869
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1870
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: Upstream deepseek CLI provider fix to OpenClaw/Hermes
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1870
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1881
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: Install Hermes gateway as systemd service for cron job firin
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1881
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1885
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Configure Telegram messaging platform for Hermes gateway on '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1885
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1900
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'memory: test cron job 8c797470d7d3 in isolated Hermes sessio'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1900
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1901
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'memory: propagate bridge to digitalmodel/ and aceengineer-st'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1901
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1902
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'memory: automate memory quality before bridge commit'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1902
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1917
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'memory: backup and rollback mechanism for .claude/memory/'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1917
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1919
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'docs: create memory ecosystem quick-reference card'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1919
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1922
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'infra: Ollama ecosystem rollout -- GPU audit (ace-linux-2 ha'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1922
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1985
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Daily system health review 2026-04-06: 4 real cron failures,'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1985
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2006
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "audit(worldenergydata): 14000+ orphan modules \u2014 triage for a"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2006
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2012
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'Review backlog: 22 unreviewed commits from 2026-04-07'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2012
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2040
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'feat: cronize engineering wiki incremental ingest'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2040
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2041
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'chore: add LaTeX to manim-env for MathTex rendering'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2041
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2061
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Session governance Phase 4: Hermes-orchestrated session life'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2061
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2065
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(governance): derive FAST_PATH_CEILING dynamically from'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2065
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2071
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Batch remediate historical stage-prompt drift with evidence '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2071
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2078
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'test(governance): harden block assertion and error-tracker s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2078
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2080
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'fix(tests): repair 14 pre-existing skill test failures in te'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2080
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2083
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: 'chore(skills): reconcile duplicate session-corpus-audit (coo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2083
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2111
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(governance): Phase 4b inter-session continuity validati'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2111
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2123
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(llm-wiki): add llm-wiki search to OrcaFlex/OrcaWave age'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2123
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2131
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "chore(reflect): regenerate reflect-state.yaml \u2014 47 days stal"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2131
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2132
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'fix(health-check): cron job counter shows 0 scheduled despit'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2132
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2133
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'fix(today): research-highlights extraction returns empty for'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2133
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2157
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): implement native PowerShell probe collecto'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2157
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2158
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(operations): add Git Bash launcher and path-normalizati'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2158
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2159
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): build publication bundle assembler for week'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2159
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2160
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): validate latest/history navigation and rela'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2160
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2163
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): add Windows Task Scheduler invocation harn'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2163
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2164
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'test(operations): build cygpath/native-path fixture suite fo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2164
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2165
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): validate publication asset/path integrity f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2165
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2166
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): add fixture-derived Markdown/HTML golden sn'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2166
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2167
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(knowledge): build session-read coherence golden fixture'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2167
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2168
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(validation): add cross-registry coverage and drift repo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2168
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2169
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(operations): define Windows licensed-tool probe adapter'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2169
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2170
+  repo: vamseeachanta/workspace-hub
+  domain: marine
+  provider: claude
+  title: 'feat(operations): implement OrcaFlex, OrcaWave, and ANSYS/AQ'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2170
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2171
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): add end-to-end weekly publication smoke sce'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2171
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2172
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): verify rerun and idempotence behavior for w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2172
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2173
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): wire provider-session ecosystem audit into '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2173
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2174
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(knowledge): generate unresolved session-read triage rep'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2174
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2175
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(operations): add fixture-backed OrcaFlex Windows probe '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2175
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2176
+  repo: vamseeachanta/workspace-hub
+  domain: marine
+  provider: claude
+  title: 'test(operations): add OrcaWave diffraction smoke fixtures an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2176
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2177
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): implement atomic weekly publication promoti'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2177
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2178
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): add bundle checksum manifest and tree-diff '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2178
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2179
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(validation): add weekly unresolved session-read regress'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2179
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2180
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(validation): add registry lineage/provenance report and'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2180
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2181
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(operations): add AQWA zero-exit runtime-failure fixture'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2181
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2182
+  repo: vamseeachanta/workspace-hub
+  domain: marine
+  provider: claude
+  title: 'test(operations): add OrcaWave L02 OC4 semi-sub manifest ass'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2182
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2183
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): add publication rollback journal and recove'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2183
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2184
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): enforce manifest-driven pre-promotion gate '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2184
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2185
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(validation): implement unresolved session-read bucket c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2185
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2186
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(validation): enforce suppression expiry and reviewer si'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2186
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2187
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(reporting): build cross-tool normalized Windows license'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2187
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2188
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): add mixed-state golden fixture bundles for '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2188
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2189
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'test(reporting): lock deterministic shared-asset canonical p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2189
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2190
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(reporting): add manifest-indexed pruning for orphaned s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2190
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2191
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'report(weekly-review): generate unresolved-read suppression '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2191
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2192
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(validation): establish historical raw-vs-canonical unre'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2192
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2193
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(reporting): generate weekly Windows licensed-tool summa'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2193
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2194
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(reporting): emit cross-tool reporter delta artifacts ag'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2194
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2195
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): add publication recovery state-machine tran'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2195
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2196
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(reporting): cover failed-gate to fix/resume/finalize pu'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2196
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2197
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'report(weekly-review): publish provider-specific repeated-of'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2197
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2198
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'feat(validation): derive suppression auto-clear candidates a'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2198
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2210
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'chore(harness): add ws_hub fallback regression coverage for '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2210
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2211
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'chore(harness): add dry-run existing-target regression cover'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2211
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2212
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'chore(harness): add invalid-update atomicity regression cove'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2212
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2219
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "chore(sync): resolve main branch divergence \u2014 9 local vs 134"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2219
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2223
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: Plan and execute safe origin/main integration for blocked wo
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2223
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2224
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Codex: reduce stale warning churn in provider-health after l'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2224
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2286
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'feat(wiki): promote SIGTTO LNG and mooring publications as b'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2286
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2287
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'feat(architecture): assess LR and Noble Denton corpus for do'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2287
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2331
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: Review and clean up stale .gemini/gsd-local-patches/ directo
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2331
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2335
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(cron): retro-refactor state-size-report.sh to use cade'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2335
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2336
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "chore(cron): cadence-report retention policy \u2014 auto-archive "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2336
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2337
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(cron): cadence-schedule index generator + pre-commit g'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2337
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2338
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "chore(cron): cadence-lib smoke test \u2014 pre-commit --smoke dry"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2338
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2339
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'Ecosystem: canonical .gitignore fragment + propagation for C'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2339
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2353
+  repo: vamseeachanta/workspace-hub
+  domain: solver
+  provider: claude
+  title: 'feat(enforcement): port queue-git-tracked rule to solver que'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2353
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2356
+  repo: vamseeachanta/workspace-hub
   domain: gtm
   provider: claude
-  title: 'feat(analysis): operator-aggregate HSE benchmarking (#423 ch'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/425
+  title: 'feat(ci): add GH Actions workflow to run npm test on aceengi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2356
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#403
-  repo: vamseeachanta/worldenergydata
-  domain: gtm
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2386
+  repo: vamseeachanta/workspace-hub
+  domain: testing
   provider: claude
-  title: 'feat(marketing): hurricane mooring risk-avoidance infographi'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/403
+  title: 'chore(tests): move session-analysis fixtures out of gitignor'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2386
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#364
-  repo: vamseeachanta/worldenergydata
-  domain: gtm
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2387
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
   provider: claude
-  title: "docs(gtm): publish capability matrix \u2014 production-ready vs s"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/364
+  title: 'chore(governance): cross-ref cleanup for 4 predecessor issue'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2387
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#363
-  repo: vamseeachanta/worldenergydata
-  domain: gtm
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2418
+  repo: vamseeachanta/workspace-hub
+  domain: skills
   provider: claude
-  title: "feat(api): public Python query API for HSE module \u2014 parity w"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/363
+  title: 'feat(automation): add compounding multi-iteration autoresear'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2418
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#361
-  repo: vamseeachanta/worldenergydata
-  domain: gtm
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2436
+  repo: vamseeachanta/workspace-hub
+  domain: content
   provider: claude
-  title: 'feat(provenance): adopt calc-citation-contract for worldener'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/361
+  title: 'feat(aceengineer-website): redesign templated page chrome (c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2436
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#420
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2447
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
   provider: claude
-  title: 'policy(legal): operator-aggregation deny-list for public-rep'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/420
+  title: "Residual #2045 gaps \u2014 CODEX.md legacy WRK ref + GEMINI.md de"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2447
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#418
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2449
+  repo: vamseeachanta/workspace-hub
+  domain: testing
   provider: claude
-  title: "feat(code): intervention HSE \u2014 Phase 2 reusable module extra"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/418
+  title: 'chore(ci-health): audit .planning/templates/ orphan refs fro'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2449
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#407
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2450
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
   provider: claude
-  title: 'research+plan(vessel_fleet): dry-run findings + Noble/Seadri'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/407
+  title: "chore(ci-health): triage tests/work-queue/ \u2014 port to GSD or "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2450
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#367
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2491
+  repo: vamseeachanta/workspace-hub
+  domain: harness
   provider: claude
-  title: 'refactor(bsee): migrate ProductionAPI12 NPV from legacy path'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/367
+  title: Extend pyramid-conformance-check.py DT1_REQUIRED_FIELDS to i
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2491
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#366
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2494
+  repo: vamseeachanta/workspace-hub
+  domain: repo
   provider: claude
-  title: 'feat(data): HSE bulk deduplication + ingest pipeline (unlock'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/366
+  title: "chore(cleanup): aceengineer-admin \u2014 remove legacy src/aceeng"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2494
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#365
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2496
+  repo: vamseeachanta/workspace-hub
+  domain: ai
   provider: claude
-  title: 'feat(data): BSEE binary tier decompression + ingest pipeline'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/365
+  title: 'chore(routines): use $(date -u) substitution in execution-ag'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2496
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#278
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2519
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
   provider: claude
-  title: 'Restore broken modules.* compatibility shims after bsee and '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/278
+  title: 'feat(hermes): orchestrate AI provider usage and workstation '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2519
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#275
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2520
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
   provider: claude
-  title: 'fix(scripts): make migrate_print_to_logging.py AST-aware to '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/275
+  title: 'fix(workstations): repair and gate ace-linux-2 GitHub auth b'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2520
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#269
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2666
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "Multi-repo codex-burn-20260511 batch \u2014 2 unmerged branches r"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2666
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2714
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
   provider: claude
-  title: Implement SODIR, Brazil ANP, and UKCS adapters
-  url: https://github.com/vamseeachanta/worldenergydata/issues/269
+  title: 'research: Gulf of Mexico production progress + Lower Tertiar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2714
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#268
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2723
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
   provider: claude
-  title: "Implement metocean adapter \u2014 connect Open-Meteo API"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/268
+  title: 'chore(enforcement): clean up dead code in .git/hooks/pre-com'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2723
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#153
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2753
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
   provider: claude
-  title: 'WRK-069: Acquire USCG MISLE bulk dataset'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/153
+  title: "Operational tracker: fresh-machine setup runs (evergreen \u2014 d"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2753
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#151
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2761
+  repo: vamseeachanta/workspace-hub
+  domain: uncategorised
   provider: claude
-  title: 'WRK-584: feat(worldenergydata): index NSTA UK National Data '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/151
+  title: Explore 3-night Broken Bow-style family getaway alternatives
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2761
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#143
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2784
+  repo: vamseeachanta/workspace-hub
+  domain: repo
   provider: claude
-  title: "WRK-261: BSEE field economics case study \u2014 rebuild on calibr"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/143
+  title: Confirm and delete acma-projects-freeze-work snapshot
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2784
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#136
-  repo: vamseeachanta/worldenergydata
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2793
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'arch(kaggle-rogii-2026): keep experiment repo shallow until '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2793
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2795
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: Domain-categorized boards + machine/provider dispatch (GitHu
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2795
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2843
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "statusline: surface Claude (C:) usage \u2014 currently always dim"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2843
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2844
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'statusline: add Codex 5-hour burst window + stale/estimate m'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2844
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3027
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(config): purge archived OGManufacturing from config ar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3027
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3186
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'Reconcile ~/.codex/skills design conflict: unification-symli'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3186
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3287
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: codex
+  title: 'wf-api(assethold): adopt ResultEnvelope after #3066 engine w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3287
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3289
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'wf-api(workspace-hub): [DEFERRED] HTTP/FastAPI gateway over '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3289
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3293
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'seamless(ci): fix two startup-failing docs.yml (worldenergyd'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3293
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3358
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Propagate UserPromptSubmit hooks cross-repo (propagate-ecosy
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3358
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3362
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: Drive-file-search 30-day metrics review (review after 2026-0
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3362
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3552
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'security: make Gitleaks configuration fail closed with defau'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3552
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3587
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'phone-media: choose the ongoing incremental sync lane'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3587
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3588
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'phone-media: evaluate self-hosted family photo browser (Immi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3588
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3596
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "Compliance alert: W30 \u2014 18% (critical)"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3596
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3680
+  repo: vamseeachanta/workspace-hub
+  domain: pipeline
+  provider: claude
+  title: "WRK-560: docs(digitalmodel): add calc_examples mapping \u2014 pip"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3680
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3681
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: "WRK-604: chore(doc-index): remap legacy HDD records \u2014 va-hdd"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3681
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3687
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "WRK-1276: Create audit-calc-methodology.py \u2014 auto-score exam"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3687
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3691
+  repo: vamseeachanta/workspace-hub
   domain: ingest
   provider: claude
   title: 'WRK-1291: Expand standards transfer ledger domain coverage f'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/136
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3691
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#129
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3693
+  repo: vamseeachanta/workspace-hub
+  domain: governance
   provider: claude
-  title: 'WRK-1234: BOEM/BSEE data refresh CLI script'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/129
+  title: "Compliance alert: W31 \u2014 0% (critical)"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3693
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#128
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#315
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'WRK-1231: Implement CompanyLoader for BOEM company/operator '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/128
+  title: "fix(reporting): render-rule for report templates \u2014 run-dir-r"
+  url: https://github.com/vamseeachanta/deckhand/issues/315
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#127
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#342
+  repo: vamseeachanta/deckhand
+  domain: knowledge
   provider: claude
-  title: 'WRK-1204: Ingest rig metadata from state railroad commission'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/127
+  title: "feat(knowledge): strengthen llm-wiki for Design & CAD \u2014 weld"
+  url: https://github.com/vamseeachanta/deckhand/issues/342
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#126
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#343
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'WRK-1192: Ingest CMEMS ocean physics'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/126
+  title: 'fix(rating): N/A the analytical axes (tech_cred/scope_realis'
+  url: https://github.com/vamseeachanta/deckhand/issues/343
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#125
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#440
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'WRK-1191: Ingest ERA5 reanalysis metocean'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/125
+  title: Wire riser workflows + atlases into the live bot (EXECUTE pa
+  url: https://github.com/vamseeachanta/deckhand/issues/440
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#124
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#441
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'WRK-1189: Ingest BOEM lease data'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/124
+  title: Source-tagged CTA funnel wiring for CAD/Manufacturing channe
+  url: https://github.com/vamseeachanta/deckhand/issues/441
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#29
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#442
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: BSEE | APM Data
-  url: https://github.com/vamseeachanta/worldenergydata/issues/29
+  title: "Topic\u2192domain\u2192subdomain specialization map (on taxonomy.yaml)"
+  url: https://github.com/vamseeachanta/deckhand/issues/442
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#13
-  repo: vamseeachanta/worldenergydata
-  domain: ingest
+  routed_by: manual
+- gh: vamseeachanta/deckhand#443
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'engg debt | Structures Data '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/13
+  title: Subagent profile schema + per-domain profiles
+  url: https://github.com/vamseeachanta/deckhand/issues/443
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#422
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#444
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'chore(legal): exclude reports/coverage/htmlcov/ from legal-d'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/422
+  title: Subdomain granularity + escalation rules
+  url: https://github.com/vamseeachanta/deckhand/issues/444
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#368
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#445
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
   provider: claude
-  title: 'chore(hygiene): periodic verifier for recently-closed issues'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/368
+  title: 'Client-result eval harness: specialist vs generalist'
+  url: https://github.com/vamseeachanta/deckhand/issues/445
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#360
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#446
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: codex
+  title: 'Routing integration: dispatch to specialized subagent'
+  url: https://github.com/vamseeachanta/deckhand/issues/446
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#447
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: "ops(scheduler): verify and instrument refresh health \u2014 last "
-  url: https://github.com/vamseeachanta/worldenergydata/issues/360
+  title: "Pilot: 2\u20133 specialized subagents end-to-end"
+  url: https://github.com/vamseeachanta/deckhand/issues/447
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#351
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#457
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'audit(scheduler): prepare source refresh runtime readiness m'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/351
+  title: Deliver LT well-benchmarking table into FDAS channel as firs
+  url: https://github.com/vamseeachanta/deckhand/issues/457
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#350
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#458
+  repo: vamseeachanta/deckhand
+  domain: capability
   provider: claude
-  title: 'audit(data): build data completeness and freshness scorecard'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/350
+  title: Deliver field-economics summary into FDAS channel
+  url: https://github.com/vamseeachanta/deckhand/issues/458
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#349
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#474
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: Upgrade live-share to tier-B (self-updating data.json) for c
+  url: https://github.com/vamseeachanta/deckhand/issues/474
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#475
+  repo: vamseeachanta/deckhand
+  domain: onboarding
   provider: claude
-  title: 'audit(repo): build capability inventory and module readiness'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/349
+  title: Onboard Roy + Frontier team into Telegram (fdas scope)
+  url: https://github.com/vamseeachanta/deckhand/issues/475
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#342
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#483
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: 'bug(cost): restore broken proxy comparison regression bounda'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/342
+  title: 'licensed-run: Telegram-event trigger for prompt dispatch (P1'
+  url: https://github.com/vamseeachanta/deckhand/issues/483
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#341
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#513
+  repo: vamseeachanta/deckhand
+  domain: routing,capability
   provider: claude
-  title: 'follow-up(tests): reconcile remaining NPV comparison suite d'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/341
+  title: "[proposal] Grow the API catalog \u2014 register existing digitalm"
+  url: https://github.com/vamseeachanta/deckhand/issues/513
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#339
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#522
+  repo: vamseeachanta/deckhand
+  domain: routing
   provider: claude
-  title: 'follow-up(tests): re-enable or delete legacy NPV comparison '
-  url: https://github.com/vamseeachanta/worldenergydata/issues/339
+  title: 'Routing config: register worldenergydata + digitalmodel capa'
+  url: https://github.com/vamseeachanta/deckhand/issues/522
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#328
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#523
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'Tooling: flake8 reports different F821 counts across runs on'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/328
+  title: Channel + scope binding for the capabilities run-channel (op
+  url: https://github.com/vamseeachanta/deckhand/issues/523
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#325
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#524
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
   provider: claude
-  title: 'Bugs: 8 pre-existing defects surfaced by PR #320''s xfail mar'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/325
+  title: "Operator runbook + end-to-end deploy & smoke (Telegram \u2192 rep"
+  url: https://github.com/vamseeachanta/deckhand/issues/524
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#316
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#525
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: "Type: incremental mypy cleanup \u2014 ~2918 untyped-def errors"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/316
+  title: Public POST /api/run reachability + scoped-token issuance fo
+  url: https://github.com/vamseeachanta/deckhand/issues/525
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#315
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#529
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: 'Lint: evaluate ruff migration to replace black + isort + fla'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/315
+  title: "licensed-run: per-host request routing \u2014 required before ace"
+  url: https://github.com/vamseeachanta/deckhand/issues/529
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#313
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#545
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: "Test infrastructure cleanup \u2014 unify pytest config, restore t"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/313
+  title: 'licensed-run agent: return diffraction_results.json (small R'
+  url: https://github.com/vamseeachanta/deckhand/issues/545
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#277
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#546
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: 'perf: investigate test suite performance regressions flagged'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/277
+  title: 'Triage: licensed-run lr_acma_cd6fe46df9a4 (aqwa-diffraction-'
+  url: https://github.com/vamseeachanta/deckhand/issues/546
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#276
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#564
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: 'test: add integration test for DataValidator.generate_intera'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/276
+  title: 'licensed-run: transactional bounded result-set return and ho'
+  url: https://github.com/vamseeachanta/deckhand/issues/564
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#274
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/deckhand#568
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: Add attested OrcaFlex riser bundle execution and hashed resu
+  url: https://github.com/vamseeachanta/deckhand/issues/568
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#569
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: Prove OrcaFlex execution trust and fail-closed rejection
+  url: https://github.com/vamseeachanta/deckhand/issues/569
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#570
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: Run the first signed OrcaFlex riser canary on logical ace-wi
+  url: https://github.com/vamseeachanta/deckhand/issues/570
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#571
+  repo: vamseeachanta/deckhand
+  domain: workstations
   provider: claude
-  title: 'fix(ci): remove || true from bandit security scan step'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/274
+  title: 'ops: external SSH via Tailscale wired for ace-linux-1 + ace-'
+  url: https://github.com/vamseeachanta/deckhand/issues/571
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#273
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#476
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: Fix SODIR scheduler runtime endpoint contract
-  url: https://github.com/vamseeachanta/worldenergydata/issues/273
+  title: Connect jumper pipeline to OrcaFlex modular model generator
+  url: https://github.com/vamseeachanta/digitalmodel/issues/476
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#271
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#498
+  repo: vamseeachanta/digitalmodel
+  domain: testing
   provider: claude
-  title: Wire `output_dir` into all scheduler jobs
-  url: https://github.com/vamseeachanta/worldenergydata/issues/271
+  title: "OrcaFlex builder test coverage uplift \u2014 missing builder + in"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/498
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#267
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#611
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
   provider: claude
-  title: Fix BSEE scheduler runtime download/extraction compatibility
-  url: https://github.com/vamseeachanta/worldenergydata/issues/267
+  title: 'OrcaWave: define result export and postprocess contract for '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/611
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#266
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#623
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
   provider: claude
-  title: "Operationalize EIA scheduler job \u2014 config, API key, first su"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/266
+  title: "Diffraction (a): inverse entry point + resolver \u2014 outcome + "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/623
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#119
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#624
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
   provider: claude
-  title: Nightly build failed - 2026-01-30
-  url: https://github.com/vamseeachanta/worldenergydata/issues/119
+  title: "Diffraction (a): AssumptionLedger \u2014 surface every assumed va"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/624
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#52
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#711
+  repo: vamseeachanta/digitalmodel
+  domain: repo
   provider: claude
-  title: AI Native practices
-  url: https://github.com/vamseeachanta/worldenergydata/issues/52
+  title: 'Durable workflows v2: onboard remaining script examples to t'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/711
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#48
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#785
+  repo: vamseeachanta/digitalmodel
+  domain: structural
   provider: claude
-  title: Repository AI-enablement
-  url: https://github.com/vamseeachanta/worldenergydata/issues/48
+  title: Onboard ship_design (SEASAM combined-fatigue) as durable wor
+  url: https://github.com/vamseeachanta/digitalmodel/issues/785
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#46
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#808
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: NPV Analysis
-  url: https://github.com/vamseeachanta/worldenergydata/issues/46
+  title: "Riser corpus ingestion \u2192 de-identified golden-case manifest"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/808
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#37
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#809
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Unify riser input schema + `uv run -m digitalmodel` parity
+  url: https://github.com/vamseeachanta/digitalmodel/issues/809
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#810
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: Field Reserve Map
-  url: https://github.com/vamseeachanta/worldenergydata/issues/37
+  title: SCR/SLWR touchdown fatigue workflow + report (DNV-RP-C203)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/810
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#18
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#811
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Drilling-riser stackup + operability workflow
+  url: https://github.com/vamseeachanta/digitalmodel/issues/811
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#812
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: VIV screening workflow
+  url: https://github.com/vamseeachanta/digitalmodel/issues/812
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#813
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Wellhead/conductor fatigue workflow
+  url: https://github.com/vamseeachanta/digitalmodel/issues/813
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#814
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: engg debt | TXRRC | Data
-  url: https://github.com/vamseeachanta/worldenergydata/issues/18
+  title: Riser report-template generator (deliverable of record)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/814
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#2
-  repo: vamseeachanta/worldenergydata
-  domain: quality
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#815
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Riser parametric atlases (fan-out of #794)'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/815
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#816
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: engg debt | wind | data APIs
-  url: https://github.com/vamseeachanta/worldenergydata/issues/2
+  title: Atlas validation harness vs the historical corpus
+  url: https://github.com/vamseeachanta/digitalmodel/issues/816
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#419
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#817
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
   provider: claude
-  title: "feat(analysis): intervention HSE \u2014 Phase 1B operator-aggrega"
-  url: https://github.com/vamseeachanta/worldenergydata/issues/419
+  title: "Riser orchestration agent \u2014 drive riser analysis end-to-end"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/817
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#416
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#818
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'First runnable Manufacturing proof: weld-fatigue S-N quick-c'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/818
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#819
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: codex
+  title: CAD geometry-verification demo (plate-buckling + render, pac
+  url: https://github.com/vamseeachanta/digitalmodel/issues/819
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#838
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(analysis): intervention-activity HSE patterns + day-to-'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/416
+  title: "Solve: PE Problem 6/19/2026 \u2014 Productivity index \u2014 current &"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/838
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#362
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#839
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(report): operator cost benchmarking from annual disclos'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/362
+  title: "Solve: PE Problem 4/20/2026 \u2014 Tertiary thermal EOR (steam, h"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/839
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#344
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#840
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(cost): add restatement/version lineage for annual discl'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/344
+  title: "Solve: PE Problem 1/15/2026 \u2014 Standing valve purpose in a ga"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/840
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#343
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#841
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(cost): build major-operator annual statement source reg'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/343
+  title: "Solve: PE Problem 3/5/2026 \u2014 Depletion drive with limited aq"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/841
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#336
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#842
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(cost): add currency normalization and comparability pol'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/336
+  title: "Solve: PE Problem 5/21/2026 \u2014 OOIP volumetrics + primary/sec"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/842
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/worldenergydata#334
-  repo: vamseeachanta/worldenergydata
-  domain: reports
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#843
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
   provider: claude
-  title: 'feat(cost): annual operator disclosures dataset for year-ove'
-  url: https://github.com/vamseeachanta/worldenergydata/issues/334
+  title: "Solve: PE Problem 5/19/2026 \u2014 Fluid's internal resistance to"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/843
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#844
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 5/8/2026 \u2014 Curved component at the front o"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/844
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#845
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 6/3/2026 \u2014 Main purpose of drilling fluid "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/845
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#846
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/13/2026 \u2014 Real-time formation measuremen"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/846
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#847
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 1/4/2026 \u2014 Underbalanced drilling well con"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/847
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#848
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/23/2026 \u2014 Electrochemical/chemical degra"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/848
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#851
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: 'API: post Collide PE problem to Telegram for Deckhand to con'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/851
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#859
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 1/12/2026 \u2014 acid job above fracture pressu"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/859
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#860
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 3/6/2026 \u2014 drive mechanism in unconvention"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/860
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#861
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/24/2026 \u2014 what an SP log actually measur"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/861
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#862
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 6/17/2026 \u2014 depositional environment (MC)"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/862
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#863
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 2/12/2026 \u2014 components of a conventional p"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/863
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#864
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/15/2026 \u2014 high potassium on spectral gam"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/864
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#865
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/22/2026 \u2014 three main types of artificial"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/865
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#866
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 3/1/2026 \u2014 modified Archie for shaly sands"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/866
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#867
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 3/26/2026 \u2014 new wellbore branching off exi"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/867
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#868
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/3/2026 \u2014 volatile distillate hydrocarbon"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/868
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#872
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/16/2026 \u2014 semilog buildup analysis techn"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/872
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#873
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/17/2026 \u2014 map flow paths injector\u2192produc"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/873
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#874
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 3/25/2026 \u2014 adaptive closed-loop annular p"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/874
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#875
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 4/4/2026 \u2014 mobile well-intervention unit"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/875
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#876
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "Solve: PE Problem 6/15/2026 \u2014 drilling trouble in reactive s"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/876
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#877
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: codex
+  title: 'field_development: absolute-CAPEX override for concept scree'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/877
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#878
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'wall_thickness: implement DNV-ST-F201 (dynamic-riser LRFD)'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/878
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#898
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: 'benchmark: unit_box.gdf has inverted panel normals (negative'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/898
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#913
+  repo: vamseeachanta/digitalmodel
+  domain: website
+  provider: claude
+  title: 'Pages demo: OrcaWave/AQWA hydro benchmarks, OCIMF explorer, '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/913
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#949
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'ci: root-cause of 9-domain quality-gates baseline failure'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/949
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#978
+  repo: vamseeachanta/digitalmodel
+  domain: ai
+  provider: claude
+  title: 'Reference: public datasets for agentic AI in chemical/proces'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/978
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1002
+  repo: vamseeachanta/digitalmodel
+  domain: ci-release
+  provider: claude
+  title: 'Quality Gates red on main: hardcoded /mnt/local-analysis pat'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1002
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1005
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[CAD discovery 1/5] Full CAD/CAM file inventory on /mnt/ace '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1005
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1006
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[CAD discovery 2/5] CAD software-ecosystem & format profile '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1006
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1007
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: "[CAD discovery 3/5] Project \u2192 domain/client map of CAD-beari"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1007
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1008
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[CAD discovery 4/5] Deep-dive sample: representative assembl'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1008
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1009
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[CAD discovery 5/5] Synthesis: CAD/CAM automation-opportunit'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1009
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1012
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[Adapters 1/5] CAD-geometry adapter matrix (STEP/IGES/Paraso'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1012
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1014
+  repo: vamseeachanta/digitalmodel
+  domain: document-intelligence
+  provider: claude
+  title: '[Adapters 3/5] Office/other document adapter matrix (pdf/doc'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1014
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1015
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[Adapters 4/5] Evaluate license-free CAD readers on real sha'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1015
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1016
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[Adapters 5/5] Recommend & scaffold the digitalmodel/cad/ ad'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1016
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1017
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[Adapters 6/6] CAD-AI spike: shape-similarity + feature reco'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1017
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1019
+  repo: vamseeachanta/digitalmodel
+  domain: gtm
+  provider: codex
+  title: Report blocks read from single source of truth + mandatory p
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1019
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1038
+  repo: vamseeachanta/digitalmodel
+  domain: cad,document-intelligence
+  provider: claude
+  title: '[Adapters] Evaluate baidu/Unlimited-OCR (DeepSeek-OCR, MIT) '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1038
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1094
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'Adversarial review findings: FFS strength methods (applicabi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1094
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1142
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: "chore(repo-health): digitalmodel checkout degraded \u2014 git ops"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1142
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1146
+  repo: vamseeachanta/digitalmodel
+  domain: pipeline
+  provider: claude
+  title: 'FFS: implement DNV-RP-F101 Sec 3.7.4 combined-loading H1 fac'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1146
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1147
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: 'materials: converge scattered grade tables to canonical ISO '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1147
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1148
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'fatigue: Efthymiou short-chord F2/F3 factors for pinned-fixi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1148
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1153
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'Workflow: flange / bolted-connection analysis (ASME Sec VIII'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1153
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1182
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'seismic/response_spectrum: elastic + constant-ductility resp'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1182
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1195
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'Tug: intact/dynamic stability + girting heeling-arm check'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1195
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1196
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'Tug: fender-height optimization vs assisted-fleet hull-geome'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1196
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1197
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'Tug: towline load & breaking-strength / class safety-factor '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1197
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1198
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'Tug: hybrid power sizing & fuel/emissions compliance model'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1198
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1213
+  repo: vamseeachanta/digitalmodel
+  domain: capability
+  provider: claude
+  title: 'Capabilities page: ''Run live'' deep-links + implement workflo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1213
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1234
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'CI health: 4 domain-test shards red on main (stale-test back'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1234
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1250
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: Bump assetutilities pin + remove engine root_folder/configur
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1250
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1263
+  repo: vamseeachanta/digitalmodel
+  domain: models
+  provider: claude
+  title: 'Dynacard: classifier fails on solver-transformed cards (NORM'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1263
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1274
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "ffs: damage-mechanism roadmap \u2014 API 579 Parts 3 (brittle fra"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1274
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1277
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'ci: pre-existing baseline-red tests in misc / specialized / '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1277
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1296
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'ffs: composite-repair selection helper behind the REPAIR ver'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1296
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1299
+  repo: vamseeachanta/digitalmodel
+  domain: knowledge
+  provider: claude
+  title: 'Dynacard automation ideas backlog: surveillance KPIs, valve '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1299
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1318
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: Restore mooring-tension-iteration test inputs (relocated off
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1318
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1350
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: riser-fatigue atlas reports STALE on main but `refresh --app
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1350
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1357
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: '[#1356-A] wave_forecast: phase-resolved surface synthesis + '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1357
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1358
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: '[#1356-B] motion_forecast: time-domain 6-DOF motion reconstr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1358
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1359
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: '[#1356-C] Derived operability quantities + rolling go/no-go '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1359
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1360
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: '[#1356-D] Learning loop: forecast-vs-measured skill, recalib'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1360
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1365
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: 'envelopes D-follow-up: CMEMS (Copernicus Marine) metocean cl'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1365
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1367
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: "[#1356-F] Real-time MMS / measurement-system ingest \u2014 measur"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1367
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1427
+  repo: vamseeachanta/digitalmodel
+  domain: models
+  provider: codex
+  title: Monte Carlo uncertainty-quantification engine (LHS + tornado
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1427
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1468
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: "AMJIG per-category envelope criteria \u2014 RULING (a): named ide"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1468
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1469
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Populate solver-backed envelope tier (C3 stub) \u2014 dynamic cov"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1469
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1470
+  repo: vamseeachanta/digitalmodel
+  domain: workflow
+  provider: codex
+  title: 'Registry batch coverage: lift 8/21 runnable via wave-6 extra'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1470
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1475
+  repo: vamseeachanta/digitalmodel
+  domain: website
+  provider: claude
+  title: '[#1471] Accessibility baseline for public capability pages'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1475
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1495
+  repo: vamseeachanta/digitalmodel
+  domain: workstations
+  provider: claude
+  title: Onboard dedicated CFD compute box + offload CFD from ace-lin
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1495
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1531
+  repo: vamseeachanta/digitalmodel
+  domain: gis
+  provider: claude
+  title: 'Layout surfaces from real DEM files (wed fetch_dem consumer '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1531
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1532
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: Screening consumes the generalized layout model natively
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1532
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1533
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: Wire electrical cable screening into screen() for array/expo
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1533
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1534
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Floating-host riser shape via existing catenary modules
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1534
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1540
+  repo: vamseeachanta/digitalmodel
+  domain: models
+  provider: claude
+  title: 'Unify the Hugging Face run-manifest schema across #1528 (CFD'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1540
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1551
+  repo: vamseeachanta/digitalmodel
+  domain: models
+  provider: claude
+  title: 'feat(hf): digitalmodel''s first HF dataset + registry entry ('
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1551
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1556
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: "feat(operability): rollup workflow \u2014 batch run results \u2192 env"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1556
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1557
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'feat(sweeps): standing mini-run sweep catalog (YAML) + licen'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1557
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1588
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Verify DNV-RP-C203 seawater-CP S-N basis and fail-closed cit
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1588
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1605
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Add traceable riser model, response, and operating-envelope '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1605
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1606
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'alt_fuel_ship_sizing: engine CLI run fails - missing base_co'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1606
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1607
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Reconcile #1602 riser ownership, hierarchy, and lifecycle bo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1607
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1608
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Prove a synthetic completion/workover case through the pre-l
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1608
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1609
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Prove a public drilling case through the shared pre-license '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1609
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1610
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'Verify a completion/workover result through the engineering '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1610
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1611
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Verify a drilling result through the engineering oracle
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1611
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1612
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Populate one verified drilling result into the existing oper
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1612
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1613
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Populate a bounded licensed dynamic riser operating envelope
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1613
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1614
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Build the fail-closed riser release compiler and local verif
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1614
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1615
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Authorize and atomically publish the verified riser HF relea
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1615
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1616
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Render traceable pre-run and verified post-run riser visuals
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1616
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1617
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Bind immutable riser release evidence into twin replay and m
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1617
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1620
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Bind one immutable riser release to a versioned operating en
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1620
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1621
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Map telemetry to canonical riser, host, and envelope identit
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1621
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1622
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Track deterministic real-time riser operating state
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1622
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1623
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Approve and activate advisory riser alarm policy
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1623
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1624
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: Validate riser-monitoring risk-reduction evidence
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1624
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1625
+  repo: vamseeachanta/digitalmodel
+  domain: content
+  provider: claude
+  title: 'report_pack: wide result tables overflow the page - no per-t'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1625
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1626
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'test_foam_report_pack: byte-exact CSV regeneration compare f'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1626
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1646
+  repo: vamseeachanta/digitalmodel
+  domain: capability
+  provider: claude
+  title: "C1 \u2014 Publish all 36 capability datasets to Hugging Face (0 o"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1646
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1647
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: "C5 \u2014 Repo architecture drawing: capability inventory + data "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1647
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1855
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: 'Rod-pump surface dynacard: explain the upstroke undulations '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1855
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1860
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: Data gap matrix + roadmap for the Collide dynacard well (#18
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1860
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1865
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: Collect labelled real dynacard set from small operators (cal
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1865
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1874
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: 'Open-platform dynacard data sweep: one CC0 plate usable now,'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1874
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1881
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: 'ci(capabilities): live-surface monitoring job for aceenginee'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1881
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1903
+  repo: vamseeachanta/digitalmodel
+  domain: capability
+  provider: claude
+  title: Every capability generator has drifted from its committed pa
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1903
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1915
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'Wall-thickness explorer: promote tension and bending moment '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1915
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1920
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: ISO-13623 and PD-8010-2 collapse solvers select the spurious
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1920
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1947
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: "SLWR buoyancy-module optimization \u2014 minimise touchdown fatig"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1947
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1948
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: "SLWR riser BOM cost model \u2014 public schema, private cost basi"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1948
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3029
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Wire lane: labels into dispatch routing + planning template '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3029
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3030
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Dispatch-time codex weekly-quota gate: suspend lane:codex ro'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3030
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3034
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Quota cache agent-quota-latest.json: stale data, no timestam'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3034
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3044
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity audit on ace-linux-1 (Part A) \u2014 epic #3043"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3044
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3051
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity: config flip \u2014 registry + propagation \u2014 epic #3"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3051
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3052
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Model parity: context-window parity (1M lever / opus-4-8[1m]'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3052
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3053
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Model parity: dynamic workflows, orchestration & cadence/quo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3053
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3054
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Model parity: skills + learning/signal loops + memory re-bas'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3054
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3055
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity: model-swap playbook + parity decision ADR \u2014 ep"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3055
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3077
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Orchestrator consistency drift (2026-06-14)
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3077
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3086
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: Standardize agy (Antigravity CLI) default model = Gemini 3.1
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3086
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3087
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Statusline: make Gemini (agy) usage genuine + add days/hours'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3087
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3103
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Retire dead claude-flow orchestration cluster in scripts/aut
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3103
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3106
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity: de-prescription sweep \u2014 strip Fable-degrading "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3106
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3114
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "feat(ecosystem): Omnigent-lens \u2014 make repo ecosystem AI-prov"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3114
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3116
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "feat(harness): G1 portable agent-definition format \u2014 define "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3116
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3118
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "feat(harness): G3 MCP-first tool exposure \u2014 provider-portabl"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3118
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3119
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "feat(harness): G4 budget-as-policy \u2014 stateful cost/token gua"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3119
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3120
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "feat(harness): G5 cross-surface session continuity \u2014 resumab"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3120
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3137
+  repo: vamseeachanta/workspace-hub
+  domain: skills,ai
+  provider: claude
+  title: "Skill-invocation: capture Skill-tool calls (id\u2192short_name re"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3137
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3138
+  repo: vamseeachanta/workspace-hub
+  domain: skills,ai
+  provider: claude
+  title: 'Skill-invocation: backfill historical events from transcript'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3138
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3142
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'bug(review-tooling): validate-review-output.sh + render-stru'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3142
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3143
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'bug(automation): a preserve/prune process destroys /tmp git '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3143
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3146
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: "Add ruff baseline/ratchet to check-all \u2014 pre-push gate unpas"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3146
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3179
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: run-all-tests.sh (and peer gate scripts) mis-resolve REPO_RO
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3179
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3182
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Provider-utilization tracker is blind to Hermes usage after '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3182
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3224
+  repo: vamseeachanta/workspace-hub
+  domain: website
+  provider: claude
+  title: 'Pages demo: multi-repo orchestration & governance engine (sk'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3224
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3231
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Isolate concurrent agent sessions per repo (worktree-per-ses
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3231
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3237
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'docs(workflow): canonical lifecycle for a typical GitHub iss'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3237
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3252
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Self-improvement: auto-graduate high-confidence correction c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3252
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3253
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Self-improvement: Hermes pattern auto-promotion into canonic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3253
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3254
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Self-improvement: repeating drift patterns trigger skill-upd'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3254
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3256
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Self-improvement: adaptive correction-confidence threshold +'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3256
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3298
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(session): per-session live-link HTML work-review doc (h'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3298
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3300
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "Ecosystem README API banner \u2014 every tier-1 repo points at th"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3300
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3302
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: Weekly Deckhand-API presence-sync skill + schedule
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3302
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3306
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'feat(session): make the live-link review a lean reference la'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3306
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3325
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: "chore(repo-health): git bloat reduction campaign \u2014 reclaim ~"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3325
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3366
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Auto-memory MEMORY.md index over load limit (52KB > 24.4KB) '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3366
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3382
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: codex
+  title: 'chore(dev-workflow): standardize + roll formatting pre-commi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3382
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3384
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: Bridge memory-source regen produces stale slices on the owne
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3384
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3387
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Bridge step-5 snapshot is non-monotonic \u2014 compacted live ind"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3387
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3389
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: Completeness gate reopens PR-merge-closed plan-approved issu
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3389
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3397
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: 'bug(readiness): R-HOOKS false-missing on Windows CRLF paths'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3397
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3398
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: codex
+  title: 'chore(harness): add legal-sanity precommit entries for asset'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3398
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3402
+  repo: vamseeachanta/workspace-hub
+  domain: website
+  provider: claude
+  title: '[#3401] Brand consolidation: workspace-hub (per-repo canonic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3402
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3448
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'chore(ecosystem): audit repository detection for linked work'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3448
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3450
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'fix(workflow-manifest): distinguish nested-worktree resoluti'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3450
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3451
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'Legal sanity scan: make empty diff-only runs explicit and fa'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3451
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3459
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: codex
+  title: 'bug(enforcement): check-no-abs-paths fails before scanning i'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3459
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3460
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: codex
+  title: 'bug(hooks): post-commit learning hook fails from sparse link'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3460
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3462
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: Fix Windows plan-review fanout argument overflow and auth di
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3462
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3464
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: codex
+  title: Harden descriptor-bound Git and filesystem enforcement primi
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3464
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3476
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: codex
+  title: 'refactor(cron): migrate three legacy marker installers to tr'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3476
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3477
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: codex
+  title: 'fix(scheduler): make kanban loader timer transactional acros'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3477
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3478
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: 'refactor(windows): add semantic ownership and recovery to sc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3478
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3479
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: codex
+  title: 'fix(harness-update): propagate or explicitly surface cron re'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3479
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3480
+  repo: vamseeachanta/workspace-hub
+  domain: capability
+  provider: claude
+  title: 'Land generic HF-dataset publisher: scripts/hf/save_results_t'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3480
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3490
+  repo: vamseeachanta/workspace-hub
+  domain: onboarding
+  provider: codex
+  title: 'fix(onboarding): surface cron preview failure during new-mac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3490
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3491
+  repo: vamseeachanta/workspace-hub
+  domain: solver
+  provider: claude
+  title: 'chore(solver-queue): reconcile legacy solver-queue issues (#'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3491
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3494
+  repo: vamseeachanta/workspace-hub
+  domain: capability
+  provider: claude
+  title: 'design(capabilities): reconcile existing per-repo GitHub Pag'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3494
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3495
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: codex
+  title: 'test(enforcement): make hash-pinned semantic mutation tests '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3495
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3518
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'fix(scheduler): keep setup-cron wrapper attestation pin sync'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3518
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3521
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: codex
+  title: 'Legal scanner: support explicit NUL-safe staged-blob pathset'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3521
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3522
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: codex
+  title: 'security(legal): migrate sensitive deny-list values out of p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3522
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3523
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'bug(enforcement): plan-approval gate rejects valid markers w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3523
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3527
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'fix(scheduler): reconcile identity inventory after merge-bas'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3527
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3532
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(memory): reserve cross-provider runtime budget for opera'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3532
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3533
+  repo: vamseeachanta/workspace-hub
+  domain: standards
+  provider: codex
+  title: Make standards registries edition, amendment, access, and ri
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3533
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3534
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'secure(main): require latest-base checks and block unchecked'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3534
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3536
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'CLI boundaries: prevent argparse from echoing rejected calle'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3536
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3538
+  repo: vamseeachanta/workspace-hub
+  domain: standards
+  provider: codex
+  title: Evolve calculation citation contract for amendment and exact
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3538
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3539
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: Refactor oversized equality modules and make Windows collect
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3539
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3541
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: 'test(enforcement): assert exact schemas for equivalent bypas'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3541
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3542
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'audit(config): reject duplicate YAML keys and ambiguous scal'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3542
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3544
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: codex
+  title: 'security(legal): correct and operationalize Phase A authorit'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3544
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3558
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(memory): prevent shared KNOWLEDGE rules from being omitt'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3558
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3561
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Repair and split workspace connection menu dispatch
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3561
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3562
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Audit MSYS conversion of slash-prefixed native-command token
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3562
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3564
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'bug(ci): legal rule authority receives empty AUTH_ENVELOPE o'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3564
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3571
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'equality/reconcile tooling gaps on ace-win-1: junction-follo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3571
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3577
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "fix(harness): repo-wide exec-bit audit \u2014 NTFS-FUSE working c"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3577
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3579
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(readiness): rename equality/parity provider row gemini'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3579
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3580
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'chore(harness): gemini CLI uninstall decision after agy soak'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3580
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3592
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "equality matrix: reclassify harness/scheduler/memory rows \u2014 "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3592
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3598
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(equality): add HF-token health row to the machine equiv'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3598
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3698
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'PR gate is baseline-red: two enforcement checks fail on ever'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3698
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3706
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'infra: Git LFS budget exhausted account-wide, blocking binar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3706
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3708
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: "bug(cron): no safe crontab re-apply path \u2014 audit fail-closed"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3708
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3709
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(cron): plan_cutover silently drops managed-block lines i'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3709
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3712
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "infra: no CI check is merge-blocking on main \u2014 every 'requir"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3712
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3714
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: "CI: strict-scan / authority fails on every branch \u2014 missing "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3714
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3717
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: "Context budget: harness config is 3.6% of the window \u2014 the c"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3717
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3750
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: "Windows Task Scheduler parity for harness-install-doctor \u2014 a"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3750
   dispatch_status: ready
   wip_eligible: false
   routed_by: rule
+- gh: vamseeachanta/workspace-hub#3751
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: Onboard the remaining RDS host to config/workstations/regist
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3751
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: rule
+- gh: vamseeachanta/workspace-hub#3755
+  repo: vamseeachanta/workspace-hub
+  domain: admin,repo
+  provider: claude
+  title: 'PII: client identifiers persist repo-wide after epic #3095 c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3755
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual

--- a/.claude/dispatch/dev-secondary.yaml
+++ b/.claude/dispatch/dev-secondary.yaml
@@ -1,255 +1,239 @@
 machine: dev-secondary
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
-- gh: vamseeachanta/workspace-hub#2755
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'throughput(workstations): activate ace-linux-2 provider/mach'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2755
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1582
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Install and configure Hermes on ace-linux-2
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1582
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1565
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: Verify cron-health-check.sh runs correctly on ace-linux-2
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1565
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1506
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'Verify Claude Desktop install: ace-linux-2'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1506
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1395
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-1395: Add Equinor Northern Lights dataset as curated dat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1395
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1394
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-1394: Add Equinor/Norce U7 reference data as curated dat'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1394
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1353
-  repo: vamseeachanta/workspace-hub
-  domain: data
-  provider: claude
-  title: 'WRK-1353: Deep extraction & table promotion for ace_standard'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1353
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1607
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Capytaine BEM end-to-end integration with parametric hull sw
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1607
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1464
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Capytaine BEM available for hull mesh wave load analysis
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1464
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1460
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate WEIS floating wind co-design framework
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1460
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1453
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate ANYstructure DNV steel design tool
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1453
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1445
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate WISDEM wind plant system design
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1445
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1444
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate RAFT floating wind turbine dynamics
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1444
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1443
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate FLORIS wind farm wake modelling
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1443
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1442
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Integrate FEniCSx PDE solver into ACE ecosystem
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1442
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1441
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
+- gh: vamseeachanta/digitalmodel#1686
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
   title: Integrate OpenDrift ocean trajectory modelling into ACE ecos
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1441
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1686
+  dispatch_status: ready
+  wip_eligible: true
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1687
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Integrate FEniCSx PDE solver into ACE ecosystem
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1687
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1440
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: Install Capytaine BEM solver into ACE ecosystem
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1440
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1400
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1400: Spot-check va-hdd-2 classification accuracy for en'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1400
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1399
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1399: Phase B batch summaries for va-hdd-2 engineering f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1399
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1360
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK: extract algorithms and methods from riser-eng-job archi'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1360
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1677
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Deploy harness-update lifecycle to ace-linux-2 (#1668 follow
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1677
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1564
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: Sync crontab on ace-linux-2 from schedule-tasks.yaml
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1564
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1362
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK: fix broken README_MIGRATED.md pointers in /mnt/ace/docs'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1362
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1357
-  repo: vamseeachanta/workspace-hub
-  domain: harness
-  provider: claude
-  title: 'WRK: LLM-classify va-hdd-2 remaining content into digitalmod'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1357
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#2739
-  repo: vamseeachanta/workspace-hub
-  domain: ops
-  provider: claude
-  title: 'feat(hermes): promote ace-linux-2 as first Telegram/Hermes d'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2739
+- gh: vamseeachanta/digitalmodel#1688
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Integrate FLORIS wind farm wake modelling
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1688
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#2645
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: workstations
   provider: claude
   title: 'fix(workstations): normalize ace-linux-2 repo, mount, and pa'
   url: https://github.com/vamseeachanta/workspace-hub/issues/2645
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
+- gh: vamseeachanta/workspace-hub#2739
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(hermes): promote ace-linux-2 as first Telegram/Hermes d'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2739
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2755
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'throughput(workstations): activate ace-linux-2 provider/mach'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2755
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1689
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Integrate RAFT floating wind turbine dynamics
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1689
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1690
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Integrate WISDEM wind plant system design
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1690
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1691
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: Integrate ANYstructure DNV steel design tool
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1691
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1692
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Integrate WEIS floating wind co-design framework
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1692
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1705
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Capytaine BEM end-to-end integration with parametric hull sw
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1705
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1353
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'WRK-1353: Deep extraction & table promotion for ace_standard'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1353
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1564
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Sync crontab on ace-linux-2 from schedule-tasks.yaml
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1564
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1565
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Verify cron-health-check.sh runs correctly on ace-linux-2
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1565
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/workspace-hub#1581
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: workstations
   provider: claude
   title: Post-update display/VNC recovery on ace-linux-2
   url: https://github.com/vamseeachanta/workspace-hub/issues/1581
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
+- gh: vamseeachanta/workspace-hub#1582
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Install and configure Hermes on ace-linux-2
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1582
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1677
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Deploy harness-update lifecycle to ace-linux-2 (#1668 follow
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1677
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3550
+  repo: vamseeachanta/workspace-hub
+  domain: workstations,security
+  provider: claude
+  title: 'ops(dev-secondary): roll out and verify Tailscale plus harde'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3550
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1693
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: codex
+  title: Capytaine BEM available for hull mesh wave load analysis
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1693
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1360
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: codex
+  title: 'WRK: extract algorithms and methods from riser-eng-job archi'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1360
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1362
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: 'WRK: fix broken README_MIGRATED.md pointers in /mnt/ace/docs'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1362
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/workspace-hub#1393
   repo: vamseeachanta/workspace-hub
-  domain: null
+  domain: ingest
   provider: claude
   title: 'WRK-1393: Add Equinor ASA Databricks marketplace as oil and '
   url: https://github.com/vamseeachanta/workspace-hub/issues/1393
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1394
+  repo: vamseeachanta/workspace-hub
+  domain: ingest
+  provider: claude
+  title: 'WRK-1394: Add Equinor/Norce U7 reference data as curated dat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1394
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1395
+  repo: vamseeachanta/workspace-hub
+  domain: ingest
+  provider: claude
+  title: 'WRK-1395: Add Equinor Northern Lights dataset as curated dat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1395
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1506
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'Verify Claude Desktop install: ace-linux-2'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1506
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3045
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity audit on ace-linux-2 (Part A) \u2014 epic #3043"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3045
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual

--- a/.claude/dispatch/home-win.yaml
+++ b/.claude/dispatch/home-win.yaml
@@ -1,12 +1,23 @@
 machine: home-win
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
 - gh: vamseeachanta/workspace-hub#1507
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: workstations
   provider: claude
   title: 'Verify Claude Desktop install: home-win'
   url: https://github.com/vamseeachanta/workspace-hub/issues/1507
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3048
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity audit on home-win (Part A) \u2014 epic #3043"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3048
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual

--- a/.claude/dispatch/licensed-win-1.yaml
+++ b/.claude/dispatch/licensed-win-1.yaml
@@ -1,411 +1,8 @@
 machine: licensed-win-1
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
-- gh: vamseeachanta/digitalmodel#596
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'chore(repo-structure): normalize digitalmodel folder/file st'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/596
-  dispatch_status: ready
-  wip_eligible: true
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#483
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'sub: curves.py decomposition -- break up 29,666-line monolit'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/483
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#283
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-131: Passing ship analysis for moored vessels \u2014 AQWA-bas"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/283
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#282
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-130: Standardize analysis reporting for each OrcaWave st'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/282
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#270
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-630: feat(client2): engineering AI demo \u2014 diffraction + "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/270
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#269
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-629: feat(client2): engineering AI demo \u2014 diffraction + "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/269
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#206
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-5065: Structural analysis study \u2014 literature, methods an"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/206
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#203
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-5062: Mooring analysis study \u2014 literature, methods and i"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/203
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#170
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-311: improve: QTF benchmarking for case 3.1 \u2014 charts, co"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/170
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#161
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-1281: Extract numerical test vectors from all naval arch'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/161
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#595
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Assess client PDF packaging for vessel capability GTM materi
-  url: https://github.com/vamseeachanta/digitalmodel/issues/595
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#593
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Assess vessel data provenance, confidence, and capability sc
-  url: https://github.com/vamseeachanta/digitalmodel/issues/593
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#592
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Assess client-ready vessel capability GTM narrative and char
-  url: https://github.com/vamseeachanta/digitalmodel/issues/592
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#577
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Safety Case / MAH ALARP framework module (NORSOK Z-013, UK H
-  url: https://github.com/vamseeachanta/digitalmodel/issues/577
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#470
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "Seakeeping analysis using OpenFOAM \u2014 CFD-based ship motion s"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/470
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#464
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Add hydrodynamic BEM analysis module (Capytaine)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/464
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#265
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-622: feat(geotechnical): anchor capacity \u2014 drag, suction"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/265
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#207
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "WRK-5067: Hydrodynamics and wave mechanics study \u2014 literatur"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/207
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#199
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-5056: feat(digitalmodel): integrate theoretical naval ar'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/199
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#178
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-480: feat(worldenergydata): integrate CMEMS Wave Multi-Y'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/178
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#173
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-473: feat(hydrodynamics): integrate wavespectra library '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/173
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#588
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_find_chain_with_safety_factor needs ch'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/588
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#564
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_ocimf_mooring_integration.py::test_env'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/564
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#561
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_ocimf_mooring_integration.py::test_com'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/561
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#560
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_couplin'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/560
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#559
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_full_ma'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/559
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#558
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_damping'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/558
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#501
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'OrcaWave: expand QTF config + field points + irregular frequ'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/501
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#467
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "Subsea structure installation analysis \u2014 vessel performance "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/467
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#466
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "Parametric hull analysis \u2014 steady speed, passing ship, narro"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/466
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#465
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: "Capytaine ship hull benchmarking \u2014 OC4 semi-sub + WAMIT vali"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/465
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#463
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Populate ship-dimensions dataset from ship plans (manual cur
-  url: https://github.com/vamseeachanta/digitalmodel/issues/463
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#457
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: Ship dimensions template + loader (WRK-1380)
-  url: https://github.com/vamseeachanta/digitalmodel/issues/457
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#253
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-587: research: evaluate Code_Aster for large-scale topsi'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/253
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#136
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-043: Parametric hull form analysis with RAO generation a'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/136
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#134
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: 'WRK-036: OrcaFlex structure deployment analysis - supply boa'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/134
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#64
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: engg debt | CAD
-  url: https://github.com/vamseeachanta/digitalmodel/issues/64
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#36
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: engg debt | RAOs Analysis feature
-  url: https://github.com/vamseeachanta/digitalmodel/issues/36
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#29
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: engg debt | fatigue | SN Curve module
-  url: https://github.com/vamseeachanta/digitalmodel/issues/29
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#28
-  repo: vamseeachanta/digitalmodel
-  domain: hydro
-  provider: claude
-  title: engg debt | Fatigue | ship design | spectral-based fatigue a
-  url: https://github.com/vamseeachanta/digitalmodel/issues/28
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#554
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'fix(marine_ops): catenary solver bracketing + sinh overflow '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/554
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#518
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: Add model-library regression tests for strict-vs-generated O
-  url: https://github.com/vamseeachanta/digitalmodel/issues/518
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#284
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'WRK-133: Update OrcaFlex license agreement with addresses an'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/284
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#281
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'WRK-121: Extract & Catalog OrcaFlex Models from rock-oil-fie'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/281
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#157
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'WRK-126: Benchmark all example models across time domain and'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/157
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
 - gh: vamseeachanta/digitalmodel#156
   repo: vamseeachanta/digitalmodel
   domain: solver
@@ -414,214 +11,367 @@ cards:
   url: https://github.com/vamseeachanta/digitalmodel/issues/156
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#280
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#157
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'WRK-126: Benchmark all example models across time domain and'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/157
+  dispatch_status: ready
+  wip_eligible: true
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#161
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-1281: Extract numerical test vectors from all naval arch'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/161
+  dispatch_status: ready
+  wip_eligible: true
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#170
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-311: improve: QTF benchmarking for case 3.1 \u2014 charts, co"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/170
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#203
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-5062: Mooring analysis study \u2014 literature, methods and i"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/203
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#206
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: "WRK-5065: Structural analysis study \u2014 literature, methods an"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/206
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#269
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "WRK-629: feat(client2): engineering AI demo \u2014 diffraction + "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/269
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#270
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "WRK-630: feat(client2): engineering AI demo \u2014 diffraction + "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/270
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#281
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'WRK-121: Extract & Catalog OrcaFlex Models from rock-oil-fie'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/281
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#283
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-131: Passing ship analysis for moored vessels \u2014 AQWA-bas"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/283
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#284
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: 'WRK-064: ''OrcaFlex format converter: license-required valida'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/280
+  title: 'WRK-133: Update OrcaFlex license agreement with addresses an'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/284
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#194
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#321
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'WRK-026: Unified input data format converter for diffraction'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/321
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#322
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'WRK-057: Define canonical spec.yml schema for diffraction an'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/322
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#324
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "WRK-059: OrcaWave input backend \u2014 spec.yml to single .yml an"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/324
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#328
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "WRK-063: Reverse parsers \u2014 AQWA .dat and OrcaWave .yml to ca"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/328
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#371
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: 'WRK-5016: OrcaFlex demo version input-file troubleshooting w'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/194
+  title: 'WRK-127: Sanitize and categorize ideal spec.yml templates fo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/371
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#192
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#387
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "WRK-240: Diffraction spec converter skill \u2014 register as name"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/387
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#390
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: "WRK-5000: OrcaFlex scripting workflows \u2014 automation foundati"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/192
+  title: "WRK-244: OrcaFlex template library skill \u2014 get canonical spe"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/390
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#169
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: "WRK-256: Unified parametric study coordinator \u2014 orchestrate "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/169
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#141
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'WRK-099: Run 3-way benchmark on Unit Box hull'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/141
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#135
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'WRK-039: SPM project benchmarking - AQWA vs OrcaFlex'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/135
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#537
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: "OrcaFlex: manifest.yml not written when all runs skipped \u2014 c"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/537
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#536
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex: per-iteration model_validate perf for large sweep '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/536
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#535
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex: apply_dotted_override should chain ValidationError'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/535
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#534
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex: _apply_overrides direct-call StopIteration guard'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/534
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#531
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: "OrcaFlex: follow-up \u2014 9 pre-existing test failures across 5 "
-  url: https://github.com/vamseeachanta/digitalmodel/issues/531
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#529
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex: convert_batch() parallel path doesn''t aggregate su'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/529
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#509
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex: add pre-commit hook for YAML-strict validation on '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/509
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#507
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: "OrcaFlex reference: complete Orcina help ingestion \u2014 environ"
-  url: https://github.com/vamseeachanta/digitalmodel/issues/507
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#504
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: 'OrcaFlex buoys builder refactor: split 611-line mega-builder'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/504
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#503
-  repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: Ingest OrcaFlex/OrcaWave online help into LLM-accessible for
-  url: https://github.com/vamseeachanta/digitalmodel/issues/503
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
+  routed_by: manual
 - gh: vamseeachanta/digitalmodel#500
   repo: vamseeachanta/digitalmodel
-  domain: solver
+  domain: hydro
   provider: claude
   title: 'OrcaWave: mesh file pre-flight validation + auto-copy in run'
   url: https://github.com/vamseeachanta/digitalmodel/issues/500
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#487
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#501
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'OrcaWave: expand QTF config + field points + irregular frequ'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/501
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#515
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: Implement towing and marine operations analysis module
-  url: https://github.com/vamseeachanta/digitalmodel/issues/487
+  title: Clarify and close semantic-equivalence gaps between spec/LLM
+  url: https://github.com/vamseeachanta/digitalmodel/issues/515
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#140
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#516
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: 'WRK-075: OFFPIPE Integration Module \u2014 pipelay cross-val'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/140
+  title: Clarify and close semantic-equivalence gaps between spec/LLM
+  url: https://github.com/vamseeachanta/digitalmodel/issues/516
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#139
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#518
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: Add model-library regression tests for strict-vs-generated O
+  url: https://github.com/vamseeachanta/digitalmodel/issues/518
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#519
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: 'WRK-047: OpenFOAM CFD analysis capability for digitalmodel'
-  url: https://github.com/vamseeachanta/digitalmodel/issues/139
+  title: Classify and fix General/Environment/Groups fidelity gaps in
+  url: https://github.com/vamseeachanta/digitalmodel/issues/519
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#96
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#521
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | Iterate to achieve targets
-  url: https://github.com/vamseeachanta/digitalmodel/issues/96
+  title: Implement OrcaWave semantic-equivalence taxonomy, regression
+  url: https://github.com/vamseeachanta/digitalmodel/issues/521
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#88
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#554
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): catenary solver bracketing + sinh overflow '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/554
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#596
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: codex
+  title: 'chore(repo-structure): normalize digitalmodel folder/file st'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/596
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#637
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'feature(cfd): ballast-tank sloshing CFD study work package'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/637
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#638
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'feat(cfd): assess ballast-tank sloshing methodology and comp'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/638
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#718
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: engg debt | AI strategy in Engineering firms
-  url: https://github.com/vamseeachanta/digitalmodel/issues/88
+  title: "chore(orcaflex): L2 attestation \u2014 load attested model-librar"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/718
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#82
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#719
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | Postprocess enhancements
-  url: https://github.com/vamseeachanta/digitalmodel/issues/82
+  title: 'feat(orcaflex): canonical spec.yml runs full OrcaFlex analys'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/719
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1521
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'bug(aqwa): detect v261 and expose executable/license-path di'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1521
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1633
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'bug(validation): OrcaWave benchmark suite compares OrcaWave '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1633
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1641
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: "feat(orcaflex): modular_generator has no console script \u2014 th"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1641
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1857
+  repo: vamseeachanta/digitalmodel
+  domain: solver,collide-pe
+  provider: claude
+  title: "dynacard: Gibbs solver never transforms load \u2014 downhole card"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1857
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1871
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'dynacard: calculators return values that are not the quantit'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1871
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2229
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: 'feat(windows-parity): validate licensed-win-1 NightlyReadine'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2229
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2756
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'throughput(workstations): activate licensed-win-1 provider/m'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2756
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2772
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'decision(workstations): choose tier-1 repo placement for lic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2772
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2815
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): Windows Task Scheduler reads schedule-ta'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2815
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#40
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Installation | Batch Files | Reiterate runs and s
+  url: https://github.com/vamseeachanta/digitalmodel/issues/40
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/digitalmodel#79
   repo: vamseeachanta/digitalmodel
   domain: solver
@@ -630,211 +380,967 @@ cards:
   url: https://github.com/vamseeachanta/digitalmodel/issues/79
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#62
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#135
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-039: SPM project benchmarking - AQWA vs OrcaFlex'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/135
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#141
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-099: Run 3-way benchmark on Unit Box hull'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/141
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#169
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: "WRK-256: Unified parametric study coordinator \u2014 orchestrate "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/169
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#173
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-473: feat(hydrodynamics): integrate wavespectra library '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/173
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#199
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-5056: feat(digitalmodel): integrate theoretical naval ar'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/199
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#207
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "WRK-5067: Hydrodynamics and wave mechanics study \u2014 literatur"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/207
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#265
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "WRK-622: feat(geotechnical): anchor capacity \u2014 drag, suction"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/265
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#280
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'WRK-064: ''OrcaFlex format converter: license-required valida'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/280
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#326
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'WRK-061: CLI and integration layer for spec converter'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/326
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#463
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Populate ship-dimensions dataset from ship plans (manual cur
+  url: https://github.com/vamseeachanta/digitalmodel/issues/463
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#464
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Add hydrodynamic BEM analysis module (Capytaine)
+  url: https://github.com/vamseeachanta/digitalmodel/issues/464
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#465
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "Capytaine ship hull benchmarking \u2014 OC4 semi-sub + WAMIT vali"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/465
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#466
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "Parametric hull analysis \u2014 steady speed, passing ship, narro"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/466
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#467
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: "Subsea structure installation analysis \u2014 vessel performance "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/467
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#470
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: "Seakeeping analysis using OpenFOAM \u2014 CFD-based ship motion s"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/470
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#503
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: Ingest OrcaFlex/OrcaWave online help into LLM-accessible for
+  url: https://github.com/vamseeachanta/digitalmodel/issues/503
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#507
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: "OrcaFlex reference: complete Orcina help ingestion \u2014 environ"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/507
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#517
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: engg debt | OrcaWave
-  url: https://github.com/vamseeachanta/digitalmodel/issues/62
+  title: Define OrcaFlex YAML semantic-diff taxonomy and comparison p
+  url: https://github.com/vamseeachanta/digitalmodel/issues/517
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#41
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#520
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | Installation | Implement catenary equations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/41
+  title: 'Improve and document reverse extraction limits for OrcaFlex '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/520
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#40
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#529
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'OrcaFlex: convert_batch() parallel path doesn''t aggregate su'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/529
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#534
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | Installation | Batch Files | Reiterate runs and s
-  url: https://github.com/vamseeachanta/digitalmodel/issues/40
+  title: 'OrcaFlex: _apply_overrides direct-call StopIteration guard'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/534
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#19
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#535
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | Postprocess | Visualizations | For a/ QA and b/ R
-  url: https://github.com/vamseeachanta/digitalmodel/issues/19
+  title: 'OrcaFlex: apply_dotted_override should chain ValidationError'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/535
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#18
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#558
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_damping'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/558
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#559
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_full_ma'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/559
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#560
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_hydro_rao_integration.py::test_couplin'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/560
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#561
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_ocimf_mooring_integration.py::test_com'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/561
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#564
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_ocimf_mooring_integration.py::test_env'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/564
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#577
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: Safety Case / MAH ALARP framework module (NORSOK Z-013, UK H
+  url: https://github.com/vamseeachanta/digitalmodel/issues/577
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#588
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'fix(marine_ops): test_find_chain_with_safety_factor needs ch'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/588
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#592
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,website
+  provider: claude
+  title: Assess client-ready vessel capability GTM narrative and char
+  url: https://github.com/vamseeachanta/digitalmodel/issues/592
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#593
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,website
+  provider: claude
+  title: Assess vessel data provenance, confidence, and capability sc
+  url: https://github.com/vamseeachanta/digitalmodel/issues/593
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#595
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,website
+  provider: claude
+  title: Assess client PDF packaging for vessel capability GTM materi
+  url: https://github.com/vamseeachanta/digitalmodel/issues/595
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#640
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'feat(openfoam): build 3D L-shaped ballast-tank geometry and '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/640
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#642
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'feat(cfd-post): extract sloshing frequencies, pressure loads'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/642
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#686
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | SeastateRAOs | Filtering for analysis
-  url: https://github.com/vamseeachanta/digitalmodel/issues/18
+  title: Adopt vetted OSS tooling for Excel-to-code and solver-data l
+  url: https://github.com/vamseeachanta/digitalmodel/issues/686
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#16
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#691
   repo: vamseeachanta/digitalmodel
   domain: solver
   provider: claude
-  title: OrcaFlex | SeastateRAOs | Visualizations
-  url: https://github.com/vamseeachanta/digitalmodel/issues/16
+  title: Export Orcina L07 OrcaFlex model to YAML on ace-win-1
+  url: https://github.com/vamseeachanta/digitalmodel/issues/691
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#13
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#692
   repo: vamseeachanta/digitalmodel
   domain: solver
-  provider: claude
-  title: 'OrcaFlex | Installation | Modal Analysis '
-  url: https://github.com/vamseeachanta/digitalmodel/issues/13
+  provider: codex
+  title: Register Orcina L07 YAML export in digitalmodel and ace refe
+  url: https://github.com/vamseeachanta/digitalmodel/issues/692
   dispatch_status: ready
   wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/digitalmodel#9
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#714
   repo: vamseeachanta/digitalmodel
-  domain: solver
-  provider: claude
-  title: OrcaFlex | Installation | Rigging module
-  url: https://github.com/vamseeachanta/digitalmodel/issues/9
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: rule
-- gh: vamseeachanta/workspace-hub#2756
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
-  provider: claude
-  title: 'throughput(workstations): activate licensed-win-1 provider/m'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2756
+  domain: hydro
+  provider: codex
+  title: 'OrcaWave: investigate L01 180-case API benchmark timeout + p'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/714
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2717
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
+- gh: vamseeachanta/digitalmodel#1433
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
   provider: claude
-  title: "infra: live AQWA env access on licensed Windows host \u2014 prere"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2717
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#2709
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'feat(solver-queue): add AQWA runner adapter and schema exten'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2709
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1827
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'licensed-win-1: extract .sim model metadata to JSON for snap'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1827
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1789
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'licensed-win-1: retry hemisphere.owr fixture generation (mis'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1789
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1652
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'OrcaFlex reporting: integration test with real .sim fixture '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1652
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1586
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Harden solver queue: batch submission, result watcher, auto '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1586
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1509
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'Verify Claude Desktop install: licensed-win-1'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1509
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1292
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: "WRK-1342: OrcaFlex parachute deployment template \u2014 time-doma"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1292
-  dispatch_status: ready
-  wip_eligible: false
-  routed_by: manual
-- gh: vamseeachanta/workspace-hub#1264
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
-  provider: claude
-  title: 'WRK-1365: OrcaFlex frame analysis'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1264
+  title: 'proposal(cfd): further sloshing CFD benchmarking plan (cylin'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1433
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#2257
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: ci-release
   provider: claude
   title: 'fix(windows-scheduler): align RepoSync cadence with schedule'
   url: https://github.com/vamseeachanta/workspace-hub/issues/2257
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2229
+- gh: vamseeachanta/workspace-hub#3679
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: repo
   provider: claude
-  title: 'feat(windows-parity): validate licensed-win-1 NightlyReadine'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2229
+  title: Ship dimensions template + loader (WRK-1380)
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3679
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1502
+- gh: vamseeachanta/workspace-hub#3683
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: solver
   provider: claude
-  title: "[WRK] Maximize OpenAI Codex account utilization \u2014 dual 0 Plu"
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1502
+  title: 'WRK-5016: OrcaFlex demo version input-file troubleshooting w'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3683
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3684
+  repo: vamseeachanta/workspace-hub
+  domain: solver
+  provider: claude
+  title: "WRK-5000: OrcaFlex scripting workflows \u2014 automation foundati"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3684
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#9
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Installation | Rigging module
+  url: https://github.com/vamseeachanta/digitalmodel/issues/9
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#13
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'OrcaFlex | Installation | Modal Analysis '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/13
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#16
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | SeastateRAOs | Visualizations
+  url: https://github.com/vamseeachanta/digitalmodel/issues/16
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#19
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Postprocess | Visualizations | For a/ QA and b/ R
+  url: https://github.com/vamseeachanta/digitalmodel/issues/19
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#28
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: engg debt | Fatigue | ship design | spectral-based fatigue a
+  url: https://github.com/vamseeachanta/digitalmodel/issues/28
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#36
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: engg debt | RAOs Analysis feature
+  url: https://github.com/vamseeachanta/digitalmodel/issues/36
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#41
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Installation | Implement catenary equations
+  url: https://github.com/vamseeachanta/digitalmodel/issues/41
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#64
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: engg debt | CAD
+  url: https://github.com/vamseeachanta/digitalmodel/issues/64
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#82
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Postprocess enhancements
+  url: https://github.com/vamseeachanta/digitalmodel/issues/82
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#88
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: engg debt | AI strategy in Engineering firms
+  url: https://github.com/vamseeachanta/digitalmodel/issues/88
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#96
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: OrcaFlex | Iterate to achieve targets
+  url: https://github.com/vamseeachanta/digitalmodel/issues/96
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#134
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'WRK-036: OrcaFlex structure deployment analysis - supply boa'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/134
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#136
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'WRK-043: Parametric hull form analysis with RAO generation a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/136
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#140
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: codex
+  title: 'WRK-075: OFFPIPE Integration Module \u2014 pipelay cross-val'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/140
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#253
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: codex
+  title: 'WRK-587: research: evaluate Code_Aster for large-scale topsi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/253
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#487
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: Implement towing and marine operations analysis module
+  url: https://github.com/vamseeachanta/digitalmodel/issues/487
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#509
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'OrcaFlex: add pre-commit hook for YAML-strict validation on '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/509
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#536
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'OrcaFlex: per-iteration model_validate perf for large sweep '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/536
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#537
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "OrcaFlex: manifest.yml not written when all runs skipped \u2014 c"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/537
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1629
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'bug(orcaflex): process_summary_by_model_and_cfg returns hard'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1629
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1630
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'bug(mooring): DNV-OS-E301 compliance hardcoded True; compreh'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1630
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1631
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'bug(licensed-lane): runs report returncode 0 / finished desp'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1631
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1875
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'dynacard: synthetic generator shapes do not match canonical '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1875
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#1343
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
   title: 'WRK-1343: ace-license-win-2 network drive sharing from ace-l'
   url: https://github.com/vamseeachanta/workspace-hub/issues/1343
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2772
+- gh: vamseeachanta/workspace-hub#1502
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: ai
   provider: claude
-  title: 'decision(workstations): choose tier-1 repo placement for lic'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2772
+  title: "[WRK] Maximize OpenAI Codex account utilization \u2014 dual 0 Plu"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1502
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1509
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'Verify Claude Desktop install: licensed-win-1'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1509
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1789
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'licensed-win-1: retry hemisphere.owr fixture generation (mis'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1789
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#495
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "OrcaFlex YAML-strict validator \u2014 automated load-test for gen"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/495
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#496
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'OrcaFlex spec schema: multi-wave-train + multi-current-profi'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/496
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#497
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'OrcaFlex builders: raw_properties round-trip emission + cros'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/497
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#502
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'OrcaFlex spec audit: fix remaining 13 failures to reach 100%'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/502
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#801
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'Parametric Refresh: sparse atlas libraries for licensed solv'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/801
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#834
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'Parametric: extend the sparse-library model to OrcaFlex (#80'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/834
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#852
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'vessel_db: off-repo RAO library adapter for real model-test/'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/852
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#885
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "orcaflex-strength-post template can't post-process itself \u2014 "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/885
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#929
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'Bulk diffraction model generator: fleet deck-gen over instal'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/929
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#941
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'OrcaFlex use-case template catalog + gap-fill (dispatchable '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/941
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#942
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'OrcaWave use-case template catalog + gap-fill (dispatchable '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/942
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#953
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'OrcaWave gap specs: mean-drift, field-points, control-surfac'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/953
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1013
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: '[Adapters 2/5] Simulation/analysis adapter catalog (OrcaFlex'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1013
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1154
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "Workflow: 2nd-order / QTF vessel motions \u2014 mean & slow-drift"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1154
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1155
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: Wire licensed-solver workflows (OrcaFlex/OrcaWave/AQWA/ANSYS
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1155
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1437
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'feat(cfd-viz): free-surface (VOF) field visualizations for t'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1437
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1439
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "feat(compute-opt): CFD runtime characterization \u2014 mesh/param"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1439
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1467
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: '[#1356-G] Field pilot: instrumented vessel motion-forecast v'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1467
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1538
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: 'installation_pamphlet: BokaLift actual RAO basis (T3 ship_pr'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1538
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1548
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: Low-frequency diffraction RAO artifact for install_bokalift_
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1548
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1553
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'EPIC: Continuous batch mini-runs on ace-win-1 (OrcaFlex mult'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1553
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1554
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: "feat(orcaflex): licensed orcaflex-run-batch \u2014 N-parallel dyn"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1554
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1564
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: codex
+  title: 'orcaflex_run_batch: missing engine base-config yml (same rc-'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1564
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1574
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Remove project-specific identifiers from reusable sloshing m
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1574
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1577
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'Sloshing harmonic reducer: normalize roll damping and stiffn'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1577
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1578
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'Coupled roll response: consume sloshing moment coefficients'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1578
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1579
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Make diffraction inertia-tensor origin strict and consistent
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1579
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1580
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Define a solver-neutral diffraction restoring-stiffness cont
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1580
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1581
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: Support typed interior and damping-lid surfaces in diffracti
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1581
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1582
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'Normalize diffraction matrix units across AQWA and OrcaWave '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1582
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1596
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'Hosted solver execution: enforce reusable launch and path-bo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1596
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1618
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,subsea
+  provider: codex
+  title: Bind one public drilling rig to a physical vessel hydrodynam
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1618
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1619
+  repo: vamseeachanta/digitalmodel
+  domain: hydro,subsea
+  provider: codex
+  title: Prove one solver-neutral public MODU diffraction-to-RAO reco
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1619
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1862
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'dynacard: synthetic card generators produce downhole cards b'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1862
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1873
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'LA-0024 SCADA export: real surface-card format reference (no'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1873
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1944
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: 'tests/solvers unrunnable on a licensed host: modular_model s'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1944
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3046
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity audit on ace-win-1 (Part A) \u2014 epic #3043"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3046
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual

--- a/.claude/dispatch/licensed-win-2.yaml
+++ b/.claude/dispatch/licensed-win-2.yaml
@@ -1,30 +1,77 @@
 machine: licensed-win-2
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
 - gh: vamseeachanta/workspace-hub#2757
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: workstations
   provider: claude
   title: 'throughput(workstations): activate licensed-win-2 provider/m'
   url: https://github.com/vamseeachanta/workspace-hub/issues/2757
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
+- gh: vamseeachanta/workspace-hub#2773
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'decision(workstations): choose tier-1 repo placement for lic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2773
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2926
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): ace-win-2 licensed-solver machine missin'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2926
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3721
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: "ops(ace-win-2): install OpenSSH Server \u2014 host is up and answ"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3721
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
 - gh: vamseeachanta/workspace-hub#1510
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: workstations
   provider: claude
   title: 'Verify Claude Desktop install: ace-win-2'
   url: https://github.com/vamseeachanta/workspace-hub/issues/1510
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2773
+- gh: vamseeachanta/workspace-hub#3047
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: ai
   provider: claude
-  title: 'decision(workstations): choose tier-1 repo placement for lic'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2773
+  title: "Model parity audit on ace-win-2 (Part A) \u2014 epic #3043"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3047
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3526
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(windows): daily report-only ecosystem reconciliation au'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3526
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3595
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'ace-win-2 on-box: schema-5 equality re-collect verification '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3595
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual

--- a/.claude/dispatch/macbook-portable.yaml
+++ b/.claude/dispatch/macbook-portable.yaml
@@ -1,9 +1,11 @@
 machine: macbook-portable
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
 - gh: vamseeachanta/workspace-hub#1508
   repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+  domain: workstations
   provider: claude
   title: 'Verify Claude Desktop install: macbook-portable'
   url: https://github.com/vamseeachanta/workspace-hub/issues/1508

--- a/.claude/dispatch/multi.yaml
+++ b/.claude/dispatch/multi.yaml
@@ -1,84 +1,1832 @@
 machine: multi
 generated_by: dispatch.py
+generated_at: '2026-08-02T02:26:55Z'
+ttl_hours: 24
 cards:
-- gh: vamseeachanta/workspace-hub#1504
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/deckhand#24
+  repo: vamseeachanta/deckhand
+  domain: security
   provider: claude
-  title: Install Claude Desktop on all ecosystem machines
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1504
+  title: "Epic: Open Deck hardening \u2014 public-tier launch readiness"
+  url: https://github.com/vamseeachanta/deckhand/issues/24
+  dispatch_status: ready
+  wip_eligible: true
+  routed_by: manual
+- gh: vamseeachanta/deckhand#187
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: codex
+  title: 'EPIC: Channels run real engineering compute (subagent expert'
+  url: https://github.com/vamseeachanta/deckhand/issues/187
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1378
-  repo: vamseeachanta/workspace-hub
-  domain: ai-orchestration
+- gh: vamseeachanta/deckhand#192
+  repo: vamseeachanta/deckhand
+  domain: routing,security,onboarding
   provider: claude
-  title: 'WRK-PENDING: Review local-analysis folders for relocation to'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1378
+  title: "Epic: Personal family Telegram workspace \u2014 private scope wit"
+  url: https://github.com/vamseeachanta/deckhand/issues/192
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2641
-  repo: vamseeachanta/workspace-hub
-  domain: engineering
+- gh: vamseeachanta/deckhand#389
+  repo: vamseeachanta/deckhand
+  domain: capability,onboarding
   provider: claude
-  title: 'feat(solver-queue): hands-off multi-machine inbox ingestion '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2641
+  title: "Epic: Marketable workflows per Open Deck channel \u2014 define, c"
+  url: https://github.com/vamseeachanta/deckhand/issues/389
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#2089
-  repo: vamseeachanta/workspace-hub
-  domain: harness
+- gh: vamseeachanta/deckhand#405
+  repo: vamseeachanta/deckhand
+  domain: routing,security,onboarding
   provider: claude
-  title: 'feat(harness): weekly Hermes + AI provider settings review f'
-  url: https://github.com/vamseeachanta/workspace-hub/issues/2089
+  title: 'Epic: Marketing onboarding funnel + standardized channel reg'
+  url: https://github.com/vamseeachanta/deckhand/issues/405
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#577
+  repo: vamseeachanta/deckhand
+  domain: gateway-ops
+  provider: claude
+  title: '[Epic] What''s reviewed is what runs: config and patch drift '
+  url: https://github.com/vamseeachanta/deckhand/issues/577
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#622
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: codex
+  title: 'Epic: Output-driven diffraction domain module (OrcaWave pilo'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/622
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#890
+  repo: vamseeachanta/digitalmodel
+  domain: udw-well-access
+  provider: claude
+  title: "[Epic] Quantify the UDW well-access supply\u2013demand gap (Front"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/890
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1161
+  repo: vamseeachanta/digitalmodel
+  domain: cfd
+  provider: claude
+  title: "[Epic] CFD capability \u2014 activate OpenFOAM stack for 2D/3D ma"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1161
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1429
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "[Epic] CFD-benchmarked sloshing master curve \u2014 overlay measu"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1429
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1523
+  repo: vamseeachanta/digitalmodel
+  domain: gis
+  provider: claude
+  title: 'epic(explorer-bridge): engineering feeds for the wed World E'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1523
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1825
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "[Epic] Diffraction results agree across solvers \u2014 one strict"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1825
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1826
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: '[Epic] OrcaFlex model library: real models in, semantically-'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1826
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1827
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "[Epic] marine_ops regression suite green \u2014 RAO, OCIMF and mo"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1827
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1833
+  repo: vamseeachanta/digitalmodel
+  domain: solver,marine
+  provider: claude
+  title: '[Epic] Solver queue runs licensed batches unattended across '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1833
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1835
+  repo: vamseeachanta/digitalmodel
+  domain: subsea,pipeline
+  provider: claude
+  title: '[Epic] Close the design-code gap: pipeline, riser and subsea'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1835
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1837
+  repo: vamseeachanta/digitalmodel
+  domain: subsea,pipeline
+  provider: claude
+  title: '[Epic] VIV and fatigue damage chain: no silent numbers from '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1837
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1354
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'WRK-1354: frontierdeepwater: sync missing files from remote '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1354
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#1782
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: knowledge
   provider: claude
   title: "epic: zero-loss agent learnings \u2014 git-track ALL AI agent mem"
   url: https://github.com/vamseeachanta/workspace-hub/issues/1782
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1678
+- gh: vamseeachanta/workspace-hub#2887
   repo: vamseeachanta/workspace-hub
-  domain: harness
+  domain: workstations
   provider: claude
-  title: Deploy harness-update-windows.sh to licensed-win-1 and licen
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1678
+  title: 'epic(workstations): machine + AI-provider equivalence status'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2887
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1583
+- gh: vamseeachanta/workspace-hub#2894
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): #0 revive + verify the equality-matrix s'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2894
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2998
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'epic(workstations): extend consistent-experience backbone to'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2998
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3050
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'EPIC: confirm tier-1 repos + drive workflows through the UV '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3050
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3281
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "EPIC: Deterministic Workflow API \u2014 make every tier-1 workflo"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3281
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3290
   repo: vamseeachanta/workspace-hub
   domain: harness
   provider: claude
-  title: Hermes config parity via repo ecosystem templates
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1583
+  title: "EPIC: Seamless ecosystem development \u2014 fast green CI, a work"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3290
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3331
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(codex): frontier-model harness and memory parity harden'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3331
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3414
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: 'epic(landman-project-desk): broker workflow, QA, and federal'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3414
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3427
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: 'epic: repository-linked algorithm run datasets and decision '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3427
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3455
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(workstations): reconcile ace-win-1 with the live RDS-002'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3455
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3485
+  repo: vamseeachanta/workspace-hub
+  domain: capability
+  provider: claude
+  title: 'epic: Live HF-backed capability surfaces on aceengineer.com '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3485
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3497
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "EPIC: Fleet dispatch ecosystem \u2014 ace-linux-1 single dispatch"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3497
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3516
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "bug(equivalence): ref blobs keyed by role \u2014 same-role boxes "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3516
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3559
+  repo: vamseeachanta/workspace-hub
+  domain: capability
+  provider: codex
+  title: 'feat(field-explorer): immutable Hugging Face field/well HTML'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3559
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3600
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "fix(harness): R-MODEL-DRIFT validates only openai_primary \u2014 "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3600
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3601
+  repo: vamseeachanta/workspace-hub
+  domain: solver
+  provider: claude
+  title: 'INITIATIVE: Engineering compute & solver trust'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3601
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3602
+  repo: vamseeachanta/workspace-hub
+  domain: ingest
+  provider: claude
+  title: 'INITIATIVE: World Energy Field Explorer & asset data spine'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3602
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3603
+  repo: vamseeachanta/workspace-hub
+  domain: gtm
+  provider: claude
+  title: 'INITIATIVE: Deckhand & Open Deck platform'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3603
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3604
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'INITIATIVE: Knowledge ingestion & the llm-wiki corpus'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3604
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3605
+  repo: vamseeachanta/workspace-hub
+  domain: business-development
+  provider: claude
+  title: 'INITIATIVE: ACMA & client delivery'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3605
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3606
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: 'INITIATIVE: Harness runtime, workflow & skills'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3606
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3607
+  repo: vamseeachanta/workspace-hub
+  domain: gtm
+  provider: claude
+  title: 'INITIATIVE: Brand, public surfaces & go-to-market'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3607
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3608
+  repo: vamseeachanta/workspace-hub
+  domain: cad
+  provider: claude
+  title: 'INITIATIVE: CAD/CAM & manufacturing capability'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3608
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3609
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'INITIATIVE: Personal & family operations'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3609
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3669
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: "INITIATIVE: AI platform \u2014 provider parity, routing, memory &"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3669
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3670
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: "INITIATIVE: Fleet operations \u2014 machine readiness, cross-plat"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3670
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3671
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: 'INITIATIVE: Repo structure, test health & governance'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3671
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3724
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: 'bug(equality): 4 of 5 matrix rows are stale and render ident'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3724
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#38
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: claude
+  title: "Epic: flagship-prompt delivery \u2014 technical capability paths "
+  url: https://github.com/vamseeachanta/deckhand/issues/38
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#141
+  repo: vamseeachanta/deckhand
+  domain: onboarding
+  provider: claude
+  title: 'Epic: Onboard a software-side SME via an operator/admin scop'
+  url: https://github.com/vamseeachanta/deckhand/issues/141
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#142
+  repo: vamseeachanta/deckhand
+  domain: onboarding
+  provider: claude
+  title: 'Epic: Onboard an electrical-domain SME (new domain + Open De'
+  url: https://github.com/vamseeachanta/deckhand/issues/142
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#425
+  repo: vamseeachanta/deckhand
+  domain: onboarding
+  provider: claude
+  title: "epic(marketing): demo videos v3 \u2014 exact-UX with real deliver"
+  url: https://github.com/vamseeachanta/deckhand/issues/425
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#572
+  repo: vamseeachanta/deckhand
+  domain: workstations
+  provider: claude
+  title: '[Epic] Licensed-run reaches production: ANSYS/AQWA/OrcaFlex '
+  url: https://github.com/vamseeachanta/deckhand/issues/572
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#573
+  repo: vamseeachanta/deckhand
+  domain: workstations
+  provider: claude
+  title: '[Epic] Execution-host fleet: one role per machine, one reach'
+  url: https://github.com/vamseeachanta/deckhand/issues/573
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#574
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: claude
+  title: '[Epic] One resolver decides every route: voice, paths, escal'
+  url: https://github.com/vamseeachanta/deckhand/issues/574
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#575
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: claude
+  title: '[Epic] No engineering ask falls through: seven missing disci'
+  url: https://github.com/vamseeachanta/deckhand/issues/575
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#576
+  repo: vamseeachanta/deckhand
+  domain: chat-quality
+  provider: claude
+  title: '[Epic] Every reply is rated, grounded, and free of internal '
+  url: https://github.com/vamseeachanta/deckhand/issues/576
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#578
+  repo: vamseeachanta/deckhand
+  domain: onboarding
+  provider: claude
+  title: '[Epic] Standing up a new client scope is one automated flow,'
+  url: https://github.com/vamseeachanta/deckhand/issues/578
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1530
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: "EPIC: Field-development hardening \u2014 real data, native screen"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1530
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1828
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "[Epic] License-free BEM lane \u2014 Capytaine + parametric hull s"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1828
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1829
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: "[Epic] Station-keeping answers for moored vessels \u2014 dynamic "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1829
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1830
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "[Epic] From .sim to a report a client can read \u2014 standard Or"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1830
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1831
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: '[Epic] Installation and marine operations analyses that neve'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1831
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1832
+  repo: vamseeachanta/digitalmodel
+  domain: hydro
+  provider: claude
+  title: '[Epic] Every hydrodynamic method traceable to a cited source'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1832
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1834
+  repo: vamseeachanta/digitalmodel
+  domain: subsea,pipeline
+  provider: claude
+  title: '[Epic] Cathodic protection: a CP design a client can be hand'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1834
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1836
+  repo: vamseeachanta/digitalmodel
+  domain: subsea,marine
+  provider: claude
+  title: '[Epic] Installation analysis end to end: spec to go/no-go de'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1836
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1838
+  repo: vamseeachanta/digitalmodel
+  domain: subsea,pipeline
+  provider: claude
+  title: '[Epic] Soil is modelled, not assumed: geotechnical layer for'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1838
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1839
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture,marine
+  provider: claude
+  title: '[Epic] Hydrodynamic coefficients you can defend: hull regist'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1839
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1840
+  repo: vamseeachanta/digitalmodel
+  domain: marine
+  provider: claude
+  title: '[Epic] Open-source solver stack as a licence-free cross-chec'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1840
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1841
+  repo: vamseeachanta/digitalmodel
+  domain: marine,pipeline
+  provider: claude
+  title: '[Epic] Data supply: real external feeds in, legacy engineeri'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1841
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1842
+  repo: vamseeachanta/digitalmodel
+  domain: solver,marine
+  provider: claude
+  title: '[Epic] Deliverables under test: snapshot-verified reports an'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1842
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1843
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "[Epic] Fatigue answers you can defend \u2014 cycle counting, full"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1843
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1844
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: "[Epic] Make mooring & station-keeping code-complete \u2014 API RP"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1844
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1845
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: "[Epic] Cathodic protection that respects the metallurgy \u2014 IS"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1845
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1846
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "[Epic] A license-free solver stack we can trust \u2014 CalculiX, "
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1846
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1847
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "[Epic] The routine structural component check \u2014 sections, AI"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1847
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1848
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: '[Epic] Turn the naval-architecture reference corpus into val'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1848
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1849
+  repo: vamseeachanta/digitalmodel
+  domain: standards
+  provider: claude
+  title: "[Epic] Floating offshore wind capability \u2014 carry the deepwat"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1849
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1850
+  repo: vamseeachanta/digitalmodel
+  domain: testing
+  provider: claude
+  title: "[Epic] Green the digitalmodel test suite \u2014 clear the marine_"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1850
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1851
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: '[Epic] A digitalmodel checkout that agents and CI can operat'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1851
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
 - gh: vamseeachanta/workspace-hub#1462
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: harness
   provider: claude
   title: Install and configure tmux (or chosen multiplexer) across al
   url: https://github.com/vamseeachanta/workspace-hub/issues/1462
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual
-- gh: vamseeachanta/workspace-hub#1354
+- gh: vamseeachanta/workspace-hub#1583
   repo: vamseeachanta/workspace-hub
-  domain: ops
+  domain: workstations
   provider: claude
-  title: 'WRK-1354: client-a: sync missing files from remote '
-  url: https://github.com/vamseeachanta/workspace-hub/issues/1354
+  title: Hermes config parity via repo ecosystem templates
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1583
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1678
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Deploy harness-update-windows.sh to licensed-win-1 and licen
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1678
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2089
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(harness): weekly Hermes + AI provider settings review f'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2089
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2888
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): AI-tool version-currency cell (installed'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2888
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2890
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): repo-sync-status cell (ahead/behind/dirt'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2890
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2891
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): network/data-availability reachability c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2891
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2892
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): OSS custom-program inventory + version-c'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2892
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#2893
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'feat(workstations): cross-provider statusline parity (Claude'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/2893
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3370
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'EPIC: Repo-ecosystem data retention, backup & fingertip-acce'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3370
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3524
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: '[WRK] bug(workstations): RDP microphone input not negotiated'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3524
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3565
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(agent-ux): align Linux Codex dictation hotkey with Wind'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3565
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3566
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'fix(agent-ux): make keyboard and context-menu text paste equ'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3566
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3567
+  repo: vamseeachanta/workspace-hub
+  domain: workstations,ai
+  provider: claude
+  title: 'feat(machine-equivalence): add interaction-UX evidence and p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3567
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3568
+  repo: vamseeachanta/workspace-hub
+  domain: workstations,ai
+  provider: claude
+  title: 'epic(agent-ux): cross-machine input interaction parity'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3568
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3589
+  repo: vamseeachanta/workspace-hub
+  domain: family
+  provider: claude
+  title: 'EPIC: family phone-media extraction & archive ecosystem'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3589
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3611
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: '[Epic] Make the SKILL.md authoring contract machine-checkabl'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3611
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3612
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: '[Epic] One canonical copy per skill, non-zero domain coverag'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3612
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3613
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: '[Epic] Finish the agent/command to SKILL.md migration and st'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3613
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3614
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: '[Epic] Close eight named domain-skill coverage gaps'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3614
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3615
+  repo: vamseeachanta/workspace-hub
+  domain: skills
+  provider: claude
+  title: '[Epic] Make workspace-hub''s own operational skills and pre-p'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3615
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3616
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "[Epic] Provider parity \u2014 Claude, Codex and agy are interchan"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3616
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3617
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "[Epic] Retire the WRK work-queue \u2014 one work-tracking system,"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3617
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3618
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "[Epic] Model routing & AI credit governance \u2014 right model fo"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3618
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3619
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "[Epic] Trustworthy autonomous dispatch \u2014 approval, plan-revi"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3619
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3620
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "[Epic] Make workflow compliance consequential \u2014 a gate behin"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3620
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3621
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "[Epic] Durable agent memory \u2014 canonical, fresh and lossless "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3621
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3622
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "[Epic] Every issue leaves a standard durable trail \u2014 plan, r"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3622
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3623
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: '[Epic] Cross-provider review fanout produces trustworthy, co'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3623
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3624
+  repo: vamseeachanta/workspace-hub
+  domain: workflow
+  provider: claude
+  title: "[Epic] Close the email-as-queue loop \u2014 extract, act, delete,"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3624
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3625
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "[Epic] Skill & prompt corpus \u2014 measure real usage, remove mo"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3625
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3626
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: '[Epic] Hermes gateway & the self-hosted / free provider tier'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3626
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3627
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: '[Epic] One consistent agent harness configuration on every m'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3627
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3628
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: '[Epic] Security hardening for AI agent workflows and credent'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3628
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3629
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: '[Epic] Weekly ecosystem review publishes reproducible, promo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3629
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3630
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: '[Epic] Adopting a new model or harness update is a verified,'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3630
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3631
+  repo: vamseeachanta/workspace-hub
+  domain: ci-release
+  provider: claude
+  title: '[Epic] Every harness script and scheduled task runs identica'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3631
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3632
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: '[Epic] llm-wiki ingest pipeline: complete source coverage, i'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3632
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3633
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: '[Epic] Plan-approval evidence is fail-closed and machine-ver'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3633
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3634
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: '[Epic] Promote the named O&G standards backlog into the wiki'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3634
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3635
+  repo: vamseeachanta/workspace-hub
+  domain: governance
+  provider: claude
+  title: '[Epic] Every open issue routes to exactly one domain, board '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3635
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3636
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: '[Epic] Enforce knowledge promotion: ledger, audit trail, and'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3636
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3637
+  repo: vamseeachanta/workspace-hub
+  domain: security,governance
+  provider: claude
+  title: '[Epic] Public repositories are hardened and contributor inte'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3637
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3638
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: '[Epic] Make ecosystem intelligence findable and provably fre'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3638
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3639
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: '[Epic] Every workstation is reachable only over hardened, re'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3639
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3640
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: '[Epic] Secret and legal scanning fails closed with positive '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3640
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3641
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: '[Epic] Harness tooling is hardened against hostile and malfo'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3641
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3642
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Weekly review publication pipeline: validated, reprod'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3642
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3643
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "[Epic] Machine readiness matrix \u2014 evidence bundles on every "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3643
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3644
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "[Epic] Clear node bring-up debt \u2014 ace-linux-2 and gpu-claw t"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3644
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3645
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: '[Epic] One-command harness bootstrap + unattended update lif'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3645
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3646
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Every tier-1 repo has the same anatomy and a current '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3646
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3647
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] Every scheduled task installs, runs, and surfaces its'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3647
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3648
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Cross-review enforcement: reliable, blocking, provide'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3648
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3649
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] One trustworthy answer to "is this plan approved?" ac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3649
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3650
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] A session''s state and learnings survive the session a'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3650
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3651
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] Identical harness behaviour on every machine and ever'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3651
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3652
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] Harness automation never destroys live work or unveri'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3652
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3653
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] The weekly review reports something a human can act o'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3653
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3654
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] Get commit-review compliance out of critical and stop'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3654
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3655
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: '[Epic] The operator can see and steer the harness without op'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3655
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3656
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Pre-push and merge gates: deterministic, passable, by'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3656
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3657
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Wind down secondary repos: extract the value, then ar'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3657
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3658
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Return red test suites to green (digitalmodel, worlde'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3658
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3659
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Coverage uplift for untested engineering and calculat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3659
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3660
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Delete dead weight: stale code, orphan modules, and m'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3660
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3661
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Smoke coverage for licensed and platform-specific eng'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3661
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3662
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Every repo clean, synced, and free of stray branches'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3662
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3663
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Test-health telemetry: trends, baselines and enforced'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3663
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3664
+  repo: vamseeachanta/workspace-hub
+  domain: testing
+  provider: claude
+  title: '[Epic] Regression coverage for ecosystem-sync and harness mu'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3664
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3665
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Shared dev toolchain works in every checkout: worktre'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3665
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3666
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Architecture and readiness reporting runs itself'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3666
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3667
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] One implementation per capability: consolidate duplic'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3667
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3668
+  repo: vamseeachanta/workspace-hub
+  domain: repo
+  provider: claude
+  title: '[Epic] Promote packages up the maturity ladder to PRODUCTION'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3668
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3723
+  repo: vamseeachanta/workspace-hub
+  domain: security
+  provider: claude
+  title: 'ops(fleet): derive fleet-ssh-hosts.yml reachability from the'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3723
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3734
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: 'feat(capability): ace-win-1 has idle licensed AQWA capacity '
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3734
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1640
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "INITIATIVE: Trustworthy OrcaFlex results \u2014 arm the merge gat"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1640
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1378
+  repo: vamseeachanta/workspace-hub
+  domain: knowledge
+  provider: claude
+  title: 'WRK-PENDING: Review local-analysis folders for relocation to'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1378
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#1504
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: Install Claude Desktop on all ecosystem machines
+  url: https://github.com/vamseeachanta/workspace-hub/issues/1504
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3594
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'chore(registry): gpu-claw entry stale after 2026-07-22 reloc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3594
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#439
+  repo: vamseeachanta/deckhand
+  domain: routing
+  provider: claude
+  title: "[Epic] Topic/Domain/Subdomain Subagent Specialization \u2014 best"
+  url: https://github.com/vamseeachanta/deckhand/issues/439
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/deckhand#521
+  repo: vamseeachanta/deckhand
+  domain: capability
+  provider: claude
+  title: "[EPIC] Live callable capabilities via Telegram \u2192 hermes (wor"
+  url: https://github.com/vamseeachanta/deckhand/issues/521
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#794
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: "[Epic] Parametric Refresh \u2014 atlas-backed instant answers for"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/794
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#807
+  repo: vamseeachanta/digitalmodel
+  domain: subsea
+  provider: claude
+  title: "[Epic] Riser Analysis Automation \u2014 engine hardening, paramet"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/807
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#836
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "[Epic] Collide PE Problem of the Day \u2014 solve the series (hot"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/836
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#837
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: '[Epic] Deckhand-routed Claude API solver for Collide PE prob'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/837
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#938
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "EPIC: Solver run preparedness \u2014 programs (AQWA/ANSYS), use-c"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/938
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1004
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: '[Epic] Catalog & understand existing CAD/CAM models on the a'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1004
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1011
+  repo: vamseeachanta/digitalmodel
+  domain: cad
+  provider: claude
+  title: "[Epic] File-format adapter review \u2014 read & convert all CAD/C"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1011
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1057
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: "EPIC: Fitness-For-Service (FFS) decision layer \u2014 field-to-of"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1057
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1080
+  repo: vamseeachanta/digitalmodel
+  domain: structural
+  provider: claude
+  title: 'EPIC: Ship structural strength expansion + unified material '
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1080
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1095
+  repo: vamseeachanta/digitalmodel
+  domain: repo
+  provider: claude
+  title: "[Epic] LLM spec-authoring: project SSOT \u2192 analysis SSOT (spe"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1095
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1152
+  repo: vamseeachanta/digitalmodel
+  domain: solver
+  provider: claude
+  title: "[Epic] Open simulation workflows \u2192 future Deckhand API paths"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1152
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1193
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: 'EPIC: Tug analysis toolkit (power, stability, fendering, tow'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1193
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1356
+  repo: vamseeachanta/digitalmodel
+  domain: naval-architecture
+  provider: claude
+  title: "EPIC: Short-horizon vessel/structure MOTION forecast \u2192 opera"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1356
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1391
+  repo: vamseeachanta/digitalmodel
+  domain: capability
+  provider: claude
+  title: "EPIC: capabilities-page content expansion \u2014 7 verified drop-"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1391
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1471
+  repo: vamseeachanta/digitalmodel
+  domain: website
+  provider: claude
+  title: 'EPIC: Brand & layout consistency for public capability pages'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1471
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1858
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: '[Epic] Rod-pump artificial lift: dynamometer cards you can d'
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1858
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/digitalmodel#1870
+  repo: vamseeachanta/digitalmodel
+  domain: collide-pe
+  provider: claude
+  title: "INITIATIVE: Dynacard diagnostics you can defend \u2014 solver, ho"
+  url: https://github.com/vamseeachanta/digitalmodel/issues/1870
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3043
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Model parity: make the repo ecosystem equivalent for Opus an'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3043
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3049
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Model parity: synthesize audits \u2192 gap report, PRs, Opus play"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3049
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3056
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Model parity: analyze the Fable-5 session corpus (behavioral'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3056
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3058
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Epic: Harden the repo ecosystem \u2014 enforce equivalence, model"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3058
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3059
+  repo: vamseeachanta/workspace-hub
+  domain: null
+  provider: claude
+  title: "Harden: machine-equivalence drift sentinel \u2014 epic #3058"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3059
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3061
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: "Harden: continuous parity instrumentation \u2014 epic #3058"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3061
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3074
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Harden: provider-behavior parity across machines (SOUL.runti'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3074
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3112
+  repo: vamseeachanta/workspace-hub
+  domain: skills,ai
+  provider: claude
+  title: 'Harden: instrument true skill/command invocation (the measur'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3112
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3223
+  repo: vamseeachanta/workspace-hub
+  domain: website
+  provider: claude
+  title: 'Epic: Demonstrate ecosystem work via GitHub Pages (determini'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3223
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3248
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'Epic: robust cross-provider self-improvement & skill-currenc'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3248
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3401
+  repo: vamseeachanta/workspace-hub
+  domain: website
+  provider: claude
+  title: 'EPIC: One brand + layout system across all public-facing eco'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3401
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3408
+  repo: vamseeachanta/workspace-hub
+  domain: harness
+  provider: claude
+  title: Add harness-checkup (/doctor) hygiene dimension to machine-e
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3408
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3505
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "ops(ace-win-1): equivalence fingerprint ABSENT \u2014 sentinel no"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3505
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3506
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: "ops(ace-win-2): equivalence fingerprint ABSENT \u2014 sentinel no"
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3506
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3511
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equivalence): Windows sentinel emits empty unknown finge'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3511
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3513
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(harness): Windows soul installer reports LINK for ordina'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3513
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3554
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): Windows publish-equality misclassifies missin'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3554
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3555
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(agent-ux): pilot persistent goals and native Codex stat'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3555
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3557
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): reconcile marks dirty STALE-CHECKOUT auto-saf'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3557
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3573
+  repo: vamseeachanta/workspace-hub
+  domain: ai
+  provider: claude
+  title: 'feat(ai-orchestration): replace gemini with agy as the third'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3573
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3702
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): equality-matrix-cron writes generated artifac'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3702
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3703
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): reconcile-ecosystem.sh fails open to an empty'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3703
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3704
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(equality): reconcile-ecosystem.sh scans stale refs witho'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3704
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3705
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: claude
+  title: 'bug(sync): repository_sync auto-commits to protected main br'
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3705
+  dispatch_status: ready
+  wip_eligible: false
+  routed_by: manual
+- gh: vamseeachanta/workspace-hub#3707
+  repo: vamseeachanta/workspace-hub
+  domain: workstations
+  provider: codex
+  title: "bug(cron): daily-cleanup has never disposed of anything \u2014 4 "
+  url: https://github.com/vamseeachanta/workspace-hub/issues/3707
   dispatch_status: ready
   wip_eligible: false
   routed_by: manual

--- a/scripts/dispatch/route.py
+++ b/scripts/dispatch/route.py
@@ -1012,14 +1012,24 @@ def fetch_issues_for_coverage(repo: str) -> list[dict]:
     with one name and different return types is a collision no test asserts
     against, which is why the shapes are now in the names.
     """
+    # `title` is here for the ROUTING caller, not for coverage. Coverage needs
+    # only number+labels — which is why this function was written with two
+    # fields and why nothing noticed when #3736 reused it as propose()'s input.
+    # `issue_to_card` reads `issue["title"]`, so omitting it here silently gave
+    # every routed card `title: ''`: 1341 of 1341 on dev-primary (#3763).
     r = subprocess.run(
         ["gh", "issue", "list", "--repo", repo, "--state", "open",
-         "--limit", "2000", "--json", "number,labels"],
+         "--limit", "2000", "--json", "number,title,labels"],
         capture_output=True, text=True,
     )
     if r.returncode != 0:
         return []
-    return [{"number": i["number"], "labels": [lab["name"] for lab in i.get("labels", [])]}
+    return [{"number": i["number"],
+             # `or ""` not `.get("title", "")`: gh can return an explicit null,
+             # which the default form would pass through as None and break the
+             # `[:60]` slice in propose().
+             "title": i.get("title") or "",
+             "labels": [lab["name"] for lab in i.get("labels", [])]}
             for i in json.loads(r.stdout or "[]")]
 
 

--- a/tests/dispatch/test_route_card_title.py
+++ b/tests/dispatch/test_route_card_title.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""TDD tests for card titles surviving the live-GitHub routing input (#3763).
+
+Every card in every regenerated queue file carried `title: ''` — 1341 of 1341
+on dev-primary. The cards were otherwise correct; only the title was gone.
+
+The cause is a reuse mismatch, not broken code. `fetch_issues_for_coverage`
+requests `--json number,labels`, which is exactly right for coverage reporting
+— its namesake purpose. #3736 then reused it as the ROUTING input, and routing
+additionally needs the title. `issue_to_card` does `issue.get("title") or ""`,
+which is correct given an input that never carries one.
+
+So the assertion that matters is not "does issue_to_card handle a title" (it
+always did) but "does a title put on the wire by gh reach the card". That is a
+property of the PIPELINE, and it is what nothing asserted.
+
+Per feedback_tests_that_pin_a_name_not_a_property: the primary test below fails
+if the title is dropped ANYWHERE between gh and the card, rather than pinning
+the literal field list of the gh invocation. The field-list test is kept as a
+cheaper, more localised signal, but it is the secondary one deliberately — it
+would keep passing if a later refactor requested `title` and then discarded it.
+
+Hermetic: gh is stubbed; no network.
+
+Run: uv run --with pyyaml --with pytest pytest tests/dispatch/test_route_card_title.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_PY = REPO_ROOT / "scripts" / "dispatch" / "route.py"
+
+ISSUE_TITLE = "Deckhand: wire + harden rate-limit / abuse controls"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("route", ROUTE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["route"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _CompletedProcess:
+    """Stand-in for subprocess.CompletedProcess with only what the code reads."""
+
+    def __init__(self, stdout: str, returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+@pytest.fixture
+def route():
+    return _load()
+
+
+@pytest.fixture
+def gh_payload():
+    """What `gh issue list --json ...` would emit for one titled, labelled issue."""
+    return json.dumps(
+        [
+            {
+                "number": 4,
+                "title": ISSUE_TITLE,
+                "labels": [{"name": "priority:high"}, {"name": "domain:routing"}],
+            }
+        ]
+    )
+
+
+def _stub_gh(monkeypatch, route, payload, captured):
+    def fake_run(argv, *a, **kw):
+        captured.append(argv)
+        return _CompletedProcess(payload)
+
+    monkeypatch.setattr(route.subprocess, "run", fake_run)
+
+
+def test_title_survives_the_fetch_to_card_pipeline(monkeypatch, route, gh_payload):
+    """THE test. A title on the wire must reach the card.
+
+    Fails on main: the fetch drops every field except number and labels, so the
+    card's title is "" no matter what gh returned.
+    """
+    _stub_gh(monkeypatch, route, gh_payload, [])
+
+    issues = route.fetch_issues_for_coverage("vamseeachanta/deckhand")
+    assert issues, "fetch returned nothing — stub not wired"
+
+    card = route.issue_to_card(issues[0], "vamseeachanta/deckhand")
+
+    assert card["title"] == ISSUE_TITLE, (
+        f"card title is {card['title']!r}; the title gh returned was dropped "
+        "between the fetch and the card. This is what put `title: ''` on all "
+        "1341 dev-primary queue cards."
+    )
+
+
+def test_fetch_requests_the_title_field(monkeypatch, route, gh_payload):
+    """Secondary, localised signal: the gh query must ask for the title.
+
+    Weaker than the pipeline test on purpose — it pins the request, not the
+    outcome, and would survive a refactor that asked for the title and then
+    threw it away.
+    """
+    captured: list[list[str]] = []
+    _stub_gh(monkeypatch, route, gh_payload, captured)
+
+    route.fetch_issues_for_coverage("vamseeachanta/deckhand")
+
+    assert captured, "gh was never invoked"
+    argv = captured[0]
+    assert "--json" in argv, f"no --json in gh invocation: {argv}"
+    fields = argv[argv.index("--json") + 1].split(",")
+    assert "title" in fields, (
+        f"gh --json field list is {fields}; routing needs the title and the "
+        "coverage reporter's two-field list does not provide it."
+    )
+
+
+def test_labels_and_number_still_survive(monkeypatch, route, gh_payload):
+    """Regression guard: adding the title must not disturb what already worked.
+
+    Coverage reporting is the original caller and depends on exactly these two.
+    """
+    _stub_gh(monkeypatch, route, gh_payload, [])
+
+    issues = route.fetch_issues_for_coverage("vamseeachanta/deckhand")
+    card = route.issue_to_card(issues[0], "vamseeachanta/deckhand")
+
+    assert issues[0]["number"] == 4
+    assert issues[0]["labels"] == ["priority:high", "domain:routing"]
+    assert card["priority"] == 3, "priority:high must still resolve to 3"
+    assert "domain:routing" in card["gh_labels"]
+
+
+def test_missing_title_still_yields_empty_string(monkeypatch, route):
+    """An issue with no title must not crash the pass.
+
+    A single malformed card must not take down a 1,700-issue run — the same
+    fail-closed-per-card posture propose() already takes for contradictory axes.
+    """
+    payload = json.dumps([{"number": 9, "labels": []}])
+    _stub_gh(monkeypatch, route, payload, [])
+
+    issues = route.fetch_issues_for_coverage("vamseeachanta/deckhand")
+    card = route.issue_to_card(issues[0], "vamseeachanta/deckhand")
+
+    assert card["title"] == ""


### PR DESCRIPTION
Readies the dispatch surface so a session can actually drain from it, and fixes the defect that regeneration exposed.

Closes #3763.

## Why

The loop from #3740 was proven on both platforms but had moved only two synthetic pilots. Attempting a real drain surfaced three problems in the surface itself.

## What was wrong

**All 7 queue files were stale.** `dispatch.py`'s own reporter flagged every one with *"no timestamp"* — they predate the `generated_at`/`ttl_hours` mechanism and were built from the kanban mirror that #3736 retired as a routing input.

The consequences were not cosmetic:

| | stale file | after regeneration |
|---|---|---|
| dev-primary WIP slots | `aceengineer-admin` #25/#23/#22 — **#25 (`priority:medium`) ahead of #23 (`priority:high`)**, an order the current sort cannot produce | `deckhand` #4/#22/#33, all `priority:high` |
| card titles | every card `title: ''` | 0 empty |
| `cfd-dedicated` | no queue file at all | 16 cards |

**Every routed card had an empty title (#3763).** `propose()` builds cards from `fetch_issues_for_coverage()`, which requests `--json number,labels`. That is exactly right for the coverage reporter it was named and written for; #3736 reused it as the routing input, which also needs the title. `issue_to_card` does `issue.get("title") or ""` — correct code, given an input that never carries one.

The name described the property it was built for. The new caller depended on a property it does not discriminate.

## Tests

`tests/dispatch/test_route_card_title.py` asserts the **property** — a title on the wire reaches the card — rather than the gh field list. The field-list assertion is kept as a cheaper localised signal but is deliberately secondary: it would survive a refactor that requested the title and then discarded it. Both were verified RED before the fix.

```
tests/dispatch/test_route_card_title.py   4 passed
tests/dispatch/                           500 passed  (was 496)
scripts/legal/legal-sanity-scan.sh        PASS
```

The legal scan matters here: 1342 issue titles from every routed repo now appear in these files, and the PII gate scans whole files in a diff.

## Fleet state after regeneration

```
cfd-dedicated       16   (0 wip-eligible)
dev-primary       1342   (3)
dev-secondary       26   (1)
home-win             2   (0)
licensed-win-1     149   (2)
licensed-win-2       8   (0)
macbook-portable     1   (0)
multi              203   (1)
```

7 eligible across the fleet. Nothing was spawned; each machine drains its own.

## Verified end to end

deckhand#33 was drained for real from this surface — first non-synthetic drain. Record on `main`: `state=done returncode=0`, job `drain-20260802T023313Z-5bdc00`. It reproduced the ParaView SIGSEGV and ruled out both cheap fixes; findings posted to the issue.

That drain also exposed a claim-protocol defect now filed as #3764 (a refused claim still publishes). Not fixed here.

## Not addressed

- The quota gate reports `stale codex quota snapshot (source=manual, resets_at_epoch=None) — fail open` on every run.
- `fetch_issues_for_coverage` caps at `--limit 2000` with no truncation check, while `fetch_open_issues` uses 100000 and aborts explicitly because silent truncation never self-heals. Noted in #3763.
