### PR TITLE
ci: enable uv caching and frozen installs

### DIFF
--- a/.github/workflows/baseline-check.yml
+++ b/.github/workflows/baseline-check.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          uv sync --group dev
+          uv sync --frozen --group dev
 
       - name: Run Python tests
         run: |

--- a/.github/workflows/baseline-check.yml
+++ b/.github/workflows/baseline-check.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/baseline-check.yml
+++ b/.github/workflows/baseline-check.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pip'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/domain-matrix.yml
+++ b/.github/workflows/domain-matrix.yml
@@ -45,7 +45,7 @@ on:
         description: "Command to install dependencies in each domain job."
         type: string
         required: false
-        default: "uv sync --all-extras"
+        default: "uv sync --frozen --all-extras"
       test-runner:
         description: "Command prefix used to run pytest on the shard targets."
         type: string

--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Validate scheduler mutation registry
@@ -60,7 +60,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0  # full history for commit range analysis
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -292,7 +292,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Check skill-index coherence

--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           PYTHONPATH: src
         run: |
-          uv sync --group dev
+          uv sync --frozen --group dev
           uv run python -m pytest tests/ci_smoke/test_workspace_hub_importable.py -v --tb=short
 
       - name: Check newly introduced stage prompt drift

--- a/.github/workflows/enforcement-gate.yml
+++ b/.github/workflows/enforcement-gate.yml
@@ -26,6 +26,8 @@ jobs:
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Validate scheduler mutation registry
         run: uv run python scripts/enforcement/check-scheduler-mutation-surfaces.py
       - name: Validate exact cron identity inventory
@@ -59,6 +61,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       # PYTHONPATH=src is REQUIRED for `from workspace_hub...` imports because:
       #   1. src/workspace_hub/ has NO __init__.py — it's an intentional PEP 420
@@ -117,6 +121,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Check review evidence for PR commits
         env:
@@ -287,6 +293,8 @@ jobs:
           fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Check skill-index coherence
         run: |
           set -o pipefail

--- a/.github/workflows/kanban-reconcile.yml
+++ b/.github/workflows/kanban-reconcile.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/kanban-reconcile.yml
+++ b/.github/workflows/kanban-reconcile.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Mint GitHub App token
         id: app-token

--- a/.github/workflows/legal-client-pii-gate.yml
+++ b/.github/workflows/legal-client-pii-gate.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Materialize private client map from secret
         env:

--- a/.github/workflows/legal-client-pii-gate.yml
+++ b/.github/workflows/legal-client-pii-gate.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/legal-rule-authority-reusable.yml
+++ b/.github/workflows/legal-rule-authority-reusable.yml
@@ -32,6 +32,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        with:
+          enable-cache: true
       - name: Materialize protected envelope
         env:
           AUTH_ENVELOPE: ${{ secrets.LEGAL_SCAN_AUTH_CURRENT }}

--- a/.github/workflows/scheduler-mutation-main.yml
+++ b/.github/workflows/scheduler-mutation-main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Validate scheduler mutation registry

--- a/.github/workflows/scheduler-mutation-main.yml
+++ b/.github/workflows/scheduler-mutation-main.yml
@@ -22,6 +22,8 @@ jobs:
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Validate scheduler mutation registry
         run: uv run python scripts/enforcement/check-scheduler-mutation-surfaces.py
       - name: Validate exact cron identity inventory

--- a/.github/workflows/skills-validation.yml
+++ b/.github/workflows/skills-validation.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Run skill validator
         run: |

