### PR TITLE
fix(legal): scope the client-name scan out of the public field-development corpus

### DIFF
--- a/.legal-deny-list.yaml
+++ b/.legal-deny-list.yaml
@@ -148,6 +148,31 @@ exclusions:
   # from being blocked while keeping the scan effective for actual code and documentation.
   # See: scripts/cron/commit-learning-artifacts.sh, issue #1985.
   - "logs/orchestrator/"
+  # data/field-development/ and docs/field-development/ are the world-energy
+  # field-development corpus: wholly PUBLIC data (BSEE / SubseaIQ / operator
+  # disclosures) about Gulf of Mexico and international fields.
+  #
+  # The patterns above block strings like "Perdido" and "Prelude FLNG" because
+  # they were CLIENT ENGAGEMENT names under /mnt/ace. The same strings are also
+  # the public names of those fields, and public field-development analysis is
+  # work this ecosystem does deliberately. Exact-string matching cannot tell the
+  # two apart: "Perdido" from a client folder is a leak, "Perdido" in a scan of
+  # public SubseaIQ data is the subject matter. Scanning the public corpus
+  # therefore produces only false positives — 22 of them as of 2026-08-03 — and
+  # a gate that is mostly noise stops being read at all.
+  #
+  # Owner decision 2026-08-03: this corpus is wholly public, vendors are
+  # verified from public sources, and the client-name scan does not apply here.
+  #
+  # SCOPE IS DELIBERATELY NARROW. It is these two directories only. The genuine
+  # findings this scan exists for — "2H Offshore" (copyrighted vendor source)
+  # and "Shankar Sundararaman" (named author), both from the #1773 incident —
+  # live in docs/plans, docs/session-handoffs and scripts/, which stay fully in
+  # scope. Do not widen this to `docs/` or `data/`; that would silently disable
+  # the #1773 protection. Guarded by
+  # tests/legal/test_public_field_data_exclusion.py.
+  - "data/field-development/"
+  - "docs/field-development/"
   - "*.sim"
   - "*.dat"
 

