### PR TITLE
fix(legal): redact pattern names from the handoffs that documented the scan noise

### DIFF
--- a/docs/session-handoffs/2026-05-20-issue-2745-execution-complete-2746-and-2745-closeout.md
+++ b/docs/session-handoffs/2026-05-20-issue-2745-execution-complete-2746-and-2745-closeout.md
@@ -34,7 +34,7 @@ Continued from prior handoff `2026-05-20-issue-2746-execution-complete-2745-pend
 | Evidence file 404 on workspace-hub:main | BLOCKER | Committed `f6086ccbd` + `1dea82a57`, pushed; 0/0 divergence confirmed |
 | Backup file-count not literally re-run (path-isolation proxy) | BLOCKER | Re-ran find once ext4 contention eased: 10,729 = 10,729 ✓ |
 | Hook tested via direct-exec only | MAJOR | Verified via actual `git add + git commit`: FROZEN message + blocked commit + working tree restored ✓ |
-| Broad legal-sanity-scan substituted | MAJOR | Ran broad scan; surfaced ONLY legacy-log false-positives (Prelude FLNG=128, 2H Offshore=25, Shankar Sundararaman=8+74+6+6 — all in `logs/quality/comprehensive-learning-*.log` + `logs/orchestrator/hermes/session_*.jsonl`). #2745 artifacts contributed ZERO. Follow-up: scanner should exclude `logs/`. |
+| Broad legal-sanity-scan substituted | MAJOR | Ran broad scan; surfaced ONLY legacy-log false-positives (field-name pattern=128, vendor-name pattern=25, author-name pattern=8+74+6+6 — pattern names withheld 2026-08-04: quoting them here made this handoff itself fail the scan it describes — all in `logs/quality/comprehensive-learning-*.log` + `logs/orchestrator/hermes/session_*.jsonl`). #2745 artifacts contributed ZERO. Follow-up: scanner should exclude `logs/`. |
 
 Claude minor findings (reversal-step gap, cleanup audit) — documented in evidence file + T10 comment.
 

--- a/docs/session-handoffs/2026-07-02-ace-linux-2-equality-bringup-session.md
+++ b/docs/session-handoffs/2026-07-02-ace-linux-2-equality-bringup-session.md
@@ -32,7 +32,7 @@ Live matrix: <https://vamseeachanta.github.io/workspace-hub/machine-equality-mat
 - **memory_freshness: MEMORY-EXPIRED** — `context.md` 143h, hermes memories 121h; content staleness, fleet-wide, needs actual memory-surface refresh, not wiring.
 - **R-PRECOMMIT fail:** assetutilities / worldenergydata / assethold `.pre-commit-config.yaml` lack the `legal-sanity-scan` entry → 3 small sibling PRs.
 - **dev-primary column is STALE-CHECKOUT from its own evidence** (published 06:54 today with `dirty:true, behind:5` from its interactive checkout) — fix belongs on ace-linux-1; it also skews this box's peer-comparison cells (`behavior/scheduler/memory: DIVERGES`, `harness: NO-MAJORITY`).
-- **Legal-scan noise:** full-repo scan FAILs on ~142 pre-existing legacy-log false positives (Prelude FLNG / 2H Offshore in `logs/`), already documented 2026-05-20 with a "scanner should exclude logs/" follow-up — worth a small PR.
+- **Legal-scan noise:** full-repo scan FAILs on ~142 pre-existing legacy-log false positives (deny-list field-name / vendor-name patterns in `logs/`; names withheld 2026-08-04), already documented 2026-05-20 with a "scanner should exclude logs/" follow-up — worth a small PR.
 - ace-win-1 / ace-win-2 steps from the #3342 rollout prompt (gh auth, Git Bash manual publish, #2815 schedules) remain for those boxes.
 
 ## No-external-action status


### PR DESCRIPTION
## Takes the legal gate to PASS

```
  RESULT: PASS — no block violations found
  WARNINGS: 104 advisory match(es) — reported, not blocking
```

First green run of this gate. Chain: #3799 (public field-development corpus) → #3800 (severity tiers + redact real findings) → this.

## What

The last 3 blocking hits were **self-referential**: two session handoffs that quoted deny-list pattern names *while recording this very false-positive problem*. The 2026-07-02 handoff reports "full-repo scan FAILs on ~142 pre-existing false positives" — and was itself one of them.

## Redacted, not path-excluded

`docs/session-handoffs/` carries real content. Blinding the whole directory to satisfy three lines would trade a narrow annoyance for a wide blind spot — and handoffs are exactly where a future client identifier is most likely to be written down.

The **analytic content is preserved**: which *class* of pattern was noisy, and the per-pattern counts, which is what those lines were actually communicating. Only the literals are gone, each with an inline note saying so, so a future reader is not left guessing what was removed.

```diff
- (Prelude FLNG=128, 2H Offshore=25, Shankar Sundararaman=8+74+6+6 — all in `logs/...`)
+ (field-name pattern=128, vendor-name pattern=25, author-name pattern=8+74+6+6 —
+  pattern names withheld 2026-08-04: quoting them here made this handoff itself
+  fail the scan it describes — all in `logs/...`)
```

## Verification

- Scan on this branch: `rc=0`, `RESULT: PASS`.
- `tests/legal/`: **16 passed**, same 7 pre-existing resolution failures (verified identical on `origin/main`, unrelated to this change).
- Warnings unchanged in substance — 52 unique. Nothing stopped being **seen**; the gate now fails only on things that should fail it.

## Related

- Residual git-history exposure from the #3800 redactions: **accepted by owner**, closed as #3801.
- The root scan double-counts every match (`global_list` and `local_list` resolve to the same file at repo root), which is why 52 unique warnings report as 104. Tracked separately.