--- a/.github/workflows/skills-validation.yml
+++ b/.github/workflows/skills-validation.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/docs/reports/2026-07-11-issue-3470-scheduler-mutation-safety.html
+++ b/docs/reports/2026-07-11-issue-3470-scheduler-mutation-safety.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en" data-input-digest="8aecb52bd133ceb899fe48bdfc2c27fbf8909e00a133a85b604871fc38ecbb86"><head><meta charset="utf-8">
+<html lang="en" data-input-digest="ae5a9cf7468096ce61bb6ed155b6b5469736a4065744b93bcf8f1885ef4d2d1f"><head><meta charset="utf-8">
 <title>Scheduler Mutation Safety Audit</title>
 <style>body{font:16px system-ui;max-width:1200px;margin:2rem auto;padding:0 1rem}table{border-collapse:collapse;width:100%}th,td{border:1px solid #bbb;padding:.5rem;text-align:left}code{font-size:.9em}.warning{border-left:4px solid #b45309;padding:1rem;background:#fff7ed}</style></head>
 <body><h1>Scheduler Mutation Safety Audit</h1>
-<p><strong>Input digest:</strong> <code>8aecb52bd133ceb899fe48bdfc2c27fbf8909e00a133a85b604871fc38ecbb86</code></p>
+<p><strong>Input digest:</strong> <code>ae5a9cf7468096ce61bb6ed155b6b5469736a4065744b93bcf8f1885ef4d2d1f</code></p>
 <p class="warning">Registry inclusion does not authorize live scheduler mutation.</p>
 <table><thead><tr><th>Surface</th><th>Kind</th><th>Derived status</th><th>Operations</th><th>Disposition</th></tr></thead><tbody>
 <tr data-surface="scripts/coordination/context/setup_cron.sh"><td><code>scripts/coordination/context/setup_cron.sh</code></td><td>direct-owner</td><td>migration-required</td><td><section class="operation" data-operation="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace" data-target-kind="current-user-cron" data-scheduler-identity="local-current-user-crontab" data-execution-host-binding="physical-local"><strong>marker-filtered-crontab-replace</strong><br>Target: current-user-cron; identity: local-current-user-crontab; binding: physical-local<br>Authority:<ul><li data-authority="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace::marker-filter" data-mechanism="command-substring" data-strength="substring">marker-filter:command-substring/substring</li></ul>Transaction gaps: <span class="transaction-gaps" data-transaction-for="scripts/coordination/context/setup_cron.sh::marker-filtered-crontab-replace">lock=false, baseline_snapshot=false, backup=false, pre_write_cas=false, post_write_preservation_verify=false, post_write_exact_state_verify=false, rollback_cas=false</span></section></td><td><a href="https://github.com/vamseeachanta/workspace-hub/issues/3476">#3476</a></td></tr>

--- a/tests/ci_smoke/test_ci_workflows_use_uv.py
+++ b/tests/ci_smoke/test_ci_workflows_use_uv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -17,10 +18,27 @@ def test_pyproject_declares_uv_dev_dependencies_for_local_pytest_runs() -> None:
     assert '"pytest>=8.0"' in text
 
 
+def _assert_syncs_dev_group(text: str, workflow: str) -> None:
+    """Assert the workflow installs the dev group via uv, whatever flags it uses.
+
+    This previously asserted the literal substring ``uv sync --group dev``, which
+    pins a *spelling* rather than the *property* the test is named for. Adding a
+    strictly better flag -- ``uv sync --frozen --group dev``, which installs the
+    lockfile without re-resolving -- broke it, while a real regression (dropping
+    uv for pip) could pass simply by being worded differently.
+
+    Match any ``uv sync`` invocation carrying ``--group dev``, so correct flags
+    are free to change and the guarantee still holds.
+    """
+    assert re.search(r"uv sync(?:\s+--[\w-]+)*\s+--group dev\b", text), (
+        f"{workflow} must install the dev group with `uv sync ... --group dev`"
+    )
+
+
 def test_baseline_workflow_uses_uv_managed_test_environment() -> None:
     text = BASELINE.read_text(encoding="utf-8")
 
-    assert "uv sync --group dev" in text
+    _assert_syncs_dev_group(text, "baseline-check.yml")
     assert "uv run python -m pytest tests/test_deduplication_fix.py" in text
     assert "uv run python -m pytest tests/ci_smoke/" in text
     assert "pip install pytest" not in text
@@ -29,6 +47,22 @@ def test_baseline_workflow_uses_uv_managed_test_environment() -> None:
 def test_enforcement_workflow_uses_uv_managed_test_environment() -> None:
     text = ENFORCEMENT.read_text(encoding="utf-8")
 
-    assert "uv sync --group dev" in text
+    _assert_syncs_dev_group(text, "enforcement-gate.yml")
     assert "uv run python -m pytest tests/ci_smoke/test_workspace_hub_importable.py" in text
     assert "pip install pytest" not in text
+
+
+def test_dev_group_assertion_rejects_a_missing_uv_sync() -> None:
+    """The helper must still fail when uv genuinely is not used.
+
+    A looser matcher is only an improvement if it still catches the regression
+    the strict one caught. Pinning that here so the loosening cannot silently
+    become a no-op.
+    """
+    import pytest
+
+    with pytest.raises(AssertionError):
+        _assert_syncs_dev_group("run: pip install -r requirements.txt\n", "fake.yml")
+
+    with pytest.raises(AssertionError):
+        _assert_syncs_dev_group("run: uv sync --frozen\n", "fake.yml")


### PR DESCRIPTION
## Summary

- enable setup-uv caching in all 11 workflow steps
- add `--frozen` to all three lockfile-backed `uv sync` installs, including the reusable domain-matrix default
- standardize mutable setup-uv references on v7 while preserving the legal-authority workflow's immutable v6.4.3 SHA pin

## Verification

- all eight changed workflows parse with PyYAML
- setup-uv cache coverage: 11/11
- every repository-defined `uv sync` command now includes `--frozen`
- `git diff --check origin/main...HEAD -- .github/workflows`
- per-commit diff stats reviewed

## Version exception

- `legal-rule-authority-reusable.yml` retains its immutable v6.4.3 SHA rather than weakening a trusted-tool boundary to mutable `@v7`

Refs #3291
