### PR TITLE
fix(legal): count each match once — the root scan parsed one deny list twice

### DIFF
--- a/scripts/legal/legal-sanity-scan.sh
+++ b/scripts/legal/legal-sanity-scan.sh
@@ -277,6 +277,72 @@ parse_deny_list() {
 }
 
 # --------------------------------------------------------------------------
+# dedupe_patterns: collapse duplicate patterns from the merged deny lists.
+#
+# Reads `pattern|case_flag|severity` on stdin, emits each distinct PATTERN once,
+# in first-appearance order.
+#
+# WHY THIS EXISTS
+# ---------------
+# scan_directory merges a global and a local deny list. When the scan target IS
+# the workspace root the two paths name THE SAME FILE, so every pattern arrived
+# twice, was searched twice, and every hit was counted twice — the scan reported
+# exactly 2x its real findings, and had done so for as long as it has existed.
+# A submodule that re-declares a pattern the global list already carries (which
+# "extend, not replace" positively invites) produces the same doubling by a
+# different route. Deduplicating the work list fixes both, and needs no realpath
+# comparison — so it is unaffected by symlinked or bind-mounted deny lists, and
+# by realpath/readlink -f not being portable to BSD and git-bash.
+#
+# Searching for the same string twice cannot find anything the first search
+# missed, so collapsing duplicates is information-preserving by construction.
+#
+# MERGE RULES — fail-OPEN on breadth, fail-CLOSED on severity, so the collapsed
+# entry finds exactly the union of what the duplicates found and never demotes:
+#   case_flag  "i" wins — case-insensitive matches are a superset of
+#              case-sensitive ones, so the single search returns the union.
+#   severity   "block" wins — a duplicate declaration must never downgrade a
+#              blocking pattern to advisory. Same posture as the
+#              unrecognised-severity handling below.
+#
+# The split is right-anchored (${x##*|} / ${x%|*}) because a pattern may itself
+# contain '|'; case_flag and severity never do.
+# --------------------------------------------------------------------------
+dedupe_patterns() {
+  local -A seen_case=()
+  local -A seen_sev=()
+  local order=()
+  local line sev rest cf pat p
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    sev="${line##*|}"
+    rest="${line%|*}"
+    cf="${rest##*|}"
+    pat="${rest%|*}"
+    [[ -z "$pat" ]] && continue
+
+    if [[ -z "${seen_case[$pat]+set}" ]]; then
+      order+=("$pat")
+      seen_case["$pat"]="$cf"
+      seen_sev["$pat"]="$sev"
+    else
+      # Written as plain `if`s, not `[[ ]] && ...`: under `set -e` a trailing
+      # short-circuit that evaluates false makes the enclosing block return
+      # non-zero. In a legal gate an accidental early return is a silent
+      # scan-nothing pass, so the branch must not depend on that subtlety.
+      if [[ "$cf" == "i" ]]; then seen_case["$pat"]="i"; fi
+      if [[ "$sev" == "block" ]]; then seen_sev["$pat"]="block"; fi
+    fi
+  done
+
+  [[ ${#order[@]} -eq 0 ]] && return 0
+  for p in "${order[@]}"; do
+    printf '%s|%s|%s\n' "$p" "${seen_case[$p]}" "${seen_sev[$p]}"
+  done
+}
+
+# --------------------------------------------------------------------------
 # Build exclusion args for ripgrep from the exclusions list
 # --------------------------------------------------------------------------
 parse_exclusions() {
@@ -384,21 +450,30 @@ scan_directory() {
   local global_list="$WORKSPACE_ROOT/.legal-deny-list.yaml"
   local local_list="$scan_dir/.legal-deny-list.yaml"
 
+  # A local list EXTENDS the global one (per the deny list's own header), but
+  # for a root scan the two are the same file — dedupe_patterns collapses the
+  # resulting duplicates so each pattern is searched, and counted, exactly once.
   local patterns
-  patterns="$(parse_deny_list "$global_list"; parse_deny_list "$local_list")"
+  patterns="$( { parse_deny_list "$global_list"; parse_deny_list "$local_list"; } \
+                 | dedupe_patterns )"
   [[ -z "$patterns" ]] && return 0
+
+  # Exclusions, parsed ONCE and deduped for the same reason. `awk !seen[$0]++`
+  # preserves first-appearance order; every entry is a negation, so order is not
+  # load-bearing, but keeping it makes the change a pure no-op on behaviour.
+  local exclusions
+  exclusions="$( { parse_exclusions "$global_list"; parse_exclusions "$local_list"; } \
+                   | awk 'NF && !seen[$0]++' )"
 
   # Build exclusion globs
   local excl_args=()
-  while IFS= read -r glob; do
-    [[ -n "$glob" ]] && excl_args+=("--glob" "!$glob")
-  done < <(parse_exclusions "$global_list"; parse_exclusions "$local_list")
-
   # Build exclusion pattern list for file filtering
   local excl_patterns=()
   while IFS= read -r glob; do
-    [[ -n "$glob" ]] && excl_patterns+=("$glob")
-  done < <(parse_exclusions "$global_list"; parse_exclusions "$local_list")
+    [[ -n "$glob" ]] || continue
+    excl_args+=("--glob" "!$glob")
+    excl_patterns+=("$glob")
+  done <<< "$exclusions"
 
   # Determine file list
   local file_args=()

--- a/tests/legal/test_no_double_count.py
+++ b/tests/legal/test_no_double_count.py
@@ -1,0 +1,293 @@
+"""Every match is counted exactly once, no matter which deny lists supplied it.
+
+WHY
+---
+`scan_directory` merges a global and a local deny list::
+
+    global_list="$WORKSPACE_ROOT/.legal-deny-list.yaml"
+    local_list="$scan_dir/.legal-deny-list.yaml"
+    patterns="$(parse_deny_list "$global_list"; parse_deny_list "$local_list")"
+
+For a submodule those are two different files and merging is the documented
+intent — "Per-project deny lists in each submodule extend (not replace) this
+file". For a scan of the workspace ROOT, `scan_dir` IS `WORKSPACE_ROOT`, so the
+two variables name THE SAME FILE. It was parsed twice, every pattern entered the
+work list twice, every pattern was searched twice, and every hit was counted
+twice.
+
+Measured on origin/main 2026-08-03, scanning the workspace root: 6 block + 108
+warn reported against 3 + 54 unique `file:line` hits. Exactly 2x. Every headline
+number this gate has ever printed was double the truth — including the "71
+unique violations" figure that the severity-tier work was reasoned from, which
+the scan itself had been reporting as 142.
+
+A gate whose headline number is wrong by a constant factor is worse than one
+that is merely noisy: the noise is visible, the factor is not.
+
+WHY THE COUNT AND NOT JUST THE EXIT CODE
+----------------------------------------
+The existing tests all assert on presence and return code, which double-counting
+cannot disturb — 2 violations fail exactly like 1. That is why the bug survived
+every one of them. These tests assert on the COUNT, which is the only thing that
+moved.
+
+NOTE ON THIS FILE'S OWN CONTENT
+-------------------------------
+No deny-listed literal appears here. Every pattern is an invented ZZ...ZZ marker
+written into a throwaway deny list, per
+`test_public_field_data_exclusion.test_no_legal_test_trips_the_scan_it_guards`.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNER = REPO_ROOT / "scripts" / "legal" / "legal-sanity-scan.sh"
+
+MARK_ROOT = "ZZROOTCOUNTMARKERZZ"
+MARK_WARNCOUNT = "ZZWARNCOUNTMARKERZZ"
+MARK_GLOBALONLY = "ZZGLOBALONLYMARKERZZ"
+MARK_LOCALONLY = "ZZLOCALONLYMARKERZZ"
+MARK_DUP = "ZZDUPACROSSLISTSMARKERZZ"
+MARK_SEVCONFLICT = "ZZSEVCONFLICTMARKERZZ"
+
+
+def _deny_list(body: str, default_severity: str = "block") -> str:
+    return (
+        f"client_references:\n{body}"
+        f'exclusions:\n  - ".git/"\n'
+        f'default_severity: "{default_severity}"\n'
+    )
+
+
+def _entry(pattern: str, severity: str | None = None) -> str:
+    line = f'  - pattern: "{pattern}"\n    case_sensitive: true\n'
+    if severity is not None:
+        line += f"    severity: {severity}\n"
+    return line
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> Path:
+    w = tmp_path / "workspace-hub"
+    (w / "scripts" / "legal").mkdir(parents=True)
+    shutil.copy(SCANNER, w / "scripts" / "legal" / "legal-sanity-scan.sh")
+    subprocess.run(["git", "init", "-q"], cwd=w, check=True)
+    return w
+
+
+def _scan(w: Path, *args: str, env: dict[str, str] | None = None
+          ) -> subprocess.CompletedProcess:
+    run_env = None
+    if env is not None:
+        run_env = {**os.environ, **env}
+    return subprocess.run(
+        ["bash", "scripts/legal/legal-sanity-scan.sh", *args],
+        cwd=w, capture_output=True, text=True, timeout=180, env=run_env,
+    )
+
+
+def _scan_subdir(w: Path, sub: Path) -> subprocess.CompletedProcess:
+    """Scan `sub` as a separate repo, so global and local deny lists differ.
+
+    Deliberately routed through `--all` + LEGAL_SCAN_REPO_ROOTS rather than the
+    more obvious `--repo=<name>`. `--repo` is unusable here: `resolve_repo_path`
+    is defined TWICE in the scanner, and the second definition returns its
+    result in `RESOLVED_REPO_PATH` while printing nothing — but the call site
+    does `repo_path="$(resolve_repo_path ...)"`. So `--repo=<name>` scans the
+    empty string, finds nothing, and reports PASS. That is a separate and more
+    serious defect (a legal gate passing by scanning nothing), already covered
+    by the failing tests in test_repo_resolution.py / test_legal_scan_resolution.py
+    and NOT in scope here. `--all` with registered roots calls `scan_directory`
+    directly and is unaffected.
+    """
+    return _scan(w, "--all", env={"LEGAL_SCAN_REPO_ROOTS": str(sub)})
+
+
+def _blocks(out: str) -> int:
+    m = re.search(r"RESULT: FAIL .*?(\d+) block violation", out)
+    return int(m.group(1)) if m else 0
+
+
+def _warns(out: str) -> int:
+    m = re.search(r"WARNINGS: (\d+) advisory match", out)
+    return int(m.group(1)) if m else 0
+
+
+def _match_counts(out: str) -> list[int]:
+    """The per-pattern `matches=N` figures, in report order."""
+    return [int(n) for n in re.findall(r"\bmatches=(\d+)", out)]
+
+
+# ---------------------------------------------------------------------------
+# The bug: root scan parses one file as both global and local
+# ---------------------------------------------------------------------------
+
+
+def test_root_scan_counts_a_single_hit_once(ws: Path) -> None:
+    """One occurrence of one pattern is one violation, not two."""
+    (ws / ".legal-deny-list.yaml").write_text(_deny_list(_entry(MARK_ROOT, "block")))
+    (ws / "sample.md").write_text(f"{MARK_ROOT}\n")
+
+    r = _scan(ws)
+    out = r.stdout + r.stderr
+
+    assert MARK_ROOT in out, f"the hit must still be reported:\n{out}"
+    assert _match_counts(out) == [1], (
+        f"the workspace root's deny list is loaded as BOTH the global and the "
+        f"local list, so its patterns are searched twice; expected matches=1, "
+        f"got {_match_counts(out)}\n{out}"
+    )
+    assert _blocks(out) == 1, (
+        f"expected 1 block violation, got {_blocks(out)}\n{out}"
+    )
+    assert r.returncode == 1
+
+
+def test_root_scan_does_not_double_count_warnings(ws: Path) -> None:
+    """The warn tier is counted by the same code path and doubles identically."""
+    (ws / ".legal-deny-list.yaml").write_text(
+        _deny_list(_entry(MARK_WARNCOUNT, "warn"))
+    )
+    (ws / "sample.md").write_text(f"{MARK_WARNCOUNT}\n")
+
+    r = _scan(ws)
+    out = r.stdout + r.stderr
+
+    assert MARK_WARNCOUNT in out
+    assert _warns(out) == 1, f"expected 1 advisory match, got {_warns(out)}\n{out}"
+    assert r.returncode == 0
+
+
+def test_root_scan_json_emits_one_record_per_hit(ws: Path) -> None:
+    """JSON consumers see the duplication as two distinct findings."""
+    (ws / ".legal-deny-list.yaml").write_text(_deny_list(_entry(MARK_ROOT, "block")))
+    (ws / "sample.md").write_text(f"{MARK_ROOT}\n")
+
+    r = _scan(ws, "--json")
+    records = [ln for ln in r.stdout.splitlines() if MARK_ROOT in ln]
+
+    assert len(records) == 1, (
+        f"one hit must produce exactly one JSON record, got {len(records)}:\n"
+        + "\n".join(records)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The intent that must survive the fix: local lists EXTEND the global one
+# ---------------------------------------------------------------------------
+
+
+def test_submodule_local_list_still_extends_the_global_list(ws: Path) -> None:
+    """Guard against "fix" by dropping the local list.
+
+    The deny list's own header states the contract: "Per-project deny lists in
+    each submodule extend (not replace) this file." A submodule scan must still
+    see BOTH lists' patterns, each counted once.
+    """
+    (ws / ".legal-deny-list.yaml").write_text(
+        _deny_list(_entry(MARK_GLOBALONLY, "block"))
+    )
+    sub = ws / "submod"
+    sub.mkdir()
+    (sub / ".legal-deny-list.yaml").write_text(
+        _deny_list(_entry(MARK_LOCALONLY, "block"))
+    )
+    (sub / "sample.md").write_text(f"{MARK_GLOBALONLY}\n{MARK_LOCALONLY}\n")
+
+    r = _scan_subdir(ws, sub)
+    out = r.stdout + r.stderr
+
+    assert MARK_GLOBALONLY in out, f"global pattern must apply to submodules:\n{out}"
+    assert MARK_LOCALONLY in out, f"local pattern must be honoured:\n{out}"
+    assert _match_counts(out) == [1, 1], (
+        f"two distinct patterns, one hit each; got {_match_counts(out)}\n{out}"
+    )
+    assert _blocks(out) == 2, f"expected 2 block violations, got {_blocks(out)}\n{out}"
+
+
+def test_pattern_declared_in_both_lists_is_counted_once(ws: Path) -> None:
+    """The same doubling, reached the other way.
+
+    "Extend, not replace" invites a submodule author to re-declare a pattern the
+    global list already carries — they cannot be expected to have read all 23.
+    Searching for the same string twice cannot find anything the first search
+    missed, so the second pass contributes only inflation.
+    """
+    (ws / ".legal-deny-list.yaml").write_text(_deny_list(_entry(MARK_DUP, "block")))
+    sub = ws / "submod"
+    sub.mkdir()
+    (sub / ".legal-deny-list.yaml").write_text(_deny_list(_entry(MARK_DUP, "block")))
+    (sub / "sample.md").write_text(f"{MARK_DUP}\n")
+
+    r = _scan_subdir(ws, sub)
+    out = r.stdout + r.stderr
+
+    assert MARK_DUP in out
+    assert _blocks(out) == 1, (
+        f"a pattern declared in both lists describes ONE thing to look for; "
+        f"expected 1 block violation, got {_blocks(out)}\n{out}"
+    )
+
+
+def test_duplicate_pattern_keeps_the_blocking_severity(ws: Path) -> None:
+    """Collapsing duplicates must fail CLOSED on severity.
+
+    Global says block, the local list re-declares the same pattern as warn. A
+    naive last-one-wins collapse would let a submodule silently demote a
+    workspace-wide blocking pattern to advisory — turning a counting fix into a
+    privilege escalation. Same posture as the unrecognised-severity handling in
+    the scanner ("a typo must not silently downgrade a pattern").
+    """
+    (ws / ".legal-deny-list.yaml").write_text(
+        _deny_list(_entry(MARK_SEVCONFLICT, "block"))
+    )
+    sub = ws / "submod"
+    sub.mkdir()
+    (sub / ".legal-deny-list.yaml").write_text(
+        _deny_list(_entry(MARK_SEVCONFLICT, "warn"))
+    )
+    (sub / "sample.md").write_text(f"{MARK_SEVCONFLICT}\n")
+
+    r = _scan_subdir(ws, sub)
+    out = r.stdout + r.stderr
+
+    assert _blocks(out) == 1, (
+        f"the blocking declaration must survive the collapse; got "
+        f"{_blocks(out)} block / {_warns(out)} warn\n{out}"
+    )
+    assert _warns(out) == 0, (
+        f"the demoted duplicate must not also be reported as advisory; got "
+        f"{_warns(out)} warn\n{out}"
+    )
+    assert r.returncode == 1, "a block-severity pattern must still fail the scan"
+
+
+# ---------------------------------------------------------------------------
+# Multiplicity that is REAL must survive
+# ---------------------------------------------------------------------------
+
+
+def test_genuinely_repeated_hits_are_all_counted(ws: Path) -> None:
+    """Deduplicating PATTERNS must not deduplicate MATCHES.
+
+    Three real occurrences across two files stay three. A fix that collapsed
+    identical findings instead of identical patterns would under-report, which
+    is the one direction a legal gate must never fail in.
+    """
+    (ws / ".legal-deny-list.yaml").write_text(_deny_list(_entry(MARK_ROOT, "block")))
+    (ws / "a.md").write_text(f"{MARK_ROOT}\nfiller\n{MARK_ROOT}\n")
+    (ws / "b.md").write_text(f"{MARK_ROOT}\n")
+
+    r = _scan(ws)
+    out = r.stdout + r.stderr
+
+    assert _blocks(out) == 3, (
+        f"three genuine occurrences must all count; got {_blocks(out)}\n{out}"
+    )


### PR DESCRIPTION
## The bug

`scan_directory()` merges a global and a local deny list:

```bash
local global_list="$WORKSPACE_ROOT/.legal-deny-list.yaml"
local local_list="$scan_dir/.legal-deny-list.yaml"
patterns="$(parse_deny_list "$global_list"; parse_deny_list "$local_list")"
```

For a **submodule** those are two different files, and merging is the documented intent — the deny list's own header says *"Per-project deny lists in each submodule extend (not replace) this file."*

For a scan of the **workspace root**, `scan_dir` **is** `WORKSPACE_ROOT`, so both variables name **the same file**. It was parsed twice, every pattern entered the work list twice, every pattern was searched twice, and every hit was counted twice.

## Evidence

Every headline number this gate has ever printed for a root scan was exactly double the truth — including the **71 unique violations** the severity-tier work (#3800) was reasoned from, which the scan itself had been reporting as **142**.

Measured on a clean `origin/main` tree, workspace-root scan:

| | block | warn | JSON records | unique `file:line` |
|---|---|---|---|---|
| before | 6 | 108 | 114 | 57 |
| after | **3** | **54** | **57** | **57** |

Exactly 2x → 1x, and JSON records now match unique hits 1:1.

<details>
<summary>Why not the 32/110 figure quoted from the main checkout</summary>

That number is not reproducible in that working copy anymore — it carries untracked auto-sync `logs/quality/*.log` files contributing ~1792 of a now-2086 count. Untracked generated files move the total on every sync, so a clean tree at `origin/main` is the only stable measurement surface. The **2x ratio** is the invariant, and it held in every measurement taken.
</details>

## The fix — dedupe the pattern list, not the file path

The obvious alternative was to skip `local_list` when `realpath(local) == realpath(global)`. Deduplicating the merged pattern list was chosen because it is a **strict superset** fix:

- It also closes the same doubling reached the other way — a submodule that re-declares a pattern the global list already carries, which *"extend, not replace"* positively invites (nobody re-reads all 23 global patterns before adding one). A realpath comparison leaves that case doubled.
- No `realpath` / `readlink -f`, which is not portable to BSD or git-bash; and it is unaffected by a deny list that is a symlink or bind mount.
- Information-preserving by construction: searching for the same string twice cannot find anything the first search missed.

Collapsing is **fail-open on breadth, fail-closed on severity**, so the merged entry finds exactly the union of what the duplicates found and never demotes:

- `case_flag` — **`i` wins**: case-insensitive matches are a superset of case-sensitive ones, so one search returns the union.
- `severity` — **`block` wins**: a duplicate must never downgrade a blocking pattern to advisory. Same posture as the existing unrecognised-severity handling.

**Considered and accepted:** a submodule declaring a pattern the global list already has collapses to one entry. That is correct — the pattern only needs searching once — and the fail-closed severity merge means the collapse cannot be used to weaken a global rule.

Splitting is right-anchored (`${x##*|}` / `${x%|*}`) because a pattern may itself contain `|`; `case_flag` and `severity` never do.

### Exclusions: same double-parse, but harmless

`parse_exclusions` ran **4x** (two lists × two loops). That one was **not** harmful — duplicate ripgrep `--glob '!X'` negations are idempotent, and the diff-only filter loop breaks on first match. So that part is pure hygiene: parsed once, deduped order-preservingly, both arrays derived from the single result. No behaviour change.

## Tests — TDD, RED first

`tests/legal/test_no_double_count.py`, 7 cases, confirmed failing before the fix:

```
matches=[1, 1] vs [1]              # root scan, per-pattern count
2 advisory vs 1                    # warn tier doubles identically
2 JSON records vs 1                # one hit, two findings
2 block vs 1                       # pattern declared in both lists
demoted duplicate also counted warn # fail-closed severity merge
6 vs 3                             # three genuine occurrences
```

The existing tests could not catch this: they assert on **presence and exit code**, and 2 violations fail exactly like 1. That is why the bug survived all of them. These assert on the **count**, which is the only thing that moved.

Two cases guard the directions a fix could go wrong:
- local lists must still **extend** the global one (guards a "fix" that just drops the local list);
- deduplicating **patterns** must never deduplicate **matches** — three real occurrences stay three. Under-reporting is the one direction a legal gate must never fail in.

No deny-listed literal appears in the new test file; all markers are invented `ZZ...ZZ` strings. `test_no_legal_test_trips_the_scan_it_guards` verified passing.

## Verification

- `tests/legal/`: **16 passed / 7 failed → 23 passed / 7 failed**. The 7 are pre-existing resolution failures on `origin/main`, unchanged and out of scope.
- `shellcheck -S warning`: **byte-identical** warning set before and after (`1×SC2034, 2×SC2053, 1×SC2254` — all in untouched code).
- `bash -n` clean; `--json` and `--diff-only` paths smoke-tested.

## Separate defect found — NOT fixed here

`resolve_repo_path` is **defined twice** (lines 168 and 324). The second definition wins; it returns its result in `RESOLVED_REPO_PATH` and **prints nothing** — but both call sites do `repo_path="$(resolve_repo_path ...)"`.

So `--repo=<name>` scans the **empty string** and reports:

```
Scanning: submod ()
  RESULT: PASS — no block violations found
```

...having scanned nothing, exit 0. That is precisely the failure the script's own comment warns against: *"A legal gate must never pass by scanning nothing."* `shellcheck` flags it independently as SC2034.

This is the cause of the 7 pre-existing test failures. It is a **fail-open gate defect and more severe than the one this PR fixes** — it deserves its own issue and its own fix, so it is deliberately left alone here. The new tests route around it via `--all` + `LEGAL_SCAN_REPO_ROOTS`, which reaches `scan_directory` directly.