--- a/tests/legal/test_public_field_data_exclusion.py
+++ b/tests/legal/test_public_field_data_exclusion.py
@@ -1,0 +1,167 @@
+"""The public field-development corpus is out of scope for the client-name scan.
+
+WHY THIS CARVE-OUT EXISTS
+-------------------------
+`.legal-deny-list.yaml` blocks a set of Gulf of Mexico field and project names
+because they were CLIENT ENGAGEMENT names under /mnt/ace. Those same strings are
+also the PUBLIC names of the fields, and public field-development analysis is
+work this ecosystem does deliberately — the hits live in a scan of public
+SubseaIQ data and a GoM field-development dataset.
+
+Exact-string matching cannot tell provenance apart: a field name taken from a
+client folder is a leak; the same name in a scan of public data is the subject
+matter. Scanning the public corpus therefore yields only false positives, and a
+gate that is mostly noise stops being read.
+
+Owner decision 2026-08-03: the world-energy field-development corpus is wholly
+public, vendors are verified from public sources, and the scan does not apply
+there.
+
+WHY THE SECOND TEST MATTERS MORE
+--------------------------------
+Narrowing a legal gate is safe only if the narrowing is BOUNDED. The genuine
+findings this scan exists for — the copyrighted-vendor and named-author entries
+recorded under the #1773 incident — live in docs/plans, docs/session-handoffs
+and scripts/, NOT in the field-development corpus. The carve-out must drop the
+public-data false positives and leave those blocking.
+`test_pattern_outside_the_carveout_still_blocks` is the guard against a future
+"just add one more path" that quietly disables that protection.
+
+NOTE ON THIS FILE'S OWN CONTENT
+-------------------------------
+Deny-listed strings are read from the deny list AT RUNTIME and never written
+literally here. An earlier draft spelled them out and added 22 fresh violations
+to the very scan it tests — the enforcement artifact tripping its own check.
+Reading them at runtime also means this test follows deny-list edits instead of
+drifting from them.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DENY_LIST = REPO_ROOT / ".legal-deny-list.yaml"
+SCANNER = REPO_ROOT / "scripts" / "legal" / "legal-sanity-scan.sh"
+
+# The corpus the owner ruled out of scope.
+PUBLIC_FIELD_CORPUS = ["data/field-development", "docs/field-development"]
+
+# Paths carrying the genuine #1773 findings — these must stay in scope.
+MUST_STAY_IN_SCOPE = ["docs/plans", "docs/session-handoffs", "scripts"]
+
+
+def _a_denied_pattern() -> str:
+    """Any blocking pattern, read from the deny list rather than hardcoded.
+
+    Which one does not matter: the behaviour under test is "excluded path is not
+    reported, other path is", not the semantics of a particular name.
+    """
+    for line in DENY_LIST.read_text().splitlines():
+        m = re.match(r'\s*-\s*pattern:\s*"([^"]+)"', line)
+        if m:
+            return m.group(1)
+    pytest.fail("no pattern entries found in .legal-deny-list.yaml")
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """A throwaway workspace carrying the REAL deny list and scanner.
+
+    The real deny list is the artifact under test — a fixture copy would test a
+    fiction. The tree itself is fake, so no real repo is ever scanned.
+    """
+    ws = tmp_path / "workspace-hub"
+    (ws / "scripts" / "legal").mkdir(parents=True)
+    shutil.copy(SCANNER, ws / "scripts" / "legal" / "legal-sanity-scan.sh")
+    shutil.copy(DENY_LIST, ws / ".legal-deny-list.yaml")
+    subprocess.run(["git", "init", "-q"], cwd=ws, check=True)
+    return ws
+
+
+def _write(ws: Path, rel: str, text: str) -> None:
+    p = ws / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def _scan(ws: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "scripts/legal/legal-sanity-scan.sh"],
+        cwd=ws, capture_output=True, text=True, timeout=180,
+    )
+
+
+@pytest.mark.parametrize("corpus", PUBLIC_FIELD_CORPUS)
+def test_denied_pattern_inside_the_public_corpus_does_not_block(
+    workspace: Path, corpus: str
+) -> None:
+    _write(workspace, f"{corpus}/public-scan.md", f"{_a_denied_pattern()}\n")
+    result = _scan(workspace)
+    combined = result.stdout + result.stderr
+    assert "public-scan.md" not in combined, (
+        f"{corpus} is public field data and must be out of scope, but the scan "
+        f"reported it:\n{combined[-2000:]}"
+    )
+    assert result.returncode == 0, (
+        f"a workspace whose only matches are inside the public corpus must "
+        f"pass; rc={result.returncode}\n{combined[-2000:]}"
+    )
+
+
+def test_pattern_outside_the_carveout_still_blocks(workspace: Path) -> None:
+    """The carve-out must not leak into paths that carry real findings (#1773)."""
+    pattern = _a_denied_pattern()
+    _write(workspace, "data/field-development/public-scan.md", f"{pattern}\n")
+    _write(workspace, "docs/plans/some-plan.md", f"{pattern}\n")
+    result = _scan(workspace)
+    combined = result.stdout + result.stderr
+    assert "some-plan.md" in combined, (
+        f"a denied pattern outside the public corpus MUST still be reported:\n"
+        f"{combined[-2000:]}"
+    )
+    assert result.returncode != 0, "a genuine hit must fail the scan"
+    assert "public-scan.md" not in combined, (
+        "the public corpus must stay out of scope even when the scan fails for "
+        "an unrelated, genuine reason"
+    )
+
+
+@pytest.mark.parametrize("path", MUST_STAY_IN_SCOPE)
+def test_exclusions_do_not_swallow_in_scope_paths(path: str) -> None:
+    """Config-shape guard: no exclusion entry may cover a must-scan path.
+
+    Cheap and independent of scanner behaviour — it catches an over-broad glob
+    (e.g. `docs/`) at review time, before the protection is gone.
+    """
+    text = DENY_LIST.read_text()
+    in_exclusions = text.split("exclusions:", 1)[1] if "exclusions:" in text else ""
+    for line in in_exclusions.splitlines():
+        entry = line.strip().lstrip("-").strip().strip('"').strip("'")
+        if not entry or entry.startswith("#"):
+            continue
+        prefix = entry.rstrip("*/")
+        assert not prefix or not path.startswith(prefix), (
+            f"exclusion {entry!r} would remove {path!r} from the scan; that path "
+            f"carries genuine vendor/author findings (#1773)"
+        )
+
+
+def test_this_guard_does_not_trip_the_scan_it_guards() -> None:
+    """No deny-listed literal may appear in this file.
+
+    An enforcement artifact that trips its own check adds noise to the signal it
+    exists to protect. An earlier draft of this file did exactly that.
+    """
+    own_text = Path(__file__).read_text()
+    patterns = re.findall(r'\s*-\s*pattern:\s*"([^"]+)"', DENY_LIST.read_text())
+    assert patterns, "deny list yielded no patterns to check against"
+    hits = [p for p in patterns if p in own_text]
+    assert not hits, (
+        f"this test file contains deny-listed literals {hits}; read them from "
+        f"the deny list at runtime instead"
+    )


### PR DESCRIPTION
## Decision

**Owner ruling 2026-08-03:** the world-energy field-development corpus is wholly public data, vendors are verified from public sources, and the client-name scan does not apply there.

## Why the scan was failing on it

`.legal-deny-list.yaml` blocks a set of GoM field and project names because they were **client engagement** names under `/mnt/ace`. Those same strings are the **public** names of the fields, and public field-development analysis is work this ecosystem does deliberately. The hits were in a scan of public SubseaIQ data and a GoM field-development dataset.

Exact-string matching cannot tell provenance apart: a field name taken from a client folder is a leak; the same name in a scan of public data is the subject matter. The result was 24 false positives and nothing else — and a gate that is mostly noise stops being read.

## Scope is deliberately narrow

Two directories: `data/field-development/` and `docs/field-development/`. Nothing else.

The genuine findings this scan exists for — copyrighted vendor source and a named author, both from the **#1773** incident — live in `docs/plans`, `docs/session-handoffs` and `scripts/`, which stay **fully in scope**.

## Measured on the real repo

| | Before | After |
|---|---|---|
| Block violations | 166 | **142** |
| Hits in the two excluded dirs | 24 | **0** |
| #1773 vendor/author lines still blocking | 28 | **28** |
| Scan exit code | 1 | **1** (still fails on real findings) |

The carve-out removed exactly the public-data false positives and nothing else.

## The guard, and why its second half matters more

Narrowing a legal gate is safe only if the narrowing is **bounded**:

- `test_denied_pattern_inside_the_public_corpus_does_not_block` — the carve-out works.
- `test_pattern_outside_the_carveout_still_blocks` — **the important one.** A denied pattern outside the corpus must still be reported, so a future "just add one more path" cannot quietly disable the #1773 protection.
- `test_exclusions_do_not_swallow_in_scope_paths` — config-shape guard rejecting any exclusion glob that would cover a must-scan path, catching an over-broad `docs/` at review time rather than after the protection is gone.
- `test_this_guard_does_not_trip_the_scan_it_guards` — see below.

## A trap worth reading

The first draft of the guard **spelled the denied strings out literally**, adding 22 fresh violations to the very scan it tests. The exclusion removed 24 and the test file re-added 22, so the real-repo total moved 166 → 164 and looked like the change had barely worked. The tests were green throughout — only measuring the actual scan caught it.

Patterns are now read from the deny list at runtime (which also means the test follows deny-list edits instead of drifting), and the fourth test asserts this file never regains a denied literal.

## Verification

`tests/legal/` goes **3 passed → 10 passed**. The 7 pre-existing failures in `test_repo_resolution.py` / `test_legal_scan_resolution.py` are **unchanged and unrelated** — confirmed identical on `origin/main`.

## Still open, not addressed here

The scan still exits 1 with 142 violations from other paths (`docs/plans`, `docs/session-handoffs`, `docs/reports`, `docs/content-pipeline`). Those are a mix of the genuine #1773 vendor/author findings and more public field names in prose. Deciding that split is a separate legal-posture call.