### PR TITLE
fix(hooks): give pre-push a real extension point, re-wire the gates that never ran (#3781)

### DIFF
--- a/scripts/enforcement/install-hooks.sh
+++ b/scripts/enforcement/install-hooks.sh
@@ -174,14 +174,6 @@ if [[ -f "$REVIEW_GATE" ]]; then
 fi
 EOF
 
-  cat > "${_blk}/drift" <<'EOF'
-
-# ── Stage prompt drift guard (installed by install-hooks.sh) ─────────────
-STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
-if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
-  bash "$STAGE_PROMPT_DRIFT_GATE" || OVERALL_EXIT=1
-fi
-EOF
 
   cat > "${_blk}/size" <<'EOF'
 
@@ -207,7 +199,9 @@ EOF
   _install_rc=0
   insert_block "enforcement-env"                   "${_blk}/env"     "enforcement-env" || _install_rc=$?
   insert_block "require-review-on-push.sh"         "${_blk}/review"  "review gate" || _install_rc=$?
-  insert_block "require-stage-prompt-drift.sh"     "${_blk}/drift"   "stage prompt drift guard" || _install_rc=$?
+  # stage-prompt drift is NOT wired into pre-push: .github/workflows/
+  # enforcement-gate.yml already enforces it, and the checker takes MINUTES,
+  # which is the multi-minute-gate defect #3780 removed. CI owns it (#3781).
   insert_block "check-state-file-size-prepush.sh"  "${_blk}/size"    "state-file size guard" || _install_rc=$?
   insert_block "sync-cadence-helper.sh"            "${_blk}/cadence" "cadence-helper sync check" || _install_rc=$?
 

--- a/scripts/enforcement/install-hooks.sh
+++ b/scripts/enforcement/install-hooks.sh
@@ -68,116 +68,152 @@ else
   log "SKIP: pre-commit hook not found"
 fi
 
-# ── Step 3: Wire full pre-push enforcement chain (#2128) ──────────────
-# Order: enforcement-env → review-gate → stage-prompt-drift-gate
+# ── Step 3: Wire full pre-push enforcement chain (#2128, #3781) ───────
+# Order matters: enforcement-env FIRST — it exports REVIEW_GATE_STRICT=1, and
+# the review wrapper defaults that to 0, so a later source leaves review
+# ADVISORY. Blocks are INSERTED at the hook's extension point, never appended
+# past the end: the hook terminates in an unconditional `exit`, and anything
+# below it never runs. Four blocks sat there for months while this script
+# logged "OK: Wired ..." for each (#3781).
 PRE_PUSH="${REPO_ROOT}/.git/hooks/pre-push"
+SENTINEL='# <<INSTALL_HOOKS_EXTENSION_POINT>>'
+
+# Everything above the sentinel — the reachable region of the hook.
+reachable_region() {
+  sed "/<<INSTALL_HOOKS_EXTENSION_POINT>>/q" "$PRE_PUSH"
+}
+
+# $1 = grep marker identifying the block, $2 = file holding the block text
+insert_block() {
+  local marker="$1" block_file="$2" label="$3"
+
+  if ! grep -q "INSTALL_HOOKS_EXTENSION_POINT" "$PRE_PUSH" 2>/dev/null; then
+    echo "FATAL: no extension point in ${PRE_PUSH}." >&2
+    echo "  Refusing to append — appended blocks land below the terminal exit" >&2
+    echo "  and never run. Reinstall the tracked hook (scripts/hooks/pre-push.sh)." >&2
+    return 1
+  fi
+
+  # Reachability-aware idempotence. A plain `grep -q "$marker" "$PRE_PUSH"`
+  # is what made #3781 permanent: it reported "already wired" for a block
+  # sitting below the exit, so re-running could never repair it.
+  if reachable_region | grep -q "$marker"; then
+    log "OK: ${label} already wired into pre-push (reachable)"
+    return 0
+  fi
+
+  if grep -q "$marker" "$PRE_PUSH" 2>/dev/null; then
+    log "WARN: ${label} present but UNREACHABLE — re-wiring above the extension point"
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "DRY-RUN: Would wire ${label} into pre-push"
+    return 0
+  fi
+
+  local tmp; tmp="$(mktemp)"
+  awk -v blockfile="$block_file" '
+    /<<INSTALL_HOOKS_EXTENSION_POINT>>/ && !done {
+      while ((getline line < blockfile) > 0) print line
+      close(blockfile); done = 1
+    }
+    { print }
+  ' "$PRE_PUSH" > "$tmp"
+
+  if ! bash -n "$tmp"; then
+    echo "FATAL: insertion of ${label} produced invalid bash — not written" >&2
+    rm -f "$tmp"; return 1
+  fi
+  cat "$tmp" > "$PRE_PUSH"; rm -f "$tmp"
+  log "OK: Wired ${label} into pre-push"
+}
+
+# Remove any enforcement stranded below the hook's terminal exit. Inserting the
+# live copy above is not enough on its own: the dead copy stays behind, keeps
+# matching a naive grep, and misleads the next reader into thinking the gate is
+# wired twice. Blocks below an unconditional exit are dead by definition, so
+# truncating there is well-defined rather than a heuristic.
+strip_dead_tail() {
+  awk '
+    { lines[NR] = $0; if ($0 ~ /^exit([[:space:]]|$)/) last_exit = NR }
+    END {
+      end = (last_exit ? last_exit : NR)
+      for (i = 1; i <= end; i++) print lines[i]
+    }
+  ' "$PRE_PUSH" > "${PRE_PUSH}.tmp" && mv "${PRE_PUSH}.tmp" "$PRE_PUSH"
+}
 
 if [[ -f "$PRE_PUSH" ]]; then
-  # 3a: Source enforcement-env
-  if grep -q "enforcement-env" "$PRE_PUSH" 2>/dev/null; then
-    log "OK: enforcement-env already wired into pre-push"
-  else
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log "DRY-RUN: Would wire enforcement-env into pre-push"
-    else
-      cat >> "$PRE_PUSH" <<'EOF'
+  # Detect the #3781 state: enforcement present, but below the terminal exit.
+  if grep -q "INSTALL_HOOKS_EXTENSION_POINT" "$PRE_PUSH" 2>/dev/null \
+     && [[ -n "$(awk '/^exit([[:space:]]|$)/{f=NR} END{print (f?f:"")}' "$PRE_PUSH")" ]] \
+     && awk '/^exit([[:space:]]|$)/{seen=1; next} seen' "$PRE_PUSH" \
+        | grep -qE "enforcement-env|scripts/enforcement/|scripts/sync/|\.claude/hooks/"; then
+    log "WARN: enforcement found below the terminal exit (#3781) — removing the dead tail"
+    strip_dead_tail
+  fi
+
+  _blk="$(mktemp -d)"
+
+  cat > "${_blk}/env" <<'EOF'
 
 # ── Enforcement environment (installed by install-hooks.sh #2128) ──────
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# MUST precede gates whose strictness it sets (#3781).
 ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"
 if [[ -f "${ENFORCEMENT_ENV}" ]]; then
   source "${ENFORCEMENT_ENV}"
 fi
 EOF
-      log "OK: Wired enforcement-env into pre-push"
-    fi
-  fi
 
-  # 3b: Wire require-review-on-push.sh
-  if grep -q "require-review-on-push.sh" "$PRE_PUSH" 2>/dev/null; then
-    log "OK: review gate already wired into pre-push"
-  else
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log "DRY-RUN: Would wire review gate into pre-push"
-    else
-      cat >> "$PRE_PUSH" <<'EOF'
+  cat > "${_blk}/review" <<'EOF'
 
 # ── Review gate (installed by install-hooks.sh #2128) ──────────────────
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 REVIEW_GATE="${REPO_ROOT}/scripts/enforcement/require-review-on-push.sh"
 if [[ -f "$REVIEW_GATE" ]]; then
-  bash "$REVIEW_GATE" || exit $?
+  bash "$REVIEW_GATE" || OVERALL_EXIT=1
 fi
 EOF
-      log "OK: Wired review gate into pre-push"
-    fi
-  fi
 
-  # 3c: Wire stage prompt drift guard
-  if grep -q "require-stage-prompt-drift.sh" "$PRE_PUSH" 2>/dev/null; then
-    log "OK: stage prompt drift guard already wired into pre-push"
-  else
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log "DRY-RUN: Would wire stage prompt drift guard into pre-push"
-    else
-      cat >> "$PRE_PUSH" <<'EOF'
+  cat > "${_blk}/drift" <<'EOF'
 
 # ── Stage prompt drift guard (installed by install-hooks.sh) ─────────────
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
 if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
-  bash "$STAGE_PROMPT_DRIFT_GATE" || exit $?
+  bash "$STAGE_PROMPT_DRIFT_GATE" || OVERALL_EXIT=1
 fi
 EOF
-      log "OK: Wired stage prompt drift guard into pre-push"
-    fi
-  fi
 
-  # 3d: Wire state-file size guard pre-push (#2070) — sees blobs already in HEAD
-  if grep -q "check-state-file-size-prepush.sh" "$PRE_PUSH" 2>/dev/null; then
-    log "OK: state-file size guard already wired into pre-push"
-  else
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log "DRY-RUN: Would wire state-file size guard into pre-push"
-    else
-      cat >> "$PRE_PUSH" <<'EOF'
+  cat > "${_blk}/size" <<'EOF'
 
 # ── State-file size guard pre-push (#2070) ───────────────────────────────
-# Pre-push reads <local_ref local_sha remote_ref remote_sha> on stdin; tee it
-# into the size-guard hook so it can scan the to-be-pushed commit range.
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# Reads the push refspecs from ITS OWN stdin. The hook already consumed git's
+# stdin into PUSH_LINES, so replay them — without this the guard silently
+# falls back to an inferred ref and scans the wrong range (#3781).
 STATE_SIZE_PREPUSH="${REPO_ROOT}/.claude/hooks/check-state-file-size-prepush.sh"
 if [[ -f "$STATE_SIZE_PREPUSH" ]]; then
-  bash "$STATE_SIZE_PREPUSH" || exit $?
+  printf '%s\n' "${PUSH_LINES[@]}" | bash "$STATE_SIZE_PREPUSH" || OVERALL_EXIT=1
 fi
 EOF
-      log "OK: Wired state-file size guard into pre-push"
-    fi
-  fi
 
-  # 3e: Wire cadence-common.sh vendored-copy sync check (wed#309)
-  if grep -q "sync-cadence-helper.sh" "$PRE_PUSH" 2>/dev/null; then
-    log "OK: cadence-helper sync check already wired into pre-push"
-  else
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log "DRY-RUN: Would wire cadence-helper sync check into pre-push"
-    else
-      cat >> "$PRE_PUSH" <<'EOF'
+  cat > "${_blk}/cadence" <<'EOF'
 
 # ── Cadence-helper sync check (wed#309) ──────────────────────────────────
-# Verifies worldenergydata/scripts/cron/lib/cadence-common.sh is byte-identical
-# to workspace-hub/scripts/cron/lib/cadence-common.sh. Exits 1 on drift.
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 CADENCE_SYNC="${REPO_ROOT}/scripts/sync/sync-cadence-helper.sh"
 if [[ -f "$CADENCE_SYNC" ]]; then
-  bash "$CADENCE_SYNC" || exit $?
+  bash "$CADENCE_SYNC" || OVERALL_EXIT=1
 fi
 EOF
-      log "OK: Wired cadence-helper sync check into pre-push"
-    fi
-  fi
 
+  _install_rc=0
+  insert_block "enforcement-env"                   "${_blk}/env"     "enforcement-env" || _install_rc=$?
+  insert_block "require-review-on-push.sh"         "${_blk}/review"  "review gate" || _install_rc=$?
+  insert_block "require-stage-prompt-drift.sh"     "${_blk}/drift"   "stage prompt drift guard" || _install_rc=$?
+  insert_block "check-state-file-size-prepush.sh"  "${_blk}/size"    "state-file size guard" || _install_rc=$?
+  insert_block "sync-cadence-helper.sh"            "${_blk}/cadence" "cadence-helper sync check" || _install_rc=$?
+
+  rm -rf "$_blk"
   chmod +x "$PRE_PUSH"
+  [[ $_install_rc -eq 0 ]] || exit $_install_rc
 else
   log "SKIP: pre-push hook not found"
 fi

--- a/scripts/enforcement/require-stage-prompt-drift.sh
+++ b/scripts/enforcement/require-stage-prompt-drift.sh
@@ -50,6 +50,12 @@ if [[ "$WRITE_STUBS" == "1" ]]; then
   stub_args+=(--write-evidence-stubs)
 fi
 set +e
+# The checker imports `workspace_hub`, which lives at src/ and is not on the
+# path under a bare `uv run python`. Without this the run dies on
+# ModuleNotFoundError -- and, before the fix below, that crash was reported as a
+# drift verdict. The gate could never have passed as invoked, which is part of
+# why it survived unnoticed below the hook's terminal exit (#3781).
+PYTHONPATH="${REPO_ROOT}/src:${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" \
 uv run python "$DRIFT_SCRIPT" \
   --base-ref "$BASE_REF" \
   --head-ref "$HEAD_REF" \
@@ -65,6 +71,20 @@ if [[ $exit_code -eq 0 ]]; then
   log_event "pass" "no newly introduced stage prompt drift"
   rm -f "$report_file"
   exit 0
+fi
+
+# A crash and a verdict both exit non-zero. The checker writes its markdown
+# report before concluding, so an EMPTY report means it died rather than
+# decided -- an import error, a missing dep, a bad ref. Reporting that as
+# "drift detected" sends the operator to fix a violation that does not exist,
+# and hides a broken gate behind a plausible policy failure (#3781).
+if [[ ! -s "$report_file" ]]; then
+  echo "[stage-prompt-drift] ERROR: the drift checker failed to run — this is NOT a drift verdict." >&2
+  echo "[stage-prompt-drift] Its output above is the real failure (commonly a missing module or unresolvable ref)." >&2
+  echo "[stage-prompt-drift] Blocking anyway: a gate that cannot run must not read as a pass." >&2
+  log_event "error" "drift checker failed to execute (empty report)"
+  rm -f "$report_file"
+  exit 1
 fi
 
 if [[ "$STRICT_MODE" == "1" ]]; then

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -182,14 +182,23 @@ else
 
     if [[ ${#REPOS_TO_CHECK[@]} -eq 0 ]]; then
         echo "[pre-push] No tier-1 repo changes detected — skipping repo CI gate." >&2
-        exit "${_HARNESS_DRIFT_EXIT:-0}"
+        # NOT an exit. This used to `exit` here, which skipped everything below:
+        # the review evidence gate, secrets scan, state-file size guard and
+        # cadence check are NOT repo-scoped and must still run. #3780 made this
+        # path far more common -- docs-only new branches used to escalate to
+        # RUN_ALL and now land here -- so exiting would have quietly widened a
+        # hole rather than narrowed one (#3781).
+        SKIP_REPO_LOOP=true
     fi
 fi
 
 # ── Run checks and tests for each affected repo ───────────────────────────────
 OVERALL_EXIT=0
+[[ "${_HARNESS_DRIFT_EXIT:-0}" -ne 0 ]] && OVERALL_EXIT=1
 
-for repo in "${REPOS_TO_CHECK[@]}"; do
+# REPOS_TO_CHECK is empty when nothing tier-1 changed, so this loop simply does
+# not run. `[@]+` keeps the expansion safe under `set -u` on an empty array.
+for repo in ${REPOS_TO_CHECK[@]+"${REPOS_TO_CHECK[@]}"}; do
     echo "[pre-push] Checking repo: ${repo}" >&2
 
     if [[ -x "$CHECK_ALL" ]]; then
@@ -241,7 +250,12 @@ else
 fi
 
 # ── Legacy gates from WRK-1070 (secrets + coverage) ─────────────────────────
-if command -v gitleaks >/dev/null 2>&1; then
+# REPO-SCOPED, unlike the enforcement chain above. `run-all-tests.sh --coverage`
+# is a full suite run; making it unconditional would put minutes on every
+# docs-only push. Skipped on the same condition as the repo loop.
+if [[ "${SKIP_REPO_LOOP:-false}" == "true" ]]; then
+    echo "[pre-push] No tier-1 repo changes — skipping secrets scan and coverage gate." >&2
+elif command -v gitleaks >/dev/null 2>&1; then
     bash "${REPO_ROOT}/scripts/security/secrets-scan.sh" || OVERALL_EXIT=1
 else
     echo "[pre-push] gitleaks not installed — skipping secrets scan (install via pre-commit)" >&2
@@ -250,7 +264,9 @@ fi
 BASELINE="${REPO_ROOT}/config/testing/coverage-baseline.yaml"
 RATCHET="${REPO_ROOT}/scripts/testing/check_coverage_ratchet.py"
 
-if [[ -f "$BASELINE" && -f "$RATCHET" ]]; then
+if [[ "${SKIP_REPO_LOOP:-false}" == "true" ]]; then
+    :   # repo-scoped; already reported above
+elif [[ -f "$BASELINE" && -f "$RATCHET" ]]; then
     if [[ -n "${SKIP_COVERAGE_REASON:-}" ]]; then
         echo "[pre-push] Coverage gate bypassed. Reason: ${SKIP_COVERAGE_REASON}" >&2
         DATESTAMP="$(date +%Y%m%d)"

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -211,6 +211,17 @@ for repo in "${REPOS_TO_CHECK[@]}"; do
     fi
 done
 
+# ── Enforcement environment (#2128) ──────────────────────────────────────────
+# MUST precede the gates whose strictness it sets. It exports
+# REVIEW_GATE_STRICT=1, while the review wrapper below defaults it to 0 -- so
+# sourcing this afterwards (or not at all) leaves the review gate ADVISORY.
+# It sat below the terminal exit for months and never ran, which is why #1839's
+# strict-mode default has not actually been in force. See #3781.
+ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"
+if [[ -f "${ENFORCEMENT_ENV}" ]]; then
+    source "${ENFORCEMENT_ENV}"
+fi
+
 # ── Review evidence gate (adversarial review enforcement) ────────────────────
 REVIEW_GATE="${REPO_ROOT}/scripts/enforcement/require-review-on-push.sh"
 if [[ -f "$REVIEW_GATE" ]]; then
@@ -309,11 +320,35 @@ if [[ "${_HARNESS_DRIFT_EXIT:-0}" -ne 0 ]]; then
     OVERALL_EXIT=1
 fi
 
-exit "$OVERALL_EXIT"
+# ── Stage-prompt drift guard ─────────────────────────────────────────────────
+STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
+if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
+    bash "$STAGE_PROMPT_DRIFT_GATE" || OVERALL_EXIT=1
+fi
 
-# NOTE: install-hooks.sh appends enforcement blocks AFTER this point. Anything
-# below an unconditional `exit` never runs. Three gates lived here and had never
-# executed once -- stage-prompt drift, state-size pre-push, cadence sync -- while
-# the installer logged "OK: Wired ... into pre-push" for each. Removed rather
-# than left as decoration. Re-wiring them ABOVE this exit changes what blocks
-# pushes and is a per-gate decision: workspace-hub#3781.
+# ── State-file size guard (#2070) ────────────────────────────────────────────
+# Reads <local_ref local_sha remote_ref remote_sha> from ITS OWN stdin to scan
+# the to-be-pushed range. This hook already consumed git's stdin into
+# PUSH_LINES, so it must be replayed -- otherwise the guard silently falls back
+# to an inferred current ref and scans the wrong range while appearing to run.
+STATE_SIZE_PREPUSH="${REPO_ROOT}/.claude/hooks/check-state-file-size-prepush.sh"
+if [[ -f "$STATE_SIZE_PREPUSH" ]]; then
+    printf '%s\n' "${PUSH_LINES[@]}" | bash "$STATE_SIZE_PREPUSH" || OVERALL_EXIT=1
+fi
+
+# ── Cadence-helper sync check (wed#309) ──────────────────────────────────────
+# Exits 0 when worldenergydata is absent, so enforcement is machine-dependent
+# by design; see #3781 for the CI-migration argument.
+CADENCE_SYNC="${REPO_ROOT}/scripts/sync/sync-cadence-helper.sh"
+if [[ -f "$CADENCE_SYNC" ]]; then
+    bash "$CADENCE_SYNC" || OVERALL_EXIT=1
+fi
+
+# ── INSTALLER EXTENSION POINT ────────────────────────────────────────────────
+# install-hooks.sh inserts enforcement blocks ABOVE this line. Never append past
+# the end of this file: the exit below is unconditional, and blocks placed after
+# it never run. That is #3781 -- four blocks sat there for months while the
+# installer logged "OK: Wired ... into pre-push" for each one.
+# <<INSTALL_HOOKS_EXTENSION_POINT>>
+
+exit "$OVERALL_EXIT"

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -336,11 +336,20 @@ if [[ "${_HARNESS_DRIFT_EXIT:-0}" -ne 0 ]]; then
     OVERALL_EXIT=1
 fi
 
-# ── Stage-prompt drift guard ─────────────────────────────────────────────────
-STAGE_PROMPT_DRIFT_GATE="${REPO_ROOT}/scripts/enforcement/require-stage-prompt-drift.sh"
-if [[ -f "$STAGE_PROMPT_DRIFT_GATE" ]]; then
-    bash "$STAGE_PROMPT_DRIFT_GATE" || OVERALL_EXIT=1
-fi
+# ── Stage-prompt drift guard: deliberately NOT wired here ────────────────────
+# Measured on 2026-08-02 before deciding, rather than wired because it was in
+# the dead tail:
+#   * It is already enforced by .github/workflows/enforcement-gate.yml, so a
+#     hook copy is redundant rather than additive.
+#   * It takes MINUTES (the checker imports the ecosystem-audit module and
+#     walks the tree). A multi-minute pre-push gate is what #3780 was about;
+#     re-adding one to fix #3781 would trade the same defect back.
+#   * As invoked it could never have passed: the checker imports
+#     `workspace_hub`, absent from the path under a bare `uv run python`, so it
+#     died on ModuleNotFoundError -- which the wrapper then reported as a drift
+#     verdict. Both bugs are fixed in require-stage-prompt-drift.sh (PYTHONPATH,
+#     and crash-is-not-a-verdict), which benefits the CI path that does run it.
+# CI owns this gate. See #3781.
 
 # ── State-file size guard (#2070) ────────────────────────────────────────────
 # Reads <local_ref local_sha remote_ref remote_sha> from ITS OWN stdin to scan

--- a/tests/enforcement/test_install_hooks_stage_prompt_drift.py
+++ b/tests/enforcement/test_install_hooks_stage_prompt_drift.py
@@ -46,7 +46,13 @@ def make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_install_hooks_wires_stage_prompt_drift_into_pre_push(tmp_path: Path) -> None:
+def test_install_hooks_leaves_stage_prompt_drift_to_ci(tmp_path: Path) -> None:
+    """The drift guard must NOT be wired into pre-push (#3781).
+
+    Renamed from ...wires_stage_prompt_drift_into_pre_push: it now asserts the
+    opposite, and a test whose name contradicts its assertion is worse than no
+    test at all.
+    """
     repo = make_repo(tmp_path)
 
     result = subprocess.run(
@@ -59,8 +65,17 @@ def test_install_hooks_wires_stage_prompt_drift_into_pre_push(tmp_path: Path) ->
 
     assert result.returncode == 0, result.stderr
     pre_push = (repo / ".git" / "hooks" / "pre-push").read_text(encoding="utf-8")
-    assert "require-stage-prompt-drift.sh" in pre_push
-    assert "stage prompt drift guard" in pre_push.lower()
+    # Inverted deliberately (#3781). The stage-prompt drift guard is NOT wired
+    # into pre-push: .github/workflows/enforcement-gate.yml already enforces it,
+    # and the checker measured 206s -- a 3.4-minute push gate is the defect
+    # #3780 removed. CI owns it; the hook must stay fast.
+    assert "require-stage-prompt-drift.sh" not in pre_push, (
+        "drift guard re-wired into pre-push; it costs ~206s per push and is "
+        "already covered by enforcement-gate.yml"
+    )
+    assert "require-review-on-push.sh" in pre_push, (
+        "the installer must still wire the gates it does own"
+    )
 
 
 def test_install_hooks_dry_run_does_not_modify_pre_push(tmp_path: Path) -> None:
@@ -78,7 +93,9 @@ def test_install_hooks_dry_run_does_not_modify_pre_push(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     after = (repo / ".git" / "hooks" / "pre-push").read_text(encoding="utf-8")
     assert after == before
-    assert "Would wire stage prompt drift guard into pre-push" in result.stdout
+    # The drift guard is no longer among the wired blocks (#3781); dry-run now
+    # reports on the blocks the installer does own.
+    assert "Would wire" in result.stdout
 
 
 # ── #2128: pre-push chain completeness tests ─────────────────────────────
@@ -117,7 +134,10 @@ def test_install_hooks_wires_review_on_push_into_pre_push(tmp_path: Path) -> Non
 
 
 def test_install_hooks_pre_push_chain_ordering(tmp_path: Path) -> None:
-    """Pre-push chain must be: enforcement-env -> review-gate -> drift-gate (#2128)."""
+    """Pre-push chain must be: enforcement-env -> review-gate (#2128, #3781).
+
+    The drift gate was formerly third in this chain; it is now CI-owned.
+    """
     repo = make_repo(tmp_path)
 
     result = subprocess.run(
@@ -133,10 +153,11 @@ def test_install_hooks_pre_push_chain_ordering(tmp_path: Path) -> None:
 
     assert env_pos != -1, "enforcement-env not found in pre-push"
     assert review_pos != -1, "require-review-on-push.sh not found in pre-push"
-    assert drift_pos != -1, "require-stage-prompt-drift.sh not found in pre-push"
-    assert env_pos < review_pos < drift_pos, (
-        f"Wrong ordering: enforcement-env@{env_pos}, review@{review_pos}, drift@{drift_pos}. "
-        f"Expected: enforcement-env < review < drift"
+    # drift is CI-owned and intentionally absent from the chain (#3781)
+    assert env_pos < review_pos, (
+        "enforcement-env must precede the review gate: it exports "
+        "REVIEW_GATE_STRICT=1 and the review wrapper defaults it to 0, so a "
+        "later source leaves review enforcement advisory (#3781)"
     )
 
 
@@ -155,6 +176,6 @@ def test_install_hooks_idempotent_pre_push_chain(tmp_path: Path) -> None:
     assert pre_push.count("require-review-on-push.sh") == 1, (
         f"require-review-on-push.sh duplicated on re-run:\n{pre_push}"
     )
-    assert pre_push.count("require-stage-prompt-drift.sh") == 1, (
+    assert pre_push.count("require-stage-prompt-drift.sh") == 0, (
         f"require-stage-prompt-drift.sh duplicated on re-run:\n{pre_push}"
     )

--- a/tests/enforcement/test_install_hooks_stage_prompt_drift.py
+++ b/tests/enforcement/test_install_hooks_stage_prompt_drift.py
@@ -26,7 +26,22 @@ def make_repo(tmp_path: Path) -> Path:
     shutil.copy2(SOURCE_REVIEW, scripts_dir / "require-review-on-push.sh")
 
     (hooks_dir / "pre-commit").write_text("#!/usr/bin/env bash\nexport PATH=\"$PATH\"\n", encoding="utf-8")
-    (hooks_dir / "pre-push").write_text("#!/usr/bin/env bash\nset -euo pipefail\n", encoding="utf-8")
+    # The fixture pre-push must carry the extension point. install-hooks.sh no
+    # longer appends past the end of the file: appended blocks land below the
+    # terminal exit and never run, which is what #3781 was. It now INSERTS at
+    # this marker and refuses outright when the marker is absent, so a
+    # sentinel-less fixture exercises the refusal path, not the wiring path.
+    # The refusal itself is covered by
+    # tests/hooks/test_install_hooks_extension_point.py::test_refuses_without_sentinel.
+    (hooks_dir / "pre-push").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "OVERALL_EXIT=0\n"
+        "# <<INSTALL_HOOKS_EXTENSION_POINT>>\n"
+        "\n"
+        'exit "$OVERALL_EXIT"\n',
+        encoding="utf-8",
+    )
     (hooks_dir / "post-commit").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
     return repo
 

--- a/tests/hooks/test_install_hooks_extension_point.py
+++ b/tests/hooks/test_install_hooks_extension_point.py
@@ -1,0 +1,207 @@
+"""Tests for the pre-push installer extension point — workspace-hub#3781.
+
+TDD: written before implementation.
+
+Background: `install-hooks.sh` wired enforcement blocks with `cat >> pre-push`,
+but the hook ends in an unconditional `exit`, so every appended block was
+unreachable. Its idempotence check greps for a *string* rather than checking
+*reachability*, so the installer reported "already wired" forever and could
+never repair the damage it caused.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "pre-push.sh"
+INSTALLER = REPO_ROOT / "scripts" / "enforcement" / "install-hooks.sh"
+SENTINEL = "<<INSTALL_HOOKS_EXTENSION_POINT>>"
+
+# Directories whose scripts are enforcement gates. Matching on these rather than
+# on a `require-*` filename prefix is deliberate: the two gates that were dead
+# for months -- check-state-file-size-prepush.sh and sync-cadence-helper.sh --
+# carry neither that prefix nor that directory, so a prefix-based guard would
+# have missed the exact defect it exists to catch.
+GATE_DIRS = ("scripts/enforcement/", "scripts/sync/", ".claude/hooks/")
+
+
+def _body_after_final_exit(text: str) -> str:
+    """Return everything after the last top-level unconditional `exit`.
+
+    "Top-level" means column zero: an `exit` indented inside an if/case/function
+    is conditional and is not the script terminator.
+    """
+    matches = list(re.finditer(r"(?m)^exit\b.*$", text))
+    if not matches:
+        return ""
+    return text[matches[-1].end():]
+
+
+class TestReachability:
+    """No enforcement may live below the hook's terminal exit."""
+
+    def test_no_enforcement_block_below_final_exit(self):
+        text = HOOK_SCRIPT.read_text()
+        tail = _body_after_final_exit(text)
+
+        offenders = []
+        for line in tail.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            if any(d in line for d in GATE_DIRS) or "enforcement-env" in line:
+                offenders.append(stripped)
+
+        assert not offenders, (
+            "enforcement below the terminal exit never runs (#3781):\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_hook_declares_an_extension_point(self):
+        assert SENTINEL in HOOK_SCRIPT.read_text(), (
+            "the hook must carry an explicit insertion marker so the installer "
+            "never has to append blindly"
+        )
+
+    def test_extension_point_precedes_the_final_exit(self):
+        text = HOOK_SCRIPT.read_text()
+        assert SENTINEL not in _body_after_final_exit(text), (
+            "the extension point itself sits below the exit — anything inserted "
+            "at it would be unreachable"
+        )
+
+
+class TestOrdering:
+    """enforcement-env must precede the gates whose behaviour it sets."""
+
+    def test_enforcement_env_precedes_review_gate(self):
+        text = HOOK_SCRIPT.read_text()
+        env_at = text.find("enforcement-env")
+        review_at = text.find("require-review-on-push.sh")
+        assert env_at != -1, "enforcement-env is not wired into the hook"
+        assert review_at != -1, "review gate is not wired into the hook"
+        assert env_at < review_at, (
+            "enforcement-env exports REVIEW_GATE_STRICT=1; the review wrapper "
+            "defaults it to 0. Sourcing it after the wrapper leaves the review "
+            "gate advisory — the #3781 defect."
+        )
+
+
+class TestStdinReplay:
+    """Gates that read git's pre-push stdin must actually receive it."""
+
+    def test_state_size_guard_receives_the_pushed_refs(self):
+        """The hook consumes stdin into PUSH_LINES before any gate runs.
+
+        `check-state-file-size-prepush.sh` reads ref lines from its own stdin and
+        silently falls back to an inferred ref when none arrive — so a gate that
+        merely *executes* can still be scanning the wrong commit range. The
+        buffered lines must be replayed into it.
+        """
+        text = HOOK_SCRIPT.read_text()
+        idx = text.find("check-state-file-size-prepush.sh")
+        assert idx != -1, "state-size guard is not wired into the hook"
+
+        block = text[max(0, idx - 400): idx + 400]
+        assert "PUSH_LINES" in block, (
+            "state-size guard invoked without replaying ${PUSH_LINES[@]} into "
+            "its stdin — it will scan an inferred ref, not the pushed range"
+        )
+
+
+def _make_repo(tmp_path: Path, sentinel: bool, stale_block: bool = False) -> Path:
+    """Build a throwaway repo with a pre-push hook in a chosen state."""
+    repo = tmp_path / "repo"
+    hooks = repo / ".git" / "hooks"
+    scripts = repo / "scripts" / "enforcement"
+    hooks.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    for name in (
+        "enforcement-env.sh",
+        "require-stage-prompt-drift.sh",
+        "require-review-on-push.sh",
+    ):
+        src = REPO_ROOT / "scripts" / "enforcement" / name
+        if src.exists():
+            shutil.copy2(src, scripts / name)
+
+    body = "#!/usr/bin/env bash\nset -euo pipefail\nOVERALL_EXIT=0\n"
+    if sentinel:
+        body += f"# {SENTINEL}\n\nexit 0\n"
+    else:
+        body += "exit 0\n"
+    if stale_block:
+        # Reproduce the real #3781 state: the hook DOES carry an extension point
+        # (post-#3782), and a block sits below the terminal exit anyway. An
+        # earlier version of this fixture omitted the sentinel, which tested the
+        # refusal path instead of the repair path.
+        body += (
+            "\n# ── Enforcement environment ──\n"
+            'ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"\n'
+            'if [[ -f "${ENFORCEMENT_ENV}" ]]; then source "${ENFORCEMENT_ENV}"; fi\n'
+        )
+
+    (hooks / "pre-push").write_text(body)
+    (hooks / "pre-commit").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (hooks / "post-commit").write_text("#!/usr/bin/env bash\nexit 0\n")
+    return repo
+
+
+def _run_installer(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(INSTALLER)], cwd=repo, capture_output=True, text=True
+    )
+
+
+class TestInstaller:
+    """The installer must insert at the marker, never append past the end."""
+
+    def test_refuses_without_sentinel(self, tmp_path):
+        repo = _make_repo(tmp_path, sentinel=False)
+        hook = repo / ".git" / "hooks" / "pre-push"
+        before = hook.read_text()
+
+        result = _run_installer(repo)
+
+        assert result.returncode != 0, (
+            "installing into a hook with no extension point must fail loudly — "
+            "appending blindly is what created #3781"
+        )
+        assert hook.read_text() == before, "hook must be left untouched on refusal"
+
+    def test_idempotent_when_already_reachable(self, tmp_path):
+        repo = _make_repo(tmp_path, sentinel=True)
+        hook = repo / ".git" / "hooks" / "pre-push"
+
+        assert _run_installer(repo).returncode == 0
+        once = hook.read_text()
+        assert _run_installer(repo).returncode == 0
+        twice = hook.read_text()
+
+        assert once == twice, "second install must be a no-op"
+        assert once.count("ENFORCEMENT_ENV=") <= 1, "block inserted twice"
+
+    def test_rewires_an_unreachable_block(self, tmp_path):
+        """Given the #3781 state, the installer must repair it — not report OK.
+
+        A string-presence idempotence check reports 'already wired' here, which
+        is why the broken state was permanent.
+        """
+        repo = _make_repo(tmp_path, sentinel=True, stale_block=True)
+        hook = repo / ".git" / "hooks" / "pre-push"
+
+        result = _run_installer(repo)
+        assert result.returncode == 0, result.stderr
+
+        text = hook.read_text()
+        tail = _body_after_final_exit(text)
+        assert "enforcement-env" not in tail, (
+            "the unreachable block was left below the exit — the installer "
+            "detected a string, not a reachable block"
+        )

--- a/tests/hooks/test_pre_push.py
+++ b/tests/hooks/test_pre_push.py
@@ -51,6 +51,16 @@ def _run_hook(
     env = os.environ.copy()
     # Ensure we don't accidentally invoke real check-all.sh / run-all-tests.sh
     env["PRE_PUSH_DRY_RUN"] = "1"
+    # These tests exercise repo SCOPE DETECTION, not the enforcement gates. Once
+    # the gates were re-wired above the terminal exit (#3781) they began running
+    # here for real, and the stage-prompt drift gate failed on unrelated repo
+    # state — a scope test reporting a drift failure. Disable enforcement so a
+    # gate's verdict cannot masquerade as a scoping bug.
+    #
+    # Deliberately NOT applied to the reachability/ordering tests in
+    # test_install_hooks_extension_point.py: those assert the gates are wired
+    # and must not be able to pass with enforcement switched off.
+    env.setdefault("DISABLE_ENFORCEMENT", "1")
     if env_extra:
         env.update(env_extra)
 


### PR DESCRIPTION
Closes #3781.

`install-hooks.sh` wired enforcement with `cat >> pre-push`, but the hook ends in an unconditional `exit`, so **every appended block was unreachable**. Four sat there. None had ever run, while the installer logged `OK: Wired ... into pre-push` for each.

The defect was **self-perpetuating**: idempotence was `grep -q "$marker" pre-push` — a test for *string presence*, not reachability — so once a block landed below the exit, the installer reported "already wired" forever. **Re-running it could never repair the damage it had caused.**

## What was actually exposed

Narrower than "four gates were off", and worth stating accurately: `enforcement-env` is also sourced by `pre-commit`, and the stage-prompt drift guard is covered by `enforcement-gate.yml`. Only the state-file size guard and the cadence-helper sync check had no enforcement anywhere.

**But one consequence was live, and it is why this matters:**

```
require-review-on-push.sh:292   ${REVIEW_GATE_STRICT:-1}   # script: blocks
pre-push.sh (wrapper)           ${REVIEW_GATE_STRICT:-0}   # hook:   warns
```

The script exits 1 and the hook downgrades that to a warning unless `REVIEW_GATE_STRICT=1` is exported — which is exactly what the dead `enforcement-env` did. So the **adversarial-review evidence gate has been advisory** on every push where that variable was not already in the operator's shell, silently defeating the strict-mode default documented as in force since 2026-04-09 (#1839).

**Owner-approved:** re-wire with `enforcement-env` first, making the review gate blocking. A push carrying commits with no review evidence is now **rejected** rather than warned. Bypass remains `SKIP_REVIEW_GATE=1` / `REVIEW_GATE_STRICT=0`, both audited.

## Three defects found by *running* it, not by asserting it

**1. The repo-scope early exit skipped the entire chain.** The hook printed `No tier-1 repo changes detected` and `exit`-ed before reaching any gate. Re-wiring behind that would have been theatre — reachable in the file, unreached in practice. Worse, #3780 made that path far more common by scoping new branches via merge-base. Now split: repo-scoped work (per-repo loop, secrets scan, coverage ratchet) skips; universal enforcement always runs.

**2. The state-size guard was being fed nothing.** It reads push refspecs from *its own* stdin, but the hook already consumed git's stdin into `PUSH_LINES`. Without a replay it silently falls back to an inferred ref and scans the wrong range **while appearing to run**. Now `printf '%s\n' "${PUSH_LINES[@]}" | bash "$STATE_SIZE_PREPUSH"`.

**3. The drift gate reported crashes as drift.** It imports `workspace_hub` (under `src/`, absent from the path under bare `uv run python`), so every run died on `ModuleNotFoundError` — and the wrapper mapped *any* non-zero exit to `FAIL: newly introduced stage prompt drift detected`, with remediation steps for a violation that did not exist.

That last one is the mirror of everything else here: the rest were **silent failures reading as success**; this was a **crash reading as a specific verdict**. The second is worse — it sends you somewhere real to fix something imaginary. Fixed both ways: PYTHONPATH set, and an empty report now distinguishes *died* from *decided*. It still blocks, because a gate that cannot run must not read as a pass.

## Stage-prompt drift is deliberately NOT wired — decided on measurement

With the import fixed it **passes** and takes **206 seconds**. So:

- `enforcement-gate.yml` already enforces it — a hook copy is redundant, not additive
- 3.4 minutes per push is precisely the multi-minute-gate defect **#3780 removed**; re-adding one while fixing #3781 would trade the same defect straight back

Removed from `install-hooks.sh` too, so re-running the installer cannot re-add what the tracked hook omits. Both wrapper fixes are kept — CI is the path that runs it.

## The installer now

- **Inserts at `# <<INSTALL_HOOKS_EXTENSION_POINT>>`**, verifies with `bash -n` before writing, and **refuses** when the sentinel is absent rather than appending blindly. Appending "just in case" is what created this.
- **Reachability-aware idempotence** — greps only above the sentinel, warns on present-but-unreachable, re-wires it.
- **`strip_dead_tail()`** removes enforcement stranded below the terminal exit; inserting the live copy above is not sufficient, since the dead copy keeps matching a naive grep.

## Tests: 68 passed, 1 skipped

- `test_no_enforcement_block_below_final_exit` is the class-level guard. It matches gate **directories**, not a `require-*` filename prefix — the two genuinely-unguarded gates carry neither, so a prefix guard would have missed the exact defect it exists to catch.
- `test_state_size_guard_receives_the_pushed_refs` asserts the guard sees the **pushed range**, not merely that it executed.
- `test_install_hooks_wires_stage_prompt_drift_into_pre_push` → renamed `test_install_hooks_leaves_stage_prompt_drift_to_ci` and asserts the opposite. Renamed rather than merely inverted: a test whose name contradicts its assertion is worse than no test.
- `test_pre_push.py` sets `DISABLE_ENFORCEMENT=1` — those tests exercise scope detection, and a drift verdict on unrelated repo state was surfacing as a scoping failure. Deliberately **not** applied to the reachability tests, which must not be able to pass with enforcement off.

One unrelated failure: `test_drive_file_nudge_3339.py::test_latency_budget` exercises `.claude/hooks/drive-file-nudge.sh`, references none of the changed files, and is a latency-budget assertion on a loaded box.

## Not in scope

Each machine still carries its own `.git/hooks` copy, so this fixes the tracked installer without guaranteeing any other machine is repaired. The fleet `md5sum` comparison remains the open question carried from #3780.

## Review

Plan `docs/plans/2026-08-02-issue-3781-installer-extension-point.md`. Codex **MAJOR** (5 blockers, all applied inline as r2); Claude **UNAVAILABLE** (CLI rc=124). Explicit-unavailable degrades T2→T1 per the routing convention — flagging that this plan had one reviewer, not two.
