### PR TITLE
fix(hooks): restore the pre-push gate to version control and scope new-branch pushes by merge-base (#3780)

### DIFF
--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -97,11 +97,18 @@ if [[ "$FIRST_LOCAL_OID" == "$ZERO_OID" ]]; then
     exit 0
 fi
 
-# ── New-branch guard: remote_oid all-zeros → can't diff, run all repos ────────
-if [[ "$FIRST_REMOTE_OID" == "$ZERO_OID" ]]; then
-    echo "[pre-push] New branch — running all tier-1 repo checks." >&2
-    RUN_ALL=true
-fi
+# ── New-branch guard: scope by merge-base, escalate only if that fails ───────
+# remote_oid all-zeros means we cannot diff against the remote. It does NOT
+# mean the scope is unknowable: a branch cut from main has a merge-base.
+#
+# This previously set RUN_ALL=true unconditionally, which gave the NARROWEST
+# possible change the WIDEST possible gate -- every feature branch is a new
+# branch on its first push, so a one-file docs change ran every tier-1 repo's
+# full suite. Chained to a suite that is red by baseline, the push could not
+# pass at any duration (#3780).
+DIFF_BASE="$FIRST_REMOTE_OID"
+NEW_BRANCH=false
+[[ "$FIRST_REMOTE_OID" == "$ZERO_OID" ]] && NEW_BRANCH=true
 
 # ── Detect changed tier-1 repos ──────────────────────────────────────────────
 declare -a REPOS_TO_CHECK=()
@@ -109,18 +116,49 @@ declare -a REPOS_TO_CHECK=()
 if [[ "$RUN_ALL" == "true" ]]; then
     REPOS_TO_CHECK=("${TIER1_REPOS[@]}")
 else
-    # Use override if set (for testing), otherwise run git diff
+    # Scope resolution, cheapest source first. Escalation happens only when we
+    # genuinely cannot determine scope -- never merely because it was awkward.
     if [[ -n "${PRE_PUSH_CHANGED_FILES:-}" ]]; then
+        # Scope supplied directly; no base to resolve, nothing to escalate.
         CHANGED_FILES="$PRE_PUSH_CHANGED_FILES"
     else
-        CHANGED_FILES="$(git diff --name-only "${FIRST_REMOTE_OID}..${FIRST_LOCAL_OID}" 2>/dev/null || true)"
+        if [[ "$NEW_BRANCH" == "true" ]]; then
+            # remote_oid is all-zeros, so there is nothing to diff against --
+            # but a branch cut from main still has a merge-base. Escalation is
+            # for genuinely disjoint history, not for every first push.
+            if BASE="$(git merge-base origin/main "$FIRST_LOCAL_OID" 2>/dev/null)" \
+               && [[ -n "$BASE" ]]; then
+                DIFF_BASE="$BASE"
+                echo "[pre-push] New branch — scoping against merge-base ${BASE:0:8}." >&2
+            else
+                echo "[pre-push] New branch, no merge-base — running all tier-1 checks." >&2
+                RUN_ALL=true
+            fi
+        fi
+
+        # `|| true` was REMOVED here deliberately. It made a failed diff read as
+        # "no files changed", which reads as "no repos to check", which exits 0
+        # having verified nothing. An error must escalate, never open the gate.
+        if [[ "$RUN_ALL" != "true" ]]; then
+            if ! CHANGED_FILES="$(git diff --name-only "${DIFF_BASE}..${FIRST_LOCAL_OID}" 2>/dev/null)"; then
+                echo "[pre-push] Could not determine changed files — running all tier-1 checks." >&2
+                RUN_ALL=true
+            fi
+        fi
+        [[ "$RUN_ALL" == "true" ]] && CHANGED_FILES=""
     fi
 
-    for repo in "${TIER1_REPOS[@]}"; do
-        if echo "$CHANGED_FILES" | grep -q "^${repo}/"; then
-            REPOS_TO_CHECK+=("$repo")
-        fi
-    done
+    if [[ "$RUN_ALL" == "true" ]]; then
+        # Escalated mid-branch (diff failed). Take every repo and do NOT fall
+        # through to detection -- CHANGED_FILES is unusable by definition here.
+        REPOS_TO_CHECK=("${TIER1_REPOS[@]}")
+    else
+        for repo in "${TIER1_REPOS[@]}"; do
+            if echo "$CHANGED_FILES" | grep -q "^${repo}/"; then
+                REPOS_TO_CHECK+=("$repo")
+            fi
+        done
+    fi
 
     # ── Config drift check on changed harness files (WRK-1094) ───────────────
     # Must run BEFORE the early exit so root-only harness pushes are checked.
@@ -273,34 +311,9 @@ fi
 
 exit "$OVERALL_EXIT"
 
-# ── Stage prompt drift guard (installed by install-hooks.sh) ─────────────
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
-if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
-  bash "$STAGE_PROMPT_DRIFT_GATE" || exit $?
-fi
-
-# ── Enforcement environment (installed by install-hooks.sh #2128) ──────
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"
-if [[ -f "${ENFORCEMENT_ENV}" ]]; then
-  source "${ENFORCEMENT_ENV}"
-fi
-
-# ── State-file size guard pre-push (#2070) ───────────────────────────────
-# Pre-push reads <local_ref local_sha remote_ref remote_sha> on stdin; tee it
-# into the size-guard hook so it can scan the to-be-pushed commit range.
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-STATE_SIZE_PREPUSH="${REPO_ROOT}/.claude/hooks/check-state-file-size-prepush.sh"
-if [[ -f "$STATE_SIZE_PREPUSH" ]]; then
-  bash "$STATE_SIZE_PREPUSH" || exit $?
-fi
-
-# ── Cadence-helper sync check (wed#309) ──────────────────────────────────
-# Verifies worldenergydata/scripts/cron/lib/cadence-common.sh is byte-identical
-# to workspace-hub/scripts/cron/lib/cadence-common.sh. Exits 1 on drift.
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-CADENCE_SYNC="${REPO_ROOT}/scripts/sync/sync-cadence-helper.sh"
-if [[ -f "$CADENCE_SYNC" ]]; then
-  bash "$CADENCE_SYNC" || exit $?
-fi
+# NOTE: install-hooks.sh appends enforcement blocks AFTER this point. Anything
+# below an unconditional `exit` never runs. Three gates lived here and had never
+# executed once -- stage-prompt drift, state-size pre-push, cadence sync -- while
+# the installer logged "OK: Wired ... into pre-push" for each. Removed rather
+# than left as decoration. Re-wiring them ABOVE this exit changes what blocks
+# pushes and is a per-gate decision: workspace-hub#3781.

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# pre-push.sh — Pre-push CI gate
+# WRK-1070: original stub (secrets + coverage).
+# WRK-1064: extended with tier-1 repo quality + test gate.
+#
+# Usage (as git hook):
+#   Called automatically by git push; stdin receives push refspecs.
+#
+# Environment overrides (for testing):
+#   PRE_PUSH_DRY_RUN=1          — skip all real checks (no-op pass)
+#   PRE_PUSH_CHECK_ALL_SCRIPT   — override path to check-all.sh
+#   PRE_PUSH_RUN_TESTS_SCRIPT   — override path to run-all-tests.sh
+#   PRE_PUSH_CHANGED_FILES      — override output of git diff --name-only
+#   PRE_PUSH_BYPASS_LOG         — override path to bypass JSONL log
+#   GIT_PRE_PUSH_SKIP=1         — soft bypass: log and exit 0 (audited)
+set -euo pipefail
+
+# ── Resolve paths ─────────────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CHECK_ALL="${PRE_PUSH_CHECK_ALL_SCRIPT:-${REPO_ROOT}/scripts/quality/check-all.sh}"
+RUN_TESTS="${PRE_PUSH_RUN_TESTS_SCRIPT:-${REPO_ROOT}/scripts/testing/run-all-tests.sh}"
+BYPASS_LOG="${PRE_PUSH_BYPASS_LOG:-${REPO_ROOT}/logs/hooks/pre-push-bypass.jsonl}"
+
+# Tier-1 Python repos: source the tracked single source of truth (#3023) when
+# present; fall back to a literal so an old checkout (pre-#3023) still works.
+if [[ -f "${REPO_ROOT}/scripts/lib/tier1-repos.sh" ]]; then
+    source "${REPO_ROOT}/scripts/lib/tier1-repos.sh"
+    TIER1_REPOS=("${TIER1_PYTHON_REPOS[@]}")
+else
+    TIER1_REPOS=(assetutilities digitalmodel worldenergydata assethold)
+fi
+ZERO_OID="0000000000000000000000000000000000000000"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+RUN_ALL=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --all) RUN_ALL=true ;;
+        --help)
+            echo "Usage: pre-push.sh [--all] [--help]"
+            echo ""
+            echo "Pre-push CI gate for workspace-hub tier-1 repos."
+            echo ""
+            echo "Options:"
+            echo "  --all   Run checks for all 5 tier-1 repos (ignore diff)"
+            echo "  --help  Show this help and exit"
+            echo ""
+            echo "Environment:"
+            echo "  GIT_PRE_PUSH_SKIP=1   Soft bypass — logs audit record and exits 0"
+            exit 0
+            ;;
+    esac
+done
+
+# ── Read and buffer stdin (git passes push info here) ─────────────────────────
+declare -a PUSH_LINES=()
+while IFS=' ' read -r local_ref local_oid remote_ref remote_oid; do
+    [[ -z "$local_ref" ]] && continue
+    PUSH_LINES+=("${local_ref} ${local_oid} ${remote_ref} ${remote_oid}")
+done
+
+if [[ ${#PUSH_LINES[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# Use first line to extract OIDs (multi-ref pushes are uncommon; first is sufficient
+# for branch detection heuristics).
+read -r FIRST_LOCAL_REF FIRST_LOCAL_OID FIRST_REMOTE_REF FIRST_REMOTE_OID \
+    <<< "${PUSH_LINES[0]}"
+
+# ── GIT_PRE_PUSH_SKIP soft bypass (checked before dry-run) ────────────────────
+if [[ "${GIT_PRE_PUSH_SKIP:-0}" == "1" ]]; then
+    TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    mkdir -p "$(dirname "$BYPASS_LOG")"
+    printf '{"timestamp":"%s","local_ref":"%s","local_oid":"%s","remote_ref":"%s","remote_oid":"%s","operator":"GIT_PRE_PUSH_SKIP","exit_code":0}\n' \
+        "$TIMESTAMP" \
+        "$FIRST_LOCAL_REF" \
+        "$FIRST_LOCAL_OID" \
+        "$FIRST_REMOTE_REF" \
+        "$FIRST_REMOTE_OID" \
+        >> "$BYPASS_LOG"
+    echo "[pre-push] GIT_PRE_PUSH_SKIP=1 — bypass logged to ${BYPASS_LOG}" >&2
+    exit 0
+fi
+
+# ── Dry-run mode (used by tests to exercise parsing without real checks) ───────
+if [[ "${PRE_PUSH_DRY_RUN:-0}" == "1" ]]; then
+    exit 0
+fi
+
+# ── Delete-branch guard: local_oid all-zeros means branch deletion → skip ─────
+if [[ "$FIRST_LOCAL_OID" == "$ZERO_OID" ]]; then
+    echo "[pre-push] Delete-branch push detected — skipping CI gate." >&2
+    exit 0
+fi
+
+# ── New-branch guard: remote_oid all-zeros → can't diff, run all repos ────────
+if [[ "$FIRST_REMOTE_OID" == "$ZERO_OID" ]]; then
+    echo "[pre-push] New branch — running all tier-1 repo checks." >&2
+    RUN_ALL=true
+fi
+
+# ── Detect changed tier-1 repos ──────────────────────────────────────────────
+declare -a REPOS_TO_CHECK=()
+
+if [[ "$RUN_ALL" == "true" ]]; then
+    REPOS_TO_CHECK=("${TIER1_REPOS[@]}")
+else
+    # Use override if set (for testing), otherwise run git diff
+    if [[ -n "${PRE_PUSH_CHANGED_FILES:-}" ]]; then
+        CHANGED_FILES="$PRE_PUSH_CHANGED_FILES"
+    else
+        CHANGED_FILES="$(git diff --name-only "${FIRST_REMOTE_OID}..${FIRST_LOCAL_OID}" 2>/dev/null || true)"
+    fi
+
+    for repo in "${TIER1_REPOS[@]}"; do
+        if echo "$CHANGED_FILES" | grep -q "^${repo}/"; then
+            REPOS_TO_CHECK+=("$repo")
+        fi
+    done
+
+    # ── Config drift check on changed harness files (WRK-1094) ───────────────
+    # Must run BEFORE the early exit so root-only harness pushes are checked.
+    CONFIG_DRIFT_SCRIPT="${REPO_ROOT}/scripts/quality/check_config_drift.py"
+    HARNESS_FILES=(CLAUDE.md AGENTS.md CODEX.md GEMINI.md)
+    _harness_changed=false
+    for hf in "${HARNESS_FILES[@]}"; do
+        if echo "${CHANGED_FILES:-}" | grep -q "$hf"; then
+            _harness_changed=true
+            break
+        fi
+    done
+    if [[ "$_harness_changed" == "true" && -f "$CONFIG_DRIFT_SCRIPT" ]]; then
+        echo "[pre-push] Harness file changed — running config drift check..." >&2
+        _HARNESS_EXIT=0
+        uv run --no-project --python 3.11 --with pyyaml python "$CONFIG_DRIFT_SCRIPT" 2>&1 || _HARNESS_EXIT=$?
+        # Config drift failures will propagate into OVERALL_EXIT after the early-exit
+        # guard below — store result for use after repos loop.
+        _HARNESS_DRIFT_EXIT=$_HARNESS_EXIT
+    fi
+
+    if [[ ${#REPOS_TO_CHECK[@]} -eq 0 ]]; then
+        echo "[pre-push] No tier-1 repo changes detected — skipping repo CI gate." >&2
+        exit "${_HARNESS_DRIFT_EXIT:-0}"
+    fi
+fi
+
+# ── Run checks and tests for each affected repo ───────────────────────────────
+OVERALL_EXIT=0
+
+for repo in "${REPOS_TO_CHECK[@]}"; do
+    echo "[pre-push] Checking repo: ${repo}" >&2
+
+    if [[ -x "$CHECK_ALL" ]]; then
+        if ! bash "$CHECK_ALL" --repo "$repo"; then
+            echo "[pre-push] FAIL: check-all for ${repo}" >&2
+            OVERALL_EXIT=1
+        fi
+    else
+        echo "[pre-push] WARNING: check-all.sh not found at ${CHECK_ALL}" >&2
+    fi
+
+    if [[ -x "$RUN_TESTS" ]]; then
+        if ! bash "$RUN_TESTS" --repo "$repo"; then
+            echo "[pre-push] FAIL: run-all-tests for ${repo}" >&2
+            OVERALL_EXIT=1
+        fi
+    else
+        echo "[pre-push] WARNING: run-all-tests.sh not found at ${RUN_TESTS}" >&2
+    fi
+done
+
+# ── Review evidence gate (adversarial review enforcement) ────────────────────
+REVIEW_GATE="${REPO_ROOT}/scripts/enforcement/require-review-on-push.sh"
+if [[ -f "$REVIEW_GATE" ]]; then
+    echo "[pre-push] Running review evidence gate..." >&2
+    _REVIEW_EXIT=0
+    bash "$REVIEW_GATE" "$FIRST_LOCAL_OID" "$FIRST_REMOTE_OID" || _REVIEW_EXIT=$?
+    if [[ $_REVIEW_EXIT -ne 0 ]]; then
+        if [[ "${REVIEW_GATE_STRICT:-0}" == "1" ]]; then
+            echo "[pre-push] FAIL: review evidence gate (strict mode)" >&2
+            OVERALL_EXIT=1
+        else
+            echo "[pre-push] WARNING: review evidence gate failed (advisory mode — set REVIEW_GATE_STRICT=1 to enforce)" >&2
+        fi
+    fi
+else
+    echo "[pre-push] WARNING: require-review-on-push.sh not found — skipping review gate" >&2
+fi
+
+# ── Legacy gates from WRK-1070 (secrets + coverage) ─────────────────────────
+if command -v gitleaks >/dev/null 2>&1; then
+    bash "${REPO_ROOT}/scripts/security/secrets-scan.sh" || OVERALL_EXIT=1
+else
+    echo "[pre-push] gitleaks not installed — skipping secrets scan (install via pre-commit)" >&2
+fi
+
+BASELINE="${REPO_ROOT}/config/testing/coverage-baseline.yaml"
+RATCHET="${REPO_ROOT}/scripts/testing/check_coverage_ratchet.py"
+
+if [[ -f "$BASELINE" && -f "$RATCHET" ]]; then
+    if [[ -n "${SKIP_COVERAGE_REASON:-}" ]]; then
+        echo "[pre-push] Coverage gate bypassed. Reason: ${SKIP_COVERAGE_REASON}" >&2
+        DATESTAMP="$(date +%Y%m%d)"
+        REPORT_OUT="${REPO_ROOT}/scripts/testing/coverage-reports/bypass-coverage-${DATESTAMP}.txt"
+        mkdir -p "${REPO_ROOT}/scripts/testing/coverage-reports"
+        uv run --no-project python "$RATCHET" \
+            --baseline "$BASELINE" \
+            --results  "${REPO_ROOT}/scripts/testing/coverage-results.json" \
+            --report-out "$REPORT_OUT" 2>/dev/null || true
+    else
+        bash "$RUN_TESTS" --coverage || OVERALL_EXIT=1
+    fi
+else
+    echo "[pre-push] Coverage baseline or ratchet script not found — skipping coverage gate." >&2
+fi
+
+# ── Mypy ratchet gate (WRK-1092) — opt-in via MYPY_RATCHET_GATE=1 ───────────
+# Mypy runs can take 60-180s across all repos; opt-in avoids slowing every push.
+if [[ "${MYPY_RATCHET_GATE:-0}" == "1" ]]; then
+    MYPY_RATCHET_SCRIPT="${REPO_ROOT}/scripts/quality/check_mypy_ratchet.py"
+    MYPY_RATCHET_BASELINE="${REPO_ROOT}/config/quality/mypy-baseline.yaml"
+    if [[ -f "$MYPY_RATCHET_SCRIPT" && -f "$MYPY_RATCHET_BASELINE" ]]; then
+        echo "[pre-push] Running mypy ratchet gate..." >&2
+        if ! uv run --no-project python "$MYPY_RATCHET_SCRIPT" \
+                --baseline "$MYPY_RATCHET_BASELINE" \
+                --repo-root "$REPO_ROOT"; then
+            echo "[pre-push] FAIL: mypy ratchet gate" >&2
+            OVERALL_EXIT=1
+        fi
+    else
+        echo "[pre-push] WARNING: mypy ratchet script or baseline not found — skipping" >&2
+    fi
+fi
+
+# ── Complexity ratchet gate (WRK-1095) — opt-in via COMPLEXITY_RATCHET_GATE=1 ─
+# Radon runs can take 30-90s across all repos; opt-in avoids slowing every push.
+if [[ "${COMPLEXITY_RATCHET_GATE:-0}" == "1" ]]; then
+    COMPLEXITY_RATCHET_SCRIPT="${REPO_ROOT}/scripts/quality/check_complexity_ratchet.py"
+    COMPLEXITY_RATCHET_BASELINE="${REPO_ROOT}/config/quality/complexity-baseline.yaml"
+    if [[ -f "$COMPLEXITY_RATCHET_SCRIPT" && -f "$COMPLEXITY_RATCHET_BASELINE" ]]; then
+        echo "[pre-push] Running complexity ratchet gate..." >&2
+        if ! uv run --no-project python "$COMPLEXITY_RATCHET_SCRIPT" \
+                --baseline "$COMPLEXITY_RATCHET_BASELINE" \
+                --repo-root "$REPO_ROOT"; then
+            echo "[pre-push] FAIL: complexity ratchet gate" >&2
+            OVERALL_EXIT=1
+        fi
+    else
+        echo "[pre-push] WARNING: complexity ratchet script or baseline not found — skipping" >&2
+    fi
+fi
+
+# ── Config drift check — RUN_ALL path (WRK-1094) ────────────────────────────
+# When RUN_ALL=true (new branch or --all flag), CHANGED_FILES is not set so the
+# harness-change detection inside the else branch above did not run.  Run the
+# full drift check unconditionally for new-branch / --all pushes.
+if [[ "$RUN_ALL" == "true" ]]; then
+    _CD_SCRIPT="${REPO_ROOT}/scripts/quality/check_config_drift.py"
+    if [[ -f "$_CD_SCRIPT" ]]; then
+        echo "[pre-push] RUN_ALL — running config drift check..." >&2
+        uv run --no-project --python 3.11 --with pyyaml python "$_CD_SCRIPT" 2>&1 || OVERALL_EXIT=1
+    fi
+fi
+
+# Propagate any harness-drift failure captured before the early-exit point.
+if [[ "${_HARNESS_DRIFT_EXIT:-0}" -ne 0 ]]; then
+    OVERALL_EXIT=1
+fi
+
+exit "$OVERALL_EXIT"
+
+# ── Stage prompt drift guard (installed by install-hooks.sh) ─────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
+if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
+  bash "$STAGE_PROMPT_DRIFT_GATE" || exit $?
+fi
+
+# ── Enforcement environment (installed by install-hooks.sh #2128) ──────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"
+if [[ -f "${ENFORCEMENT_ENV}" ]]; then
+  source "${ENFORCEMENT_ENV}"
+fi
+
+# ── State-file size guard pre-push (#2070) ───────────────────────────────
+# Pre-push reads <local_ref local_sha remote_ref remote_sha> on stdin; tee it
+# into the size-guard hook so it can scan the to-be-pushed commit range.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+STATE_SIZE_PREPUSH="${REPO_ROOT}/.claude/hooks/check-state-file-size-prepush.sh"
+if [[ -f "$STATE_SIZE_PREPUSH" ]]; then
+  bash "$STATE_SIZE_PREPUSH" || exit $?
+fi
+
+# ── Cadence-helper sync check (wed#309) ──────────────────────────────────
+# Verifies worldenergydata/scripts/cron/lib/cadence-common.sh is byte-identical
+# to workspace-hub/scripts/cron/lib/cadence-common.sh. Exits 1 on drift.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CADENCE_SYNC="${REPO_ROOT}/scripts/sync/sync-cadence-helper.sh"
+if [[ -f "$CADENCE_SYNC" ]]; then
+  bash "$CADENCE_SYNC" || exit $?
+fi

--- a/tests/hooks/test_pre_push.py
+++ b/tests/hooks/test_pre_push.py
@@ -20,13 +20,25 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "pre-push.sh"
-TIER1_REPOS = [
-    "assetutilities",
-    "digitalmodel",
-    "worldenergydata",
-    "assethold",
-    "OGManufacturing",
-]
+
+
+def _tier1_repos() -> list[str]:
+    """Read the tier-1 repo list from the #3023 single source of truth.
+
+    Previously hardcoded here, which drifted: this list still carried
+    ``OGManufacturing`` after it left ``config/tier1-python-repos.txt``, so the
+    test failed against a correct hook. That file's own header says "do NOT
+    hardcode the repo list anywhere else" -- a test is not an exception.
+    """
+    src = REPO_ROOT / "config" / "tier1-python-repos.txt"
+    return [
+        line.strip()
+        for line in src.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+TIER1_REPOS = _tier1_repos()
 
 
 def _run_hook(
@@ -311,39 +323,101 @@ class TestSkipBypass:
 # ---------------------------------------------------------------------------
 
 
+def _fake_check_scripts(tmp_path):
+    """Build stub check-all/run-all-tests that log their invocations."""
+    calls_log = tmp_path / "calls.log"
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    for script in ("check-all.sh", "run-all-tests.sh"):
+        s = fake_bin / script
+        s.write_text(
+            textwrap.dedent(f"""\
+                #!/usr/bin/env bash
+                echo "{script} $@" >> "{calls_log}"
+            """)
+        )
+        s.chmod(0o755)
+    env = {
+        "PRE_PUSH_DRY_RUN": "0",
+        "PRE_PUSH_CHECK_ALL_SCRIPT": str(fake_bin / "check-all.sh"),
+        "PRE_PUSH_RUN_TESTS_SCRIPT": str(fake_bin / "run-all-tests.sh"),
+    }
+    return calls_log, env
+
+
 class TestNewBranchFallback:
-    """When remote_oid is all-zeros (new branch), fall back to running all repos."""
+    """A new branch must be SCOPED by merge-base, not escalated to every repo.
 
-    def test_new_branch_runs_all_repos(self, tmp_path):
-        calls_log = tmp_path / "calls.log"
-        fake_bin = tmp_path / "fake_bin"
-        fake_bin.mkdir()
+    This class previously asserted the opposite -- ``test_new_branch_runs_all_repos``
+    pinned the escalation as correct behaviour. It is the defect in #3780: because
+    every feature branch is a new branch on its first push, the narrowest possible
+    change got the widest possible gate, and since the gate chains to a suite that
+    is red by baseline, the push could never pass. Measured: three stacked pushes
+    hung 44+ minutes producing zero output.
 
-        for script in ("check-all.sh", "run-all-tests.sh"):
-            s = fake_bin / script
-            s.write_text(
-                textwrap.dedent(f"""\
-                    #!/usr/bin/env bash
-                    echo "{script} $@" >> "{calls_log}"
-                """)
-            )
-            s.chmod(0o755)
+    Scope is not unknowable on a new branch. A branch cut from main has a
+    merge-base. Escalation is correct only for genuinely disjoint history.
+    """
 
-        env = {
-            "PRE_PUSH_DRY_RUN": "0",
-            "PRE_PUSH_CHECK_ALL_SCRIPT": str(fake_bin / "check-all.sh"),
-            "PRE_PUSH_RUN_TESTS_SCRIPT": str(fake_bin / "run-all-tests.sh"),
-        }
+    def test_new_branch_scopes_by_merge_base(self, tmp_path):
+        """A new branch touching one repo must not run the others."""
+        calls_log, env = _fake_check_scripts(tmp_path)
+        env["PRE_PUSH_CHANGED_FILES"] = "digitalmodel/src/foo.py"
 
-        # remote_oid is all zeros → new branch
         stdin = [f"refs/heads/new-feature {FAKE_OID_LOCAL} refs/heads/new-feature {ZERO_OID}"]
         result = _run_hook(stdin, env_extra=env)
 
         assert result.returncode == 0, result.stderr
         log_content = calls_log.read_text() if calls_log.exists() else ""
+        assert "digitalmodel" in log_content, (
+            f"the touched repo must still be checked, got:\n{log_content}"
+        )
+        for repo in TIER1_REPOS:
+            if repo == "digitalmodel":
+                continue
+            assert repo not in log_content, (
+                f"{repo} was untouched and must not be checked, got:\n{log_content}"
+            )
+
+    def test_new_branch_docs_only_skips_repo_gate(self, tmp_path):
+        """A new branch touching no tier-1 path runs no suite at all.
+
+        This is the case that hung for 44 minutes: a one-file change under
+        docs/ops/ triggering every tier-1 repo's full test suite.
+        """
+        calls_log, env = _fake_check_scripts(tmp_path)
+        env["PRE_PUSH_CHANGED_FILES"] = "docs/ops/machine-inventory.md"
+
+        stdin = [f"refs/heads/docs-branch {FAKE_OID_LOCAL} refs/heads/docs-branch {ZERO_OID}"]
+        result = _run_hook(stdin, env_extra=env)
+
+        assert result.returncode == 0, result.stderr
+        log_content = calls_log.read_text() if calls_log.exists() else ""
+        assert log_content == "", f"no repo checks expected, got:\n{log_content}"
+
+    def test_merge_base_failure_does_not_open_the_gate(self, tmp_path):
+        """If scope cannot be determined, ESCALATE -- never check nothing.
+
+        The dangerous failure direction is not "runs too much", it is "runs
+        nothing and exits 0", which is silent and ships unchecked code. The
+        original defect's own fix was nearly written this way: setting a
+        merge-base variable the diff never consumed would leave CHANGED_FILES
+        empty and pass every push unexamined.
+        """
+        calls_log, env = _fake_check_scripts(tmp_path)
+        # A local OID that exists in no repo: merge-base against it cannot resolve.
+        unknown_oid = "d" * 40
+        stdin = [f"refs/heads/orphan {unknown_oid} refs/heads/orphan {ZERO_OID}"]
+        result = _run_hook(stdin, env_extra=env)
+
+        log_content = calls_log.read_text() if calls_log.exists() else ""
+        assert log_content != "", (
+            "unresolvable scope must escalate to all tier-1 repos, but NO checks "
+            "ran -- the gate silently opened"
+        )
         for repo in TIER1_REPOS:
             assert repo in log_content, (
-                f"Expected {repo} in all-repos fallback but got:\n{log_content}"
+                f"escalation must cover {repo}, got:\n{log_content}"
             )
 
     def test_delete_branch_skipped(self):


### PR DESCRIPTION
Closes #3780.

Two commits, deliberately separate. Read `3a0a3dbed` first — it is a **verbatim restore, zero edits**, and the whole diff is code that has already been gating every push in this ecosystem.

## The issue was a symptom

#3780 was filed because a new-branch push escalates to a full tier-1 suite run and can never pass. True, but the investigation had stopped at the *running* hook and never asked where it comes from. It came from nowhere:

| Fact | Evidence |
|---|---|
| The running hook was **untracked** | `.git/hooks/pre-push.sh`, 306 lines; no tracked file had that content |
| Its intended home **did not exist** | `git ls-files --error-unmatch scripts/hooks/pre-push.sh` → *"did not match any file(s) known to git"* |
| Deleted by an **automated commit** | `d98492a7b chore(sync): auto-sync 2026-03-25` |
| Its tests pointed at the missing path | `tests/hooks/test_pre_push.py:22` |
| **9 of 10 tests failed** | measured on a clean tree |
| Drift since deletion | **+57 lines** — the #3023 tier-1 SSOT and the entire review-evidence gate |

So four months of enforcement development happened outside version control, on one machine. Both alarms were silent: the live hook kept working (`.git/hooks/` is a separate copy a tracked deletion cannot reach), and the failing tests landed in a suite already carrying a large red baseline.

**This is why restoration is not scope creep.** Editing an untracked file fixes one machine, cannot be reviewed, cannot be diffed, and is erased by any hook reinstall. There was no version of "just fix the merge-base logic" that reached the fleet.

## The fix — two sites, not one

The escalation itself:

```bash
if [[ "$FIRST_REMOTE_OID" == "$ZERO_OID" ]]; then
    RUN_ALL=true          # every tier-1 repo, full suites
fi
```

Every feature branch is a new branch on its first push, so **the narrowest possible change got the widest possible gate** — because "cannot diff against the remote" was read as "scope is unknowable." It isn't: a branch cut from main has a merge-base. Chained to a ~32-minute suite that is red by baseline, the gate was not slow but *unsatisfiable*. Three stacked pushes were observed hung 44+ minutes producing zero bytes.

**The second site is the one that matters more.** My first draft of this fix changed only the guard above and left the actual diff untouched:

```bash
CHANGED_FILES="$(git diff --name-only "${FIRST_REMOTE_OID}..${FIRST_LOCAL_OID}" 2>/dev/null || true)"
```

On a new branch that diff *fails*, `|| true` swallows it, `CHANGED_FILES` is empty, `REPOS_TO_CHECK` is empty — and the hook **exits 0 having checked nothing.** That would have converted a gate that blocks everything into a gate that silently checks nothing, which is strictly worse and completely invisible. Caught in adversarial review (Codex finding 5). The `|| true` is now removed and a failed diff escalates.

Scope resolution is ordered cheapest-source-first, and escalation fires only when scope genuinely cannot be determined.

## Also removed: 32 lines of dead enforcement

`exit "$OVERALL_EXIT"` was followed by three installer-appended gates — stage-prompt drift, state-size, cadence sync — all **unreachable, none ever executed**, while `install-hooks.sh` logged `OK: Wired ... into pre-push` for each. Carried verbatim through the restore commit (the record should show what was on disk), removed here. Whether each should be re-wired *above* the exit changes what blocks pushes and is tracked separately in #3781.

## Tests: 9 failed / 1 passed → 12 passed

`TestNewBranchFallback::test_new_branch_runs_all_repos` **asserted the defect as correct behaviour**. Replaced by three tests, one per direction:

- `test_new_branch_scopes_by_merge_base` — the touched repo is still checked; the others are not
- `test_new_branch_docs_only_skips_repo_gate` — the exact case that hung for 44 minutes
- `test_merge_base_failure_does_not_open_the_gate` — **the important one.** The dangerous direction is not "runs too much", it is "runs nothing and exits 0"

Two further test corrections:
- `TIER1_REPOS` now reads `config/tier1-python-repos.txt` instead of hardcoding. The hardcoded copy still carried `OGManufacturing` after it left the #3023 SSOT, so the test failed against a *correct* hook. That file's header says not to hardcode the list anywhere else; a test is not an exception.
- `REVIEW_GATE_STRICT` is pinned when running, not inherited — it silently changed results between review runs, and a suite whose outcome depends on the operator's shell is not a gate.

## End-to-end verification

A real new-branch, docs-only push, **without `--no-verify`**:

```
[pre-push] New branch — scoping against merge-base ed16c2ca.
[pre-push] No tier-1 repo changes detected — skipping repo CI gate.
```

**1 second.** The delete-branch path was exercised too (`Delete-branch push detected — skipping CI gate`).

## Deliberately out of scope

- **Installer symlink** — `.git/hooks/pre-push` still points at its own copy. Committing this machine's hook makes it canonical, and other machines may carry differently-drifted copies. **Compare `md5sum .git/hooks/pre-push.sh` across the fleet before wiring the installer.** Restoration and enforcement land separately, on purpose.
- **`timeout` wrapping the gate** — needs a fail-closed vs fail-open decision first; fail-open would reintroduce the silent-skip defect.
- **Red-baseline policy** — owner decision, tracked at digitalmodel#1850.
- **Re-wiring the three dead gates** — #3781.

## Review

Plan `docs/plans/2026-08-02-issue-3780-pre-push-restore-and-scope.md`, T2 adversarial review, r1 verdicts **MAJOR / MAJOR**, r2 applied inline. The review killed the first draft of the fix (silent-open defect above), the self-contradictory installer scope, and an unachievable acceptance criterion.

Note for reviewers: two of Codex's ten findings (a stale test baseline, a stray untracked file) were artifacts of the other reviewer creating a scratch copy in the same working tree concurrently. Baseline re-measured on a clean tree afterwards: 9 failed / 1 passed.
