### PR TITLE
fix(ci): drop the pip cache baseline-check never populates

### DIFF
--- a/.github/workflows/baseline-check.yml
+++ b/.github/workflows/baseline-check.yml
@@ -39,7 +39,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
+          # No `cache: pip`. Every dependency here is installed by `uv sync`, so
+          # ~/.cache/pip is never written and setup-python's post-job cache step
+          # errors ("Cache folder path is retrieved for pip but doesn't exist on
+          # disk"), failing the job with all its test steps green. uv brings its
+          # own cache below via astral-sh/setup-uv `enable-cache: true`.
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/tests/ci_smoke/test_ci_workflows_use_uv.py
+++ b/tests/ci_smoke/test_ci_workflows_use_uv.py
@@ -52,6 +52,136 @@ def test_enforcement_workflow_uses_uv_managed_test_environment() -> None:
     assert "pip install pytest" not in text
 
 
+def _pip_cache_offenders(text: str) -> list[str]:
+    """Jobs that cache pip on setup-python while installing only through uv.
+
+    ``actions/setup-python`` with ``cache: pip`` registers a post-job step that
+    saves ``~/.cache/pip``. A job that installs everything through ``uv sync``
+    never populates that directory, so the post step errors with "Cache folder
+    path is retrieved for pip but doesn't exist on disk" and **fails the whole
+    job even when every test passed**.
+
+    That is the worst shape a CI failure can take: a red job whose test steps
+    are all green. It reads as a real regression, and because this repo
+    declares no required checks, one red non-required check puts every PR at
+    ``mergeStateStatus == UNSTABLE`` -- which `.claude/rules/merge-authorization.md`
+    rule 7 forbids an agent merging from. A caching hint that saves nothing can
+    deadlock the merge queue repo-wide.
+
+    Scoped **per job, and to the setup-python step specifically**, by parsing
+    the YAML rather than scanning text. A whole-file regex would reject a
+    legitimate mixed workflow -- one uv-managed job beside a genuinely
+    pip-managed one that must cache pip -- and would blame setup-python for a
+    ``cache:`` key belonging to some other action. The rule enforced here is the
+    operational one: *no pip cache on a setup-python step in a job whose
+    installs are uv-only.*
+    """
+    import yaml
+
+    doc = yaml.safe_load(text) or {}
+    offenders = []
+    for job_name, job in (doc.get("jobs") or {}).items():
+        steps = (job or {}).get("steps") or []
+        runs = " \n".join(str(st.get("run", "")) for st in steps if isinstance(st, dict))
+        installs_with_uv = re.search(r"uv sync\b", runs) is not None
+        populates_pip = re.search(r"\bpip install\b", runs) is not None
+        if not installs_with_uv or populates_pip:
+            continue  # not uv-only, so a pip cache may be legitimate here
+        for st in steps:
+            if not isinstance(st, dict):
+                continue
+            if not str(st.get("uses", "")).startswith("actions/setup-python"):
+                continue
+            if str(((st.get("with") or {}).get("cache", ""))).strip().lower() == "pip":
+                offenders.append(job_name)
+    return offenders
+
+
+def _assert_no_pip_cache_when_uv_installs(text: str, workflow: str) -> None:
+    offenders = _pip_cache_offenders(text)
+    assert not offenders, (
+        f"{workflow}: job(s) {offenders} install dependencies only with uv but "
+        "set `cache: pip` on actions/setup-python. Nothing populates "
+        "~/.cache/pip, so the post-job cache step errors and fails the job "
+        "despite passing tests. Drop the cache key, or cache uv."
+    )
+
+
+def test_baseline_workflow_does_not_cache_pip_it_never_populates() -> None:
+    _assert_no_pip_cache_when_uv_installs(
+        BASELINE.read_text(encoding="utf-8"), "baseline-check.yml"
+    )
+
+
+def test_enforcement_workflow_does_not_cache_pip_it_never_populates() -> None:
+    _assert_no_pip_cache_when_uv_installs(
+        ENFORCEMENT.read_text(encoding="utf-8"), "enforcement-gate.yml"
+    )
+
+
+_SETUP_PY = "      - uses: actions/setup-python@v5\n        with:\n          cache: %s\n"
+
+
+def _wf(*jobs: str) -> str:
+    return "jobs:\n" + "".join(jobs)
+
+
+def _job(name: str, cache: str | None, install: str) -> str:
+    step = _SETUP_PY % cache if cache is not None else ""
+    return f"  {name}:\n    steps:\n{step}      - run: {install}\n"
+
+
+def test_pip_cache_guard_catches_every_spelling_on_a_uv_only_job() -> None:
+    """A loosened matcher is only an improvement while it still catches the defect.
+
+    Same guard as `test_dev_group_assertion_rejects_a_missing_uv_sync`.
+    """
+    for spelling in ("'pip'", '"pip"', "pip"):
+        wf = _wf(_job("test", spelling, "uv sync --frozen --group dev"))
+        assert _pip_cache_offenders(wf) == ["test"], f"missed spelling {spelling}"
+
+
+def test_pip_cache_guard_allows_a_genuinely_pip_managed_job() -> None:
+    """A job that really uses pip may cache pip; the guard must stay quiet."""
+    assert _pip_cache_offenders(
+        _wf(_job("legacy", "'pip'", "pip install -r requirements.txt"))
+    ) == []
+
+
+def test_pip_cache_guard_does_not_false_positive_on_a_mixed_workflow() -> None:
+    """The whole-file regex this replaced would have failed this shape.
+
+    Job A is uv-only with no pip cache; job B genuinely uses pip and caches it.
+    Scanning the file as one string would see `uv sync` and `cache: pip` both
+    present and reject a correct workflow. Job scoping is what makes the guard
+    safe to apply to files that may grow new jobs later.
+    """
+    mixed = _wf(
+        _job("uv_job", None, "uv sync --frozen --group dev"),
+        _job("pip_job", "'pip'", "pip install -r requirements.txt"),
+    )
+    assert _pip_cache_offenders(mixed) == []
+
+
+def test_pip_cache_guard_blames_only_the_offending_job() -> None:
+    mixed = _wf(
+        _job("clean_uv", None, "uv sync --frozen --group dev"),
+        _job("broken_uv", "'pip'", "uv sync --frozen --group dev"),
+        _job("pip_job", "'pip'", "pip install -r requirements.txt"),
+    )
+    assert _pip_cache_offenders(mixed) == ["broken_uv"]
+
+
+def test_pip_cache_guard_ignores_a_cache_key_on_another_action() -> None:
+    """The message blames setup-python, so the matcher must prove it is that step."""
+    wf = (
+        "jobs:\n  test:\n    steps:\n"
+        "      - uses: some/other-action@v1\n        with:\n          cache: 'pip'\n"
+        "      - run: uv sync --frozen --group dev\n"
+    )
+    assert _pip_cache_offenders(wf) == []
+
+
 def test_dev_group_assertion_rejects_a_missing_uv_sync() -> None:
     """The helper must still fail when uv genuinely is not used.
 


### PR DESCRIPTION
Unblocks agent-run merges repo-wide. Two files: one workflow line removed, one test guard added.

## The bug

`Baseline Testing` has failed on `main` **continuously** — every run back through 2026-09-01 — while **every one of its test steps passed.** The job's only error is `actions/setup-python`'s *post-job* cache step:

```
##[error]Cache folder path is retrieved for pip but doesn't exist on disk:
/home/runner/.cache/pip. This likely indicates that there are no dependencies to cache.
```

The test job installs everything through `uv sync --frozen --group dev` and runs tests through `uv run`. Nothing ever writes `~/.cache/pip`. So `cache: 'pip'` registers a post step with nothing to save, it errors, and it fails the whole job. `astral-sh/setup-uv` already provides caching two steps later via `enable-cache: true`.

Codex verified the mechanism independently rather than taking my word: setup-python v5.2.0 reports the missing directory as a **failing post-run error, not a warning** ([actions/setup-python#932](https://github.com/actions/setup-python/issues/932)).

## Why it was worth fixing rather than filing

This is the worst shape a CI failure can take: **a red job whose test steps are all green.** It reads as a real regression, so it trains everyone to ignore the signal.

It also had a concrete blocking effect. The repo declares **no required checks**, so a single red non-required check puts every PR at `mergeStateStatus == UNSTABLE`. `.claude/rules/merge-authorization.md` rule 7 forbids an agent merging from UNSTABLE, explicitly stating that user authorization does not waive it. So a caching hint that saved nothing had **deadlocked agent-run merges across the whole repo**. That is how this surfaced: [#3822](https://github.com/vamseeachanta/workspace-hub/pull/3822), a two-file docs PR, could not be merged.

## TDD, then adversarial review

Guard written first, confirmed red on `baseline-check.yml` alone, then the workflow fixed.

**Codex review returned MAJOR — on the guard, not the workflow fix.** Both findings were right and are fixed here rather than argued:

- **The guard matched at whole-workflow scope.** It enabled itself if `uv sync` appeared anywhere in the file, then rejected `cache: pip` anywhere. That false-positives on a mixed workflow: one uv-managed job beside a genuinely pip-managed job that legitimately caches pip.
- **The failure message blamed `setup-python` without proving it.** A `cache:` key under any other action, a wrapper, or a future matrix branch would have been misattributed, because the regex never associated the key with a `uses:` line.
- **Minor:** the meta-test never exercised the mixed-job shape the first finding is about.

`_pip_cache_offenders` now parses the YAML and returns the **names of offending jobs**. Per job it asks: does this job install via `uv sync`, does it *not* run `pip install`, and does it carry a step whose `uses` starts with `actions/setup-python` and whose `with.cache` is `pip`? Only that conjunction fails — the narrower operational rule Codex asked for, rather than "no pip cache in these two files ever".

Seven guard tests, four of them added at review: three spellings on a uv-only job; a genuinely pip-managed job stays quiet; **a mixed workflow passes** (the shape the old regex would have failed); only the offending job is named among three; a `cache: pip` under a different action is ignored, so the message's claim is now true.

## Verification

Run on the repo's own toolchain, not a substitute. The check a loosened matcher actually needs is that it still catches the original defect:

```
cache: 'pip' reintroduced  ->  FAILED ... job(s) ['test'] ...   1 failed, 10 passed
restored                   ->  17 passed   (tests/ci_smoke/)
                               12 passed   (tests/test_deduplication_fix.py --noconftest)
```

Workflow YAML re-parsed after the edit; the `with:` block reduces to `python-version` alone.

Review evidence at `scripts/review/results/2026-09-03-ci-pip-cache-codex-r1.md` (that directory is gitignored, so it is local gate evidence rather than part of this diff).

## Note on how this was pushed

Branched directly off `origin/main` through a temporary index, so none of the ~200 unrelated local commits or the dirty working tree on this machine came along. The diff is exactly the two intended files.

## Follow-on, deliberately not in this PR

The deeper issue is that this repo has **no required checks at all**, which makes UNSTABLE the default state for any PR whenever anything is red. That is a governance change worth making separately.
