### PR TITLE
feat(dispatch): make the pull loop real and give it rails to run unattended

### DIFF
--- a/.claude/state/session-signals/2026-08-01.jsonl
+++ b/.claude/state/session-signals/2026-08-01.jsonl
@@ -1,2 +1,3 @@
 {"ts":"2026-08-01T06:36:59Z","event":"stop_signal_captured","session_id":"18f70568-d2d0-4a07-b87b-11d984e902bc"}
 {"ts":"2026-08-01T07:37:06Z","event":"stop_signal_captured","session_id":"019fbc40-42b5-7b61-9fd8-d07e7fe5f8d7"}
+{"ts":"2026-08-02T04:11:51Z","event":"session_tool_summary","session_id":"019fc0a8-8779-7442-80bd-9bb564cc8595","wrk":"none","tool_calls":49,"edits":0,"reads":0}

--- a/scripts/dispatch/chain.py
+++ b/scripts/dispatch/chain.py
@@ -39,6 +39,38 @@ with `evidence: no-records-consulted` — distinct from `records-consulted`, so
 "we looked and found nothing" can never be confused with "we never looked",
 which is the same defect one level up.
 
+## `ran` is not `succeeded` — the second axis (#3773 rail R5)
+
+`records.py` keeps two things apart on purpose:
+
+    state: done      the payload RAN TO COMPLETION — NOT that it worked
+    is_success       `done` AND `returncode == 0` — whether it actually worked
+
+The STAGE axis above answers *how far did this card get*, and a card that ran
+and failed did reach `executed` — it is counted there, correctly. But until
+this file consulted `records.is_success`, that was the ONLY thing it reported,
+so **a night that failed every card printed exactly the same report as a night
+that completed every card.** Over an unattended run of 1344 cards, that is the
+whole morning read saying nothing.
+
+The fix is a second axis rather than a correction to the first: folding failure
+into a stage count would put two questions behind one number again. `executed`
+still counts what RAN; the OUTCOMES block says what WORKED, and it holds the
+same standard as the rest of this file —
+
+  * an absence never reads as a success: no `--records` yields NOT-MEASURED
+    counts, never `failed: 0`, for the same reason `published` is not a zero;
+  * a count never stands in for evidence: every card needing attention is
+    named, with its returncode, failure_category and attempt number;
+  * silence stays evidence-backed: "read N records, none failed", "there are no
+    records", and "we never looked" are three different reports.
+
+`done` with no returncode is its own verdict (UNATTESTED), not a success and
+not a clean failure: nobody observed an exit code, so nobody knows. drain.py
+promises never to write that shape — which is exactly why the reporter cannot
+assume it, since a guarantee held in another module is one this one cannot see
+break.
+
 ## What it found on first run
 
 `SCHEMA.yaml:125` documents `dispatch:<state>` as `ready | active | done`. Only
@@ -48,8 +80,8 @@ next two states have no vocabulary.
 Usage:
     chain.py                          # all default repos
     chain.py --repo owner/name
-    chain.py --records .dispatch/records
-    chain.py --json
+    chain.py --records .dispatch/records   # also measures ran-vs-succeeded
+    chain.py --json                        # {"repos": {...}, "outcomes": {...}}
     chain.py --strict                 # exit non-zero on NEVER-OBSERVED too
 """
 
@@ -60,6 +92,15 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+
+# Sibling scripts, not a package — same loader shape as reconcile.py and
+# drain.py, so `records` resolves whether chain.py is run directly, imported by
+# a test, or exec'd from another cwd.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import records  # noqa: E402
 
 #: Ordered chain. An issue is reported at its FURTHEST stage — reporting the
 #: earliest would make progress invisible.
@@ -107,6 +148,35 @@ EV_RECORDS_CONSULTED = "records-consulted"  # records were read; none reached it
 EV_NO_RECORDS = "no-records-consulted"      # nothing was read; absence proves nothing
 EV_UNREPRESENTABLE = "no-label"
 EV_NOT_APPLICABLE = "not-label-borne"
+
+#: The OUTCOME axis. Deliberately not spellable as flavours of one another: the
+#: cheapest mutation that restores this rail's defect is collapsing two of these
+#: into a single "finished" bucket. Benign verdicts are lowercase, the ones that
+#: want a human are shouted — the same convention `MISSING` and `NEVER-OBSERVED`
+#: already use against `present`.
+OUTCOME_SUCCEEDED = "succeeded"          # records.is_success: done AND exit 0
+OUTCOME_FAILED = "FAILED"                # ran to completion, nonzero exit
+OUTCOME_UNATTESTED = "UNATTESTED"        # done, no exit code — nobody observed one
+OUTCOME_QUARANTINED = "QUARANTINED"      # blocked: terminal, will not be retried
+OUTCOME_IN_FLIGHT = "in-flight"          # ready/active — no outcome YET
+OUTCOME_UNRECOGNISED = "UNRECOGNISED"    # a state this reporter does not know
+
+#: Fixed order so the histogram reads the same every morning, and so a new
+#: outcome cannot be added without deciding where it sits.
+OUTCOME_ORDER = (OUTCOME_SUCCEEDED, OUTCOME_FAILED, OUTCOME_UNATTESTED,
+                 OUTCOME_QUARANTINED, OUTCOME_UNRECOGNISED, OUTCOME_IN_FLIGHT)
+
+#: Everything that is not a success and not still running. Ordered worst-first:
+#: a quarantined card is dead, a failed one gets another attempt, an unattested
+#: one may have worked and we cannot tell. `in-flight` is NOT here — mid-run is
+#: not failure, and crying one trains the reader to ignore both, the same reason
+#: NEVER-OBSERVED is not filed as a BREAK.
+OUTCOMES_NEEDING_ATTENTION = (OUTCOME_QUARANTINED, OUTCOME_UNATTESTED,
+                              OUTCOME_FAILED, OUTCOME_UNRECOGNISED)
+
+#: How many flagged cards land on the morning screen. The DATA keeps all of
+#: them; only the render is capped, and it states the true total when it cuts.
+ATTENTION_PRINT_LIMIT = 12
 
 DEFAULT_REPOS = (
     "vamseeachanta/workspace-hub",
@@ -158,27 +228,146 @@ def states_evidenced_by(record: dict) -> set[str]:
     return seen
 
 
-def observed_states(records_root) -> set[str]:
-    """Every record state this system can PROVE it has reached. READ-ONLY.
+def read_records(records_root) -> list[dict]:
+    """Every readable record under the root, in a stable order. READ-ONLY.
 
-    A missing root yields an empty set rather than an error, and — importantly —
-    is not created on the way past: a reporter that materialises the directory
+    A missing root yields an empty list rather than an error, and — importantly
+    — is not created on the way past: a reporter that materialises the directory
     it is measuring has changed the answer. A single unreadable record is
     skipped rather than fatal, for the reason `reconcile.reconcile` gives: one
     corrupt file must not strand the other 866.
+
+    Both axes read the records ONCE through here. Two readers with two skip
+    rules would let a record count toward the stage evidence and vanish from the
+    outcome tally, and the disagreement would be invisible in either report.
     """
     root = Path(records_root)
-    seen: set[str] = set()
+    out: list[dict] = []
     if not root.is_dir():
-        return seen
+        return out
     for path in sorted(root.glob("*.json")):
         try:
             record = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
         if isinstance(record, dict):
-            seen |= states_evidenced_by(record)
+            out.append(record)
+    return out
+
+
+def observed_in(records: list[dict]) -> set[str]:
+    """Every record state this population can PROVE was reached. Pure: no IO."""
+    seen: set[str] = set()
+    for record in records:
+        seen |= states_evidenced_by(record)
     return seen
+
+
+def observed_states(records_root) -> set[str]:
+    """Every record state this system can PROVE it has reached. READ-ONLY."""
+    return observed_in(read_records(records_root))
+
+
+# ---------------------------------------------------------------------------
+# the outcome axis: did it WORK, as distinct from did it RUN
+# ---------------------------------------------------------------------------
+
+
+def outcome_of(record: dict) -> str:
+    """What this ONE record says about whether the work succeeded.
+
+    Success is asked of `records.is_success` and never re-derived here. A second
+    definition of "worked" is how the two drift: that function could gain a
+    condition tomorrow and a local copy would go on answering yesterday's
+    question while looking maintained.
+
+    The three ways of not succeeding are kept apart because the follow-up
+    differs. `FAILED` has an exit code to investigate. `QUARANTINED` is terminal
+    — attempts are exhausted and nothing will retry it, so it needs a human, not
+    a rerun. `UNATTESTED` is a `done` carrying no exit code: nobody observed one,
+    so calling it a failure accuses a card that may well have worked, and calling
+    it a success is this rail's defect exactly. It is a measurement defect, and
+    it is reported as one.
+    """
+    if records.is_success(record):
+        return OUTCOME_SUCCEEDED
+    state = record.get("state")
+    if state == "done":
+        rc = record.get("returncode")
+        # bool is an int in Python, and a `returncode: true` is not an exit code.
+        if isinstance(rc, int) and not isinstance(rc, bool):
+            return OUTCOME_FAILED
+        return OUTCOME_UNATTESTED
+    if state == "blocked":
+        return OUTCOME_QUARANTINED
+    if state in records.STATES:
+        return OUTCOME_IN_FLIGHT
+    # No bucket, no count, no line in the report — a record nobody classified is
+    # invisible, and invisible reads as fine. Named instead.
+    return OUTCOME_UNRECOGNISED
+
+
+def _attention_entry(record: dict, outcome: str) -> dict:
+    """The evidence that travels with a flagged card.
+
+    "4 failed" sends nobody anywhere; the returncode and the category do.
+    `attempt`/`max_attempts` is on it because "failed once of three" and "failed
+    the last time it will ever be tried" are different mornings.
+
+    A record with no `issue` is still reported. Dropping it would be an absence
+    manufactured by the very corruption the entry is evidence of.
+    """
+    return {
+        "issue": record.get("issue") or "<record carries no issue field>",
+        "outcome": outcome,
+        "state": record.get("state"),
+        "returncode": record.get("returncode"),
+        "failure_category": record.get("failure_category"),
+        "attempt": record.get("attempt"),
+        "max_attempts": record.get("max_attempts"),
+        "host": record.get("host"),
+    }
+
+
+def outcome_report(consulted: list[dict] | None) -> dict:
+    """Ran-vs-succeeded over a records population. Pure: no IO.
+
+    `None` means records were NOT consulted, and is reported as NOT-MEASURED
+    with `counts: None` — never as a dict of zeros. `failed: 0` from a run that
+    never read a record is the same lie as `published: 0` from an unbuilt join,
+    and it is the more dangerous of the two: zero failures is the answer
+    everyone wants to see.
+
+    An EMPTY population is a third answer again. A typo in `--records` produces
+    one, and it must not print like a clean night — it is NEVER-OBSERVED, on the
+    same three-way distinction the stage axis draws.
+    """
+    if consulted is None:
+        return {"consulted": False, "vocabulary": VOCAB_NOT_MEASURED,
+                "evidence": EV_NO_RECORDS, "records_read": None,
+                "counts": None, "attention": None}
+
+    counts = {o: 0 for o in OUTCOME_ORDER}
+    attention = []
+    for record in consulted:
+        outcome = outcome_of(record)
+        counts[outcome] += 1
+        if outcome in OUTCOMES_NEEDING_ATTENTION:
+            attention.append(_attention_entry(record, outcome))
+
+    # Worst first, then by issue: the cards that will never retry themselves are
+    # the ones worth reading if the reader stops after the first few lines.
+    attention.sort(key=lambda a: (OUTCOMES_NEEDING_ATTENTION.index(a["outcome"]),
+                                  str(a["issue"])))
+
+    return {
+        "consulted": True,
+        "vocabulary": VOCAB_PRESENT if consulted else VOCAB_NEVER_OBSERVED,
+        "evidence": EV_RECORDS_CONSULTED,
+        "records_read": len(consulted),
+        "counts": counts,
+        "attention": attention,
+    }
 
 
 def chain_report(issues: list[dict], vocabulary: set[str],
@@ -264,6 +453,75 @@ def chain_report(issues: list[dict], vocabulary: set[str],
             "records_consulted": observed is not None}
 
 
+def format_outcomes(block: dict) -> list[str]:
+    """The OUTCOMES section as printed lines. Pure: no IO.
+
+    Separate from the per-repo loop on purpose. A records root spans every repo,
+    so printing this per repo would show the same failures three times and imply
+    a per-repo join that was never made.
+    """
+    lines = [""]
+    if not block["consulted"]:
+        # No numbers here at all. A stray `0` beside a bucket name is precisely
+        # the reading this section exists to prevent.
+        lines.append("\033[1mOUTCOMES\033[0m  \033[2mnot measured here\033[0m")
+        lines.append("\033[33m  Whether any card SUCCEEDED is unmeasured. The stages above say how far")
+        lines.append("  each card got, not whether it worked — a night that fails every card and a")
+        lines.append("  night that completes every card print identical stage counts. Pass")
+        lines.append("  --records <dir> to measure it.\033[0m")
+        return lines
+
+    read = block["records_read"]
+    counts = block["counts"]
+    attention = block["attention"]
+
+    if not read:
+        lines.append("\033[1mOUTCOMES\033[0m  \033[33mno records under the root — "
+                     "LABEL EXISTS, NEVER USED\033[0m")
+        lines.append("\033[33m  Nothing attests to any outcome. This is not a clean night;")
+        lines.append("  it is an unexercised one, or a --records path that points "
+                     "somewhere empty.\033[0m")
+        return lines
+
+    lines.append(f"\033[1mOUTCOMES\033[0m  records={read}  "
+                 f"\033[2m(ran ≠ succeeded; {EV_RECORDS_CONSULTED})\033[0m")
+    for outcome in OUTCOME_ORDER:
+        # Pad the NAME, then colour it. Padding the coloured string counts the
+        # escape bytes, which are zero-width on screen — the count column would
+        # sit several places left on exactly the rows that matter most.
+        cell = f"{outcome:<14}"
+        colour = ""
+        if counts[outcome]:
+            if outcome in (OUTCOME_FAILED, OUTCOME_QUARANTINED, OUTCOME_UNRECOGNISED):
+                colour = "\033[1;31m"
+            elif outcome == OUTCOME_UNATTESTED:
+                colour = "\033[1;33m"
+        lines.append(f"    {colour}{cell}\033[0m{counts[outcome]:>6}"
+                     if colour else f"    {cell}{counts[outcome]:>6}")
+
+    if not attention:
+        lines.append(f"  \033[2mevery one of the {read} record(s) consulted reached "
+                     f"exit 0 — verdict from records.is_success\033[0m")
+        return lines
+
+    lines.append(f"  \033[1;31mNOT SUCCEEDED: {len(attention)} of {read} record(s).\033[0m "
+                 "\033[1mThe 'executed' stage counts cards that RAN;\033[0m")
+    lines.append("  \033[1mthese ran and did not work. `done` is completion, not success.\033[0m")
+    for entry in attention[:ATTENTION_PRINT_LIMIT]:
+        rc = entry["returncode"]
+        # An em-dash, never a 0: "no exit code was observed" and "it exited 0"
+        # are the two readings this whole section exists to keep apart.
+        rc_text = "—" if rc is None else str(rc)
+        lines.append(
+            f"    {str(entry['issue']):<34} {entry['outcome']:<13} "
+            f"rc={rc_text:<6} {str(entry['failure_category'] or '—'):<16} "
+            f"attempt {entry['attempt']}/{entry['max_attempts']}")
+    if len(attention) > ATTENTION_PRINT_LIMIT:
+        lines.append(f"    \033[2m… and {len(attention) - ATTENTION_PRINT_LIMIT} more "
+                     f"({len(attention)} flagged in total; --json carries every one)\033[0m")
+    return lines
+
+
 def fetch(repo: str) -> tuple[list[dict], set[str]]:
     def gh(args):
         r = subprocess.run(args, capture_output=True, text=True, check=False)
@@ -280,14 +538,24 @@ def fetch(repo: str) -> tuple[list[dict], set[str]]:
     return issues, vocab
 
 
-def exit_code(reports: dict, strict: bool = False) -> int:
-    """1 on a broken chain; under `--strict`, also on an unexercised one.
+def exit_code(reports: dict, strict: bool = False, *, outcomes: dict | None = None) -> int:
+    """1 on a broken chain OR a card that did not succeed; `--strict` adds the
+    unexercised one.
 
     NEVER-OBSERVED is not an error by default: right after the labels are
     created it is the only honest answer. `--strict` is for the caller who has
     decided enough time has passed that "never used" is a failure.
+
+    A failed card IS an error in either mode. Something automated reads this
+    exit code after an unattended run, and a total-failure night that exits 0 is
+    this rail's defect in its most expensive form — nobody gets as far as
+    reading the report. Cards still in flight are not failures, and an
+    unconsulted records root is not one either: absence proves nothing in both
+    directions, so it stays 0 and says NOT-MEASURED in the text instead.
     """
     if any(r["breaks"] for r in reports.values()):
+        return 1
+    if outcomes is not None and outcomes.get("attention"):
         return 1
     if strict and any(r["unproven"] for r in reports.values()):
         return 1
@@ -304,7 +572,11 @@ def main() -> int:
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
 
-    observed = observed_states(args.records) if args.records else None
+    # Read the records ONCE; both axes are derived from the same population so
+    # they cannot disagree about which files were legible.
+    consulted = read_records(args.records) if args.records else None
+    observed = observed_in(consulted) if consulted is not None else None
+    outcomes = outcome_report(consulted)
 
     out = {}
     for repo in ([args.repo] if args.repo else list(DEFAULT_REPOS)):
@@ -312,8 +584,8 @@ def main() -> int:
         out[repo] = chain_report(issues, vocab, observed)
 
     if args.json:
-        print(json.dumps(out, indent=2))
-        return exit_code(out, args.strict)
+        print(json.dumps({"repos": out, "outcomes": outcomes}, indent=2))
+        return exit_code(out, args.strict, outcomes=outcomes)
 
     for repo, rep in out.items():
         print(f"\n\033[1m{repo}\033[0m  open={rep['total']}")
@@ -323,6 +595,12 @@ def main() -> int:
                     VOCAB_NEVER_OBSERVED: "\033[33mLABEL EXISTS, NEVER USED\033[0m",
                     VOCAB_NOT_MEASURED: "\033[2mnot measured here\033[0m",
                     VOCAB_PRESENT: ""}[st["vocabulary"]]
+            # A constant pointer, never a per-repo failure count: the records
+            # root spans every repo, so any number spliced in here would be a
+            # join this tool has not made.
+            if s == "executed" and st["count"]:
+                mark = (mark + "  " if mark else "") + \
+                    "\033[2m← cards that RAN; see OUTCOMES for whether they worked\033[0m"
             print(f"    {s:<12}{st['count']:>6}   {mark}")
         if rep["wall"]:
             w = rep["wall"]
@@ -338,6 +616,9 @@ def main() -> int:
         for u in rep["unproven"]:
             print(f"  \033[33mUNPROVEN\033[0m {u['stage']}: {u['detail']}")
 
+    for line in format_outcomes(outcomes):
+        print(line)
+
     if not any(r["records_consulted"] for r in out.values()):
         print("\n\033[33mNo records root given (--records): 'never observed' above "
               "rests on live labels alone, which forget. Records are the durable "
@@ -345,8 +626,10 @@ def main() -> int:
 
     print("\n\033[2mREAD-ONLY. `result` and `published` need a join against the "
           "licensed-run queue and the website; reported as not-measured rather "
-          "than zero so an unbuilt join cannot read as 'nothing shipped'.\033[0m")
-    return exit_code(out, args.strict)
+          "than zero so an unbuilt join cannot read as 'nothing shipped'. The "
+          "same rule governs OUTCOMES: `done` means ran to completion, and "
+          "whether it WORKED is records.is_success, never a stage count.\033[0m")
+    return exit_code(out, args.strict, outcomes=outcomes)
 
 
 if __name__ == "__main__":

--- a/scripts/dispatch/claim.py
+++ b/scripts/dispatch/claim.py
@@ -12,7 +12,7 @@ design:
 
     1. write the claim record (create-only)
     2. commit + push
-    3. push REJECTED  -> another host got there first. Pull, DO NOT EXECUTE.
+    3. push REJECTED  -> UNDO THE COMMIT, pull, diagnose, DO NOT EXECUTE.
     4. push accepted  -> re-read the record FROM THE REMOTE, confirm it is ours
     5. only then      -> the caller may execute
 
@@ -21,6 +21,38 @@ drop. An accepted push proves *our write landed*. It does not prove *our claim
 survived*: a concurrent merge can accept the push while the remote's copy of the
 record names somebody else. The remote is the only authority on who holds the
 item, so the remote is what we read.
+
+## Why step 3 undoes the commit (wh#3764)
+
+A refusal is only a refusal if it leaves nothing behind. The first real drain
+refused `vamseeachanta/deckhand#33` on a rejected push — and this repo's
+auto-sync process, which periodically commits and pushes `main`, found the
+orphaned claim commit and published it. The remote then held the issue `active`
+for its full 90-minute TTL with nothing running: **exclusion without execution**,
+the worst outcome this protocol can produce.
+
+The undo is scoped hard, because dispatch lanes and auto-sync share ONE checkout
+on a dispatch host:
+
+  * the commit is identified by the RECORD it carries — `(host, job_id)` — not by
+    the branch tip and not by its message, which another host writes identically;
+  * the branch ref moves back by a compare-and-swap (`git update-ref <ref> <new>
+    <old>`), which touches neither the index nor the working tree, so no other
+    lane's staged or unstaged work is at risk. `reset --hard` would destroy it;
+  * if the CAS is lost, or another commit landed on top, history is NEVER
+    rewritten. The claim is removed *forward*, by a path-scoped commit.
+
+## Why "another host claimed it first" was the wrong thing to say
+
+That message was emitted on `deckhand#33` when no other host was involved: the
+push lost a race to a sync process on the same host. It sent an operator hunting
+a claimant that did not exist, and it hid the fact that nobody held the item, so
+the drain could simply have tried again. A rejection is therefore diagnosed from
+the remote rather than assumed (`CAUSE_HELD_ELSEWHERE` vs `CAUSE_LOST_PUSH_RACE`,
+the latter `retryable=True`).
+
+**`retryable` is not a licence.** Every rejection, whatever its cause, is still
+`ok=False` with `record=None`.
 
 ## Why this fails CLOSED (unlike deckhand#580)
 
@@ -62,6 +94,34 @@ import records
 #: than a stalled dispatcher holding a claim nobody can see.
 GIT_TIMEOUT_SECONDS = 120
 
+#: How far back to look for our own claim commit when undoing it. It is
+#: normally the tip; the window exists only because concurrent lanes and
+#: auto-sync can commit on top between our commit and our undo.
+UNDO_SEARCH_DEPTH = 20
+
+# -- why a claim was refused. Machine-readable, because operators acted on the
+#    prose and went looking for a host that did not exist (wh#3764).
+CAUSE_RECORD_REJECTED = "record-rejected"
+CAUSE_STALE_GENERATION = "stale-generation"
+CAUSE_LOCAL_CONFLICT = "local-claim-conflict"
+CAUSE_WRITE_FAILED = "write-failed"
+CAUSE_COMMIT_FAILED = "commit-failed"
+CAUSE_GIT_ERROR = "git-error"
+CAUSE_UNVERIFIABLE = "remote-unverifiable"
+CAUSE_NOT_OURS = "remote-claim-not-ours"
+#: Evidence that a DIFFERENT host holds a live claim. The only cause that
+#: justifies telling an operator somebody else has the item.
+CAUSE_HELD_ELSEWHERE = "held-by-another-host"
+#: Our push lost a race to another pusher — commonly this host's own auto-sync.
+#: Nobody holds the item, so the drain may try again.
+CAUSE_LOST_PUSH_RACE = "lost-push-race"
+
+# -- what became of the claim commit after a refusal.
+UNDO_DROPPED = "dropped"          # branch ref moved back; commit unreachable
+UNDO_REVERTED = "reverted"        # removed forward, because history was not ours
+UNDO_FAILED = "failed"            # could not be undone — a commit may remain
+UNDO_UNAVAILABLE = "unavailable"  # the injected backend has no undo surface
+
 
 @dataclass
 class ClaimResult:
@@ -70,17 +130,31 @@ class ClaimResult:
     `ok` is the only field a caller should branch on. `record` is populated
     ONLY when `ok` is True, so that a truthiness check on `record` cannot
     accidentally become a second, wrong, way of asking the same question.
+
+    `cause`, `retryable` and `undo` are REPORTING, not permission. `retryable`
+    in particular says only that nobody is known to hold the item — a caller
+    that reads it as "go ahead" has reinvented the split-brain this module
+    exists to prevent.
     """
 
     ok: bool
     reason: str
     record: dict | None = None
     warnings: list[str] = field(default_factory=list)
+    #: One of the CAUSE_* constants, or None on success.
+    cause: str | None = None
+    #: True only when the refusal was a lost race that named no holder.
+    retryable: bool = False
+    #: One of the UNDO_* constants when a claim commit had to be undone.
+    undo: str | None = None
 
 
-def _refuse(reason: str, warnings: list[str] | None = None) -> ClaimResult:
+def _refuse(reason: str, warnings: list[str] | None = None, *,
+            cause: str | None = None, retryable: bool = False,
+            undo: str | None = None) -> ClaimResult:
     return ClaimResult(ok=False, reason=reason, record=None,
-                       warnings=list(warnings or []))
+                       warnings=list(warnings or []), cause=cause,
+                       retryable=retryable, undo=undo)
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +226,134 @@ class GitBackend:
     def pull(self) -> bool:
         return self._run("pull", "--rebase", self.remote, self.branch).returncode == 0
 
+    # -- undoing a claim that was refused ---------------------------------
+
+    def undo_commit(self, path, record) -> str:
+        """Remove the claim commit for `record` so nothing can publish it.
+
+        Returns an `UNDO_*` constant. Never raises for an ordinary git refusal —
+        the caller is already refusing the claim and needs to know what state it
+        is refusing *from*, not to lose that in an exception.
+
+        Safety under concurrent writers, which is the whole difficulty:
+
+        * **The commit is identified by its content**, not by position or
+          message. Two hosts write the byte-identical subject
+          `dispatch: claim owner/repo#N`, so a message match would let this host
+          drop another host's claim. We match the `(host, job_id)` inside the
+          committed record.
+        * **A commit is only DROPPED if it is the tip and carries nothing but
+          this record.** Auto-sync commits with `git add -A`, so our record can
+          arrive inside a commit full of somebody else's work; dropping that
+          commit would delete their work to clean up our claim.
+        * **The drop is a compare-and-swap on the ref**
+          (`git update-ref <ref> <parent> <commit>`), which fails rather than
+          clobbers if anyone moved the branch since we looked. It rewrites no
+          blobs and touches neither the index nor the working tree, so another
+          lane's staged and unstaged edits survive untouched. `git reset --hard`
+          would take them; `reset --mixed` would silently unstage them.
+        * **Otherwise history is not rewritten at all** — the claim is removed
+          going forward, by a commit scoped to the record path.
+        """
+        rel = self._rel(path)
+        if rel is None:
+            return UNDO_FAILED
+
+        sha = self._find_claim_commit(rel, record)
+        if sha is None:
+            # Either it was never committed, or the commit that carries it is
+            # not ours. Both resolve to "say so" — a silent success here is how
+            # the orphan got published in the first place.
+            return UNDO_FAILED
+
+        if sha == self._rev_parse("HEAD") and self._touches_only(sha, rel):
+            parent = self._rev_parse(f"{sha}^")
+            if parent and self._cas_ref(parent, sha):
+                self._restore_path(rel)
+                return UNDO_DROPPED
+            # CAS lost, or a root commit with no parent to fall back to. Both
+            # fall through to the non-rewriting path.
+
+        return self._remove_forward(sha, rel)
+
+    def _cas_ref(self, new: str, expected: str) -> bool:
+        """Move the current branch to `new`, but only if it is still `expected`.
+
+        The compare-and-swap is the whole safety of the drop. Between reading
+        HEAD and moving it, a concurrent lane or auto-sync can commit; without
+        the expected-value argument `update-ref` would happily discard whatever
+        arrived in that window. With it, the update is refused and the caller
+        falls back to removing the claim forward.
+        """
+        return self._run("update-ref", "HEAD", new, expected).returncode == 0
+
+    def _touches_only(self, sha: str, rel: str) -> bool:
+        names = self._run("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+        if names.returncode != 0:
+            return False
+        return [n for n in (names.stdout or "").split("\n") if n.strip()] == [rel]
+
+    def _rel(self, path) -> str | None:
+        try:
+            return Path(path).resolve().relative_to(self.repo_root.resolve()).as_posix()
+        except ValueError:
+            return None
+
+    def _rev_parse(self, rev: str) -> str | None:
+        done = self._run("rev-parse", "--verify", "--quiet", rev)
+        out = (done.stdout or "").strip()
+        return out if done.returncode == 0 and out else None
+
+    def _find_claim_commit(self, rel: str, record: dict) -> str | None:
+        """The most recent commit that carries OUR version of this record."""
+        listing = self._run("rev-list", f"-n{UNDO_SEARCH_DEPTH}", "HEAD", "--", rel)
+        if listing.returncode != 0:
+            return None
+        for sha in (listing.stdout or "").split():
+            blob = self._run("show", f"{sha}:{rel}")
+            if blob.returncode != 0:
+                continue
+            try:
+                got = json.loads(blob.stdout)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(got, dict) and _same_claim(record, got):
+                return sha
+        return None
+
+    def _restore_path(self, rel: str) -> None:
+        """Put one path back the way HEAD has it. Only that path.
+
+        `git reset -- <path>` rewrites a single index entry and leaves the
+        working tree alone; `git checkout -- <path>` then refreshes the file.
+        When the path is not in HEAD at all — the ordinary case, a claim on an
+        issue with no prior record — checkout has nothing to give it, so the
+        file we wrote is simply removed.
+        """
+        self._run("reset", "-q", "--", rel)
+        if self._run("checkout", "-q", "--", rel).returncode != 0:
+            try:
+                (self.repo_root / rel).unlink()
+            except OSError:
+                pass
+
+    def _remove_forward(self, sha: str, rel: str) -> str:
+        """Undo by adding a commit, never by rewriting one that is not ours.
+
+        Restores the record to whatever the claim commit's parent had — which is
+        the previous, possibly TERMINAL, record for that issue, not necessarily
+        nothing. Deleting it outright would throw away a completed run's audit
+        trail to clean up a refused claim.
+        """
+        if self._run("checkout", f"{sha}^", "--", rel).returncode != 0:
+            if self._run("rm", "-q", "-f", "--ignore-unmatch", "--", rel).returncode != 0:
+                return UNDO_FAILED
+        done = self._run("commit", "-m", f"dispatch: undo refused claim {rel}", "--", rel)
+        if done.returncode != 0 and "nothing to commit" not in (
+                (done.stdout or "") + (done.stderr or "")):
+            return UNDO_FAILED
+        return UNDO_REVERTED
+
     def read_remote(self, issue: str) -> dict | None:
         """The remote's copy of the record, or None if it cannot be read.
 
@@ -188,6 +390,79 @@ def _same_claim(ours: dict, theirs: dict) -> bool:
     """
     return (theirs.get("host") == ours.get("host")
             and theirs.get("job_id") == ours.get("job_id"))
+
+
+def _is_live(record: dict) -> bool:
+    """A record only *holds* an issue while it is non-terminal.
+
+    A `done` or `blocked` record names the host that last ran the item, not one
+    that owns it now. Reading it as ownership would report an item as held by
+    somebody who already walked away.
+    """
+    return record.get("state") not in records.TERMINAL
+
+
+def _undo_claim_commit(git, path, record: dict, warnings: list[str]) -> str:
+    """Take the claim commit back, and say plainly if it could not be taken.
+
+    Runs BEFORE the resync pull: `pull --rebase` replays a commit that is still
+    there, re-parenting the orphan onto the new remote tip — just as publishable
+    as before, plus a conflict to resolve.
+
+    An undo that did not happen is reported, never assumed. Absence of a signal
+    read as a good signal is the failure mode this whole epic keeps meeting.
+    """
+    undo = getattr(git, "undo_commit", None)
+    if undo is None:
+        status = UNDO_UNAVAILABLE
+    else:
+        try:
+            got = undo(path, record)
+        except Exception as exc:                       # noqa: BLE001
+            warnings.append(f"undoing the claim commit raised {type(exc).__name__}: {exc}")
+            got = UNDO_FAILED
+        status = got if isinstance(got, str) else (UNDO_DROPPED if got else UNDO_FAILED)
+
+    if status not in (UNDO_DROPPED, UNDO_REVERTED):
+        warnings.append(
+            f"the claim commit for {record.get('issue')} was NOT undone "
+            f"({status}) — anything that pushes this branch, including auto-sync, "
+            "will publish a claim that was refused"
+        )
+        # The commit may survive; the record must not. Left on disk it reads as
+        # live to the next drain and blocks the retry a lost race should get.
+        try:
+            Path(path).unlink()
+        except OSError:
+            pass
+    return status
+
+
+def _diagnose_rejection(ours: dict, remote, warnings: list[str]) -> tuple[str, bool, str]:
+    """Why the push was rejected: `(cause, retryable, sentence)`.
+
+    Only a live record naming a DIFFERENT host is evidence that somebody else
+    holds the item. Anything else — no record, our own record, a finished record
+    — means our push simply lost a race, most often to this host's own auto-sync
+    process, and the item is still free.
+
+    `read_remote` returns None both for "no such record" and for "could not
+    read", which this cannot separate. Both are reported as a lost race: neither
+    is evidence of a holder, and neither licenses execution, so the worst it can
+    cost is one more refused attempt.
+    """
+    if isinstance(remote, dict) and _is_live(remote) and not _same_claim(ours, remote):
+        held = f"{remote.get('host')}/{remote.get('job_id')}"
+        return (CAUSE_HELD_ELSEWHERE, False,
+                f"the remote holds a live claim by {held}")
+    if remote is None:
+        warnings.append("the remote holds no readable record for this issue")
+        detail = "the remote holds no claim (or could not be read)"
+    else:
+        detail = "the remote's record is this host's own"
+    return (CAUSE_LOST_PUSH_RACE, True,
+            f"{detail} — the push lost a race to a concurrent pusher, "
+            f"not to another host")
 
 
 def _check_generation(record: dict, current_generation: str | None,
@@ -237,6 +512,12 @@ def acquire(root, record: dict, *, git=None, current_generation: str | None = No
     The verify runs *after* the push and reads the remote, for the reason this
     module exists: an accepted push proves our write landed, not that our claim
     is the one that survived.
+
+    Once the commit exists, every exit that is not a verified claim undoes it.
+    The original argument covered the *file* — "a refused claim that still wrote
+    a file would be indistinguishable, to the next reader, from a live one" — and
+    stopped there; the commit leaked, and auto-sync published it (wh#3764). A
+    refusal that leaves publishable state is not a refusal.
     """
     warnings: list[str] = []
     git = git or GitBackend(Path(root))
@@ -244,11 +525,11 @@ def acquire(root, record: dict, *, git=None, current_generation: str | None = No
     try:
         records.validate(record)
     except Exception as exc:                       # unknown shape -> do not run
-        return _refuse(f"record rejected: {exc}")
+        return _refuse(f"record rejected: {exc}", cause=CAUSE_RECORD_REJECTED)
 
     stale = _check_generation(record, current_generation, warnings)
     if stale:
-        return _refuse(stale, warnings)
+        return _refuse(stale, warnings, cause=CAUSE_STALE_GENERATION)
 
     issue = record["issue"]
     try:
@@ -256,45 +537,70 @@ def acquire(root, record: dict, *, git=None, current_generation: str | None = No
     except records.ClaimConflict as exc:
         # Someone else's live claim is already on disk locally. That is a
         # decided race, not a retryable one.
-        return _refuse(f"claim conflict: {exc}", warnings)
+        return _refuse(f"claim conflict: {exc}", warnings, cause=CAUSE_LOCAL_CONFLICT)
     except Exception as exc:
-        return _refuse(f"could not write claim for {issue}: {exc}", warnings)
+        return _refuse(f"could not write claim for {issue}: {exc}", warnings,
+                       cause=CAUSE_WRITE_FAILED)
 
     try:
-        if not git.commit(path, f"dispatch: claim {issue}"):
-            return _refuse(f"could not commit claim for {issue}", warnings)
+        committed = git.commit(path, f"dispatch: claim {issue}")
+    except Exception as exc:
+        return _refuse(f"git error during claim of {issue}: {exc}", warnings,
+                       cause=CAUSE_GIT_ERROR)
+    if not committed:
+        return _refuse(f"could not commit claim for {issue}", warnings,
+                       cause=CAUSE_COMMIT_FAILED)
 
-        if not git.push():
-            # THE RACE, RESOLVED AGAINST US. Pull anyway: leaving the clone
-            # behind guarantees the next drain reads the same stale queue and
-            # races again, so a rejection that does not resync is a loop.
-            try:
-                git.pull()
-            except Exception as exc:
-                warnings.append(f"pull after rejected push failed: {exc}")
-            return _refuse(
-                f"push rejected for {issue} — another host claimed it first",
-                warnings,
-            )
+    # From here a commit exists locally, and EVERY exit that is not a verified
+    # claim has to take it back — otherwise the next process to push this
+    # branch publishes a claim nobody is executing (wh#3764).
+    try:
+        pushed = git.push()
+    except Exception as exc:
+        undo = _undo_claim_commit(git, path, record, warnings)
+        return _refuse(f"git error during claim of {issue}: {exc}", warnings,
+                       cause=CAUSE_GIT_ERROR, undo=undo)
 
+    if not pushed:
+        # THE PUSH DID NOT LAND. Undo first — `pull --rebase` would replay the
+        # claim commit and leave it just as publishable.
+        undo = _undo_claim_commit(git, path, record, warnings)
+        # Pull anyway: leaving the clone behind guarantees the next drain reads
+        # the same stale queue and races again, so a rejection that does not
+        # resync is a loop.
+        try:
+            git.pull()
+        except Exception as exc:
+            warnings.append(f"pull after rejected push failed: {exc}")
+        try:
+            remote = git.read_remote(issue)
+        except Exception as exc:
+            warnings.append(f"could not read {issue} from the remote: {exc}")
+            remote = None
+        cause, retryable, detail = _diagnose_rejection(record, remote, warnings)
+        return _refuse(f"push rejected for {issue} — {detail}", warnings,
+                       cause=cause, retryable=retryable, undo=undo)
+
+    try:
         remote = git.read_remote(issue)
     except Exception as exc:
         # Any git failure at all. We do not know who holds the claim, and
         # "do not know" resolves to "do not execute".
-        return _refuse(f"git error during claim of {issue}: {exc}", warnings)
+        return _refuse(f"git error during claim of {issue}: {exc}", warnings,
+                       cause=CAUSE_GIT_ERROR)
 
     if not isinstance(remote, dict):
         return _refuse(
             f"could not read {issue} back from the remote — cannot-verify is "
             "not verified",
-            warnings,
+            warnings, cause=CAUSE_UNVERIFIABLE,
         )
 
     if not _same_claim(record, remote):
         return _refuse(
             f"claim on {issue} is not ours: remote holds "
             f"{remote.get('host')}/{remote.get('job_id')}",
-            warnings,
+            warnings, cause=CAUSE_NOT_OURS,
         )
 
     # Return the REMOTE's copy, not the one we wrote. They agree on (host,

--- a/scripts/dispatch/drain.py
+++ b/scripts/dispatch/drain.py
@@ -65,6 +65,42 @@ Real drain (the operator's command, both gates required):
         --command 'echo pilot' --apply
 
 Drop `--apply` (or the env var) for the plan.
+
+## Running it UNATTENDED (wh#3773)
+
+The four steps above close the loop for one card driven by a human. Leaving the
+loop alone over 1344 of them needs four more properties, each of which was
+missing and each of which fails in a way that LOOKS like progress:
+
+* **A cap that binds.** `route.apply_wip` only annotates a proposal with a
+  `slot`; `dispatch.py` says "WIP is enforced at claim time by the consuming
+  session" and nothing enforced it. `prepare` now counts this machine's live
+  claims against `wip_caps.per_machine` from `routing-rules.yaml` — the file
+  `route.py` and `dispatch.py --capacity` already read, not a second copy.
+* **A kill switch.** `run.sh` detaches payloads (`setsid nohup`), so killing a
+  wrapper loop does not stop what it already started, and there was no way to
+  stop what it had NOT started. A `.claude/dispatch/PAUSE` sentinel, checked
+  inside `drain()` immediately before the claim, refuses new work while a loop
+  is running. It is reported as its own stage and its own exit code: an
+  operator's stop is not a broken card.
+* **A timeout that kills.** `subprocess.run(timeout=)` kills our CHILD. `run.sh`
+  and the payload are grandchildren, so on expiry they kept running — orphaned,
+  holding the one solver seat — while the record said `unknown-outcome`. Every
+  timeout path now invokes the runner's own `cancel` verb, and a cancel that
+  did not work is reported (`ExecOutcome.cancelled is False`), never swallowed.
+* **A TTL that cannot be outlived.** `records.heartbeat()` is called once, at
+  claim time; NOTHING beats it while the child runs. A job outliving
+  `ttl_minutes` therefore has an expired record while it is still executing,
+  `reconcile.settle` returns it to `ready`, and the next `prepare` RECLAIMs it:
+  two payloads, one issue. Today's 3600s default sits just under the 90-minute
+  TTL, which masks it. Until an out-of-band beater exists, the coupling is
+  refused at startup rather than left to that coincidence.
+
+And one that made the record lie: a card that exhausted its attempts kept its
+`done`/`returncode 3` record, because the refusal wrote nothing and
+`reconcile.settle` only quarantines EXPIRED ACTIVE claims — it never sees a
+terminal one. `dispatch:done` projected, `chain.py` counted it as executed. It
+now reaches `blocked` through the same `claim.release` a real outcome uses.
 """
 
 from __future__ import annotations
@@ -125,6 +161,22 @@ TERMINAL_JOB_STATES = frozenset({"finished", "cancelled"})
 DEFAULT_TIMEOUT_SECONDS = 3600
 DEFAULT_POLL_SECONDS = 5
 
+#: A cancel must not inherit the timeout that made it necessary — the whole
+#: point is that we already waited too long. Bounded separately so a hung
+#: `cancel` verb is reported as an uncancelled job rather than hanging the loop.
+CANCEL_TIMEOUT_SECONDS = 60
+
+#: The kill switch. Relative to the CHECKOUT (`--repo-root`), not to the records
+#: directory: an operator stopping the fleet reaches for a path in the repo, and
+#: `records/` is a sibling of this file, not its parent.
+PAUSE_RELATIVE = Path(".claude") / "dispatch" / "PAUSE"
+
+#: Where the WIP caps live. Resolved by walking up from THIS file rather than
+#: through `route.load_rules`, which derives the repo root from `git rev-parse`
+#: in the process's CWD — a drain run from another directory would read another
+#: repo's caps, or none. Same file, cwd-independently.
+ROUTING_RULES_RELATIVE = Path(".claude") / "memory" / "kanban" / "routing-rules.yaml"
+
 #: Mirrors records.py's stamp format. A test round-trips a stamp minted here
 #: through `records._parse` rather than comparing the literals, so the two agree
 #: about the format instead of merely looking alike.
@@ -135,6 +187,9 @@ CLAIM = "claim"          # no record yet
 RESUME = "resume"        # our own live claim — re-entered, not re-attempted
 RECLAIM = "reclaim"      # a released/finished record, fresh attempt
 REFUSE = "refuse"
+#: Attempts are exhausted. NOT a plain refusal: a refusal writes nothing, and
+#: writing nothing is exactly how a thrice-failed card kept a `done` record.
+QUARANTINE = "quarantine"
 
 # How far the drain got. `stage` is diagnostic; `ok` is the decision.
 PLANNED = "planned"
@@ -142,12 +197,20 @@ REFUSED = "refused"
 CLAIM_REFUSED = "claim-refused"
 RELEASED = "released"
 RELEASE_FAILED = "release-failed"
+#: The operator stopped the loop. Distinct from every refusal because it is not
+#: a defect in the card — a wrapper that cannot tell them apart either spins on
+#: a paused fleet or abandons a queue that was merely paused.
+PAUSED = "paused"
+QUARANTINED = "quarantined"
 
 # failure_category values this module writes.
 PAYLOAD_ERROR = "payload-error"
 DISPATCH_ERROR = "dispatch-error"
 CANCELLED = "cancelled"
 UNKNOWN_OUTCOME = "unknown-outcome"
+#: Terminal, and written by the QUARANTINE path only. `classify` never returns
+#: it: it describes why the card stopped being retried, not how a run ended.
+ATTEMPTS_EXHAUSTED = "attempts-exhausted"
 
 #: run.sh's EX_NOINPUT: the wrapper started but could not enter the work dir, so
 #: the payload never ran. Distinguishable from a payload that ran and failed,
@@ -215,8 +278,112 @@ def identity_machine() -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# backpressure: the WIP cap, and the switch that stops the loop
+# ---------------------------------------------------------------------------
+
+
+class WipCapUnavailable(RuntimeError):
+    """The configured cap could not be read.
+
+    Raised rather than defaulted. "No cap could be read" is not "no cap": the
+    260-worker scar this config exists to prevent came from a limit that was
+    documented and enforced nowhere, which is indistinguishable from an
+    unbounded one at runtime.
+    """
+
+
+def routing_rules_path() -> Path:
+    """The routing-rules file, found by walking up from THIS module."""
+    for parent in (_HERE, *_HERE.parents):
+        candidate = parent / ROUTING_RULES_RELATIVE
+        if candidate.is_file():
+            return candidate
+    raise WipCapUnavailable(
+        f"no {ROUTING_RULES_RELATIVE} above {_HERE} — the WIP cap has no source")
+
+
+def load_routing_rules() -> dict:
+    with open(routing_rules_path(), encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def machine_wip_cap(machine: str, *, rules_loader=None) -> int:
+    """This machine's cap, from `wip_caps.per_machine`. Never invented here.
+
+    `default` is the config's own fail-closed entry for hosts it does not list;
+    a config that provides neither an entry nor a default is a config that has
+    not decided, and this refuses on its behalf.
+    """
+    loader = rules_loader or load_routing_rules
+    try:
+        cfg = loader() or {}
+    except WipCapUnavailable:
+        raise
+    except Exception as exc:                                    # noqa: BLE001
+        raise WipCapUnavailable(
+            f"routing rules are unreadable ({type(exc).__name__}: {exc})") from exc
+    if not isinstance(cfg, dict):
+        raise WipCapUnavailable("routing rules are not a mapping")
+    per_machine = (cfg.get("wip_caps") or {}).get("per_machine")
+    if not isinstance(per_machine, dict) or not per_machine:
+        raise WipCapUnavailable("wip_caps.per_machine is absent or empty")
+    raw = per_machine.get(machine, per_machine.get("default"))
+    if raw is None:
+        raise WipCapUnavailable(
+            f"wip_caps.per_machine names neither {machine!r} nor a 'default'")
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise WipCapUnavailable(
+            f"wip_caps.per_machine cap for {machine!r} is {raw!r}, not a whole number")
+    if raw < 0:
+        raise WipCapUnavailable(
+            f"wip_caps.per_machine cap for {machine!r} is negative ({raw})")
+    return raw
+
+
+def count_active_claims(records_root, machine: str) -> int:
+    """Live claims this machine already holds, read from the record store.
+
+    The record store is the state (records.py), so it is what gets counted —
+    not a process list, which sees only this box's own processes and none of the
+    claims a crashed session left behind.
+
+    A record we cannot read counts as OCCUPIED. It may be a live claim of ours,
+    and treating what we cannot read as idle capacity is how corruption turns
+    into concurrency. The cost is a machine that idles until the corrupt file is
+    dealt with; the alternative is two hosts on one licence seat.
+    """
+    root = Path(records_root)
+    if not root.is_dir():
+        return 0
+    held = 0
+    for path in sorted(root.glob("*.json")):
+        try:
+            record = records.read_record(path)
+        except (ValueError, OSError):
+            held += 1
+            continue
+        if record.get("state") == "active" and record.get("machine") == machine:
+            held += 1
+    return held
+
+
+def pause_path(root) -> Path:
+    """The kill switch for `root`'s checkout. Presence is the whole protocol."""
+    return Path(root) / PAUSE_RELATIVE
+
+
+# ---------------------------------------------------------------------------
 # execution surface
 # ---------------------------------------------------------------------------
+
+
+class RunnerTimeout(RuntimeError):
+    """A runner verb did not return. The PAYLOAD may still be running.
+
+    Distinct from every other subprocess failure because the follow-up is
+    different: a runner that could not be launched left nothing behind, while
+    one that timed out left a detached job holding the seat.
+    """
 
 
 @dataclass
@@ -227,6 +394,17 @@ class ExecOutcome:
     turned "the status verb was unreadable" into `returncode: 1` would be
     inventing an observation, and one that turned it into 0 would be inventing a
     completion — the defect this epic exists to close, wearing a helpful face.
+
+    `cancelled` is a THIRD value on purpose:
+
+        None   no cancel was needed — the job ended on its own
+        True   the runner confirmed it stopped the job
+        False  a cancel was attempted and did not work
+
+    False and None must never collapse: `False` means a payload may still be
+    running on this host, unobserved, holding the one floating solver seat
+    (wh#3721). That is the worst state this loop can reach and it must not be
+    reported as the same thing as a job that simply finished.
     """
 
     returncode: int | None
@@ -235,6 +413,7 @@ class ExecOutcome:
     log_ref: str | None = None
     started_at: str | None = None
     finished_at: str | None = None
+    cancelled: bool | None = None
 
 
 class SubprocessRunner:
@@ -270,6 +449,9 @@ class SubprocessRunner:
     def status_argv(self, job_id: str) -> list[str]:
         raise NotImplementedError
 
+    def cancel_argv(self, job_id: str) -> list[str]:
+        raise NotImplementedError
+
     def describe(self, *, issue: str, job_id: str, command: str,
                  work_dir: str | None) -> str:
         return " ".join(self.submit_argv(issue=issue, job_id=job_id,
@@ -277,11 +459,22 @@ class SubprocessRunner:
 
     # -- plumbing ---------------------------------------------------------
 
-    def _invoke(self, argv: list[str]) -> dict | None:
-        """One JSON object, or None. Both runners guarantee exactly one."""
+    def _invoke(self, argv: list[str], *, timeout: int | None = None) -> dict | None:
+        """One JSON object, or None. Both runners guarantee exactly one.
+
+        A TIMEOUT is raised, not folded into None. `subprocess.run`'s timeout
+        kills the process we started — `bash run.sh`, or `powershell` — and the
+        wrapper and payload beneath it are grandchildren that survive. Returning
+        None here made that indistinguishable from "the runner printed rubbish",
+        so the only path that leaves an orphaned payload behind was the one the
+        caller could not detect.
+        """
+        limit = self.timeout if timeout is None else timeout
         try:
             done = subprocess.run(argv, capture_output=True, text=True,
-                                  timeout=self.timeout, check=False, env=self.env)
+                                  timeout=limit, check=False, env=self.env)
+        except subprocess.TimeoutExpired as exc:
+            raise RunnerTimeout(f"{argv[0]} did not return within {limit}s") from exc
         except (OSError, subprocess.SubprocessError):
             return None
         try:
@@ -290,17 +483,56 @@ class SubprocessRunner:
             return None
         return obj if isinstance(obj, dict) else None
 
+    def cancel(self, job_id: str, *, why: str) -> tuple[bool, str]:
+        """Ask the runner to stop the job. Returns (confirmed, detail).
+
+        The runner's own verb, because it is the only thing that knows which pid
+        is the PAYLOAD: `run.sh cmd_cancel` signals the child and deliberately
+        leaves the wrapper alive so the outcome still gets recorded. Killing the
+        process group from here would stop the one process whose job is to
+        report, turning a cancellation into a disappearance.
+
+        A failure is RETURNED, never swallowed. `ok=False` here means a payload
+        may still be running unobserved.
+        """
+        try:
+            answer = self._invoke(self.cancel_argv(job_id),
+                                  timeout=CANCEL_TIMEOUT_SECONDS)
+        except NotImplementedError:
+            return False, (f"{why}; this runner has no cancel verb — the payload "
+                           f"may still be running")
+        except RunnerTimeout:
+            return False, (f"{why}; cancel did not return within "
+                           f"{CANCEL_TIMEOUT_SECONDS}s — the payload may still be running")
+        if not answer or answer.get("ok") is not True:
+            reason = (answer or {}).get("error", "no parseable cancel output")
+            return False, (f"{why}; CANCEL FAILED ({reason}) — the payload may "
+                           f"still be running")
+        return True, f"{why}; the runner was asked to cancel job {job_id}"
+
     def execute(self, *, issue: str, job_id: str, command: str,
                 work_dir: str | None = None) -> ExecOutcome:
-        submitted = self._invoke(self.submit_argv(
-            issue=issue, job_id=job_id, command=command, work_dir=work_dir))
+        try:
+            submitted = self._invoke(self.submit_argv(
+                issue=issue, job_id=job_id, command=command, work_dir=work_dir))
+        except RunnerTimeout as exc:
+            # On the shell runner `submit --foreground` IS the payload, so this
+            # is the common orphan: our bash died, run.sh and the work did not.
+            confirmed, detail = self.cancel(job_id, why=str(exc))
+            return ExecOutcome(None, detail=detail, cancelled=confirmed)
         if not submitted or submitted.get("ok") is not True:
             detail = (submitted or {}).get("error", "no parseable submit output")
             return ExecOutcome(None, detail=f"submit refused: {detail}")
 
         deadline = self._clock() + self.timeout
         while True:
-            status = self._invoke(self.status_argv(job_id))
+            try:
+                status = self._invoke(self.status_argv(job_id))
+            except RunnerTimeout as exc:
+                # We can no longer observe the job. Leaving it running would be
+                # an unobserved payload on the seat.
+                confirmed, detail = self.cancel(job_id, why=str(exc))
+                return ExecOutcome(None, detail=detail, cancelled=confirmed)
             if status is None:
                 return ExecOutcome(None, detail="status verb produced nothing readable")
             state = status.get("state")
@@ -314,9 +546,11 @@ class SubprocessRunner:
                     log_ref=status.get("dir"),
                 )
             if self._clock() >= deadline:
-                return ExecOutcome(
-                    None, job_state=state,
-                    detail=f"still {state!r} after {self.timeout}s — outcome unknown")
+                confirmed, detail = self.cancel(
+                    job_id,
+                    why=f"still {state!r} after {self.timeout}s — outcome unknown")
+                return ExecOutcome(None, job_state=state, detail=detail,
+                                   cancelled=confirmed)
             self._sleep(self.poll_seconds)
 
 
@@ -343,6 +577,9 @@ class ShellRunner(SubprocessRunner):
 
     def status_argv(self, job_id):
         return [self.bash, str(self.script), "status", "--job-id", job_id]
+
+    def cancel_argv(self, job_id):
+        return [self.bash, str(self.script), "cancel", "--job-id", job_id]
 
 
 class PowerShellRunner(SubprocessRunner):
@@ -371,6 +608,10 @@ class PowerShellRunner(SubprocessRunner):
     def status_argv(self, job_id):
         return [self.powershell, "-NoProfile", "-File", str(self.script),
                 "-Action", "status", "-JobId", job_id]
+
+    def cancel_argv(self, job_id):
+        return [self.powershell, "-NoProfile", "-File", str(self.script),
+                "-Action", "cancel", "-JobId", job_id]
 
 
 #: The two real execution surfaces. Named here so the dry-run plan can print the
@@ -415,7 +656,7 @@ def prepare(records_root, issue: str, *, host: str, job_id: str,
             machine: str | None = None, queue_generation_id: str | None = None,
             ttl_minutes: int = records.DEFAULT_TTL_MINUTES,
             max_attempts: int = records.DEFAULT_MAX_ATTEMPTS,
-            now=None) -> Preparation:
+            rules_loader=None, now=None) -> Preparation:
     """Decide the record to claim with — or refuse. READ-ONLY.
 
     Resumability lives here. Re-running against our OWN live claim re-enters it
@@ -426,13 +667,39 @@ def prepare(records_root, issue: str, *, host: str, job_id: str,
     Re-running against SOMEONE ELSE's claim refuses, whatever its heartbeat says.
     See the module docstring: liveness is reconcile's job, and a second opinion
     about it is a race.
+
+    The WIP cap is applied HERE, at the two decisions that start a payload —
+    CLAIM and RECLAIM. RESUME is exempt because it re-enters a slot this machine
+    already holds; counting it would make an operator's re-run after a dropped
+    session impossible on a machine at its cap, which is the case where re-runs
+    happen. Nothing in `route.py`'s `slot` annotation reaches a direct drain, so
+    this is the only place a cap binds before work starts.
     """
     root = Path(records_root)
     path = records.record_path(root, issue)
+    owner = machine or host
+
+    def capped(action: str) -> Preparation | None:
+        try:
+            cap = machine_wip_cap(owner, rules_loader=rules_loader)
+        except WipCapUnavailable as exc:
+            return Preparation(False, REFUSE,
+                               f"the WIP cap for {owner!r} could not be read "
+                               f"({exc}) — refusing to {action} without a limit")
+        held = count_active_claims(root, owner)
+        if held >= cap:
+            return Preparation(False, REFUSE,
+                               f"{owner} already holds {held} active claim(s) and "
+                               f"its WIP cap is {cap} — refusing to {action}; the "
+                               f"cap is backpressure, not advice")
+        return None
 
     if not path.exists():
+        over = capped(CLAIM)
+        if over is not None:
+            return over
         return Preparation(True, CLAIM, "no record yet — first attempt",
-                           records.new_claim(issue, machine=machine or host,
+                           records.new_claim(issue, machine=owner,
                                              host=host, job_id=job_id,
                                              queue_generation_id=queue_generation_id,
                                              ttl_minutes=ttl_minutes,
@@ -471,10 +738,18 @@ def prepare(records_root, issue: str, *, host: str, job_id: str,
     # `ready` (reconcile returned an expired claim) or `done` (a finished run).
     # Both are fresh attempts, and both consume one.
     if records.should_quarantine(existing):
-        return Preparation(False, REFUSE,
+        # QUARANTINE, not REFUSE, and it carries the record. A bare refusal
+        # wrote nothing, and `reconcile.settle` only quarantines EXPIRED ACTIVE
+        # claims — so a card that failed three times kept its terminal `done`
+        # record, projected `dispatch:done`, and was counted as executed.
+        return Preparation(False, QUARANTINE,
                            f"{issue} has used {existing.get('attempt')} of "
                            f"{existing.get('max_attempts')} attempts — refusing to "
-                           f"start an unbounded retry loop")
+                           f"start an unbounded retry loop",
+                           record=existing)
+    over = capped(RECLAIM)
+    if over is not None:
+        return over
     return Preparation(True, RECLAIM,
                        f"fresh attempt on a record in state {state!r} "
                        f"(attempt {int(existing.get('attempt') or 1) + 1})",
@@ -527,7 +802,7 @@ def plan_text(issue: str, prep: Preparation, *, command: str, records_root,
         f"  records      {records_root}",
         f"  action       {prep.action}: {prep.reason}",
     ]
-    if prep.record is not None:
+    if prep.ok and prep.record is not None:
         lines += [
             f"  claim as     {prep.record.get('host')}/{prep.record.get('job_id')} "
             f"attempt {prep.record.get('attempt')}/{prep.record.get('max_attempts')}",
@@ -551,7 +826,9 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
           queue_generation_id: str | None = None,
           ttl_minutes: int = records.DEFAULT_TTL_MINUTES,
           max_attempts: int = records.DEFAULT_MAX_ATTEMPTS,
-          labels=None, gh_fn=None, now=None, log=None) -> DrainResult:
+          timeout: int = DEFAULT_TIMEOUT_SECONDS, rules_loader=None,
+          pause_file=None, labels=None, gh_fn=None, now=None,
+          log=None) -> DrainResult:
     """Take one issue through claim -> execute -> release -> project.
 
     Dry run unless `apply` AND the environment gate are BOTH set; a dry run
@@ -580,6 +857,29 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
                            f"(letters, digits, dot, underscore, hyphen; max 64)",
                            dry_run=not apply)
 
+    # A payload allowed to outlive the record's TTL gets a SECOND payload:
+    # nothing beats `heartbeat_at` while the child runs (records.heartbeat is
+    # called once, at claim time), so the record expires under a live job,
+    # `reconcile.settle` returns it to `ready`, and the next prepare RECLAIMs
+    # it. Refused here rather than left to the coincidence that the shipped
+    # 3600s happens to be under 90 minutes. Checked before the write gate so a
+    # dry run surfaces the misconfiguration, and against the RUNNER's own
+    # timeout too — the runner is what actually waits.
+    ttl_seconds = int(ttl_minutes) * 60
+    waits = [int(timeout)]
+    runner_timeout = getattr(runner, "timeout", None)
+    if isinstance(runner_timeout, (int, float)) and not isinstance(runner_timeout, bool):
+        waits.append(int(runner_timeout))
+    longest = max(waits)
+    if longest >= ttl_seconds:
+        return DrainResult(
+            False, REFUSED,
+            f"a payload may wait {longest}s but the record's ttl is {ttl_minutes} "
+            f"minutes ({ttl_seconds}s), and nothing refreshes the heartbeat while "
+            f"it runs — the record would expire under a live job and be reclaimed, "
+            f"running the same issue twice. Lower --timeout or raise --ttl-minutes.",
+            dry_run=not apply)
+
     armed = apply and reconcile.writes_armed()
     if apply and not armed:
         # Asking for writes is not being permitted them. Same sentence as
@@ -592,7 +892,7 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
 
     prep = prepare(records_root, issue, host=host, job_id=job_id, machine=machine,
                    queue_generation_id=queue_generation_id, ttl_minutes=ttl_minutes,
-                   max_attempts=max_attempts, now=now)
+                   max_attempts=max_attempts, rules_loader=rules_loader, now=now)
 
     def plan() -> str:
         # The description is built from a FRESH runner of the requested kind, never
@@ -604,13 +904,18 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
         return plan_text(issue, prep, command=command, records_root=records_root,
                          work_dir=work_dir, runner_desc=desc, armed=armed)
 
-    if not prep.ok:
+    if not prep.ok and prep.action != QUARANTINE:
         log(plan())
         return DrainResult(False, REFUSED, prep.reason, action=prep.action,
                            dry_run=not armed)
 
     if not armed:
         log(plan())
+        if prep.action == QUARANTINE:
+            # A refusal, still — but a dry run must not claim it did the write.
+            return DrainResult(False, REFUSED,
+                               f"{prep.reason} (armed, this would record `blocked`)",
+                               action=prep.action, dry_run=True)
         # `planned`, not `record`: a plan must not be reachable through the field
         # a caller reads after a real drain. Same discipline as ClaimResult's
         # `record=None` on refusal.
@@ -618,9 +923,27 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
                            "dry run — nothing claimed, nothing executed, nothing written",
                            planned=prep.record, action=prep.action, dry_run=True)
 
-    runner = runner or RUNNERS[runner_kind]()
+    # ---- 0. the kill switch --------------------------------------------
+    # Before the claim, and before the quarantine write below, because BOTH
+    # touch the shared record store. Checked on every drain rather than once at
+    # loop start: `run.sh` detaches payloads (`setsid nohup`), so the only thing
+    # a stop can still govern is work that has NOT been claimed yet — and a
+    # wrapper loop is exactly the case where a loop is already running.
+    stop = Path(pause_file) if pause_file else pause_path(repo_root or records_root)
+    if stop.exists():
+        return DrainResult(False, PAUSED,
+                           f"paused: {stop} exists — nothing claimed, nothing run. "
+                           f"Remove it to resume.",
+                           action=prep.action)
+
     git = git or claim.GitBackend(Path(repo_root or records_root),
                                   records_dir=Path(records_root))
+
+    if prep.action == QUARANTINE:
+        return _quarantine(records_root, issue, prep, git=git, labels=labels,
+                           gh_fn=gh_fn, now=now, log=log)
+
+    runner = runner or RUNNERS[runner_kind]()
 
     # ---- 1. claim ------------------------------------------------------
     held = claim.acquire(records_root, prep.record, git=git,
@@ -647,6 +970,13 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
         outcome = ExecOutcome(None, detail=f"runner raised {type(exc).__name__}: {exc}")
 
     state, reason, category = classify(outcome)
+    if outcome.cancelled is False:
+        # The record will say `blocked`/`unknown-outcome` either way. Whether a
+        # payload is STILL RUNNING is a different fact, and it is the one that
+        # decides whether this host may be given more work.
+        warnings.append(
+            f"job {rec.get('job_id')!r} timed out and the runner did NOT confirm "
+            f"cancellation — a payload may still be running on this host")
     if outcome.log_ref:
         rec["log_ref"] = outcome.log_ref
     if category is not None:
@@ -668,19 +998,8 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
 
     # ---- 4. project ----------------------------------------------------
     final = released.record
-    intended = reconcile.intended_label(final)
-    stats = None
-    if labels is not None:
-        outcome_ = reconcile.reconcile_issue(final, tuple(labels), now=now)
-        report = reconcile.Report(outcomes=[outcome_],
-                                  findings=list(outcome_.findings),
-                                  records_root=Path(records_root))
-        log(reconcile.format_report(report, armed=True))
-        stats = reconcile.apply(report, records_root, gh_fn=gh_fn)
-    else:
-        log(f"  label projection: {issue} -> {intended}. Project it with:\n"
-            f"    {APPLY_FLAG}=1 python {_HERE / 'reconcile.py'} "
-            f"--records {records_root} --repo {issue.rpartition('#')[0]} --apply")
+    intended, stats = _project(records_root, issue, final, labels=labels,
+                               gh_fn=gh_fn, now=now, log=log)
 
     return DrainResult(True, RELEASED, f"{state}: {reason}", record=final,
                        returncode=outcome.returncode, action=prep.action,
@@ -688,12 +1007,73 @@ def drain(records_root, issue: str, *, command: str, host: str | None = None,
                        warnings=warnings)
 
 
+def _project(records_root, issue: str, final: dict, *, labels, gh_fn, now,
+             log) -> tuple[str, dict | None]:
+    """Records -> labels, one direction. Shared by the release and quarantine
+    paths so a quarantined card cannot keep projecting the label its old state
+    implied."""
+    intended = reconcile.intended_label(final)
+    if labels is None:
+        log(f"  label projection: {issue} -> {intended}. Project it with:\n"
+            f"    {APPLY_FLAG}=1 python {_HERE / 'reconcile.py'} "
+            f"--records {records_root} --repo {issue.rpartition('#')[0]} --apply")
+        return intended, None
+    outcome_ = reconcile.reconcile_issue(final, tuple(labels), now=now)
+    report = reconcile.Report(outcomes=[outcome_],
+                              findings=list(outcome_.findings),
+                              records_root=Path(records_root))
+    log(reconcile.format_report(report, armed=True))
+    return intended, reconcile.apply(report, records_root, gh_fn=gh_fn)
+
+
+def _quarantine(records_root, issue: str, prep: Preparation, *, git, labels,
+                gh_fn, now, log) -> DrainResult:
+    """Write the `blocked` record a bare refusal never wrote.
+
+    `records.should_quarantine` tripping used to return `Preparation(False,
+    REFUSE, ...)`, which writes nothing — and `reconcile.settle` only quarantines
+    EXPIRED ACTIVE claims, so it never saw a card that had already reached a
+    terminal state. The record therefore stayed `done` with `returncode: 3`, its
+    intended label stayed `dispatch:done`, and `chain.py` counted three failures
+    as an executed card.
+
+    `claim.release` does the write, exactly as a real outcome does: one code
+    path reaches `blocked`, so a quarantine cannot drift from a release. The
+    observed `returncode` is left alone (passing None means `records.transition`
+    does not overwrite it) — the last exit code is evidence, and erasing it
+    would trade one silent record for another.
+
+    NOT executing is the point, so no runner is constructed here at all.
+    """
+    record = dict(prep.record or {})
+    record["failure_category"] = ATTEMPTS_EXHAUSTED
+    released = claim.release(records_root, record, state="blocked",
+                             reason=prep.reason, git=git)
+    if not released.ok:
+        return DrainResult(False, RELEASE_FAILED,
+                           f"{released.reason} (intended 'blocked': {prep.reason})",
+                           action=prep.action)
+
+    final = released.record
+    intended, stats = _project(records_root, issue, final, labels=labels,
+                               gh_fn=gh_fn, now=now, log=log)
+    return DrainResult(False, QUARANTINED, prep.reason, record=final,
+                       returncode=final.get("returncode"), action=prep.action,
+                       intended_label=intended, label_stats=stats)
+
+
 def exit_code(result: DrainResult) -> int:
     """0 only for a dry run or work that actually succeeded.
 
-    Three values, because two would force a caller to conflate "the work failed"
-    with "the loop did not close" — and those need different humans.
+    Four values, because fewer would force a caller to conflate outcomes that
+    need different responses: "the work failed" (investigate the card), "the
+    loop did not close" (investigate the dispatch), and "an operator stopped
+    the fleet" (do nothing at all). A wrapper loop that cannot tell the last
+    from the second either spins against a paused fleet or abandons a queue
+    that was merely paused.
     """
+    if result.stage == PAUSED:
+        return 3
     if result.dry_run and result.ok:
         return 0
     if not result.ok:
@@ -711,7 +1091,11 @@ def main(argv=None) -> int:
     ap.add_argument("--issue", required=True, help="owner/repo#123")
     ap.add_argument("--records", required=True, help="directory of record JSON files")
     ap.add_argument("--command", required=True, help="the payload to run")
-    ap.add_argument("--repo-root", help="checkout the records live in (default: --records)")
+    ap.add_argument("--repo-root",
+                    help=f"checkout the records live in (default: --records). "
+                         f"Also where the kill switch lives: create "
+                         f"<repo-root>/{PAUSE_RELATIVE} and every drain refuses "
+                         f"new work (exit 3) until it is removed")
     ap.add_argument("--work-dir", help="working directory for the payload")
     ap.add_argument("--host", help="claim identity (default: this host's name)")
     ap.add_argument("--machine", help="logical machine label recorded with the claim")
@@ -754,7 +1138,7 @@ def main(argv=None) -> int:
                    current_generation=args.current_generation,
                    queue_generation_id=args.queue_generation,
                    ttl_minutes=args.ttl_minutes, max_attempts=args.max_attempts,
-                   labels=labels, log=print)
+                   timeout=args.timeout, labels=labels, log=print)
 
     for warning in result.warnings:
         print(f"  WARN {warning}")

--- a/scripts/operations/dispatch_pull.py
+++ b/scripts/operations/dispatch_pull.py
@@ -148,6 +148,13 @@ def claim_run(
         attempted += 1
         try:
             executor(item)
+        except FleetPaused as exc:
+            # STOP, do not `continue`. The operator set the sentinel; every
+            # remaining card would refuse identically, and recording each as a
+            # failure buries the one fact that matters. Not marked done — the
+            # card was never started and stays claimable.
+            emit({"id": item["id"], "status": "paused", "reason": str(exc)})
+            break
         except Exception as exc:  # noqa: BLE001 — record and keep going; item stays claimable
             emit({"id": item["id"], "status": "failed", "error": str(exc)})
             continue
@@ -284,6 +291,25 @@ class DrainFailed(RuntimeError):
         super().__init__(f"{issue}: drain.py exited {returncode}")
 
 
+#: drain.py's PAUSED exit (#3773 R2) — the `.claude/dispatch/PAUSE` sentinel is
+#: set, so it refused to claim ANYTHING. This is not a property of the card.
+FLEET_PAUSED_EXIT = 3
+
+
+class FleetPaused(RuntimeError):
+    """The operator paused the fleet. Stop the run; do not blame the card.
+
+    Separated from `DrainFailed` because collapsing them makes the kill switch
+    produce the loudest possible false alarm and stop nothing: every card walks
+    the queue recording a failure it did not cause — ~1344 of them on
+    `dev-primary`. An exit that means "the system said no" is not an exit that
+    means "this unit of work broke", and only the first should end the loop.
+    """
+
+    def __init__(self, issue: str):
+        super().__init__(f"{issue}: drain.py reports the fleet is paused")
+
+
 def item_key(item: dict) -> str:
     """The issue ref a card binds under — `owner/repo#N`."""
     card = item.get("card") or {}
@@ -406,6 +432,11 @@ def make_drain_executor(*, repo, records_dir, machine: str, bindings: dict,
         if apply:
             argv.append("--apply")
         done = run(argv, cwd=str(repo), check=False)
+        # Checked BEFORE the generic nonzero branch: a paused fleet is not a
+        # failed card, and the order is what keeps the kill switch from being
+        # reported as 1344 defects (#3773 R2).
+        if done.returncode == FLEET_PAUSED_EXIT:
+            raise FleetPaused(issue)
         if done.returncode != 0:
             raise DrainFailed(issue, done.returncode)
         return done.returncode

--- a/scripts/operations/dispatch_pull.py
+++ b/scripts/operations/dispatch_pull.py
@@ -62,6 +62,12 @@ def default_lease_name(item: dict) -> str:
 
 
 # ── pure core ────────────────────────────────────────────────────────────────
+#: Status for a card the run declined to reach because it hit its own ceiling.
+#: Distinct from WIP_CAPPED (the ROUTER capped it) — the two need different
+#: actions from an operator, and a shared "skipped" would hide which one fired.
+RUN_CAPPED = "run_capped"
+
+
 def claim_run(
     items: Iterable[dict],
     holder: str,
@@ -74,6 +80,10 @@ def claim_run(
     liveness_fn: Optional[Callable[[str], bool]] = None,
     mark_done: Optional[Callable[[dict], Any]] = None,
     lease_name_fn: Optional[Callable[[dict], str]] = None,
+    max_cards: Optional[int] = None,
+    delay_s: float = 0.0,
+    sleep_fn: Optional[Callable[[float], Any]] = None,
+    on_outcome: Optional[Callable[[dict], Any]] = None,
 ) -> list[dict]:
     """Claim each item under a fenced git-ref lease, run it once, record completion.
 
@@ -86,31 +96,67 @@ def claim_run(
           - superseded mid-run -> status ``lost_fence`` (NOT marked done);
         an executor exception -> status ``failed`` (NOT marked done -> retried later).
 
-    Returns a per-item list of ``{"id", "status"[, "error"]}``. No lease is ever
-    released; it lapses via TTL. Pure — all effects are injected.
+    Pacing (#3773 R6). ``max_cards`` bounds how many cards this run may HAND TO
+    the executor, and ``delay_s`` puts a gap between those hand-offs. Both matter
+    because one card is not one cheap operation: each drain writes two commits to
+    `main` and pushes them, so an unbounded pass over the `dev-primary` queue was
+    ~1344 cards x 2 commits, unattended, into a repo with CI and a PII gate.
+
+      * The budget is spent on EXECUTOR CALLS, not on items seen. A card held by
+        another host writes nothing to `main`, so it must not consume the ceiling
+        — otherwise a busy fleet would starve this host's run of real work.
+      * A card that FAILED still spent its budget: the drain had already run and
+        already committed by the time it returned nonzero.
+      * Cards past the ceiling are reported as ``run_capped``, never dropped. A
+        queue that silently shrinks to the cap reads as a completed night.
+      * The delay separates executions only; the run does not wait out a pause
+        for cards it has already declined.
+      * There is NO retry loop here. A card that failed stays claimable and is
+        picked up by a later run, which is bounded by its own ceiling.
+
+    ``on_outcome`` is called with each outcome dict as it is produced, so a caller
+    can journal progress while the run is still in flight (a summary written only
+    at the end is lost exactly when the run dies mid-way).
+
+    Returns a per-item list of ``{"id", "status"[, "error"|"reason"]}``. No lease
+    is ever released; it lapses via TTL. Pure — all effects are injected.
     """
     name_of = lease_name_fn or default_lease_name
     out: list[dict] = []
+    attempted = 0
+
+    def emit(outcome: dict) -> None:
+        out.append(outcome)
+        if on_outcome is not None:
+            on_outcome(outcome)
+
     for item in items:
+        if max_cards is not None and attempted >= max_cards:
+            emit({"id": item["id"], "status": RUN_CAPPED,
+                  "reason": f"per-run cap of {max_cards} cards reached"})
+            continue
+        if attempted and delay_s > 0 and sleep_fn is not None:
+            sleep_fn(delay_s)
         name = name_of(item)
         tok = token_fn()
         blob = acquire(git, name, holder, ttl_s, now_fn(), tok)
         if blob is None and liveness_fn is not None:
             blob = reclaim(git, name, holder, ttl_s, now_fn(), tok, liveness_fn)
         if blob is None:
-            out.append({"id": item["id"], "status": "skipped_held"})
+            emit({"id": item["id"], "status": "skipped_held"})
             continue
+        attempted += 1
         try:
             executor(item)
         except Exception as exc:  # noqa: BLE001 — record and keep going; item stays claimable
-            out.append({"id": item["id"], "status": "failed", "error": str(exc)})
+            emit({"id": item["id"], "status": "failed", "error": str(exc)})
             continue
         if verify_token(git, name, tok):
             if mark_done is not None:
                 mark_done(item)
-            out.append({"id": item["id"], "status": "ran"})
+            emit({"id": item["id"], "status": "ran"})
         else:
-            out.append({"id": item["id"], "status": "lost_fence"})
+            emit({"id": item["id"], "status": "lost_fence"})
     return out
 
 
@@ -139,16 +185,35 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
 
 
-def _fetch_lease_refs(repo: Path) -> None:
+# The namespace the LEASE WRITER uses, imported — never restated. Two literals
+# that happen to agree are one edit away from the #3772 defect: this module used
+# to sync `refs/heads/dispatch-lease/*` while `dispatch_lease` wrote
+# `refs/heads/dispatch/leases/*`, so no lease ever left the host and every host
+# won every claim it made. Cross-machine mutual exclusion was zero.
+LEASE_REF_GLOB = _dl.REF_PREFIX + "*"
+
+
+def lease_fetch_refspec() -> str:
+    """Force-fetch refspec: overwrite our view with the fleet's (peers are truth)."""
+    return f"+{LEASE_REF_GLOB}:{LEASE_REF_GLOB}"
+
+
+def lease_push_refspec() -> str:
+    """Non-forced push refspec. Each lease commit is parented on the one it
+    supersedes, so a legitimate CAS fast-forwards and a stale one is rejected."""
+    return LEASE_REF_GLOB
+
+
+def _fetch_lease_refs(repo: Path) -> subprocess.CompletedProcess:
     """Bring remote lease refs local so CAS sees other hosts' claims (best-effort)."""
-    _git(repo, "fetch", "origin",
-         "+refs/heads/dispatch-lease/*:refs/heads/dispatch-lease/*")
+    return _git(repo, "fetch", "origin", lease_fetch_refspec())
 
 
-def _push_lease_refs(repo: Path) -> None:
-    """Publish our lease CAS updates to origin (best-effort; per-ref CAS push is the
-    operator-verified live step on the no-SSH hosts)."""
-    _git(repo, "push", "origin", "refs/heads/dispatch-lease/*")
+def _push_lease_refs(repo: Path) -> subprocess.CompletedProcess:
+    """Publish our lease CAS updates to origin. Best-effort, but the return code is
+    handed back so the run summary can say the fleet went unsynced rather than
+    leaving a silent no-op that looks exactly like a clean night."""
+    return _git(repo, "push", "origin", lease_push_refspec())
 
 
 def _dry_run_executor(item: dict) -> None:
@@ -348,9 +413,103 @@ def make_drain_executor(*, repo, records_dir, machine: str, bindings: dict,
     return executor
 
 
-def main(argv=None) -> int:
-    import time
+# ── the run log ─────────────────────────────────────────────────────────────
+#
+# The failure this closes: a night that refused 1344 cards and a night that
+# completed 1344 produced the SAME evidence — the stdout of a process nobody was
+# attached to. There was no artifact to read in the morning, so "nothing broke"
+# and "everything broke" were indistinguishable.
+#
+# It is a dated JSONL under `logs/`, which `.gitignore` excludes wholesale
+# (`logs/*`, with named exceptions this path is not among). That is deliberate
+# and load-bearing, not incidental: this repo is PUBLIC and gated by a PII scan.
 
+#: Log directory, relative to the repo root. Local-only by `.gitignore`.
+RUN_LOG_DIR_REL = Path("logs") / "dispatch-pull"
+
+#: The ONLY keys copied out of an outcome into a log line.
+#:
+#: An allow-list, not a filter. Issue TITLES were removed from the dispatch
+#: surface because they leaked client identifiers into this public repo (#3768);
+#: a journal that serialised the outcome — or worse, the card — would reinstate
+#: exactly that leak one layer below the fix. `owner/repo#N` is a reference, not
+#: prose, and is what an operator needs to act. `reason` and `error` are this
+#: module's own strings (a cap message, a drain exit code), never child output.
+LOGGED_KEYS = ("status", "reason", "error")
+
+
+def run_log_path(repo, *, today: Optional[str] = None) -> Path:
+    """Dated log file for a run: ``<repo>/logs/dispatch-pull/YYYY-MM-DD.jsonl``."""
+    from datetime import datetime, timezone
+    day = today or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return Path(repo) / RUN_LOG_DIR_REL / f"{day}.jsonl"
+
+
+class RunLog:
+    """Append-only JSONL journal: one line per card, one summary line per run.
+
+    Append, never truncate — two runs can share a night, and the second must not
+    erase the first's evidence. Each line is written and flushed as it happens,
+    so a run killed mid-way still leaves everything it got through.
+    """
+
+    def __init__(self, path, *, run_id: str, machine: str,
+                 now_fn: Optional[Callable[[], float]] = None):
+        import time as _time
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.run_id = run_id
+        self.machine = machine
+        self._now = now_fn or _time.time
+
+    def _append(self, record: dict) -> dict:
+        import json
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+        return record
+
+    def _stamp(self, event: str) -> dict:
+        return {"event": event, "ts": self._now(), "run_id": self.run_id,
+                "machine": self.machine}
+
+    def card(self, outcome: dict, *, attempt: int = 1) -> dict:
+        """One line for one card on one attempt. Built from `LOGGED_KEYS` only."""
+        record = self._stamp("card")
+        record["issue"] = str(outcome.get("id", ""))
+        record["attempt"] = attempt
+        for key in LOGGED_KEYS:
+            if outcome.get(key) is not None:
+                record[key] = str(outcome[key])
+        return self._append(record)
+
+    def summary(self, outcomes: Iterable[dict], **extra) -> dict:
+        """The end-of-run line: how many of each cause, so the morning question
+        ("did anything happen?") has an answer that outlives the terminal."""
+        counts: dict[str, int] = {}
+        total = 0
+        for outcome in outcomes:
+            counts[str(outcome.get("status"))] = counts.get(str(outcome.get("status")), 0) + 1
+            total += 1
+        record = self._stamp("run_summary")
+        record["counts"] = counts
+        record["total"] = total
+        record.update({k: v for k, v in extra.items() if k not in record})
+        return self._append(record)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+#: Conservative by construction. Five cards is ten commits to `main` per run —
+#: a number an operator can review in the morning. Raising it is a deliberate
+#: flag on the command line, which is where that decision belongs.
+DEFAULT_MAX_CARDS = 5
+
+#: Seconds between hand-offs. Spaces the pushes so a run cannot present CI and
+#: the PII gate with a burst.
+DEFAULT_DELAY_S = 30.0
+
+
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="lease-arbitrated pull dispatch (#3000)")
     ap.add_argument("--machine", default=None, help="registry machine id (default: this host)")
     ap.add_argument("--ttl", type=int, default=900, help="lease TTL seconds (default 900)")
@@ -359,7 +518,37 @@ def main(argv=None) -> int:
     ap.add_argument("--commands", default=None,
                     help=f"per-issue command map (default: <repo>/{COMMAND_MAP_REL})")
     ap.add_argument("--repo", default=str(_REPO))
-    args = ap.parse_args(argv)
+    # A ceiling, not a switch: there is no value here that means "unbounded".
+    # `0` runs nothing, negatives are rejected, and the default is finite.
+    ap.add_argument("--max-cards", type=_non_negative_int, default=DEFAULT_MAX_CARDS,
+                    help=f"cards this run may hand to the executor "
+                         f"(default {DEFAULT_MAX_CARDS}; 0 runs none)")
+    ap.add_argument("--delay", type=_non_negative_float, default=DEFAULT_DELAY_S,
+                    help=f"seconds between cards (default {DEFAULT_DELAY_S})")
+    ap.add_argument("--log-dir", default=None,
+                    help=f"run-log directory (default: <repo>/{RUN_LOG_DIR_REL})")
+    return ap
+
+
+def _non_negative_int(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(
+            f"{text}: the per-run cap is a ceiling; there is no unbounded value")
+    return value
+
+
+def _non_negative_float(text: str) -> float:
+    value = float(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"{text}: delay cannot be negative")
+    return value
+
+
+def main(argv=None) -> int:
+    import time
+
+    args = build_parser().parse_args(argv)
 
     # Two gates, checked before anything is fetched, read or claimed. Asking for
     # writes is not being permitted them, and a refusal that happens after the
@@ -384,19 +573,33 @@ def main(argv=None) -> int:
     bindings = load_command_bindings(Path(args.commands) if args.commands
                                      else repo / COMMAND_MAP_REL)
 
-    _fetch_lease_refs(repo)
+    # Opened BEFORE anything is claimed. A journal created only once there is
+    # something to write reports nothing about the runs that died before their
+    # first card — which are the runs worth reading about.
+    run_id = uuid.uuid4().hex[:12]
+    log_path = run_log_path(repo)
+    if args.log_dir:
+        log_path = Path(args.log_dir) / log_path.name
+    log = RunLog(log_path, run_id=run_id, machine=mid)
+
+    fetch = _fetch_lease_refs(repo)
     items = _read_ready_cards(dispatch_file)
     runnable, deferred = partition_runnable(items, bindings)
     print(f"--- dispatch-pull {mid}: {len(items)} ready, {len(runnable)} runnable, "
-          f"{len(deferred)} deferred [{'apply' if args.apply else 'dry-run'}] ---")
+          f"{len(deferred)} deferred, cap {args.max_cards}, delay {args.delay}s "
+          f"[{'apply' if args.apply else 'dry-run'}] run {run_id} ---")
+    for o in deferred:
+        log.card(o)
 
     executor = make_drain_executor(repo=repo, records_dir=repo / ".claude" / "dispatch" / "records",
                                    machine=mid, bindings=bindings, apply=args.apply)
     outcomes = claim_run(
         runnable, holder=holder, git=git_lease, executor=executor,
         ttl_s=args.ttl, now_fn=time.time, token_fn=lambda: uuid.uuid4().hex,
+        max_cards=args.max_cards, delay_s=args.delay, sleep_fn=time.sleep,
+        on_outcome=log.card,
     )
-    _push_lease_refs(repo)
+    push = _push_lease_refs(repo)
 
     # Deferrals are printed with the runs, not summarised away: a card nobody has
     # bound must be as visible as one that ran, or the queue silently stalls at
@@ -405,6 +608,19 @@ def main(argv=None) -> int:
         print(f"  {o['status']:>12}  {o['id']}"
               + (f"  — {o['reason']}" if o.get("reason") else "")
               + (f"  — {o['error']}" if o.get("error") else ""))
+
+    # The line that answers "what happened last night". `fetch_rc`/`push_rc` are
+    # in it because a sync that failed leaves this host's leases invisible to the
+    # fleet — the #3772 failure mode, reachable again transiently (offline host,
+    # rejected push) and otherwise indistinguishable from a quiet night.
+    summary = log.summary(deferred + outcomes, apply=bool(args.apply),
+                          max_cards=args.max_cards, delay_s=args.delay,
+                          ready=len(items), fetch_rc=fetch.returncode,
+                          push_rc=push.returncode)
+    print(f"--- summary {summary['counts']} of {summary['total']} "
+          f"(fetch rc {fetch.returncode}, push rc {push.returncode}) "
+          f"-> {log.path} ---")
+
     # Nonzero only for a drain that actually failed. `no_command` is a standing
     # configuration gap across a 1300-card backlog; alarming on it every poll
     # would train the operator to ignore the exit code that reports a real break.

--- a/scripts/operations/dispatch_pull.py
+++ b/scripts/operations/dispatch_pull.py
@@ -157,6 +157,197 @@ def _dry_run_executor(item: dict) -> None:
           f"(provider={card.get('provider', '?')}, repo={card.get('repo', '?')})")
 
 
+# ── card -> command binding ──────────────────────────────────────────────────
+#
+# A card is an ISSUE, and an issue's work is generally not a shell one-liner.
+# The card carries `gh`, `repo`, `url`, `domain`, `provider`, `dispatch_status`,
+# `wip_eligible`, `routed_by` — and, deliberately, no title (#3768). There is no
+# field on it a payload could be read from.
+#
+# Three ways to supply one were available; this module takes the third.
+#
+#   1. A `command:` field ON the card. Rejected: `dispatch.py --write` rebuilds
+#      `.claude/dispatch/<machine>.yaml` wholesale from `route.py` proposals, so
+#      a hand-added field is destroyed by the next routing run. A binding that
+#      evaporates on a schedule is worse than none.
+#   2. A per-domain / per-provider default template. Rejected: `domain` is a
+#      routing axis, not a statement about what the work IS. `dev-primary` alone
+#      holds 1344 cards; one template per domain would fire the same command at
+#      hundreds of unrelated issues, and every one of them would produce a
+#      record. That is the false-completion failure this stack exists to close,
+#      automated.
+#   3. An explicit per-issue map, kept OUTSIDE the generated queue. Chosen. It
+#      survives regeneration, it is reviewable in a diff, and — the part that
+#      matters — writing an entry is a deliberate human act, which is where the
+#      plan-approval gate already lives. An issue nobody has bound is an issue
+#      nobody has authorised to run unattended.
+#
+# An unbound card is REFUSED and reported as `no_command`. It is never executed,
+# never marked done, and never silently absent from the report.
+
+#: Default location of the map, relative to the repo root. Not under
+#: `.claude/dispatch/<machine>.yaml`'s naming, so `dispatch.py`'s glob and the
+#: staleness sweep both leave it alone.
+COMMAND_MAP_REL = Path(".claude") / "dispatch" / "commands.yaml"
+
+#: Same shape drain.py validates (`ISSUE_RE`). Checked at LOAD time: a key that
+#: cannot match any card would otherwise be an entry that binds nothing, forever,
+#: with no signal — a typo indistinguishable from a deliberate omission.
+_BINDING_KEY_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$")
+
+#: The environment gate drain.py and reconcile.py already share. Declared here by
+#: NAME only: this module never sets it. `--apply` is the first gate, this is the
+#: second, and one flag must not be able to satisfy both.
+APPLY_FLAG = "DISPATCH_APPLY_ENABLED"
+
+#: Deferral statuses. Distinct values, not a shared "skipped": an operator
+#: reading a nightly log has to be able to tell "the router capped this" from
+#: "nobody has said what this card runs", because the two need different actions.
+NO_COMMAND = "no_command"
+WIP_CAPPED = "wip_capped"
+
+
+class UndefinedPayload(RuntimeError):
+    """No command is bound to this card. Raised instead of running anything."""
+
+
+class DrainFailed(RuntimeError):
+    """drain.py exited nonzero. Carries the child's code so it is not lost."""
+
+    def __init__(self, issue: str, returncode: int):
+        self.returncode = returncode
+        super().__init__(f"{issue}: drain.py exited {returncode}")
+
+
+def item_key(item: dict) -> str:
+    """The issue ref a card binds under — `owner/repo#N`."""
+    card = item.get("card") or {}
+    return str(card.get("gh") or item.get("id") or "")
+
+
+def load_command_bindings(path) -> dict[str, str]:
+    """Read the per-issue command map. Absent file -> no bindings (not an error).
+
+    A missing map means the fleet runs nothing, loudly — the correct posture for
+    a loop that would otherwise have to guess. What is NOT tolerated is a map
+    that looks like it binds something and does not: a malformed key or a
+    non-string command raises rather than being skipped, because both would read
+    as "configured" in review and behave as "unbound" at runtime.
+    """
+    path = Path(path)
+    if not path.exists():
+        return {}
+    import yaml
+    data = yaml.safe_load(path.read_text()) or {}
+    raw = data.get("commands") or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: 'commands' must be a mapping of issue -> command")
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        key = str(key)
+        if not _BINDING_KEY_RE.match(key):
+            raise ValueError(
+                f"{path}: binding key {key!r} is not owner/repo#N — it can never "
+                f"match a card, so it would bind nothing without saying so")
+        if not isinstance(value, str):
+            raise ValueError(
+                f"{path}: command for {key} must be a string, got "
+                f"{type(value).__name__}")
+        out[key] = value
+    return out
+
+
+def resolve_command(item: dict, bindings: dict) -> Optional[str]:
+    """The command bound to this card, or None. Blank is None.
+
+    An empty command is not an empty payload: `run.sh` would execute nothing and
+    exit 0, and the drain would record a clean completion for work that never
+    happened. Whitespace-only is the same defect with a space in it.
+    """
+    value = bindings.get(item_key(item))
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
+
+
+def partition_runnable(items: Iterable[dict], bindings: dict) -> tuple[list[dict], list[dict]]:
+    """Split cards into (runnable, deferred-with-a-reason) BEFORE any claim.
+
+    Deferring here rather than inside the executor keeps unrunnable cards from
+    touching the lease refs at all — a card that cannot run should not create,
+    renew, or contend for a lease that another host then has to wait out.
+
+    `wip_eligible` is checked first: the router's cap is about whether this card
+    may run NOW, which is decided regardless of what it would run. A MISSING flag
+    is treated as capped — an absent field is not permission (the same fail-closed
+    reading `dispatch.py` gives an absent `generated_at`).
+    """
+    runnable: list[dict] = []
+    deferred: list[dict] = []
+    for item in items:
+        card = item.get("card") or {}
+        if card.get("wip_eligible") is not True:
+            deferred.append({"id": item["id"], "status": WIP_CAPPED,
+                             "reason": "not wip_eligible — the router capped it"})
+            continue
+        if resolve_command(item, bindings) is None:
+            deferred.append({"id": item["id"], "status": NO_COMMAND,
+                             "reason": f"no command bound in {COMMAND_MAP_REL}"})
+            continue
+        runnable.append(item)
+    return runnable, deferred
+
+
+def make_drain_executor(*, repo, records_dir, machine: str, bindings: dict,
+                        apply: bool = False, run=None, drain_py=None,
+                        python: str | None = None) -> Callable[[dict], int]:
+    """Build the executor `claim_run` runs: one card -> one `drain.py` process.
+
+    Injected, not hardcoded — `claim_run` stays pure and this stays testable
+    without a subprocess. `run` defaults to `subprocess.run`.
+
+    drain.py is invoked rather than imported so its exit code is the interface:
+    0 only for a dry run or work that genuinely succeeded, 1 when the loop closed
+    but the work did not (`blocked` lands here, carrying `unknown-outcome`), 2
+    when the loop did not close. Anything nonzero raises, so `claim_run` records
+    `failed` and never calls `mark_done`.
+
+    The child's environment is INHERITED, never augmented: `--apply` is this
+    module's gate, `DISPATCH_APPLY_ENABLED` is drain's, and an executor that set
+    the second one would collapse two gates into one flag.
+    """
+    run = run or subprocess.run
+    repo = Path(repo)
+    records_dir = Path(records_dir)
+    drain_py = Path(drain_py) if drain_py else repo / "scripts" / "dispatch" / "drain.py"
+    python = python or sys.executable
+
+    def executor(item: dict) -> int:
+        issue = item_key(item)
+        command = resolve_command(item, bindings)
+        if command is None:
+            # Reached only when a caller wires this straight into `claim_run`
+            # without `partition_runnable`. It must still refuse: the guard that
+            # exists in one place is the guard that gets bypassed.
+            raise UndefinedPayload(
+                f"{issue}: no command bound in {COMMAND_MAP_REL} — refusing to "
+                f"invent a payload")
+        argv = [python, str(drain_py),
+                "--issue", issue,
+                "--records", str(records_dir),
+                "--repo-root", str(repo),
+                "--machine", machine,
+                "--command", command]
+        if apply:
+            argv.append("--apply")
+        done = run(argv, cwd=str(repo), check=False)
+        if done.returncode != 0:
+            raise DrainFailed(issue, done.returncode)
+        return done.returncode
+
+    return executor
+
+
 def main(argv=None) -> int:
     import time
 
@@ -165,8 +356,18 @@ def main(argv=None) -> int:
     ap.add_argument("--ttl", type=int, default=900, help="lease TTL seconds (default 900)")
     ap.add_argument("--apply", action="store_true",
                     help="run the real executor (default: dry-run, claims nothing destructive)")
+    ap.add_argument("--commands", default=None,
+                    help=f"per-issue command map (default: <repo>/{COMMAND_MAP_REL})")
     ap.add_argument("--repo", default=str(_REPO))
     args = ap.parse_args(argv)
+
+    # Two gates, checked before anything is fetched, read or claimed. Asking for
+    # writes is not being permitted them, and a refusal that happens after the
+    # lease refs move has already had an effect.
+    if args.apply and os.environ.get(APPLY_FLAG) != "1":
+        print(f"dispatch-pull: REFUSED — --apply needs {APPLY_FLAG}=1 as well. "
+              f"Nothing claimed.", file=sys.stderr)
+        return 2
 
     repo = Path(args.repo)
     registry = repo / "config" / "workstations" / "registry.yaml"
@@ -180,21 +381,34 @@ def main(argv=None) -> int:
     git_lease = _load("git_ref_lease", _HERE / "git_ref_lease.py").GitRefLease(repo)
     holder = f"{mid}:{os.getpid()}:{uuid.uuid4().hex[:8]}"  # unique (the #2991 fix)
 
+    bindings = load_command_bindings(Path(args.commands) if args.commands
+                                     else repo / COMMAND_MAP_REL)
+
     _fetch_lease_refs(repo)
     items = _read_ready_cards(dispatch_file)
-    print(f"--- dispatch-pull {mid}: {len(items)} ready item(s) "
-          f"[{'apply' if args.apply else 'dry-run'}] ---")
+    runnable, deferred = partition_runnable(items, bindings)
+    print(f"--- dispatch-pull {mid}: {len(items)} ready, {len(runnable)} runnable, "
+          f"{len(deferred)} deferred [{'apply' if args.apply else 'dry-run'}] ---")
 
-    executor = _dry_run_executor  # --apply wires a real executor in the integration follow-up
+    executor = make_drain_executor(repo=repo, records_dir=repo / ".claude" / "dispatch" / "records",
+                                   machine=mid, bindings=bindings, apply=args.apply)
     outcomes = claim_run(
-        items, holder=holder, git=git_lease, executor=executor,
+        runnable, holder=holder, git=git_lease, executor=executor,
         ttl_s=args.ttl, now_fn=time.time, token_fn=lambda: uuid.uuid4().hex,
     )
     _push_lease_refs(repo)
 
-    for o in outcomes:
-        print(f"  {o['status']:>12}  {o['id']}")
-    return 0
+    # Deferrals are printed with the runs, not summarised away: a card nobody has
+    # bound must be as visible as one that ran, or the queue silently stalls at
+    # full length while the log looks clean.
+    for o in deferred + outcomes:
+        print(f"  {o['status']:>12}  {o['id']}"
+              + (f"  — {o['reason']}" if o.get("reason") else "")
+              + (f"  — {o['error']}" if o.get("error") else ""))
+    # Nonzero only for a drain that actually failed. `no_command` is a standing
+    # configuration gap across a 1300-card backlog; alarming on it every poll
+    # would train the operator to ignore the exit code that reports a real break.
+    return 1 if any(o["status"] == "failed" for o in outcomes) else 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/operations/git_ref_lease.py
+++ b/scripts/operations/git_ref_lease.py
@@ -16,20 +16,40 @@ lease JSON is stored as the MESSAGE of a commit over the empty tree, and the ref
 points at that commit — because `refs/heads/*` must point to commits (git rejects a
 bare blob there) and GitHub only accepts pushes to `refs/heads/*`.
 
-LOCAL refs (default) arbitrate processes on one host. For CROSS-MACHINE arbitration
-the same semantics map to `git push --force-with-lease=<ref>:<old-sha>` (CAS) and a
-non-forced push (create); the remote binding is wired at the operator-cutover step.
-This module is the local/single-repo adapter, fully testable with real git.
+LOCAL refs arbitrate processes on one host. CROSS-MACHINE arbitration is the same
+refs moved by `dispatch_pull._fetch_lease_refs` / `_push_lease_refs`; a lease that
+never leaves the host arbitrates nothing, because every host then CASes against
+refs only it can see and wins every claim (#3772).
+
+The lease NAMESPACE is owned by `dispatch_lease.REF_PREFIX` and imported here
+rather than restated. It used to be a second string literal that happened to
+agree — and a third, in the pull loop's refspecs, that did not.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 from pathlib import Path
 
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+#: Single source of truth for the lease namespace (scripts/ is not a package, so
+#: the sibling core is loaded by path — same shape as dispatch_pull does it).
+_dl = _load("dispatch_lease", _HERE / "dispatch_lease.py")
+REF_PREFIX = _dl.REF_PREFIX
+
 
 def lease_ref(name: str) -> str:
-    return f"refs/heads/dispatch/leases/{name}"
+    return _dl.lease_ref(name)
 
 
 class GitRefLease:

--- a/scripts/testing/coverage-reports/WRK-1067-coverage-20260801.txt
+++ b/scripts/testing/coverage-reports/WRK-1067-coverage-20260801.txt
@@ -1,8 +1,8 @@
-coverage-ratchet report — 2026-08-01T08:02:03Z
+coverage-ratchet report — 2026-08-02T04:34:43Z
 ============================================================
+  PASS    assethold  actual=76.9%  floor=74.9%  baseline=76.9%
   PASS    assetutilities  actual=41.2%  floor=39.2%  baseline=41.2%
-  FAIL    no coverage result for 'assethold'
+  PASS    worldenergydata  actual=40.4%  floor=38.4%  baseline=40.4%
   FAIL    no coverage result for 'digitalmodel'
-  FAIL    no coverage result for 'worldenergydata'
 
-Result: 1 PASS, 3 FAIL
+Result: 3 PASS, 1 FAIL

--- a/scripts/testing/coverage-results.json
+++ b/scripts/testing/coverage-results.json
@@ -1,3 +1,5 @@
 {
-  "assetutilities": 41.17
+  "assetutilities": 41.17,
+  "worldenergydata": 40.42,
+  "assethold": 76.86
 }

--- a/tests/dispatch/test_chain_ran_is_not_succeeded.py
+++ b/tests/dispatch/test_chain_ran_is_not_succeeded.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""`ran` is not `succeeded`: the chain report must be able to tell them apart.
+
+workspace-hub#3773 rail R5, reporting half.
+
+## The defect
+
+`records.py` separates two things on purpose:
+
+    state: done      the payload RAN TO COMPLETION — not that it worked
+    is_success       done AND returncode == 0 — whether it actually worked
+
+`chain.py` never called `is_success`. A card that failed three times lands as
+`done`, projects `dispatch:done`, and is counted in the `executed` stage. So:
+
+    a night that fails every card produces a report identical to a night that
+    completes every card.
+
+That is the whole finding. It is about to run unattended over 1344 cards, and
+`chain.py` is what a human reads in the morning.
+
+## What these tests pin
+
+Properties, never rendered strings. Each one fails when a card that did not
+succeed is reported as if it did — not when the wording of the report changes.
+
+The fix must hold the standard the rest of `chain.py` holds:
+
+  * an ABSENCE must never read as a success — `--records` not given yields
+    NOT-MEASURED counts, never `failed: 0`;
+  * a COUNT must never stand in for evidence — every card needing attention is
+    named, with its returncode, failure_category and attempt number;
+  * silence stays evidence-backed — "we read 40 records and none failed" is a
+    different report from "there are no records" is a different report from "we
+    never looked".
+
+Hermetic: record dicts in `tmp_path`. No gh, no network. `chain.py` is
+read-only and takes a records directory, so nothing here needs a fixture the
+real writer would not produce — and the pinning test below uses the real writer.
+
+Run: uv run --with pyyaml --with pytest pytest tests/dispatch/ -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401  (tmp_path fixture; parity with the suite)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAIN_PY = REPO_ROOT / "scripts" / "dispatch" / "chain.py"
+RECORDS_PY = REPO_ROOT / "scripts" / "dispatch" / "records.py"
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+C = _load("chain", CHAIN_PY)
+R = _load("chain_test_records_r5", RECORDS_PY)
+
+FULL_VOCAB = {"machine:dev-primary", "dispatch:ready", "dispatch:active", "dispatch:done"}
+
+
+# --------------------------------------------------------------------------
+# fixtures — plain record dicts, the shape records.py writes
+# --------------------------------------------------------------------------
+
+
+def _rec(issue, state, returncode=None, **kw):
+    base = {"schema": 1, "issue": issue, "state": state, "returncode": returncode,
+            "failure_category": None, "attempt": 1, "max_attempts": 3,
+            "host": "ace-linux-1"}
+    base.update(kw)
+    return base
+
+
+def _ok(issue="o/r#1"):
+    return _rec(issue, "done", 0)
+
+
+def _failed(issue="o/r#2", rc=3):
+    return _rec(issue, "done", rc, failure_category="payload-error")
+
+
+def _unattested(issue="o/r#3"):
+    """`done` with no exit code. drain.py promises never to write this shape.
+
+    Which is exactly why the reporter must handle it: the guarantee lives in
+    another module, and a reporter that trusts it cannot detect its breach. A
+    `done` that attests nothing is a measurement defect, not a success and not a
+    clean failure.
+    """
+    return _rec(issue, "done", None)
+
+
+def _quarantined(issue="o/r#4"):
+    return _rec(issue, "blocked", None, failure_category="quarantine",
+                attempt=3, max_attempts=3)
+
+
+def _in_flight(issue="o/r#5"):
+    return _rec(issue, "active", None)
+
+
+def _write(root, records):
+    root.mkdir(parents=True, exist_ok=True)
+    for i, rec in enumerate(records):
+        (root / f"rec-{i}.json").write_text(json.dumps(rec), encoding="utf-8")
+    return root
+
+
+# --------------------------------------------------------------------------
+# THE HEADLINE
+# --------------------------------------------------------------------------
+
+
+def test_a_night_that_failed_every_card_does_not_report_like_one_that_worked():
+    """The defect, stated as a test.
+
+    Two nights, same 4 cards, same labels, same stages, same everything — the
+    only difference is the exit code the payload returned. If the two reports
+    compare equal, the morning read cannot distinguish total success from total
+    failure, which is the entire finding.
+    """
+    worked = [_ok(f"o/r#{n}") for n in range(4)]
+    failed = [_failed(f"o/r#{n}") for n in range(4)]
+
+    good = C.outcome_report(worked)
+    bad = C.outcome_report(failed)
+
+    assert good != bad, "a failing night and a working night print the same report"
+    assert not good["attention"], "nothing to investigate when every card exited 0"
+    assert len(bad["attention"]) == 4, "every failed card must be named"
+    assert bad["counts"][C.OUTCOME_SUCCEEDED] == 0
+
+
+def test_the_stage_counts_alone_cannot_tell_the_two_nights_apart():
+    """Why the outcome axis had to be added rather than folded into a stage.
+
+    A failed-but-done card DID execute, so it belongs in `executed`. This test
+    pins that the stage histogram is deliberately blind to success — which is
+    what makes reporting the outcome separately load-bearing rather than
+    decorative. If this ever starts failing, the outcome has leaked into the
+    stage count and one number is answering two questions again.
+    """
+    executed = [{"labels": ["machine:dev-primary", "dispatch:done"]}] * 4
+    stages = C.chain_report(executed, FULL_VOCAB, {"done"})["stages"]
+    assert stages["executed"]["count"] == 4
+    assert C.outcome_report([_failed(f"o/r#{n}") for n in range(4)])["attention"]
+
+
+def test_success_is_delegated_to_records_is_success_not_reimplemented():
+    """Equivalence with the authority, over the whole matrix that matters.
+
+    A second definition of "worked" is how the two drift: `records.is_success`
+    could gain a condition and this file would keep answering the old question.
+    Asserted as agreement on every record, not as the presence of a call.
+    """
+    matrix = [
+        _ok(), _failed(), _failed(rc=1), _failed(rc=137), _unattested(),
+        _quarantined(), _in_flight(), _rec("o/r#9", "ready"),
+        _rec("o/r#10", "blocked", 0),      # exited 0 then got quarantined
+        _rec("o/r#11", "active", 0),       # a 0 from a run that is not finished
+    ]
+    for rec in matrix:
+        agrees = C.outcome_of(rec) == C.OUTCOME_SUCCEEDED
+        assert agrees is R.is_success(rec), rec
+
+
+# --------------------------------------------------------------------------
+# the buckets, and the three-way distinction inside "not a success"
+# --------------------------------------------------------------------------
+
+
+def test_done_with_a_nonzero_returncode_is_a_failure_not_a_completion():
+    assert C.outcome_of(_failed()) == C.OUTCOME_FAILED
+
+
+def test_done_with_no_returncode_is_unattested_and_is_neither_of_the_others():
+    """The absence case. It is NOT a success, and it is NOT a clean failure.
+
+    Reporting it as either invents a fact: nobody observed an exit code, so
+    nobody knows. Folding it into `failed` would accuse a card that may have
+    worked; folding it into `succeeded` is the defect this rail exists for.
+    """
+    got = C.outcome_of(_unattested())
+    assert got == C.OUTCOME_UNATTESTED
+    assert got != C.OUTCOME_SUCCEEDED
+    assert got != C.OUTCOME_FAILED
+
+
+def test_a_blocked_record_is_terminal_quarantine_not_work_still_in_flight():
+    """`blocked` will never be retried. Reading it as in-flight hides a dead card.
+
+    Attempt-exhaustion writing a real `blocked` record is landing separately;
+    this asserts the reporter is already correct for the day it does, and today
+    stays honest because nothing has written one yet.
+    """
+    assert C.outcome_of(_quarantined()) == C.OUTCOME_QUARANTINED
+    assert C.OUTCOME_QUARANTINED in C.OUTCOMES_NEEDING_ATTENTION
+
+
+def test_ready_and_active_records_have_no_outcome_yet():
+    for rec in (_in_flight(), _rec("o/r#9", "ready")):
+        assert C.outcome_of(rec) == C.OUTCOME_IN_FLIGHT
+    assert C.OUTCOME_IN_FLIGHT not in C.OUTCOMES_NEEDING_ATTENTION
+
+
+def test_a_state_the_reporter_does_not_recognise_is_never_silently_dropped():
+    """A record that lands in no bucket is invisible, and invisible reads as fine.
+
+    Same failure as an unchecked absence: the histogram would still sum to a
+    tidy-looking number while a record nobody classified sat outside it.
+    """
+    rep = C.outcome_report([_ok(), _rec("o/r#77", "wat")])
+    assert rep["records_read"] == 2
+    assert sum(rep["counts"].values()) == 2
+    assert C.outcome_of(_rec("o/r#77", "wat")) in C.OUTCOMES_NEEDING_ATTENTION
+
+
+def test_every_record_lands_in_exactly_one_bucket():
+    """A histogram that does not sum to the population is silently lossy."""
+    population = [_ok(), _failed(), _unattested(), _quarantined(), _in_flight(),
+                  _rec("o/r#9", "ready"), _rec("o/r#77", "wat")]
+    rep = C.outcome_report(population)
+    assert rep["records_read"] == len(population)
+    assert sum(rep["counts"].values()) == len(population)
+
+
+def test_the_attention_bucket_is_exactly_the_records_that_did_not_succeed():
+    population = [_ok("o/r#1"), _failed("o/r#2"), _unattested("o/r#3"),
+                  _quarantined("o/r#4"), _in_flight("o/r#5")]
+    rep = C.outcome_report(population)
+    assert {a["issue"] for a in rep["attention"]} == {"o/r#2", "o/r#3", "o/r#4"}
+    assert len(rep["attention"]) == sum(
+        rep["counts"][o] for o in C.OUTCOMES_NEEDING_ATTENTION)
+
+
+# --------------------------------------------------------------------------
+# a count must not stand in for evidence
+# --------------------------------------------------------------------------
+
+
+def test_each_flagged_card_carries_its_own_evidence_not_just_a_tally():
+    """"4 failed" sends nobody anywhere. The returncode and category do.
+
+    `attempt`/`max_attempts` is on it because "failed once of three" and "failed
+    the last time it will ever be tried" are different mornings.
+    """
+    rep = C.outcome_report([_failed("o/r#2", rc=137), _quarantined("o/r#4")])
+    by_issue = {a["issue"]: a for a in rep["attention"]}
+
+    assert by_issue["o/r#2"]["returncode"] == 137
+    assert by_issue["o/r#2"]["failure_category"] == "payload-error"
+    assert by_issue["o/r#2"]["attempt"] == 1
+    assert by_issue["o/r#2"]["max_attempts"] == 3
+    assert by_issue["o/r#2"]["outcome"] == C.OUTCOME_FAILED
+
+    assert by_issue["o/r#4"]["outcome"] == C.OUTCOME_QUARANTINED
+    assert by_issue["o/r#4"]["attempt"] == 3
+
+
+def test_a_flagged_card_with_no_issue_field_is_still_reported():
+    """A malformed record must not be able to delete itself from the report.
+
+    Dropping it would be an absence produced by the very corruption the entry
+    is evidence of.
+    """
+    rep = C.outcome_report([{"schema": 1, "state": "done", "returncode": 3}])
+    assert len(rep["attention"]) == 1
+    assert rep["attention"][0]["issue"] is not None
+
+
+# --------------------------------------------------------------------------
+# an absence must never read as a success
+# --------------------------------------------------------------------------
+
+
+def test_records_not_consulted_reports_NOT_MEASURED_never_zero_failures():  # noqa: N802
+    """The `result`/`published` discipline, applied to the new axis.
+
+    `failed: 0` from a run that never looked at a record is the same lie as
+    `published: 0` from an unbuilt join — and it is the more dangerous of the
+    two, because zero failures is the answer everyone wants to see.
+    """
+    rep = C.outcome_report(None)
+    assert rep["consulted"] is False
+    assert rep["vocabulary"] == C.VOCAB_NOT_MEASURED
+    assert rep["evidence"] == C.EV_NO_RECORDS
+    assert rep["counts"] is None, "an unmeasured count must be absent, not 0"
+    assert rep["attention"] is None
+    assert rep["records_read"] is None
+
+
+def test_we_looked_and_found_nothing_differs_from_we_never_looked():
+    """Preserved from the stage half, on the outcome axis.
+
+    An empty records root — a typo in `--records` produces one — must not print
+    like a clean night. Both have zero failures; only one of them checked.
+    """
+    never_looked = C.outcome_report(None)
+    looked = C.outcome_report([])
+
+    assert looked["consulted"] is True
+    assert looked["records_read"] == 0
+    assert looked["evidence"] == C.EV_RECORDS_CONSULTED
+    assert looked["vocabulary"] == C.VOCAB_NEVER_OBSERVED, \
+        "no records at all is not a chain that has been exercised"
+    assert never_looked["vocabulary"] != looked["vocabulary"]
+
+
+def test_records_consulted_and_all_of_them_worked_is_its_own_verdict():
+    """The one report that is allowed to read as good — and only with evidence."""
+    rep = C.outcome_report([_ok("o/r#1"), _ok("o/r#2")])
+    assert rep["vocabulary"] == C.VOCAB_PRESENT
+    assert rep["evidence"] == C.EV_RECORDS_CONSULTED
+    assert rep["records_read"] == 2
+    assert rep["attention"] == []
+    assert rep["counts"][C.OUTCOME_SUCCEEDED] == 2
+
+
+def test_zero_successes_out_of_zero_records_is_not_a_clean_sheet():
+    """`succeeded: 0` and `failed: 0` together must not print as a good night."""
+    empty = C.outcome_report([])
+    good = C.outcome_report([_ok()])
+    assert empty["counts"][C.OUTCOME_SUCCEEDED] == 0
+    assert empty["vocabulary"] != good["vocabulary"]
+
+
+# --------------------------------------------------------------------------
+# the vocabulary itself
+# --------------------------------------------------------------------------
+
+
+def test_no_outcome_is_spellable_as_a_synonym_of_success():
+    """Collapsing two of these is the cheapest mutation that restores the defect."""
+    names = [C.OUTCOME_SUCCEEDED, C.OUTCOME_FAILED, C.OUTCOME_UNATTESTED,
+             C.OUTCOME_QUARANTINED, C.OUTCOME_IN_FLIGHT, C.OUTCOME_UNRECOGNISED]
+    assert len(set(names)) == len(names)
+    assert C.OUTCOME_SUCCEEDED not in C.OUTCOMES_NEEDING_ATTENTION
+    assert set(C.OUTCOMES_NEEDING_ATTENTION) < set(names)
+
+
+def test_in_flight_is_not_filed_as_a_failure():
+    """A card still running is not a card that failed. Crying one trains the
+    reader to ignore both — the same reason NEVER-OBSERVED is not a BREAK."""
+    rep = C.outcome_report([_in_flight()])
+    assert rep["attention"] == []
+    assert rep["counts"][C.OUTCOME_IN_FLIGHT] == 1
+
+
+# --------------------------------------------------------------------------
+# reading the records root — READ-ONLY, and one bad file is not fatal
+# --------------------------------------------------------------------------
+
+
+def test_read_records_returns_the_records_under_a_root(tmp_path):
+    root = _write(tmp_path / "records", [_ok("o/r#1"), _failed("o/r#2")])
+    got = C.read_records(root)
+    assert {r["issue"] for r in got} == {"o/r#1", "o/r#2"}
+
+
+def test_a_missing_records_root_is_empty_and_is_NOT_created(tmp_path):  # noqa: N802
+    """Read-only means the reporter does not materialise what it measures."""
+    absent = tmp_path / "nope"
+    assert C.read_records(absent) == []
+    assert not absent.exists()
+
+
+def test_one_unreadable_record_does_not_strand_the_outcome_report(tmp_path):
+    """Same line reconcile.py takes: fail closed on the file, not on the pass."""
+    root = _write(tmp_path / "records", [_ok("o/r#1"), _failed("o/r#2")])
+    (root / "bad.json").write_text("{not json", encoding="utf-8")
+    rep = C.outcome_report(C.read_records(root))
+    assert rep["records_read"] == 2
+    assert len(rep["attention"]) == 1
+
+
+def test_observed_states_still_answers_the_stage_question_unchanged(tmp_path):
+    """The outcome axis must not disturb the stage axis it sits beside."""
+    root = _write(tmp_path / "records", [_ok("o/r#1"), _quarantined("o/r#4")])
+    assert C.observed_states(root) == {"done", "blocked"}
+
+
+# --------------------------------------------------------------------------
+# pinned to the real writer, not to hand-rolled dicts
+# --------------------------------------------------------------------------
+
+
+def test_records_written_by_records_py_are_classified_correctly(tmp_path):
+    """A field rename in records.py that stopped attesting outcomes would make
+    every night read as unattested forever — an alarm that cries wolf is
+    disabled within a week. So the fixture is the real writer.
+    """
+    root = tmp_path / "records"
+
+    won = R.transition(R.new_claim("o/r#1", machine="m", host="h", job_id="j"),
+                       "done", reason="ran to completion, exit 0", returncode=0)
+    lost = R.transition(R.new_claim("o/r#2", machine="m", host="h", job_id="j"),
+                        "done", reason="payload exited 3", returncode=3,
+                        failure_category="payload-error")
+    stuck = R.transition(R.new_claim("o/r#3", machine="m", host="h", job_id="j"),
+                         "blocked", reason="attempts exhausted",
+                         failure_category="quarantine")
+    for rec in (won, lost, stuck):
+        R.write_record(root, rec)
+
+    rep = C.outcome_report(C.read_records(root))
+    assert rep["counts"][C.OUTCOME_SUCCEEDED] == 1
+    assert rep["counts"][C.OUTCOME_FAILED] == 1
+    assert rep["counts"][C.OUTCOME_QUARANTINED] == 1
+    assert {a["issue"] for a in rep["attention"]} == {"o/r#2", "o/r#3"}
+
+
+def test_drains_unknown_outcome_shape_is_not_read_as_a_success(tmp_path):
+    """drain.py writes `blocked` + `unknown-outcome` + `returncode: null` for a
+    run whose exit code it could not learn — "never a 0 nobody observed". The
+    reporter must agree that this is not a success.
+    """
+    rec = R.transition(R.new_claim("o/r#1", machine="m", host="h", job_id="j"),
+                       "blocked", reason="outcome could not be determined",
+                       failure_category="unknown-outcome")
+    assert C.outcome_of(rec) != C.OUTCOME_SUCCEEDED
+    assert C.outcome_report([rec])["attention"]
+
+
+# --------------------------------------------------------------------------
+# the exit code — what the unattended loop reads
+# --------------------------------------------------------------------------
+
+
+def _clean_reports():
+    return {"r": C.chain_report([{"labels": ["machine:dev-primary"]}], FULL_VOCAB,
+                                {"ready", "active", "done"})}
+
+
+def test_a_night_with_a_failed_card_does_not_exit_zero():
+    """1344 cards run unattended; something automated reads this exit code.
+
+    A total-failure night that exits 0 is the defect in its most expensive
+    form — nobody even gets as far as reading the report.
+    """
+    failed = C.outcome_report([_ok(), _failed()])
+    assert C.exit_code(_clean_reports(), outcomes=failed) == 1
+
+
+def test_quarantined_and_unattested_cards_also_fail_the_run():
+    for rep in (C.outcome_report([_quarantined()]), C.outcome_report([_unattested()])):
+        assert C.exit_code(_clean_reports(), outcomes=rep) == 1
+
+
+def test_a_night_where_everything_worked_exits_zero():
+    ok = C.outcome_report([_ok("o/r#1"), _ok("o/r#2")])
+    assert C.exit_code(_clean_reports(), outcomes=ok) == 0
+
+
+def test_work_still_in_flight_does_not_fail_the_run():
+    """Mid-run is not failure. Only a decided bad outcome is."""
+    flight = C.outcome_report([_in_flight(), _rec("o/r#9", "ready")])
+    assert C.exit_code(_clean_reports(), outcomes=flight) == 0
+
+
+def test_not_consulting_records_does_not_invent_a_failure_either():
+    """Absence proves nothing in BOTH directions — it is not a pass and not a
+    fail. The report says NOT-MEASURED in the text; the exit code stays 0 so
+    the default invocation keeps its meaning."""
+    assert C.exit_code(_clean_reports(), outcomes=C.outcome_report(None)) == 0
+    assert C.exit_code(_clean_reports()) == 0
+
+
+def test_the_existing_break_and_strict_semantics_are_untouched():
+    broken = {"r": C.chain_report([{"labels": ["machine:dev-primary", "dispatch:ready"]}],
+                                  {"machine:dev-primary", "dispatch:ready"}, set())}
+    unproven = {"r": C.chain_report([], FULL_VOCAB, observed=set())}
+    ok = C.outcome_report([_ok()])
+
+    assert C.exit_code(broken, outcomes=ok) == 1, "a BREAK still fails on its own"
+    assert C.exit_code(unproven) == 0
+    assert C.exit_code(unproven, strict=True) == 1
+    assert C.exit_code(unproven, strict=True, outcomes=ok) == 1
+
+
+# --------------------------------------------------------------------------
+# what the human actually reads at 8am
+# --------------------------------------------------------------------------
+
+
+def test_the_rendered_block_distinguishes_the_two_nights():
+    """The property the report exists for, at the surface a human meets.
+
+    Not a check on wording — a check that the wording cannot be the same.
+    """
+    worked = C.format_outcomes(C.outcome_report([_ok(f"o/r#{n}") for n in range(4)]))
+    failed = C.format_outcomes(C.outcome_report([_failed(f"o/r#{n}") for n in range(4)]))
+    unmeasured = C.format_outcomes(C.outcome_report(None))
+
+    assert worked != failed
+    assert unmeasured != worked
+    assert unmeasured != failed
+
+
+def test_every_flagged_card_is_named_in_the_rendered_block():
+    """The evidence has to reach the page, not just the JSON.
+
+    A summary line saying "12 failed" with the identities only in `--json` is a
+    count standing in for evidence at the exact moment someone needs to act.
+    """
+    rep = C.outcome_report([_failed("o/r#2"), _quarantined("o/r#4"),
+                            _unattested("o/r#3"), _ok("o/r#1")])
+    text = "\n".join(C.format_outcomes(rep))
+    for issue in ("o/r#2", "o/r#3", "o/r#4"):
+        assert issue in text, issue
+
+
+def test_a_long_failure_list_is_capped_on_screen_but_never_in_the_data():
+    """1344 cards can fail. The morning read must stay readable; the record of
+    what failed must stay complete, and the block must say it was truncated."""
+    rep = C.outcome_report([_failed(f"o/r#{n}") for n in range(200)])
+    assert len(rep["attention"]) == 200
+    lines = C.format_outcomes(rep)
+    assert len(lines) < 60, "the whole 200 cannot land on the morning screen"
+    assert any("200" in line for line in lines), "the true total must still be stated"
+
+
+def test_the_unmeasured_block_states_the_conflation_it_is_covering_for():
+    """A reader who never passes `--records` must be told what they cannot see —
+    otherwise the missing section is itself an absence reading as success."""
+    lines = C.format_outcomes(C.outcome_report(None))
+    assert lines, "not-measured must still print something"
+    assert any("--records" in line for line in lines)
+
+
+def test_format_outcomes_never_prints_a_count_it_did_not_measure():
+    """No digits at all in the unmeasured block: a stray `0` beside a bucket
+    name is precisely the reading this rail exists to prevent.
+
+    Colour codes are digits too, and are not counts — stripped before the check
+    so this asserts the report's content, not its escape sequences.
+    """
+    text = re.sub(r"\033\[[0-9;]*m", "",
+                  "\n".join(C.format_outcomes(C.outcome_report(None))))
+    assert not any(ch.isdigit() for ch in text), text
+
+
+# --------------------------------------------------------------------------
+# guards on the guard
+# --------------------------------------------------------------------------
+
+
+def test_the_outcome_reader_reaches_no_write_primitive():
+    """READ-ONLY is a property of the file, and the new half must not weaken it."""
+    src = CHAIN_PY.read_text(encoding="utf-8")
+    for primitive in ("write_text", ".mkdir(", "os.remove", "os.rename", "shutil",
+                      ".unlink(", "rmtree", "open("):
+        assert primitive not in src, f"chain.py reaches {primitive!r}"
+
+
+def test_outcome_report_does_not_mutate_the_records_it_is_given():
+    """A reporter that edits its evidence has changed the answer."""
+    population = [_ok(), _failed(), _quarantined()]
+    before = json.dumps(population, sort_keys=True)
+    C.outcome_report(population)
+    assert json.dumps(population, sort_keys=True) == before

--- a/tests/dispatch/test_claim_rejected_push_undo.py
+++ b/tests/dispatch/test_claim_rejected_push_undo.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""A refused claim must leave nothing behind, and must say what actually happened.
+
+workspace-hub#3764. Reproduced live on the first real drain against
+`vamseeachanta/deckhand#33`:
+
+    claim-refused: push rejected ... — another host claimed it first
+
+...and then, checking by content rather than by exit code, the claim commit that
+refusal was supposed to abandon was on `origin/main`, published by this repo's
+auto-sync process, holding the issue `active` for a 90-minute TTL with nothing
+running. **Exclusion without execution.**
+
+Two defects, tested separately here because they fail independently:
+
+**D1 — the refusal left publishable state.** `acquire` writes the record, commits
+it, pushes, and on a rejected push refuses. The *file* argument in its docstring
+("a refused claim that still wrote a file would be indistinguishable, to the next
+reader, from a live one") is right and stops one leak; the commit is the other,
+and nothing undid it. Any process that pushes this branch — an auto-sync timer, a
+parallel dispatch lane, a human `git push` — publishes the refused claim.
+
+**D2 — the diagnosis named a culprit that did not exist.** No other host was
+involved: the push lost a race to a sync process on the *same* host. "Another
+host claimed it first" sends an operator hunting a claimant who is not there, and
+it hides the fact that this rejection is *retryable* — nobody holds the item.
+
+The undo is the dangerous half. This repo runs concurrent dispatch lanes and an
+auto-sync process in ONE shared checkout, so an undo that reaches beyond the
+claim commit destroys somebody else's work. The `GitBackend` tests below run
+against a real temporary repository precisely because that is a property of the
+git mechanics, not of the protocol, and a fake cannot falsify it.
+
+Hermetic: the protocol tests inject git; the backend tests use a local
+`git init` with no remote. No network either way.
+
+Run: uv run --with pyyaml --with pytest pytest tests/dispatch/ -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLAIM_PY = REPO_ROOT / "scripts" / "dispatch" / "claim.py"
+
+
+def _load():
+    pkg = str(CLAIM_PY.parent)
+    if pkg not in sys.path:
+        sys.path.insert(0, pkg)
+    spec = importlib.util.spec_from_file_location("dispatch_claim_undo", CLAIM_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dispatch_claim_undo"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+C = _load()
+
+ISSUE = "vamseeachanta/deckhand#33"
+OURS = "ace-linux-1"
+OTHER = "ace-win-1"
+
+
+def _ours(**kw):
+    base = {"schema": 1, "issue": ISSUE, "state": "active",
+            "host": OURS, "job_id": "j1", "attempt": 1}
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------
+# doubles
+# --------------------------------------------------------------------------
+
+
+class FakeGit:
+    """Injected git surface whose push is rejected, as in the live incident.
+
+    `undo` is what the backend reports back about the undo it was asked to do.
+    A backend that says it dropped the commit is also expected to have taken the
+    working-tree file with it — that is what the real one does, and a double that
+    lies about it would let a leak through the protocol tests.
+    """
+
+    def __init__(self, *, push_ok=False, remote_record=None, undo=None):
+        self.push_ok = push_ok
+        self.remote_record = remote_record
+        self.undo_result = C.UNDO_DROPPED if undo is None else undo
+        self.calls: list[str] = []
+        self.undone: list[tuple[Path, dict]] = []
+
+    def commit(self, path, message):
+        self.calls.append("commit")
+        return True
+
+    def push(self):
+        self.calls.append("push")
+        return self.push_ok
+
+    def pull(self):
+        self.calls.append("pull")
+        return True
+
+    def read_remote(self, issue):
+        self.calls.append("read_remote")
+        return self.remote_record
+
+    def undo_commit(self, path, record):
+        self.calls.append("undo_commit")
+        self.undone.append((Path(path), dict(record)))
+        if self.undo_result in (C.UNDO_DROPPED, C.UNDO_REVERTED):
+            Path(path).unlink(missing_ok=True)
+        return self.undo_result
+
+
+class OldGit:
+    """A backend from before this fix: no undo surface at all.
+
+    Kept because `drain.py`'s test doubles are exactly this shape. A missing
+    capability must be REPORTED, never quietly treated as "nothing to undo".
+    """
+
+    def __init__(self, *, remote_record=None):
+        self.remote_record = remote_record
+        self.calls: list[str] = []
+
+    def commit(self, path, message):
+        self.calls.append("commit")
+        return True
+
+    def push(self):
+        self.calls.append("push")
+        return False
+
+    def pull(self):
+        self.calls.append("pull")
+        return True
+
+    def read_remote(self, issue):
+        self.calls.append("read_remote")
+        return self.remote_record
+
+
+# --------------------------------------------------------------------------
+# D1 — a rejected push leaves nothing publishable
+# --------------------------------------------------------------------------
+
+
+def test_a_rejected_push_undoes_the_claim_commit(tmp_path):
+    """The defect, stated positively: the commit must not survive the refusal."""
+    git = FakeGit()
+    got = C.acquire(tmp_path, _ours(), git=git)
+
+    assert got.ok is False
+    assert git.undone, "a rejected push must ask the git surface to undo the claim commit"
+    assert got.undo == C.UNDO_DROPPED
+
+
+def test_the_undo_names_the_claim_we_wrote(tmp_path):
+    """It must undo OUR commit, identified by the record, not "the last commit".
+
+    Concurrent lanes commit into the same checkout; "the tip" and "our claim" are
+    not the same object, and only the record can tell them apart.
+    """
+    rec = _ours()
+    git = FakeGit()
+    C.acquire(tmp_path, rec, git=git)
+
+    path, handed = git.undone[0]
+    assert path.name.endswith(".json")
+    assert (handed["host"], handed["job_id"]) == (rec["host"], rec["job_id"])
+
+
+def test_the_undo_happens_before_the_pull(tmp_path):
+    """Order matters: `pull --rebase` replays a commit that is still there.
+
+    Pulling first re-parents the orphaned claim onto the new remote tip, leaving
+    it just as publishable as before and adding a conflict to resolve.
+    """
+    git = FakeGit()
+    C.acquire(tmp_path, _ours(), git=git)
+
+    assert git.calls.index("undo_commit") < git.calls.index("pull")
+
+
+def test_no_rejection_path_leaves_a_local_claim_record(tmp_path):
+    """Whatever the remote says, the refused claim must not remain on disk.
+
+    A record left behind reads as live to the next drain, and blocks the retry
+    that a lost push race is supposed to get.
+    """
+    for remote in (None, _ours(), _ours(host=OTHER, job_id="theirs")):
+        git = FakeGit(remote_record=remote)
+        C.acquire(tmp_path, _ours(), git=git)
+        assert not any(tmp_path.glob("*.json")), \
+            f"a refused claim left a record behind (remote={remote})"
+
+    # ...and especially when the commit could NOT be taken back: a record left
+    # next to a surviving commit is the stranded claim, twice over.
+    for git in (FakeGit(undo=C.UNDO_FAILED), OldGit()):
+        C.acquire(tmp_path, _ours(), git=git)
+        assert not any(tmp_path.glob("*.json")), \
+            f"an un-undone claim left a record behind ({type(git).__name__})"
+
+
+@pytest.mark.parametrize("make_git, expected", [
+    (lambda: OldGit(remote_record=_ours()), C.UNDO_UNAVAILABLE),
+    (lambda: FakeGit(undo=C.UNDO_FAILED, remote_record=_ours()), C.UNDO_FAILED),
+])
+def test_a_claim_commit_that_survived_is_reported_not_assumed_gone(tmp_path, make_git,
+                                                                   expected):
+    """Absence of an undo must not read as a successful one.
+
+    This is the failure mode the whole epic keeps meeting — no signal taken for
+    a good signal — so a commit that outlived its refusal has to surface.
+
+    The control run is the point of the test. Asserting only "there is a
+    warning" passes on ANY warning from anywhere in the refusal path, which is a
+    test of the weather; pinning the same scenario with a working undo to zero
+    warnings makes the surviving commit the only thing that can produce one.
+    """
+    control = C.acquire(tmp_path, _ours(), git=FakeGit(remote_record=_ours()))
+    assert control.undo == C.UNDO_DROPPED
+    assert control.warnings == [], "control: an undone claim warns about nothing"
+
+    got = C.acquire(tmp_path, _ours(), git=make_git())
+
+    assert got.ok is False
+    assert got.undo == expected
+    assert got.warnings, "a claim commit that survived its refusal must be visible"
+
+
+# --------------------------------------------------------------------------
+# D2 — the rejection is diagnosed, not guessed
+# --------------------------------------------------------------------------
+
+
+def test_a_remote_held_by_another_host_is_a_genuine_refusal(tmp_path):
+    """The only case that justifies "someone else has it": evidence they do."""
+    git = FakeGit(remote_record=_ours(host=OTHER, job_id="theirs"))
+    got = C.acquire(tmp_path, _ours(), git=git)
+
+    assert got.ok is False
+    assert got.cause == C.CAUSE_HELD_ELSEWHERE
+    assert got.retryable is False, "another host holds it; retrying just races again"
+
+
+def test_an_absent_remote_record_is_a_lost_push_race(tmp_path):
+    """Nobody holds the item. The push simply lost to a concurrent pusher."""
+    git = FakeGit(remote_record=None)
+    got = C.acquire(tmp_path, _ours(), git=git)
+
+    assert got.cause == C.CAUSE_LOST_PUSH_RACE
+    assert got.retryable is True
+
+
+def test_a_remote_record_that_is_OURS_is_a_lost_push_race(tmp_path):
+    """The live incident, exactly.
+
+    `deckhand#33` was rejected with "another host claimed it first" while no
+    other host existed. Our own host's record on the remote is evidence of a
+    lost push race, never of a rival claimant.
+    """
+    git = FakeGit(remote_record=_ours())
+    got = C.acquire(tmp_path, _ours(), git=git)
+
+    assert got.cause == C.CAUSE_LOST_PUSH_RACE
+    assert got.retryable is True
+
+
+def test_a_finished_record_from_another_host_is_not_a_held_claim(tmp_path):
+    """`held` means live. A terminal record is history, not an owner.
+
+    Reading a `done` record as a live claim would make the item look owned by a
+    host that walked away from it.
+    """
+    git = FakeGit(remote_record=_ours(host=OTHER, job_id="theirs", state="done"))
+    got = C.acquire(tmp_path, _ours(), git=git)
+
+    assert got.cause == C.CAUSE_LOST_PUSH_RACE
+    assert got.retryable is True
+
+
+# --------------------------------------------------------------------------
+# fail closed — the guarantee neither fix may weaken
+# --------------------------------------------------------------------------
+
+
+def test_retryable_is_never_a_licence_to_execute(tmp_path):
+    """`ok` remains the only licence. A retryable refusal is still a refusal.
+
+    Getting this wrong permissively is far worse than a spurious refusal: two
+    hosts against one floating licence seat (wh#3721).
+    """
+    for remote in (None, _ours(), _ours(host=OTHER, job_id="theirs"),
+                   _ours(host=OTHER, job_id="theirs", state="done")):
+        got = C.acquire(tmp_path, _ours(), git=FakeGit(remote_record=remote))
+        assert got.ok is False
+        assert got.record is None
+
+
+def test_an_undo_failure_never_turns_a_refusal_into_a_pass(tmp_path):
+    for status in (C.UNDO_FAILED, C.UNDO_UNAVAILABLE, C.UNDO_DROPPED, C.UNDO_REVERTED):
+        git = FakeGit(undo=status, remote_record=_ours())
+        got = C.acquire(tmp_path, _ours(), git=git)
+        assert got.ok is False and got.record is None
+
+
+def test_a_successful_claim_is_not_undone_and_is_not_retryable(tmp_path):
+    rec = _ours()
+    git = FakeGit(push_ok=True, remote_record=rec)
+    got = C.acquire(tmp_path, rec, git=git)
+
+    assert got.ok is True
+    assert git.undone == [], "an accepted push must not undo anything"
+    assert got.retryable is False
+    assert got.undo is None
+
+
+# --------------------------------------------------------------------------
+# GitBackend — the undo mechanics, against a real repository
+# --------------------------------------------------------------------------
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=str(repo), capture_output=True,
+                          text=True, check=False)
+
+
+def _init(tmp_path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "dispatch@test.invalid")
+    _git(repo, "config", "user.name", "dispatch test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "commit", "-m", "seed")
+    return repo
+
+
+def _subjects(repo) -> list[str]:
+    return _git(repo, "log", "--format=%s", "--all").stdout.split("\n")
+
+
+def _backend(repo, records_dir):
+    return C.GitBackend(repo, records_dir=records_dir, branch="main")
+
+
+def _commit_a_claim(repo, records_dir, record):
+    """Write + commit a claim exactly the way `acquire` does."""
+    path = C.records.write_record(records_dir, record)
+    backend = _backend(repo, records_dir)
+    assert backend.commit(path, f"dispatch: claim {record['issue']}") is True
+    return backend, path
+
+
+def test_backend_undo_leaves_no_claim_commit_reachable(tmp_path):
+    """Unreachable is the requirement — a reachable commit is a publishable one."""
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+    before = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    backend, path = _commit_a_claim(repo, records_dir, _ours())
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() != before
+
+    assert backend.undo_commit(path, _ours()) == C.UNDO_DROPPED
+
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == before
+    assert not any(s.startswith("dispatch: claim") for s in _subjects(repo))
+    assert not path.exists(), "the record must go with the commit"
+
+
+def test_backend_undo_does_not_destroy_a_concurrent_lane_s_work(tmp_path):
+    """The reason this is not `git reset --hard`.
+
+    Other dispatch lanes and an auto-sync process share this checkout. An undo
+    that reaches past its own commit is a data-loss bug that would present as
+    "my edits vanished", with nothing pointing back here.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+
+    tracked = repo / "seed.txt"
+    tracked.write_text("another lane was editing this\n", encoding="utf-8")
+    untracked = repo / "scratch.txt"
+    untracked.write_text("untracked work in progress\n", encoding="utf-8")
+    staged = repo / "staged.txt"
+    staged.write_text("staged by another lane\n", encoding="utf-8")
+    _git(repo, "add", "staged.txt")
+
+    backend, path = _commit_a_claim(repo, records_dir, _ours())
+    assert backend.undo_commit(path, _ours()) == C.UNDO_DROPPED
+
+    assert tracked.read_text(encoding="utf-8") == "another lane was editing this\n"
+    assert untracked.read_text(encoding="utf-8") == "untracked work in progress\n"
+    assert staged.read_text(encoding="utf-8") == "staged by another lane\n"
+    assert "staged.txt" in _git(repo, "diff", "--cached", "--name-only").stdout, \
+        "another lane's staged work must still be staged"
+
+
+def test_backend_undo_never_drops_a_commit_that_landed_on_top(tmp_path):
+    """History that is not ours is never rewritten — not even to fix our mess.
+
+    When another lane commits between our commit and our undo, moving the branch
+    ref back would silently delete their commit. The claim still has to go, so it
+    goes forward instead: a commit that removes it.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+
+    backend, path = _commit_a_claim(repo, records_dir, _ours())
+    (repo / "other-lane.txt").write_text("landed after our claim\n", encoding="utf-8")
+    _git(repo, "add", "other-lane.txt")
+    _git(repo, "commit", "-m", "another lane: unrelated work")
+    theirs = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    assert backend.undo_commit(path, _ours()) == C.UNDO_REVERTED
+
+    assert _git(repo, "merge-base", "--is-ancestor", theirs, "HEAD").returncode == 0, \
+        "the other lane's commit must still be reachable"
+    rel = path.relative_to(repo).as_posix()
+    assert _git(repo, "cat-file", "-e", f"HEAD:{rel}").returncode != 0, \
+        "the refused claim must not be in the published tree"
+    assert not path.exists()
+
+
+def test_backend_undo_never_drops_a_commit_carrying_other_work(tmp_path):
+    """Auto-sync commits with `git add -A`, so our record arrives with company.
+
+    Dropping such a commit to clean up a refused claim would delete whatever
+    else it swept in. The claim still has to go, so it goes forward.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+    backend = _backend(repo, records_dir)
+
+    path = C.records.write_record(records_dir, _ours())
+    hitchhiker = repo / "swept-in.txt"
+    hitchhiker.write_text("somebody else's work\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "auto-sync: publish")
+
+    assert backend.undo_commit(path, _ours()) == C.UNDO_REVERTED
+
+    assert _git(repo, "cat-file", "-e", "HEAD:swept-in.txt").returncode == 0, \
+        "work swept into the same commit must survive the undo"
+    rel = path.relative_to(repo).as_posix()
+    assert _git(repo, "cat-file", "-e", f"HEAD:{rel}").returncode != 0
+
+
+def test_backend_ref_move_is_a_compare_and_swap(tmp_path):
+    """The guard against the window between reading HEAD and moving it.
+
+    A concurrent lane can commit in that window. Tested directly because the
+    window cannot be driven deterministically through `undo_commit`, and an
+    unconditional ref move would pass every other test in this file while
+    silently discarding whatever landed in it.
+    """
+    repo = _init(tmp_path)
+    backend = _backend(repo, repo / "records")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    stale = "0" * 40
+
+    assert backend._cas_ref(f"{head}", stale) is False
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == head
+
+
+def test_backend_undo_refuses_a_commit_that_is_not_ours(tmp_path):
+    """Identity is (host, job_id) from the record, not the commit message.
+
+    Two hosts write the same commit subject for the same issue. Undoing on the
+    message alone would let this host drop another host's claim.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+    backend, path = _commit_a_claim(repo, records_dir, _ours(host=OTHER, job_id="theirs"))
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    assert backend.undo_commit(path, _ours()) == C.UNDO_FAILED
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == head, \
+        "somebody else's claim commit must survive untouched"
+
+
+def _seed_a_finished_record(repo, records_dir):
+    """A completed run's record, committed, as a prior claim would leave it."""
+    path = C.records.write_record(records_dir, _ours(state="done", job_id="j0",
+                                                     returncode=0))
+    _git(repo, "add", "--", path.relative_to(repo).as_posix())
+    _git(repo, "commit", "-m", "dispatch: done")
+    return path, path.read_bytes()
+
+
+@pytest.mark.parametrize("crowd_the_tip, expected", [
+    (False, C.UNDO_DROPPED),
+    (True, C.UNDO_REVERTED),
+])
+def test_backend_undo_restores_a_record_the_claim_overwrote(tmp_path, crowd_the_tip,
+                                                            expected):
+    """A claim may legitimately overwrite a TERMINAL record. Undo puts it back.
+
+    Deleting it instead would destroy the completed run's audit trail — the
+    exact thing the records epic exists to stop losing. Both undo routes owe the
+    same answer: dropping the commit and removing it forward differ in how they
+    reach the prior state, not in what that state is.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+    path, finished = _seed_a_finished_record(repo, records_dir)
+
+    backend, path = _commit_a_claim(repo, records_dir, _ours(job_id="j1"))
+    if crowd_the_tip:
+        (repo / "other-lane.txt").write_text("x\n", encoding="utf-8")
+        _git(repo, "add", "other-lane.txt")
+        _git(repo, "commit", "-m", "another lane")
+
+    assert backend.undo_commit(path, _ours(job_id="j1")) == expected
+    assert path.read_bytes() == finished, "the completed run's record must come back"
+    assert json.loads(path.read_text(encoding="utf-8"))["job_id"] == "j0"
+
+
+def test_acquire_end_to_end_against_a_real_repo_publishes_nothing(tmp_path):
+    """The live incident, end to end, with the real git surface.
+
+    `push` is rejected; afterwards the branch must look exactly as it did before
+    the drain, and nothing may be left for auto-sync to publish.
+    """
+    repo = _init(tmp_path)
+    records_dir = repo / "records"
+    before = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    class RejectedPush(C.GitBackend):
+        def push(self):
+            return False
+
+        def pull(self):
+            return True
+
+        def read_remote(self, issue):
+            return None
+
+    got = C.acquire(records_dir, _ours(),
+                    git=RejectedPush(repo, records_dir=records_dir, branch="main"))
+
+    assert got.ok is False and got.record is None
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == before
+    assert not any(s.startswith("dispatch: claim") for s in _subjects(repo))
+    assert _git(repo, "status", "--porcelain").stdout.strip() == "", \
+        "a refused claim must leave the working tree as it found it"
+    assert got.retryable is True

--- a/tests/dispatch/test_drain_unattended.py
+++ b/tests/dispatch/test_drain_unattended.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+"""The five rails that let `drain.py` run UNATTENDED. workspace-hub#3773.
+
+`test_drain.py` proves the loop closes for one card driven by a human. This
+file proves the loop can be left alone over 1344 of them. Each rail closes a
+defect that an adversarial audit found would corrupt the record or lose control
+of the box, and each is asserted as a PROPERTY of the outcome — a state on disk,
+a runner that was or was not reached, an argv that was or was not issued — never
+as the wording of a message. A test that greps for a sentence pins the sentence.
+
+R1  WIP cap        a direct drain ignored `wip_caps` entirely, so N sessions on
+                   one machine could all claim at once. `dispatch.py` says "WIP
+                   is enforced at claim time by the consuming session"; nothing
+                   enforced it.
+R2  kill switch    there was no way to stop the loop short of `kill`, and
+                   `run.sh` detaches payloads so they outlive the session.
+R3  timeout kills  `subprocess.run(timeout=)` kills the CHILD. `run.sh` and the
+                   payload are grandchildren: they kept running, orphaned, while
+                   the record said the outcome was unknown.
+R4  ttl coupling   nothing refreshes `heartbeat_at` while a job runs, so a job
+                   outliving `ttl_minutes` gets settled back to `ready` and
+                   RECLAIMed — two payloads, one issue. Until an out-of-band
+                   beater exists the coupling must be refused, not left to the
+                   coincidence that 3600s < 90min.
+R5  quarantine     a thrice-failed card kept its `done`/`returncode 3` record,
+                   projected `dispatch:done`, and was counted as executed. The
+                   refusal wrote NOTHING, so nothing downstream could see it.
+
+Hermetic: git, the runner and the routing rules are injected. No network, no
+`gh`, no push, no real subprocess.
+
+Run: uv run --with pyyaml --with pytest pytest tests/dispatch/test_drain_unattended.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DRAIN_PY = REPO_ROOT / "scripts" / "dispatch" / "drain.py"
+RUN_SH = REPO_ROOT / "scripts" / "dispatch" / "run.sh"
+
+
+def _load():
+    pkg = str(DRAIN_PY.parent)
+    if pkg not in sys.path:
+        sys.path.insert(0, pkg)
+    spec = importlib.util.spec_from_file_location("dispatch_drain", DRAIN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dispatch_drain"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+D = _load()
+records = sys.modules["records"]
+reconcile = sys.modules["reconcile"]
+
+ISSUE = "vamseeachanta/digitalmodel#1885"
+OURS = "host-a"
+OTHER = "host-b"
+NOW = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def clock(dt=NOW):
+    return lambda: dt
+
+
+@pytest.fixture
+def armed(monkeypatch):
+    monkeypatch.setenv(D.APPLY_FLAG, "1")
+
+
+@pytest.fixture
+def disarmed(monkeypatch):
+    monkeypatch.delenv(D.APPLY_FLAG, raising=False)
+
+
+# --------------------------------------------------------------------------
+# doubles — same shape as test_drain.py's, sharing one call list so ORDER is
+# observable and "it refused" can be told from "it refused after executing".
+# --------------------------------------------------------------------------
+
+
+class FakeGit:
+    def __init__(self, calls=None, push_ok=True, remote_holder=OURS):
+        self.calls = calls if calls is not None else []
+        self.push_ok = push_ok
+        self.remote_holder = remote_holder
+        self.last_written: dict | None = None
+
+    def commit(self, path, message):
+        self.calls.append("commit")
+        self.last_written = json.loads(Path(path).read_text(encoding="utf-8"))
+        return True
+
+    def push(self):
+        self.calls.append("push")
+        return self.push_ok
+
+    def pull(self):
+        self.calls.append("pull")
+        return True
+
+    def read_remote(self, issue):
+        self.calls.append("read_remote")
+        if self.last_written is None:
+            return None
+        remote = dict(self.last_written)
+        remote["host"] = self.remote_holder
+        return remote
+
+
+class FakeRunner:
+    def __init__(self, calls=None, returncode=0, cancelled=None):
+        self.calls = calls if calls is not None else []
+        self.returncode = returncode
+        self.cancelled = cancelled
+        self.seen: list[dict] = []
+
+    def describe(self, **kw):
+        return "fake-runner"
+
+    def execute(self, *, issue, job_id, command, work_dir=None):
+        self.calls.append("execute")
+        self.seen.append({"issue": issue, "job_id": job_id, "command": command})
+        return D.ExecOutcome(self.returncode, job_state="finished",
+                             detail="", cancelled=self.cancelled)
+
+
+class Exploding:
+    def __getattr__(self, name):
+        def boom(*a, **kw):
+            raise AssertionError(f"this path reached {name}() — it must not")
+        return boom
+
+
+def wired(**kw):
+    calls: list[str] = []
+    git = FakeGit(calls=calls, **{k: v for k, v in kw.items()
+                                  if k in ("push_ok", "remote_holder")})
+    runner = FakeRunner(calls=calls, **{k: v for k, v in kw.items()
+                                        if k in ("returncode", "cancelled")})
+    return calls, git, runner
+
+
+def caps(**per_machine):
+    """A routing-rules loader carrying just the WIP caps, for hermeticity."""
+    per_machine.setdefault("default", 1)
+    return lambda: {"wip_caps": {"per_machine": dict(per_machine)}}
+
+
+def run_drain(tmp_path, calls_git_runner=None, **kw):
+    calls, git, runner = calls_git_runner or wired()
+    params = dict(command="echo pilot", host=OURS, job_id="j1", git=git,
+                  runner=runner, apply=True, now=clock(),
+                  rules_loader=caps(**{OURS: 1}))
+    params.update(kw)
+    return D.drain(tmp_path, ISSUE, **params), calls, git, runner
+
+
+def on_disk(tmp_path, issue=ISSUE):
+    return records.read_record(records.record_path(tmp_path, issue))
+
+
+def active_claim(tmp_path, issue, *, machine=OURS, host=OURS):
+    records.write_record(tmp_path, records.new_claim(
+        issue, machine=machine, host=host, job_id=f"job-{issue[-3:]}", now=clock()))
+
+
+def finished(tmp_path, *, issue=ISSUE, attempt=1, max_attempts=3, returncode=3):
+    rec = records.new_claim(issue, machine=OURS, host=OURS, job_id="j0",
+                            max_attempts=max_attempts, now=clock())
+    rec["attempt"] = attempt
+    records.write_record(tmp_path, records.transition(
+        rec, "done", reason="completed", returncode=returncode, now=clock()))
+
+
+# ==========================================================================
+# R1 — the WIP cap is enforced where the claim is decided
+# ==========================================================================
+
+
+def test_a_machine_already_at_its_wip_cap_claims_nothing_more(tmp_path, armed):
+    """The 260-worker scar: `route.py` only ANNOTATES a proposal with a slot.
+    A drain invoked directly never saw it, so the cap bounded nothing."""
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#101")
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#102")
+
+    got, calls, _git, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 2}))
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert runner.seen == [] and calls == [], "over the cap, nothing may be claimed"
+    assert not records.record_path(tmp_path, ISSUE).exists(), \
+        "a refused claim must leave no record behind"
+
+
+def test_below_the_cap_the_claim_still_proceeds(tmp_path, armed):
+    """Discriminator: a cap that refuses everything would pass the test above."""
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#101")
+
+    got, _calls, _git, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 2}))
+
+    assert got.ok is True and got.stage == D.RELEASED
+    assert len(runner.seen) == 1
+
+
+def test_another_machines_claims_do_not_consume_our_cap(tmp_path, armed):
+    """The cap is per-machine. Counting the fleet would idle every host."""
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#101", machine=OTHER, host=OTHER)
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#102", machine=OTHER, host=OTHER)
+
+    got, _c, _g, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is True and len(runner.seen) == 1
+
+
+def test_terminal_records_do_not_consume_the_cap(tmp_path, armed):
+    """WIP is work IN PROGRESS. Counting finished cards would wedge the machine
+    permanently after `cap` successful drains."""
+    finished(tmp_path, issue="vamseeachanta/digitalmodel#101", returncode=0)
+    finished(tmp_path, issue="vamseeachanta/digitalmodel#102", returncode=0)
+
+    got, _c, _g, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is True and len(runner.seen) == 1
+
+
+def test_a_reclaim_is_capped_too_not_only_a_first_claim(tmp_path, armed):
+    """RECLAIM starts a payload exactly as CLAIM does; exempting it would leave
+    the cap enforced on the path that happens least."""
+    finished(tmp_path)                                     # our target: reclaimable
+    active_claim(tmp_path, "vamseeachanta/digitalmodel#101")
+
+    got, calls, _g, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert runner.seen == [] and calls == []
+    assert on_disk(tmp_path)["state"] == "done", "the refused record is untouched"
+
+
+def test_re_entering_our_own_claim_is_not_a_new_slot(tmp_path, armed):
+    """A RESUME occupies the slot it already holds. Counting it against the cap
+    would make an operator's re-run after a dropped SSH session impossible."""
+    active_claim(tmp_path, ISSUE)
+
+    got, _c, _g, runner = run_drain(tmp_path, job_id="job-885",
+                                    rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is True and got.action == D.RESUME
+    assert len(runner.seen) == 1
+
+
+def test_unreadable_routing_rules_fail_closed(tmp_path, armed):
+    """No cap read is not "no cap"."""
+    def broken():
+        raise OSError("routing-rules.yaml is gone")
+
+    got, calls, _g, runner = run_drain(tmp_path, rules_loader=broken)
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert runner.seen == [] and calls == []
+    assert not records.record_path(tmp_path, ISSUE).exists()
+
+
+@pytest.mark.parametrize("cfg", [
+    {},                                             # no wip_caps at all
+    {"wip_caps": {}},                               # no per_machine
+    {"wip_caps": {"per_machine": {}}},              # empty mapping
+    {"wip_caps": {"per_machine": {"other": 4}}},    # no entry AND no default
+    {"wip_caps": {"per_machine": {"default": "lots"}}},   # unparseable
+    {"wip_caps": {"per_machine": {"default": -1}}},       # nonsense
+])
+def test_a_config_that_names_no_usable_cap_fails_closed(tmp_path, armed, cfg):
+    got, calls, _g, runner = run_drain(tmp_path, rules_loader=lambda: cfg)
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert runner.seen == [] and calls == []
+
+
+def test_an_unreadable_record_counts_against_the_cap(tmp_path, armed):
+    """It may be a live claim of ours. Skipping what we cannot read would make
+    corruption look like idle capacity."""
+    junk = tmp_path / "junk.json"
+    junk.write_text("{not json", encoding="utf-8")
+
+    got, _c, _g, runner = run_drain(tmp_path, rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is False and runner.seen == []
+
+
+def test_the_cap_is_read_from_the_routing_rules_not_from_this_module(tmp_path):
+    """The value lives in `.claude/memory/kanban/routing-rules.yaml`, the same
+    file `route.apply_wip` and `dispatch.py --capacity` read. A second copy in
+    drain.py would drift, and both would look correct in isolation."""
+    rules = D.load_routing_rules()
+    per_machine = (rules.get("wip_caps") or {}).get("per_machine") or {}
+
+    assert per_machine, "wip_caps.per_machine is where the cap lives"
+    assert isinstance(per_machine.get("default"), int), \
+        "an unlisted machine must still resolve to a number, or every host fails closed"
+    for machine, cap in per_machine.items():
+        assert D.machine_wip_cap(machine) == int(cap)
+    assert D.machine_wip_cap("a-machine-that-is-not-in-the-roster") == \
+        int(per_machine["default"])
+
+
+# ==========================================================================
+# R2 — the kill switch
+# ==========================================================================
+
+
+def pause(root) -> Path:
+    path = D.pause_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("stop\n", encoding="utf-8")
+    return path
+
+
+def test_a_pause_sentinel_stops_the_drain_before_it_claims(tmp_path, armed):
+    pause(tmp_path)
+
+    got, calls, _g, runner = run_drain(tmp_path)
+
+    assert got.stage == D.PAUSED
+    assert calls == [], "the sentinel must gate the CLAIM, not just the payload"
+    assert runner.seen == []
+    assert not records.record_path(tmp_path, ISSUE).exists()
+
+
+def test_without_the_sentinel_the_same_drain_runs(tmp_path, armed):
+    """Discriminator: an unconditional refusal would pass the test above."""
+    got, _c, _g, runner = run_drain(tmp_path)
+    assert got.ok is True and len(runner.seen) == 1
+
+
+def test_the_sentinel_is_consulted_on_every_drain_not_at_loop_start(tmp_path, armed):
+    """`run.sh` uses `setsid nohup`, so a wrapper loop already running is exactly
+    the case the switch exists for: work NOT YET CLAIMED must stop."""
+    first, _c, _g, runner1 = run_drain(tmp_path)
+    assert first.ok is True
+
+    pause(tmp_path)
+    second, calls2, _g2, runner2 = run_drain(tmp_path, job_id="j2")
+
+    assert second.stage == D.PAUSED
+    assert runner2.seen == [] and calls2 == []
+
+
+def test_a_pause_is_reported_distinctly_from_a_failure(tmp_path, armed):
+    """An operator's stop must not read as a broken card in the exit code — a
+    wrapper loop that cannot tell them apart either spins or gives up wrongly."""
+    roots = {}
+    for name in ("paused", "refused", "failed"):
+        roots[name] = tmp_path / name
+        roots[name].mkdir()
+    pause(roots["paused"])
+
+    paused, _c, _g, _r = run_drain(roots["paused"])
+    refused, _c2, _g2, _r2 = run_drain(roots["refused"],
+                                       calls_git_runner=wired(push_ok=False))
+    failed, _c3, _g3, _r3 = run_drain(roots["failed"],
+                                      calls_git_runner=wired(returncode=3))
+
+    assert paused.stage not in (D.REFUSED, D.CLAIM_REFUSED, D.RELEASE_FAILED,
+                                D.RELEASED, D.PLANNED)
+    codes = {D.exit_code(paused), D.exit_code(refused), D.exit_code(failed)}
+    assert len(codes) == 3, "paused, refused and failed must be distinguishable"
+    assert D.exit_code(paused) != 0, "a paused drain did no work"
+
+
+def test_the_sentinel_lives_where_the_operator_can_reach_it(tmp_path):
+    """A path only this module knows is not a kill switch."""
+    assert D.pause_path(tmp_path) == tmp_path / ".claude" / "dispatch" / "PAUSE"
+    assert D.pause_path(tmp_path).parent == D.pause_path(tmp_path).parent
+
+
+def test_a_dry_run_is_not_stopped_by_the_sentinel(tmp_path, disarmed):
+    """A plan writes nothing and runs nothing; refusing it would make the switch
+    look broken to the operator checking what would happen."""
+    pause(tmp_path)
+    got = D.drain(tmp_path, ISSUE, command="echo pilot", host=OURS, job_id="j1",
+                  git=Exploding(), runner=Exploding(), now=clock(),
+                  rules_loader=caps(**{OURS: 1}))
+    assert got.stage == D.PLANNED
+
+
+# ==========================================================================
+# R3 — a timeout that actually kills
+# ==========================================================================
+
+
+def fake_subprocess(script):
+    """A `subprocess` shim for drain's namespace. `script` is a list of stdout
+    strings or exceptions, consumed in call order; argv is recorded."""
+    seen: list[list[str]] = []
+
+    def run(argv, **kw):
+        seen.append(list(argv))
+        item = script.pop(0) if script else "{}"
+        if isinstance(item, BaseException):
+            raise item
+        return types.SimpleNamespace(stdout=item, stderr="", returncode=0)
+
+    shim = types.SimpleNamespace(run=run,
+                                 TimeoutExpired=subprocess.TimeoutExpired,
+                                 SubprocessError=subprocess.SubprocessError)
+    return seen, shim
+
+
+def shell_runner(**kw):
+    kw.setdefault("timeout", 10)
+    kw.setdefault("sleep", lambda _s: None)
+    return D.ShellRunner(script="/x/run.sh", **kw)
+
+
+def ticking(values):
+    it = iter(values)
+    last = [values[-1]]
+
+    def tick():
+        try:
+            last[0] = next(it)
+        except StopIteration:
+            pass
+        return last[0]
+    return tick
+
+
+def test_a_submit_that_never_returns_cancels_the_job(tmp_path, monkeypatch):
+    """`--foreground` means the submit call IS the payload. Killing our child
+    leaves `run.sh` and the payload — its grandchildren — running."""
+    timeout = subprocess.TimeoutExpired(cmd=["bash"], timeout=10)
+    seen, shim = fake_subprocess([timeout, '{"ok":true,"action":"cancel"}'])
+    monkeypatch.setattr(D, "subprocess", shim)
+
+    outcome = shell_runner().execute(issue=ISSUE, job_id="j1", command="sleep 1d")
+
+    assert outcome.returncode is None, "a timeout is not an exit code"
+    assert outcome.cancelled is True
+    assert seen[-1] == ["bash", "/x/run.sh", "cancel", "--job-id", "j1"]
+
+
+def test_a_poll_that_runs_past_the_deadline_cancels_the_job(tmp_path, monkeypatch):
+    seen, shim = fake_subprocess(['{"ok":true}', '{"state":"running"}',
+                                  '{"ok":true,"action":"cancel"}'])
+    monkeypatch.setattr(D, "subprocess", shim)
+
+    outcome = shell_runner(clock=ticking([0, 999])).execute(
+        issue=ISSUE, job_id="j1", command="sleep 1d")
+
+    assert outcome.returncode is None and outcome.job_state == "running"
+    assert outcome.cancelled is True
+    assert ["bash", "/x/run.sh", "cancel", "--job-id", "j1"] in seen
+
+
+def test_a_job_that_finished_is_never_cancelled(tmp_path, monkeypatch):
+    """Discriminator: cancelling unconditionally would pass the two above and
+    would SIGTERM every completed payload's successor."""
+    seen, shim = fake_subprocess(['{"ok":true}', '{"state":"finished","exit_code":0}'])
+    monkeypatch.setattr(D, "subprocess", shim)
+
+    outcome = shell_runner(clock=ticking([0, 1])).execute(
+        issue=ISSUE, job_id="j1", command="true")
+
+    assert outcome.returncode == 0 and outcome.cancelled is None
+    assert not any("cancel" in argv for argv in seen)
+
+
+def test_a_cancel_that_did_not_work_is_visible_not_swallowed(tmp_path, monkeypatch):
+    """A payload we could neither observe nor stop is the worst state this loop
+    can reach: it holds the one solver seat and nothing knows."""
+    timeout = subprocess.TimeoutExpired(cmd=["bash"], timeout=10)
+    seen, shim = fake_subprocess([timeout, '{"ok":false,"error":"no such job"}'])
+    monkeypatch.setattr(D, "subprocess", shim)
+
+    outcome = shell_runner().execute(issue=ISSUE, job_id="j1", command="sleep 1d")
+
+    assert outcome.cancelled is False, "attempted-and-failed is not the same as never-tried"
+    assert outcome.returncode is None
+
+
+def test_a_cancel_that_itself_hangs_is_reported_as_failed(tmp_path, monkeypatch):
+    timeouts = [subprocess.TimeoutExpired(cmd=["bash"], timeout=10),
+                subprocess.TimeoutExpired(cmd=["bash"], timeout=60)]
+    seen, shim = fake_subprocess(timeouts)
+    monkeypatch.setattr(D, "subprocess", shim)
+
+    outcome = shell_runner().execute(issue=ISSUE, job_id="j1", command="sleep 1d")
+
+    assert outcome.cancelled is False
+
+
+def test_an_uncancelled_job_reaches_the_drains_warnings(tmp_path, armed):
+    """The record says `blocked`/`unknown-outcome` either way. Whether a payload
+    is STILL RUNNING is a different fact and the operator needs it."""
+    got, _c, _g, _r = run_drain(
+        tmp_path, calls_git_runner=wired(returncode=None, cancelled=False))
+
+    assert got.record["state"] == "blocked"
+    assert got.warnings, "a payload that could not be stopped must be surfaced"
+
+    clean, _c2, _g2, _r2 = run_drain(
+        tmp_path, job_id="j2",
+        calls_git_runner=wired(returncode=None, cancelled=True))
+    assert clean.warnings == [], "a confirmed cancel is not a warning"
+
+
+def test_the_cancel_verb_exists_in_the_real_runner(tmp_path):
+    """The argv above is worthless if `run.sh` does not answer to it — the exact
+    class of defect that shipped a Windows runner path pointing at nothing."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    assert "cmd_cancel" in text and "cancel)" in text
+    assert D.ShellRunner(script="/x/run.sh").cancel_argv("j1") == \
+        ["bash", "/x/run.sh", "cancel", "--job-id", "j1"]
+    wargv = D.PowerShellRunner(script="C:/x/dispatch-run.ps1").cancel_argv("j1")
+    assert "-Action" in wargv and "cancel" in wargv and "j1" in wargv
+
+
+# ==========================================================================
+# R4 — a timeout that outlives the TTL double-executes
+# ==========================================================================
+
+
+def test_a_timeout_at_or_beyond_the_ttl_is_refused_before_anything_runs(
+        tmp_path, armed):
+    """Nothing beats `heartbeat_at` while the child runs, so a job that outlives
+    its TTL is settled back to `ready` and RECLAIMed WHILE IT IS STILL RUNNING."""
+    got, calls, _g, runner = run_drain(tmp_path, timeout=90 * 60, ttl_minutes=90)
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert calls == [] and runner.seen == []
+    assert not records.record_path(tmp_path, ISSUE).exists()
+
+
+def test_a_timeout_inside_the_ttl_is_allowed(tmp_path, armed):
+    """Discriminator."""
+    got, _c, _g, runner = run_drain(tmp_path, timeout=90 * 60 - 1, ttl_minutes=90)
+    assert got.ok is True and len(runner.seen) == 1
+
+
+def test_the_refusal_does_not_need_the_write_gate_to_fire(tmp_path, disarmed):
+    """An operator learns about the misconfiguration from the PLAN, not from the
+    first unattended double-execution."""
+    got = D.drain(tmp_path, ISSUE, command="echo pilot", host=OURS, job_id="j1",
+                  git=Exploding(), runner=Exploding(), now=clock(),
+                  timeout=5400, ttl_minutes=90, rules_loader=caps(**{OURS: 1}))
+    assert got.ok is False and got.stage == D.REFUSED
+
+
+def test_a_runner_carrying_its_own_oversized_timeout_is_caught(tmp_path, armed):
+    """The runner is what actually waits. A drain told a safe number while its
+    runner holds an unsafe one is the coupling wearing a disguise."""
+    runner = D.ShellRunner(script="/x/run.sh", timeout=99 * 60)
+    got = D.drain(tmp_path, ISSUE, command="echo pilot", host=OURS, job_id="j1",
+                  git=Exploding(), runner=runner, apply=True, now=clock(),
+                  ttl_minutes=90, rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert not records.record_path(tmp_path, ISSUE).exists()
+
+
+def test_the_shipped_defaults_satisfy_their_own_rule(tmp_path):
+    """Today's 3600s vs 90min is a coincidence that MASKS the defect. Pin it so
+    raising either default without the other fails here, not in production."""
+    assert D.DEFAULT_TIMEOUT_SECONDS < records.DEFAULT_TTL_MINUTES * 60
+
+
+def test_the_cli_refuses_the_same_coupling(tmp_path, armed, capsys):
+    rc = D.main(["--issue", ISSUE, "--records", str(tmp_path), "--command", "true",
+                 "--timeout", "5400", "--ttl-minutes", "90"])
+    capsys.readouterr()
+    assert rc != 0
+    assert list(tmp_path.iterdir()) == []
+
+
+# ==========================================================================
+# R5 — a thrice-failed card must not look like a successful one
+# ==========================================================================
+
+
+def exhausted(tmp_path):
+    """A card that has used every attempt and ended `done` with a nonzero code."""
+    finished(tmp_path, attempt=3, max_attempts=3, returncode=3)
+
+
+def test_attempt_exhaustion_writes_a_terminal_blocked_record(tmp_path, armed):
+    """`should_quarantine` tripped and the drain wrote NOTHING, so the record
+    stayed `done`/`returncode 3` — indistinguishable from a card that worked."""
+    exhausted(tmp_path)
+
+    got, calls, _g, runner = run_drain(tmp_path)
+
+    rec = on_disk(tmp_path)
+    assert rec["state"] == "blocked" and rec["state"] in records.TERMINAL
+    assert rec["returncode"] == 3, "the observed exit code is not erased"
+    assert records.is_success(rec) is False
+    assert runner.seen == [], "quarantine records the card, it does not run it"
+    assert "push" in calls, "a record nobody else can see is not a quarantine"
+
+
+def test_the_quarantined_card_stops_projecting_dispatch_done(tmp_path, armed):
+    """`chain.py` counts `dispatch:done` as executed. This is the whole defect."""
+    exhausted(tmp_path)
+    before = reconcile.intended_label(on_disk(tmp_path))
+
+    got, _c, _g, _r = run_drain(tmp_path)
+
+    assert before == "dispatch:done"
+    assert got.intended_label == reconcile.intended_label(on_disk(tmp_path))
+    assert got.intended_label != "dispatch:done"
+
+
+def test_a_quarantined_card_is_distinguishable_from_a_successful_one(tmp_path, armed):
+    """The property, stated directly: same drain, two cards, two states."""
+    good = tmp_path / "good"
+    bad = tmp_path / "bad"
+    good.mkdir()
+    bad.mkdir()
+    exhausted(bad)
+
+    ok_result, _c, _g, _r = run_drain(good)
+    bad_result, _c2, _g2, _r2 = run_drain(bad)
+
+    assert on_disk(good)["state"] != on_disk(bad)["state"]
+    assert ok_result.work_succeeded is True and bad_result.work_succeeded is False
+    assert reconcile.intended_label(on_disk(good)) != \
+        reconcile.intended_label(on_disk(bad))
+
+
+def test_the_quarantine_carries_why_it_stopped(tmp_path, armed):
+    exhausted(tmp_path)
+    got, _c, _g, _r = run_drain(tmp_path)
+
+    rec = on_disk(tmp_path)
+    assert rec["failure_category"] == D.ATTEMPTS_EXHAUSTED
+    assert rec["attempt"] >= rec["max_attempts"]
+    assert rec["attempts"][-1]["outcome"], "the attempt log records its own end"
+
+
+def test_an_already_quarantined_card_is_not_re_written(tmp_path, armed):
+    """Idempotence. Re-pushing a blocked record on every pass of an unattended
+    loop is 1344 commits a day saying nothing new."""
+    exhausted(tmp_path)
+    run_drain(tmp_path)
+    before = records.record_path(tmp_path, ISSUE).read_bytes()
+
+    got, calls, _g, runner = run_drain(tmp_path, job_id="j2")
+
+    assert got.ok is False and got.stage == D.REFUSED
+    assert calls == [] and runner.seen == []
+    assert records.record_path(tmp_path, ISSUE).read_bytes() == before
+
+
+def test_a_dry_run_quarantines_nothing(tmp_path, disarmed):
+    exhausted(tmp_path)
+    before = records.record_path(tmp_path, ISSUE).read_bytes()
+
+    got = D.drain(tmp_path, ISSUE, command="echo pilot", host=OURS, job_id="j1",
+                  git=Exploding(), runner=Exploding(), now=clock(),
+                  rules_loader=caps(**{OURS: 1}))
+
+    assert got.ok is False
+    assert records.record_path(tmp_path, ISSUE).read_bytes() == before
+
+
+def test_a_quarantine_that_cannot_be_pushed_is_reported(tmp_path, armed):
+    """Same contract as a release: locally-recorded is not recorded."""
+    exhausted(tmp_path)
+
+    got, _c, _g, runner = run_drain(tmp_path, calls_git_runner=wired(push_ok=False))
+
+    assert got.ok is False and got.stage == D.RELEASE_FAILED
+    assert runner.seen == []
+
+
+def test_a_paused_loop_does_not_quarantine_either(tmp_path, armed):
+    """The switch stops WRITES to the shared record store, not only payloads."""
+    exhausted(tmp_path)
+    pause(tmp_path)
+    before = records.record_path(tmp_path, ISSUE).read_bytes()
+
+    got, calls, _g, _r = run_drain(tmp_path)
+
+    assert got.stage == D.PAUSED
+    assert calls == []
+    assert records.record_path(tmp_path, ISSUE).read_bytes() == before
+
+
+def test_the_quarantine_category_is_pinned_to_its_literal_value():
+    """A wire contract: operators read it and tooling joins on it. Comparing it
+    only against the module's own constant would move with a rename."""
+    assert D.ATTEMPTS_EXHAUSTED == "attempts-exhausted"
+    vocabulary = {D.UNKNOWN_OUTCOME, D.PAYLOAD_ERROR, D.DISPATCH_ERROR,
+                  D.CANCELLED, D.ATTEMPTS_EXHAUSTED}
+    assert len(vocabulary) == 5, "two categories collapsed onto one string"
+
+
+# ==========================================================================
+# the guarantees these fixes must not have traded away
+# ==========================================================================
+
+
+def test_there_is_still_exactly_one_branch_that_may_execute(tmp_path, armed):
+    """Every refusal added here must reach the runner zero times."""
+    scenarios = {
+        "over-cap": lambda p: active_claim(p, "vamseeachanta/digitalmodel#101"),
+        "paused": pause,
+        "quarantined": exhausted,
+        "held-elsewhere": lambda p: active_claim(p, ISSUE, machine=OTHER, host=OTHER),
+    }
+    for name, setup in scenarios.items():
+        root = tmp_path / name
+        root.mkdir()
+        setup(root)
+        got, _c, _g, runner = run_drain(root, rules_loader=caps(**{OURS: 1}))
+        assert runner.seen == [], f"{name} reached the runner"
+        assert got.ok is False, f"{name} reported ok"
+
+
+def test_an_unverified_claim_still_licenses_nothing(tmp_path, armed):
+    got, calls, _g, runner = run_drain(
+        tmp_path, calls_git_runner=wired(remote_holder=OTHER))
+    assert got.stage == D.CLAIM_REFUSED and runner.seen == [] and "execute" not in calls
+
+
+def test_an_unknown_returncode_is_still_never_coerced_to_success(tmp_path, armed):
+    got, _c, _g, _r = run_drain(tmp_path, calls_git_runner=wired(returncode=None))
+    rec = on_disk(tmp_path)
+    assert rec["returncode"] is None and rec["state"] == "blocked"
+    assert records.is_success(rec) is False and got.work_succeeded is False

--- a/tests/operations/test_dispatch_lease_namespace.py
+++ b/tests/operations/test_dispatch_lease_namespace.py
@@ -1,0 +1,199 @@
+"""The lease has to leave the host (#3772).
+
+## The defect
+
+`dispatch_lease` writes leases under `refs/heads/dispatch/leases/`. `dispatch_pull`
+fetched and pushed `refs/heads/dispatch-lease/`. Those two namespaces do not
+overlap, so no lease ever crossed the network: every host CAS'd against refs only
+it could see, and therefore won every lease it asked for. The lease core is
+correct — CAS, monotonic generation, fencing token — and was wired to nothing.
+
+## What is asserted here, and what deliberately is not
+
+Grepping for the prefix would pin the NAME. The name is not the property; the
+property is that the ref a host WRITES is the ref its peer READS. So these tests
+run the real code against real git: two checkouts of one bare remote, a lease
+acquired on one, the module's own sync path, and then the peer's view of it.
+
+Rename the namespace and these still pass. Diverge the two ends by one character
+and `test_a_lease_taken_on_one_host_blocks_the_other` fails, because host-b
+acquires a lease host-a already holds — the exact production failure.
+
+`test_without_the_sync_path_the_second_host_wins_too` is the control: it shows
+the blocking assertion is load-bearing rather than trivially true.
+
+Hermetic: a bare repo on disk plays the remote. No network, no origin, no gh.
+
+Run: uv run --with pyyaml --with pytest pytest tests/operations/test_dispatch_lease_namespace.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(mod, rel):
+    spec = importlib.util.spec_from_file_location(mod, _ROOT / rel)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[mod] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+dl = _load("dispatch_lease", "scripts/operations/dispatch_lease.py")
+grl = _load("git_ref_lease", "scripts/operations/git_ref_lease.py")
+dp = _load("dispatch_pull", "scripts/operations/dispatch_pull.py")
+
+ISSUE = "vamseeachanta/deckhand#33"
+TTL = 900
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(list(args), capture_output=True, text=True, check=True)
+
+
+def _fleet(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A bare remote and two independent checkouts pointed at it."""
+    remote = tmp_path / "remote.git"
+    _run("git", "init", "-q", "--bare", str(remote))
+    hosts = []
+    for name in ("host-a", "host-b"):
+        repo = tmp_path / name
+        _run("git", "init", "-q", str(repo))
+        _run("git", "-C", str(repo), "config", "user.email", f"{name}@t")
+        _run("git", "-C", str(repo), "config", "user.name", name)
+        _run("git", "-C", str(repo), "remote", "add", "origin", str(remote))
+        hosts.append(repo)
+    return remote, hosts[0], hosts[1]
+
+
+def _remote_lease_refs(remote: Path) -> list[str]:
+    out = _run("git", "-C", str(remote), "for-each-ref", "--format=%(refname)").stdout
+    return [ln for ln in out.splitlines() if ln]
+
+
+# ── the headline: mutual exclusion actually crosses the wire ────────────────
+
+
+def test_a_lease_taken_on_one_host_blocks_the_other(tmp_path):
+    """host-a claims, syncs; host-b syncs and must be refused.
+
+    This is the whole point of the lease. It fails the moment the namespace the
+    writer uses and the namespace the sync moves stop being the same one.
+    """
+    remote, a, b = _fleet(tmp_path)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    assert dl.acquire(grl.GitRefLease(a), name, "host-a",
+                      ttl_s=TTL, now=1000.0, new_token="tok-a") is not None
+    dp._push_lease_refs(a)
+    dp._fetch_lease_refs(b)
+
+    assert dl.acquire(grl.GitRefLease(b), name, "host-b",
+                      ttl_s=TTL, now=1001.0, new_token="tok-b") is None
+
+
+def test_without_the_sync_path_the_second_host_wins_too(tmp_path):
+    """Control: with no sync, host-b acquires freely.
+
+    Keeps the test above honest — it proves the refusal comes from the sync, not
+    from something incidental in the fixture.
+    """
+    _remote, a, b = _fleet(tmp_path)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    assert dl.acquire(grl.GitRefLease(a), name, "host-a",
+                      ttl_s=TTL, now=1000.0, new_token="tok-a") is not None
+    assert dl.acquire(grl.GitRefLease(b), name, "host-b",
+                      ttl_s=TTL, now=1001.0, new_token="tok-b") is not None
+
+
+def test_the_pushed_lease_is_readable_by_a_second_checkout(tmp_path):
+    """The blob itself round-trips: holder and generation survive the hop."""
+    _remote, a, b = _fleet(tmp_path)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    dl.acquire(grl.GitRefLease(a), name, "host-a",
+               ttl_s=TTL, now=1000.0, new_token="tok-a")
+    dp._push_lease_refs(a)
+    dp._fetch_lease_refs(b)
+
+    seen = grl.GitRefLease(b).read_ref(dl.lease_ref(name))
+    assert seen is not None
+    _sha, blob = seen
+    assert blob["holder"] == "host-a" and blob["generation"] == 1
+
+
+def test_the_fencing_token_is_visible_across_hosts(tmp_path):
+    """`verify_token` is the pre-side-effect gate; it must see the peer's grant."""
+    _remote, a, b = _fleet(tmp_path)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    dl.acquire(grl.GitRefLease(a), name, "host-a",
+               ttl_s=TTL, now=1000.0, new_token="tok-a")
+    dp._push_lease_refs(a)
+    dp._fetch_lease_refs(b)
+
+    assert dl.verify_token(grl.GitRefLease(b), name, "tok-a") is True
+    assert dl.verify_token(grl.GitRefLease(b), name, "tok-b") is False
+
+
+def test_the_push_actually_lands_on_the_remote(tmp_path):
+    """A best-effort push that silently pushed nothing would pass a peer-less test."""
+    remote, a, _b = _fleet(tmp_path)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    dl.acquire(grl.GitRefLease(a), name, "host-a",
+               ttl_s=TTL, now=1000.0, new_token="tok-a")
+    dp._push_lease_refs(a)
+
+    assert dl.lease_ref(name) in _remote_lease_refs(remote)
+
+
+def test_a_renewal_fast_forwards_on_the_remote(tmp_path):
+    """Non-forced pushes must keep working after the first grant.
+
+    Each lease commit is parented on the prior one, so a renew advances the ref
+    rather than diverging. If it did diverge, every night after the first would
+    push-reject and the fleet would silently stop syncing.
+    """
+    remote, a, _b = _fleet(tmp_path)
+    git_a = grl.GitRefLease(a)
+    name = dp.default_lease_name({"id": ISSUE})
+
+    dl.acquire(git_a, name, "host-a", ttl_s=TTL, now=1000.0, new_token="tok-a")
+    dp._push_lease_refs(a)
+    assert dl.renew(git_a, name, "host-a", now=1100.0, new_token="tok-a2") is not None
+    push = dp._push_lease_refs(a)
+
+    assert push.returncode == 0
+    assert dl.lease_ref(name) in _remote_lease_refs(remote)
+
+
+# ── one constant, not two agreeing literals ─────────────────────────────────
+
+
+def test_sync_refspecs_are_derived_from_the_writer_namespace(tmp_path):
+    """Whatever ref the writer produces must match what fetch and push move.
+
+    Asserted by matching a REAL ref from the writer against the module's own
+    refspecs, so it holds under any renaming of the namespace.
+    """
+    name = dp.default_lease_name({"id": ISSUE})
+    ref = dl.lease_ref(name)
+
+    fetch_src, _, fetch_dst = dp.lease_fetch_refspec().lstrip("+").partition(":")
+    assert fnmatch.fnmatch(ref, fetch_src)
+    assert fnmatch.fnmatch(ref, fetch_dst)
+    assert fnmatch.fnmatch(ref, dp.lease_push_refspec())
+
+
+def test_the_adapter_does_not_carry_its_own_copy_of_the_namespace(tmp_path):
+    """`git_ref_lease` and `dispatch_lease` must agree by construction."""
+    assert grl.lease_ref("task-x") == dl.lease_ref("task-x")

--- a/tests/operations/test_dispatch_pull_executor.py
+++ b/tests/operations/test_dispatch_pull_executor.py
@@ -1,0 +1,377 @@
+"""The pull loop's REAL executor: a queue card -> a `drain.py` invocation.
+
+## The gap this closes
+
+`dispatch_pull.claim_run` has always been able to run something. What it ran was
+`_dry_run_executor`, which prints. So every drain the fleet has ever performed
+needed an operator to hand-write `--command`, and "continuous unattended
+dispatch" stopped one step short of continuous.
+
+## The part that must not be papered over
+
+A card is an ISSUE. Most issues' work is not a shell one-liner, and nothing on
+the card says what to run — `.claude/dispatch/<machine>.yaml` carries `gh`,
+`repo`, `url`, `domain`, `provider`, `dispatch_status`, `wip_eligible`,
+`routed_by` and deliberately no title. There is no field a payload could be read
+from, and inventing one per domain would fire the same command at 1344 issues
+that have nothing in common but a label.
+
+So the binding is EXPLICIT and per-issue, and an unbound card is REFUSED.
+
+The headline assertion is the negative one: a card with no bound payload must
+not reach `mark_done`, must not spawn a drain, and must carry a status that a
+reader can tell apart from a completed run. A no-op that reports success is the
+exact false completion the record protocol (#3740) exists to prevent — it would
+be manufactured here, one layer above, and look identical on the way out.
+
+Every assertion below is on a PROPERTY — which statuses were produced, whether
+the drain subprocess was reached, whether `mark_done` fired, which flags are in
+the argv — never on the wording of a message.
+
+Hermetic: FakeGit (no git), a fake `run` (no subprocess, no drain, no gh), an
+injected clock and token. Nothing here touches the network or the real queue.
+
+Run: uv run --with pyyaml --with pytest pytest tests/operations/test_dispatch_pull_executor.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(mod, rel):
+    spec = importlib.util.spec_from_file_location(mod, _ROOT / rel)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+dp = _load("dispatch_pull", "scripts/operations/dispatch_pull.py")
+
+TTL = 30
+ISSUE = "vamseeachanta/deckhand#33"
+OTHER = "vamseeachanta/deckhand#37"
+
+
+class FakeGit:
+    """Dict-backed git model — same shape as test_dispatch_pull.FakeGit."""
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter:04d}"
+
+    def read_ref(self, name):
+        if name not in self.store:
+            return None
+        sha, blob = self.store[name]
+        return sha, dict(blob)
+
+    def create_ref(self, name, blob):
+        if name in self.store:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+    def cas_update_ref(self, name, expected_sha, blob):
+        cur = self.store.get(name)
+        if cur is None or cur[0] != expected_sha:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+
+class FakeRun:
+    """Stands in for `subprocess.run`. Records every argv; returns a chosen code.
+
+    Recording the argv is what lets the tests assert the drain was NOT reached,
+    which is the whole point of the unbound-card case — an executor that
+    swallowed the card quietly and one that refused it would produce the same
+    empty side effects if we only watched `mark_done`.
+    """
+
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+        self.calls: list[list[str]] = []
+        self.kwargs: list[dict] = []
+
+    def __call__(self, argv, **kw):
+        self.calls.append(list(argv))
+        self.kwargs.append(kw)
+        return subprocess.CompletedProcess(argv, self.returncode)
+
+
+def _tokens():
+    n = {"i": 0}
+
+    def fn():
+        n["i"] += 1
+        return f"tok{n['i']}"
+    return fn
+
+
+def _card(gh=ISSUE, *, wip=True, status="ready", domain="capability",
+          provider="claude"):
+    return {
+        "gh": gh,
+        "repo": gh.rpartition("#")[0],
+        "domain": domain,
+        "provider": provider,
+        "url": f"https://github.com/{gh.replace('#', '/issues/')}",
+        "dispatch_status": status,
+        "wip_eligible": wip,
+        "routed_by": "manual",
+    }
+
+
+def _item(card):
+    return {"id": card["gh"], "card": card}
+
+
+def _write_bindings(tmp_path: Path, mapping: dict) -> Path:
+    path = tmp_path / "commands.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "commands": mapping},
+                                   sort_keys=False))
+    return path
+
+
+# ── the headline: an unbound card is never a successful run ──────────────────
+
+
+def test_unbound_card_is_not_recorded_as_a_successful_run(tmp_path):
+    """A card with no declared payload: no drain, no mark_done, not `ran`."""
+    run = FakeRun(0)
+    done: list[str] = []
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path / "records", machine="dev-primary",
+        bindings={}, apply=False, run=run)
+
+    out = dp.claim_run([_item(_card())], holder="m1", git=FakeGit(),
+                       executor=executor, ttl_s=TTL, now_fn=lambda: 100.0,
+                       token_fn=_tokens(), mark_done=lambda it: done.append(it["id"]))
+
+    assert done == []                       # never completed
+    assert run.calls == []                  # drain.py was never reached
+    assert out[0]["status"] != "ran"        # and never reported as a run
+
+
+def test_unbound_card_status_is_distinguishable_from_a_completed_one(tmp_path):
+    """`no_command` is its own status — not a silent skip, not a success."""
+    bindings = dp.load_command_bindings(_write_bindings(tmp_path, {ISSUE: "echo bound"}))
+    runnable, deferred = dp.partition_runnable(
+        [_item(_card(ISSUE)), _item(_card(OTHER))], bindings)
+
+    assert [i["id"] for i in runnable] == [ISSUE]
+    assert [(d["id"], d["status"]) for d in deferred] == [(OTHER, dp.NO_COMMAND)]
+    assert dp.NO_COMMAND not in {"ran", "failed", "skipped_held", "lost_fence"}
+
+
+def test_deferred_card_never_takes_a_lease(tmp_path):
+    """Refused BEFORE the claim: an unrunnable card must not churn lease refs."""
+    git = FakeGit()
+    bindings = dp.load_command_bindings(_write_bindings(tmp_path, {}))
+    runnable, deferred = dp.partition_runnable([_item(_card())], bindings)
+    dp.claim_run(runnable, holder="m1", git=git, executor=lambda it: None,
+                 ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens())
+
+    assert deferred and git.store == {}
+
+
+def test_blank_command_is_undefined_not_an_empty_payload(tmp_path):
+    """`command: ""` would exit 0 having run nothing — a manufactured success."""
+    for blank in ("", "   ", "\n"):
+        bindings = dp.load_command_bindings(_write_bindings(tmp_path, {ISSUE: blank}))
+        runnable, deferred = dp.partition_runnable([_item(_card())], bindings)
+        assert runnable == []
+        assert [d["status"] for d in deferred] == [dp.NO_COMMAND]
+
+
+def test_executor_refuses_an_unbound_card_even_without_the_pre_filter(tmp_path):
+    """Defence in depth: the guard does not live only in `partition_runnable`.
+
+    A caller that wires the executor straight into `claim_run` (the shape the
+    module already supports) must not be able to reach a drain for a card whose
+    payload nobody declared.
+    """
+    run = FakeRun(0)
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path / "records", machine="dev-primary",
+        bindings={}, apply=False, run=run)
+
+    with pytest.raises(dp.UndefinedPayload):
+        executor(_item(_card()))
+    assert run.calls == []
+
+
+# ── the WIP cap ─────────────────────────────────────────────────────────────
+
+
+def test_wip_ineligible_card_is_not_claimed(tmp_path):
+    """The router capped it. The puller must not run it anyway."""
+    git = FakeGit()
+    bindings = dp.load_command_bindings(_write_bindings(tmp_path, {OTHER: "echo x"}))
+    runnable, deferred = dp.partition_runnable([_item(_card(OTHER, wip=False))], bindings)
+    dp.claim_run(runnable, holder="m1", git=git, executor=lambda it: None,
+                 ttl_s=TTL, now_fn=lambda: 100.0, token_fn=_tokens())
+
+    assert runnable == []
+    assert [d["status"] for d in deferred] == [dp.WIP_CAPPED]
+    assert git.store == {}
+
+
+def test_missing_wip_flag_is_treated_as_capped(tmp_path):
+    """An absent flag is not permission. Fail closed, like queue staleness does."""
+    card = _card()
+    card.pop("wip_eligible")
+    bindings = dp.load_command_bindings(_write_bindings(tmp_path, {ISSUE: "echo x"}))
+    runnable, deferred = dp.partition_runnable([_item(card)], bindings)
+
+    assert runnable == []
+    assert [d["status"] for d in deferred] == [dp.WIP_CAPPED]
+
+
+# ── the drain invocation ────────────────────────────────────────────────────
+
+
+def test_bound_card_invokes_drain_with_the_issue_and_its_command(tmp_path):
+    run = FakeRun(0)
+    records = tmp_path / "records"
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=records, machine="dev-primary",
+        bindings={ISSUE: "bash scripts/x.sh"}, apply=False, run=run)
+
+    out = dp.claim_run([_item(_card())], holder="m1", git=FakeGit(),
+                       executor=executor, ttl_s=TTL, now_fn=lambda: 100.0,
+                       token_fn=_tokens())
+
+    assert [o["status"] for o in out] == ["ran"]
+    assert len(run.calls) == 1
+    argv = run.calls[0]
+    assert argv[1].endswith("drain.py")
+    for flag, value in (("--issue", ISSUE), ("--command", "bash scripts/x.sh"),
+                        ("--records", str(records)), ("--repo-root", str(tmp_path)),
+                        ("--machine", "dev-primary")):
+        assert argv[argv.index(flag) + 1] == value
+
+
+def test_dry_run_is_the_default_and_omits_the_apply_flag(tmp_path):
+    run = FakeRun(0)
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path, machine="dev-primary",
+        bindings={ISSUE: "echo x"}, run=run)          # `apply` not passed at all
+    executor(_item(_card()))
+
+    assert "--apply" not in run.calls[0]
+
+
+def test_apply_passes_the_flag_through_to_drain(tmp_path):
+    run = FakeRun(0)
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path, machine="dev-primary",
+        bindings={ISSUE: "echo x"}, apply=True, run=run)
+    executor(_item(_card()))
+
+    assert "--apply" in run.calls[0]
+
+
+def test_executor_does_not_arm_the_env_gate_itself(tmp_path):
+    """Two gates, not one. `--apply` must not smuggle in `DISPATCH_APPLY_ENABLED`.
+
+    If the executor set the env var for the child, the operator's second gate
+    would be satisfied by the first one — drain would be armed by a flag alone.
+    """
+    run = FakeRun(0)
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path, machine="dev-primary",
+        bindings={ISSUE: "echo x"}, apply=True, run=run)
+    executor(_item(_card()))
+
+    env = run.kwargs[0].get("env")
+    assert env is None or dp.APPLY_FLAG not in env
+
+
+@pytest.mark.parametrize("code", [1, 2, 66])
+def test_nonzero_drain_exit_is_not_recorded_as_done(tmp_path, code):
+    """`blocked`/`unknown`/a refused claim all leave drain nonzero.
+
+    drain's own exit code is three-valued: 0 dry-run-or-success, 1 the loop
+    closed but the work did not succeed (this is where `blocked` lands), 2 the
+    loop did not close. Only 0 may become `ran`.
+    """
+    run = FakeRun(code)
+    done: list[str] = []
+    executor = dp.make_drain_executor(
+        repo=tmp_path, records_dir=tmp_path, machine="dev-primary",
+        bindings={ISSUE: "echo x"}, apply=True, run=run)
+
+    out = dp.claim_run([_item(_card())], holder="m1", git=FakeGit(),
+                       executor=executor, ttl_s=TTL, now_fn=lambda: 100.0,
+                       token_fn=_tokens(), mark_done=lambda it: done.append(it["id"]))
+
+    assert out[0]["status"] == "failed"
+    assert done == []
+    assert str(code) in out[0]["error"]     # the child's status is surfaced, not swallowed
+
+
+# ── the bindings file ───────────────────────────────────────────────────────
+
+
+def test_absent_bindings_file_binds_nothing(tmp_path):
+    """Missing map is not an error — but it grants nothing either."""
+    bindings = dp.load_command_bindings(tmp_path / "nope.yaml")
+    runnable, deferred = dp.partition_runnable([_item(_card())], bindings)
+
+    assert bindings == {}
+    assert runnable == [] and [d["status"] for d in deferred] == [dp.NO_COMMAND]
+
+
+def test_malformed_binding_key_is_rejected_loudly(tmp_path):
+    """A typo'd key would otherwise bind nothing, silently, forever."""
+    with pytest.raises(ValueError):
+        dp.load_command_bindings(_write_bindings(tmp_path, {"deckhand#33": "echo x"}))
+
+
+def test_non_string_command_is_rejected(tmp_path):
+    with pytest.raises(ValueError):
+        dp.load_command_bindings(_write_bindings(tmp_path, {ISSUE: ["echo", "x"]}))
+
+
+def test_bindings_survive_a_queue_regeneration(tmp_path):
+    """The binding lives OUTSIDE the generated queue file, on purpose.
+
+    `dispatch.py` rewrites `.claude/dispatch/<machine>.yaml` wholesale from
+    `route.py` proposals; a `command:` field added to a card would be discarded
+    by the next `dispatch.py --write`. This pins the property that made the side
+    map the choice: resolution reads the map, not the card.
+    """
+    bindings = dp.load_command_bindings(_write_bindings(tmp_path, {ISSUE: "echo bound"}))
+    regenerated = _card()                    # exactly what dispatch.py emits
+    assert dp.resolve_command(_item(regenerated), bindings) == "echo bound"
+
+
+# ── the two gates, at the CLI ───────────────────────────────────────────────
+
+
+def test_main_refuses_apply_without_the_env_gate(tmp_path, monkeypatch, capsys):
+    """`--apply` alone claims nothing: refused before any git or lease call."""
+    monkeypatch.delenv(dp.APPLY_FLAG, raising=False)
+    calls: list = []
+    monkeypatch.setattr(dp, "_fetch_lease_refs", lambda *a, **k: calls.append("fetch"))
+    monkeypatch.setattr(dp, "_read_ready_cards", lambda *a, **k: calls.append("read") or [])
+
+    rc = dp.main(["--apply", "--repo", str(tmp_path), "--machine", "dev-primary"])
+
+    assert rc != 0
+    assert calls == []

--- a/tests/operations/test_dispatch_pull_pacing.py
+++ b/tests/operations/test_dispatch_pull_pacing.py
@@ -1,0 +1,403 @@
+"""Pacing and morning evidence for the pull loop (rail R6 of #3773).
+
+## The two defects
+
+**No cap, no backoff.** Nothing bounded how many cards one run attempted. Each
+drain writes two commits to `main` plus a push, so the worst case over the
+`dev-primary` queue was roughly 1344 cards x 2 commits, unattended, into a repo
+with CI and a PII gate. The run needs a ceiling and a gap between cards, and
+both need to be settable without editing the file.
+
+**Failure and silence look identical.** A night that refused all 1344 cards and
+a night that completed them produced the same artifact: the stdout of a process
+nobody was attached to. The morning question — "did anything happen?" — had no
+answer that survived the terminal.
+
+## What is asserted
+
+Properties, not messages: how many times the executor was reached, how many
+sleeps separated those calls, which statuses the log carries, and which strings
+it must never contain. The cap tests are paired with an uncapped control so a
+cap that "passes" by running nothing cannot hide.
+
+The prose guard is the one worth reading twice. Titles were removed from the
+dispatch surface because they leaked client identifiers into a public repo
+(#3768); a log that dumped the card would put them straight back. The log is
+built from a fixed key set, and the test feeds it a card carrying a title to
+prove the key set — not a filter, not a regex — is what keeps prose out.
+
+Hermetic: FakeGit, injected clock/token/sleep, tmp_path logs. No subprocess.
+
+Run: uv run --with pyyaml --with pytest pytest tests/operations/test_dispatch_pull_pacing.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(mod, rel):
+    spec = importlib.util.spec_from_file_location(mod, _ROOT / rel)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+dp = _load("dispatch_pull", "scripts/operations/dispatch_pull.py")
+
+TTL = 900
+REPO = "vamseeachanta/deckhand"
+
+
+class FakeGit:
+    """Dict-backed git model — same shape as test_dispatch_pull_executor.FakeGit."""
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter:04d}"
+
+    def read_ref(self, name):
+        if name not in self.store:
+            return None
+        sha, blob = self.store[name]
+        return sha, dict(blob)
+
+    def create_ref(self, name, blob):
+        if name in self.store:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+    def cas_update_ref(self, name, expected_sha, blob):
+        cur = self.store.get(name)
+        if cur is None or cur[0] != expected_sha:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+
+def _tokens():
+    n = {"i": 0}
+
+    def fn():
+        n["i"] += 1
+        return f"tok{n['i']}"
+    return fn
+
+
+def _items(count: int) -> list[dict]:
+    return [{"id": f"{REPO}#{n}", "card": {"gh": f"{REPO}#{n}", "wip_eligible": True}}
+            for n in range(1, count + 1)]
+
+
+class Spy:
+    """Counts executor calls; optionally raises for chosen ids."""
+
+    def __init__(self, fail_ids=()):
+        self.calls: list[str] = []
+        self.fail_ids = set(fail_ids)
+
+    def __call__(self, item):
+        self.calls.append(item["id"])
+        if item["id"] in self.fail_ids:
+            raise dp.DrainFailed(item["id"], 2)
+        return 0
+
+
+class Clock:
+    """A sleep that records instead of sleeping, and a clock it advances."""
+
+    def __init__(self):
+        self.slept: list[float] = []
+        self.t = 1000.0
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.t += seconds
+
+    def now(self):
+        return self.t
+
+
+def _run(items, *, executor, git=None, clock=None, **kw):
+    return dp.claim_run(items, holder="host-a", git=git or FakeGit(),
+                        executor=executor, ttl_s=TTL,
+                        now_fn=(clock or Clock()).now, token_fn=_tokens(), **kw)
+
+
+# ── (a) the cap ─────────────────────────────────────────────────────────────
+
+
+def test_the_run_stops_after_the_cap(tmp_path):
+    """Five cards, a cap of two: the executor is reached twice."""
+    spy = Spy()
+    _run(_items(5), executor=spy, max_cards=2)
+
+    assert len(spy.calls) == 2
+
+
+def test_without_a_cap_the_same_queue_runs_to_the_end(tmp_path):
+    """Control: the cap test above is not passing because nothing ran."""
+    spy = Spy()
+    _run(_items(5), executor=spy, max_cards=None)
+
+    assert len(spy.calls) == 5
+
+
+def test_cards_past_the_cap_are_reported_not_dropped(tmp_path):
+    """A queue that shrinks silently is the failure this rail exists to close."""
+    out = _run(_items(5), executor=Spy(), max_cards=2)
+
+    assert len(out) == 5
+    assert [o["status"] for o in out] == ["ran", "ran"] + [dp.RUN_CAPPED] * 3
+    assert dp.RUN_CAPPED not in {"ran", "failed", "skipped_held", "lost_fence",
+                                 dp.NO_COMMAND, dp.WIP_CAPPED}
+
+
+def test_a_capped_card_never_takes_a_lease(tmp_path):
+    """Past the ceiling, the loop must stop touching refs, not just stop running."""
+    git = FakeGit()
+    _run(_items(5), executor=Spy(), git=git, max_cards=2)
+
+    assert len(git.store) == 2
+
+
+def test_a_failed_card_still_consumes_the_cap(tmp_path):
+    """The ceiling bounds ATTEMPTS. A failing drain has already written to main."""
+    spy = Spy(fail_ids={f"{REPO}#1", f"{REPO}#2"})
+    out = _run(_items(5), executor=spy, max_cards=2)
+
+    assert len(spy.calls) == 2
+    assert [o["status"] for o in out[:2]] == ["failed", "failed"]
+
+
+def test_a_card_held_elsewhere_does_not_consume_the_cap(tmp_path):
+    """A skipped claim writes nothing to `main`, so it must not eat the budget."""
+    git = FakeGit()
+    items = _items(3)
+    # host-b already holds the first card's lease, fresh.
+    held = dp.default_lease_name(items[0])
+    git.create_ref(dp.lease_ref(held), {"holder": "host-b", "generation": 1,
+                                        "token": "t", "ttl_s": TTL,
+                                        "renewed_at": 1000.0})
+    spy = Spy()
+    out = _run(items, executor=spy, git=git, max_cards=2)
+
+    assert [o["status"] for o in out] == ["skipped_held", "ran", "ran"]
+    assert len(spy.calls) == 2
+
+
+# ── (a) the delay ───────────────────────────────────────────────────────────
+
+
+def test_a_delay_separates_consecutive_cards(tmp_path):
+    """Three runs, two gaps — the pause is between cards, not around them."""
+    clock = Clock()
+    _run(_items(3), executor=Spy(), clock=clock, delay_s=30.0, sleep_fn=clock.sleep)
+
+    assert clock.slept == [30.0, 30.0]
+
+
+def test_nothing_sleeps_before_the_first_card(tmp_path):
+    clock = Clock()
+    _run(_items(1), executor=Spy(), clock=clock, delay_s=30.0, sleep_fn=clock.sleep)
+
+    assert clock.slept == []
+
+
+def test_a_zero_delay_does_not_sleep(tmp_path):
+    clock = Clock()
+    _run(_items(3), executor=Spy(), clock=clock, delay_s=0.0, sleep_fn=clock.sleep)
+
+    assert clock.slept == []
+
+
+def test_capped_cards_are_not_paced(tmp_path):
+    """Waiting out a delay for cards the run has already declined is dead time."""
+    clock = Clock()
+    _run(_items(6), executor=Spy(), clock=clock, max_cards=2,
+         delay_s=30.0, sleep_fn=clock.sleep)
+
+    assert clock.slept == [30.0]
+
+
+# ── (a) both, at the CLI ────────────────────────────────────────────────────
+
+
+def test_the_cli_default_cap_is_finite_and_conservative():
+    """A default of `None`/0/unbounded would leave the overnight risk in place."""
+    default = _arg_default("--max-cards")
+
+    assert isinstance(default, int)
+    assert 0 < default <= 50
+
+
+def test_the_cli_default_delay_is_a_real_pause():
+    default = _arg_default("--delay")
+
+    assert isinstance(default, (int, float)) and default > 0
+
+
+def test_no_cli_value_can_disable_the_cap(tmp_path):
+    """`--max-cards` is a ceiling, not a switch. Unbounded must be unreachable.
+
+    Parsed, not run — and `--repo` is pinned at `tmp_path` regardless, because a
+    regression in the guard would otherwise let this test fall through into a
+    real pull against the real queue. (It did, once, while mutation-testing the
+    guard: 1344 live cards read and a 316 KB log written into the repo.)
+    """
+    for bad in ("-1", "-100"):
+        with pytest.raises(SystemExit):
+            dp.build_parser().parse_args(
+                ["--max-cards", bad, "--repo", str(tmp_path)])
+
+
+def _arg_default(flag: str):
+    parser = dp.build_parser()
+    for action in parser._actions:
+        if flag in action.option_strings:
+            return action.default
+    raise AssertionError(f"{flag} is not a CLI option")
+
+
+# ── (b) the run log ─────────────────────────────────────────────────────────
+
+
+def _read(path: Path) -> list[dict]:
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+def _log(tmp_path, **kw) -> "dp.RunLog":
+    return dp.RunLog(tmp_path / "2026-08-01.jsonl", run_id="r1",
+                     machine="dev-primary", now_fn=lambda: 1000.0, **kw)
+
+
+def test_every_card_gets_its_own_line(tmp_path):
+    log = _log(tmp_path)
+    out = _run(_items(3), executor=Spy(), on_outcome=log.card)
+
+    records = _read(log.path)
+    assert len(records) == 3
+    assert [r["issue"] for r in records] == [o["id"] for o in out]
+    assert {r["status"] for r in records} == {"ran"}
+
+
+def test_a_line_names_the_run_the_machine_and_the_attempt(tmp_path):
+    log = _log(tmp_path)
+    _run(_items(1), executor=Spy(), on_outcome=log.card)
+
+    record = _read(log.path)[0]
+    for field in ("ts", "run_id", "machine", "issue", "status", "attempt"):
+        assert field in record
+    assert record["run_id"] == "r1" and record["machine"] == "dev-primary"
+
+
+def test_deferred_cards_are_logged_too(tmp_path):
+    """`no_command` and `wip_capped` never reach `claim_run` — and still count."""
+    log = _log(tmp_path)
+    items = [{"id": f"{REPO}#1", "card": {"gh": f"{REPO}#1", "wip_eligible": False}},
+             {"id": f"{REPO}#2", "card": {"gh": f"{REPO}#2", "wip_eligible": True}}]
+    _runnable, deferred = dp.partition_runnable(items, {})
+    for outcome in deferred:
+        log.card(outcome)
+
+    assert {r["status"] for r in _read(log.path)} == {dp.WIP_CAPPED, dp.NO_COMMAND}
+
+
+def test_a_failure_carries_its_cause(tmp_path):
+    log = _log(tmp_path)
+    _run(_items(1), executor=Spy(fail_ids={f"{REPO}#1"}), on_outcome=log.card)
+
+    record = _read(log.path)[0]
+    assert record["status"] == "failed" and "2" in record["error"]
+
+
+def test_the_summary_counts_every_outcome_by_cause(tmp_path):
+    """The one line that answers "what happened last night" without a terminal."""
+    log = _log(tmp_path)
+    items = _items(6)
+    out = _run(items, executor=Spy(fail_ids={f"{REPO}#2"}), max_cards=3,
+               on_outcome=log.card)
+    deferred = [{"id": f"{REPO}#9", "status": dp.NO_COMMAND, "reason": "unbound"}]
+    summary = log.summary(deferred + out)
+
+    assert summary["counts"] == {"ran": 2, "failed": 1, dp.RUN_CAPPED: 3,
+                                 dp.NO_COMMAND: 1}
+    assert summary["total"] == 7
+    assert _read(log.path)[-1]["event"] == "run_summary"
+
+
+def test_a_run_that_refused_everything_reads_differently_from_one_that_worked(tmp_path):
+    """The defect: both nights produced identical evidence. They must not."""
+    all_refused = _log(tmp_path / "a").summary(
+        [{"id": f"{REPO}#{n}", "status": dp.NO_COMMAND} for n in range(1, 5)])
+    all_ran = _log(tmp_path / "b").summary(
+        [{"id": f"{REPO}#{n}", "status": "ran"} for n in range(1, 5)])
+
+    assert all_refused["counts"] != all_ran["counts"]
+
+
+def test_the_log_never_writes_issue_prose(tmp_path):
+    """#3768: titles left this surface because they leaked client identifiers.
+
+    The card is fed a title here precisely because a real one has none — the
+    assertion is about what the writer is ALLOWED to copy, not about what today's
+    cards happen to hold.
+    """
+    secret = "Confidential Client Alpha riser fatigue rework"
+    log = _log(tmp_path)
+    log.card({"id": f"{REPO}#1", "status": "ran", "title": secret,
+              "card": {"gh": f"{REPO}#1", "title": secret, "body": secret}})
+
+    text = log.path.read_text()
+    assert secret not in text
+    assert "title" not in text and "body" not in text
+    assert f"{REPO}#1" in text          # the issue ref itself is fine
+
+
+def test_the_summary_never_writes_issue_prose(tmp_path):
+    secret = "Confidential Client Alpha riser fatigue rework"
+    log = _log(tmp_path)
+    log.summary([{"id": f"{REPO}#1", "status": "ran", "title": secret}])
+
+    assert secret not in log.path.read_text()
+
+
+def test_the_log_appends_rather_than_truncating(tmp_path):
+    """Two runs in one night must both survive."""
+    path = tmp_path / "2026-08-01.jsonl"
+    for run_id in ("r1", "r2"):
+        log = dp.RunLog(path, run_id=run_id, machine="dev-primary",
+                        now_fn=lambda: 1000.0)
+        log.card({"id": f"{REPO}#1", "status": "ran"})
+
+    assert [r["run_id"] for r in _read(path)] == ["r1", "r2"]
+
+
+def test_the_log_is_dated_and_lands_under_the_repo(tmp_path):
+    path = dp.run_log_path(tmp_path, today="2026-08-01")
+
+    assert path.parent == tmp_path / dp.RUN_LOG_DIR_REL
+    assert path.name == "2026-08-01.jsonl"
+
+
+def test_the_log_directory_is_gitignored():
+    """A public repo with a PII gate must not be handed a nightly card log."""
+    probe = str(dp.RUN_LOG_DIR_REL / "2026-08-01.jsonl")
+    done = subprocess.run(["git", "-C", str(_ROOT), "check-ignore", "-q", probe],
+                          capture_output=True, text=True, timeout=60)
+
+    assert done.returncode == 0, f"{probe} is not gitignored"

--- a/tests/operations/test_dispatch_pull_pause.py
+++ b/tests/operations/test_dispatch_pull_pause.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""The PAUSE sentinel must stop the loop, not fail every card (#3773 R2+R6).
+
+This defect was created by fixing two things in parallel. `drain.py` gained a
+`.claude/dispatch/PAUSE` sentinel and exit code 3 to mean "the fleet is paused,
+I refused to claim anything". `dispatch_pull.py`'s executor, written at the same
+time, raises `DrainFailed` on ANY nonzero exit.
+
+Composed, a paused fleet does not stop. It walks the whole queue recording a
+failure per card — so the kill switch produces the loudest possible false alarm
+and stops nothing. On `dev-primary` that is 1344 fabricated failures.
+
+The distinction the tests below pin is a general one: an exit code that means
+"the system said no" is not an exit code that means "this unit of work broke".
+Collapsing them loses the only signal that says stop.
+
+Run: uv run --with pyyaml --with pytest pytest tests/operations/test_dispatch_pull_pause.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PULL_PY = REPO_ROOT / "scripts" / "operations" / "dispatch_pull.py"
+
+# drain.py's PAUSED exit. Imported rather than restated where possible; the
+# literal here is the point of `test_the_paused_code_matches_drains_own`.
+DRAIN_PAUSED_EXIT = 3
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("dispatch_pull", PULL_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dispatch_pull"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def dp():
+    return _load()
+
+
+class _FakeGit:
+    """Dict-backed ref store — the shape `dispatch_lease` actually drives.
+
+    `claim_run` calls the lease module's functions with this object, not methods
+    on it, so the surface that matters is `read_ref` / `create_ref`, matching
+    the FakeGit in `test_dispatch_pull_executor.py`. Every lease is granted;
+    leases are not what these tests are about.
+    """
+
+    def __init__(self):
+        self.store: dict[str, tuple[str, dict]] = {}
+        self._counter = 0
+
+    def _next_sha(self) -> str:
+        self._counter += 1
+        return f"sha{self._counter:04d}"
+
+    def read_ref(self, name):
+        if name not in self.store:
+            return None
+        sha, blob = self.store[name]
+        return sha, dict(blob)
+
+    def create_ref(self, name, blob):
+        if name in self.store:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+    def update_ref(self, name, blob, expect_sha):
+        cur = self.store.get(name)
+        if cur is None or cur[0] != expect_sha:
+            return None
+        sha = self._next_sha()
+        self.store[name] = (sha, dict(blob))
+        return sha
+
+
+def _cards(n):
+    return [{"id": f"owner/repo#{i}", "card": {"gh": f"owner/repo#{i}"}} for i in range(1, n + 1)]
+
+
+def _run(dp, executor, items, mark_done=None):
+    """Drive claim_run with leases and fencing stubbed out.
+
+    `verify_token` is a module-level alias (`dispatch_pull.verify_token`), not a
+    parameter, so it is patched on the freshly-loaded module rather than passed
+    in. Each test loads its own copy, so this cannot leak between tests.
+
+    `max_cards` is left at its default of None (unbounded) on purpose: the CLI
+    default is 5, and a capped run would truncate the ten-card case and make the
+    stop-the-loop assertion pass for the wrong reason.
+    """
+    dp.verify_token = lambda *a, **k: True
+    return dp.claim_run(
+        items,
+        holder="ace-linux-1",
+        git=_FakeGit(),
+        executor=executor,
+        ttl_s=900,
+        now_fn=lambda: 1000.0,
+        token_fn=lambda: "tok",
+        mark_done=mark_done,
+        sleep_fn=lambda s: None,
+    )
+
+
+def test_the_paused_code_matches_drains_own(dp):
+    """A pause the loop does not recognise is not a pause.
+
+    Asserts the constant, not a message: if drain renumbers its exit codes this
+    fails here rather than silently degrading to `failed` in production.
+    """
+    assert dp.FLEET_PAUSED_EXIT == DRAIN_PAUSED_EXIT
+
+
+def test_a_paused_drain_stops_the_loop_instead_of_walking_the_queue(dp):
+    """THE test. Ten cards, drain reports paused on the first.
+
+    Fails on the pre-fix code with ten `failed` outcomes — the shape that would
+    have put 1344 fabricated failures in a run log.
+    """
+    calls = []
+
+    def executor(item):
+        calls.append(item["id"])
+        raise dp.FleetPaused(item["id"])
+
+    outcomes = _run(dp, executor, _cards(10))
+
+    assert len(calls) == 1, (
+        f"the loop ran {len(calls)} cards after a pause; it must stop at the first"
+    )
+    statuses = [o["status"] for o in outcomes]
+    assert "failed" not in statuses, (
+        f"a paused fleet was recorded as card failures: {statuses}"
+    )
+
+
+def test_a_paused_card_is_not_recorded_as_a_failure(dp):
+    """`paused` and `failed` must be separable by a reader, not just by wording."""
+    outcomes = _run(dp, lambda item: (_ for _ in ()).throw(dp.FleetPaused(item["id"])), _cards(3))
+    first = outcomes[0]
+    assert first["status"] == "paused"
+    assert first["status"] != "failed"
+
+
+def test_a_paused_card_is_never_marked_done(dp):
+    """A refusal to start is not a completion. The card must stay claimable."""
+    marked = []
+    _run(
+        dp,
+        lambda item: (_ for _ in ()).throw(dp.FleetPaused(item["id"])),
+        _cards(3),
+        mark_done=lambda item: marked.append(item["id"]),
+    )
+    assert marked == []
+
+
+def test_a_real_card_failure_still_fails_and_still_continues(dp):
+    """The discriminator.
+
+    Without this, "treat every exception as a pause" would pass every test
+    above while destroying the retry path. A genuine failure must NOT stop the
+    loop, and must NOT be reported as paused.
+    """
+    calls = []
+
+    def executor(item):
+        calls.append(item["id"])
+        raise dp.DrainFailed(item["id"], 1)
+
+    outcomes = _run(dp, executor, _cards(4))
+
+    assert len(calls) == 4, "a single card failure must not halt the run"
+    assert [o["status"] for o in outcomes] == ["failed"] * 4
+
+
+def test_the_executor_raises_paused_on_drains_paused_exit(dp):
+    """End of the wire: exit 3 from the child becomes FleetPaused, not DrainFailed.
+
+    Asserts on the exception TYPE reaching the caller, not on a returncode
+    comparison inside the executor, so moving the check cannot silently break it.
+    """
+    class _Done:
+        returncode = DRAIN_PAUSED_EXIT
+
+    ex = dp.make_drain_executor(
+        repo=REPO_ROOT,
+        records_dir=REPO_ROOT / ".claude" / "dispatch" / "records",
+        machine="dev-primary",
+        bindings={"owner/repo#1": "true"},
+        apply=False,
+        run=lambda argv, **kw: _Done(),
+    )
+
+    with pytest.raises(dp.FleetPaused):
+        ex({"id": "owner/repo#1", "card": {"gh": "owner/repo#1"}})
+
+
+def test_other_nonzero_exits_are_still_drain_failures(dp):
+    """Only 3 is a pause. 1 and 2 remain per-card failures."""
+    class _Done:
+        def __init__(self, rc):
+            self.returncode = rc
+
+    for rc in (1, 2, 66):
+        ex = dp.make_drain_executor(
+            repo=REPO_ROOT,
+            records_dir=REPO_ROOT / ".claude" / "dispatch" / "records",
+            machine="dev-primary",
+            bindings={"owner/repo#1": "true"},
+            apply=False,
+            run=lambda argv, _rc=rc, **kw: _Done(_rc),
+        )
+        with pytest.raises(dp.DrainFailed):
+            ex({"id": "owner/repo#1", "card": {"gh": "owner/repo#1"}})


### PR DESCRIPTION
Closes #3764, #3772. Delivers all six rails from #3773.

Six commits, four agents working in parallel on non-overlapping files, plus one integration fix that only appeared once their work was composed.

## What was actually broken

**The loop did not exist.** `dispatch_pull.py` had a fenced, lease-arbitrated loop with an *injected* executor — wired to `_dry_run_executor`. Nothing turned a queue card into a payload.

**Cross-machine exclusion was zero** (#3772). Leases were written to `refs/heads/dispatch/leases/` and synced from `refs/heads/dispatch-lease/*`. The namespaces do not overlap, so no lease ever left the host and every host acquired every lease it asked for. The core — CAS, monotonic generation, fencing token — was sound and wired to nothing. A **third** copy of the literal sat in `git_ref_lease.py:32` that the audit missed; the prefix is now imported from one constant.

**A refused claim still published** (#3764). `acquire` refused on a rejected push but left the claim commit local, and auto-sync published it — a live `state: active` record with `command_ref: null` holding an issue for its full 90-minute TTL. Exclusion without execution.

**A thrice-failed card looked successful.** Attempt exhaustion returned a bare refusal that wrote *nothing*, so the terminal state stayed `done`, projected `dispatch:done`, and counted as executed. `chain.py` never called `records.is_success`. A night that failed every card printed identically to one that completed every card.

**The WIP cap bound nowhere.** `dispatch.py:66-68` claimed it was enforced at claim time. It was not — `apply_wip` only annotates.

**There was no kill switch**, and `run.sh` uses `setsid nohup` so payloads outlive the session.

**The timeout did not kill** — the payload is a grandchild, so it ran on orphaned while the record said "unknown".

**No pacing.** 1344 cards × 3 attempts × 2 commits ≈ 8,000 commits pushed to `main` overnight.

## Judgement calls worth reviewing

**Card→command binding** is an explicit per-issue map at `.claude/dispatch/commands.yaml`; an unbound card is refused as `no_command`, never run. Rejected: a card field (destroyed by the next `--write`), a per-domain template (fires one command at hundreds of unrelated issues), a label convention (network at the decision point), and a universal "run an agent on this issue" template — the most dangerous, since it would dispatch agents at 1344 issues that never passed the plan-approval gate. Writing a binding is a deliberate human act, landing where that gate already sits.

**`UNATTESTED` outcome bucket** exists because `drain.py` *promises* never to write `done` with a null returncode. The reporter does not rely on it: a guarantee held in another module is one this module cannot see break.

**The claim undo** is not `reset --hard` (destroys other lanes' edits) nor `reset --mixed` (silently unstages them). It identifies the commit by *content* — two hosts write byte-identical subjects, so a message match would let one host drop another's claim — drops it only if it is the tip and touches nothing else, and moves the ref by compare-and-swap. Otherwise the claim is removed *forward*, restoring a possibly-terminal parent record rather than deleting audit history.

## The integration defect

Exit 3 (PAUSED) would have been read by the executor as `DrainFailed` — so the kill switch would walk the entire queue recording ~1344 fabricated failures and stop nothing. Neither agent could see this alone. Fixed with a distinct `FleetPaused` that breaks the loop.

## Verification

```
tests/operations/ + tests/dispatch/    804 passed, 0 failed
```

Every rail mutation-verified — break the guard, confirm RED, restore. Roughly 55 mutants across the six commits, all killed. Two are worth reading in the commit messages: one initially **escaped** because a test asserted `warnings` was merely truthy while an unrelated warning was already present ("the test was measuring the weather"), and the `break`→`continue` mutant that proves the pause actually stops the loop.

## Not safe to arm yet

- `.claude/dispatch/commands.yaml` does not exist, so a run today reports 1344 × `no_command` and executes zero. That is the design, not an oversight.
- No heartbeat beater, so no payload may run longer than `ttl_minutes` (90 min). The coupling is now *refused* rather than silently violated.
- `per_provider` caps and `budget_pools.max_concurrent` still bind nowhere at claim time.
- No scheduler entry on ace-linux-1.