### PR TITLE
fix(memory): resolve Claude auto-memory across workspace moves, and fail loudly

### DIFF
--- a/scripts/memory/bridge-hermes-claude.sh
+++ b/scripts/memory/bridge-hermes-claude.sh
@@ -27,9 +27,16 @@ MEMORY_DIR="${REPO_ROOT}/.claude/memory"
 TEMPLATE_DIR="${MEMORY_DIR}/templates"
 TOPICS_DIR="${MEMORY_DIR}/topics"
 HERMES_MEM_DIR="${HOME}/.hermes/memories"
-# Derive Claude auto-memory path from workspace root (portable across Linux / Windows Git Bash)
-_project_slug="$(cd "${REPO_ROOT}" && pwd | tr '/' '-')"
-CLAUDE_MEM_DIR="${HOME}/.claude/projects/${_project_slug}/memory"
+# Resolve Claude auto-memory across workspace moves. Deriving the slug inline from
+# the CURRENT repo path silently broke when the ecosystem moved to /mnt/ace/ws:
+# Claude Code pins the project slug at session start and kept writing to the old
+# one, so the mirror copied nothing while still printing a tick for the stale
+# snapshot. The resolver tries the exact slug, known aliases, then any slug
+# ending in this repo's basename -- and fails LOUDLY rather than resolving to a
+# path it cannot verify.
+# shellcheck source=scripts/memory/resolve-auto-memory.sh
+source "${REPO_ROOT}/scripts/memory/resolve-auto-memory.sh"
+CLAUDE_MEM_DIR="$(resolve_claude_memory_dir "${REPO_ROOT}" "${HOME}")" || CLAUDE_MEM_DIR=""
 TIMESTAMP="$(date +%Y-%m-%d)"
 COMMIT_MODE="${1:-}"
 
@@ -197,7 +204,13 @@ echo "[bridge] context.md regenerated"
 CLAUDE_AUTO="${CLAUDE_MEM_DIR}/MEMORY.md"
 SNAPSHOT_OUT="${MEMORY_DIR}/claude-auto-memory.md"
 
-if [[ -f "${CLAUDE_AUTO}" ]]; then
+if [[ -z "${CLAUDE_MEM_DIR}" || ! -f "${CLAUDE_AUTO}" ]]; then
+    # Never skip silently. An unreachable source and a completed mirror looked
+    # identical before this, which is how the bridge ran dead for weeks.
+    echo -e "${YELLOW}[bridge] WARNING: Claude auto-memory index not found" \
+            "(${CLAUDE_AUTO:-<unresolved>}) — claude-auto-memory.md left STALE," \
+            "not refreshed. The snapshot below is NOT current.${NC}" >&2
+else
     {
         echo "# Claude Code Auto-Memory Snapshot"
         echo ""

--- a/scripts/memory/resolve-auto-memory.sh
+++ b/scripts/memory/resolve-auto-memory.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# ABOUTME: Resolves Claude Code's auto-memory directory for a repo, across workspace moves.
+#
+# Claude Code stores per-project auto-memory under
+#   $HOME/.claude/projects/<absolute-repo-path-with-slashes-as-dashes>/memory
+# and the harness pins that slug at SESSION START. When a workspace is moved on
+# disk, Claude Code keeps writing to the ORIGINAL slug, so anything deriving the
+# slug from the CURRENT path silently stops finding it.
+#
+# That is what happened when the ecosystem moved from /mnt/local-analysis to
+# /mnt/ace/ws: the bridge derived a slug for the new path, the directory did not
+# exist, and a bare `if [[ -f ... ]]` with no else meant the mirror quietly
+# stopped while the summary still printed a tick for the stale file left behind.
+#
+# Design rules, in order of importance:
+#   1. failing to resolve is a LOUD non-zero exit that emits no path -- never a
+#      silent skip, and never a guess;
+#   2. AMBIGUITY IS FATAL. Slugification maps '/' and '-' to the same character,
+#      so '/tmp/x/my-workspace-hub' and '/mnt/ace/ws/workspace-hub' both end in
+#      '-workspace-hub' and cannot be told apart by shape. Rather than pick by
+#      mtime -- which an editor, backup or unrelated session can flip -- the
+#      search refuses to choose between multiple candidates and prints them.
+#   3. a candidate counts only if it holds MEMORY.md; an empty directory is not
+#      a memory store, and selecting one would mirror nothing while reporting
+#      success.
+#
+# Usage:  source resolve-auto-memory.sh
+#         dir="$(resolve_claude_memory_dir "$REPO_ROOT" "$HOME")" || handle-failure
+
+# Slugify an absolute path the way Claude Code does.
+_auto_memory_slug() { printf '%s' "$1" | tr '/' '-'; }
+
+# A candidate directory is only a memory store if it carries the index.
+# Namespaced and top-level: defining it inside the resolver would leak a
+# generic name into any shell that sources this file.
+_auto_memory_has_index() { [[ -f "$1/MEMORY.md" ]]; }
+
+# Rewrite only a LEADING workspace prefix. Substring replacement would rewrite a
+# path that merely contains the prefix further along, or one that repeats it.
+_auto_memory_alias() {
+    local path="$1" from="$2" to="$3"
+    [[ "${path}" == "${from}"/* ]] || return 1
+    printf '%s' "${to}/${path#"${from}"/}"
+}
+
+# Echo the resolved memory directory on stdout; return 1 and explain on stderr.
+resolve_claude_memory_dir() {
+    local repo_root="$1" home_dir="${2:-$HOME}"
+    local projects="${home_dir}/.claude/projects"
+    local abs base cand
+    abs="$(cd "${repo_root}" 2>/dev/null && pwd -P)" || abs="${repo_root%/}"
+    base="$(basename "${abs}")"
+
+    # 1. the exact current path
+    cand="${projects}/$(_auto_memory_slug "${abs}")/memory"
+    if _auto_memory_has_index "${cand}"; then printf '%s\n' "${cand}"; return 0; fi
+
+    # 2. known workspace aliases, anchored to the leading prefix.
+    #    /mnt/local-analysis is a compatibility symlink to the /mnt/ace/ws
+    #    surface, so the two spellings name the same repo.
+    local alias_path
+    while read -r from to; do
+        [[ -n "${from}" ]] || continue
+        alias_path="$(_auto_memory_alias "${abs}" "${from}" "${to}")" || continue
+        cand="${projects}/$(_auto_memory_slug "${alias_path}")/memory"
+        if _auto_memory_has_index "${cand}"; then printf '%s\n' "${cand}"; return 0; fi
+    done <<'ALIASES'
+/mnt/ace/ws /mnt/local-analysis
+/mnt/local-analysis /mnt/ace/ws
+ALIASES
+
+    # 3. last resort: any project slug ending in this repo's basename. Because a
+    #    slug cannot be unambiguously reversed, MORE THAN ONE MATCH IS FATAL --
+    #    picking by mtime here would let '/tmp/x/my-workspace-hub' shadow
+    #    '/mnt/ace/ws/workspace-hub'. A single match is reported on stderr so a
+    #    wrong guess is visible rather than silent.
+    local -a found=()
+    while IFS= read -r cand; do
+        [[ -n "${cand}" ]] || continue
+        _auto_memory_has_index "${cand}" && found+=("${cand}")
+    done < <(find "${projects}" -maxdepth 2 -type d -name memory 2>/dev/null \
+             | grep -- "-$(_auto_memory_slug "${base}")/memory$" || true)
+
+    if [[ "${#found[@]}" -eq 1 ]]; then
+        echo "[resolve-auto-memory] NOTE: no exact or alias slug matched; falling back to" >&2
+        echo "[resolve-auto-memory]   ${found[0]}" >&2
+        echo "[resolve-auto-memory]   (sole slug ending in '-${base}'). Verify this is the right repo." >&2
+        printf '%s\n' "${found[0]}"
+        return 0
+    fi
+    if [[ "${#found[@]}" -gt 1 ]]; then
+        echo "[resolve-auto-memory] FATAL: ${#found[@]} candidate memory stores end in '-${base}':" >&2
+        printf '[resolve-auto-memory]   %s\n' "${found[@]}" >&2
+        echo "[resolve-auto-memory]   Slugs are not reversible, so choosing between these would be a" >&2
+        echo "[resolve-auto-memory]   guess. Add an explicit alias to this script instead." >&2
+        return 1
+    fi
+
+    echo "[resolve-auto-memory] FATAL: no Claude auto-memory directory found for ${abs}" >&2
+    echo "[resolve-auto-memory]   looked under ${projects} for the exact slug, known" >&2
+    echo "[resolve-auto-memory]   workspace aliases, and any slug ending in '-${base}'." >&2
+    echo "[resolve-auto-memory]   Refusing to report success for a mirror that would copy nothing." >&2
+    return 1
+}

--- a/scripts/memory/tests/test_resolve_auto_memory.py
+++ b/scripts/memory/tests/test_resolve_auto_memory.py
@@ -1,0 +1,200 @@
+"""TDD tests for scripts/memory/resolve-auto-memory.sh :: resolve_claude_memory_dir().
+
+WHY THIS EXISTS. bridge-hermes-claude.sh derived Claude's auto-memory directory by
+slugifying the CURRENT repo root:
+
+    _project_slug="$(cd "${REPO_ROOT}" && pwd | tr '/' '-')"
+    CLAUDE_MEM_DIR="${HOME}/.claude/projects/${_project_slug}/memory"
+
+When the ecosystem moved from /mnt/local-analysis/workspace-hub to
+/mnt/ace/ws/workspace-hub, that started resolving to a directory that does not
+exist -- Claude Code keeps writing to the ORIGINAL slug, because the harness
+pins the project path at session start. The snapshot block is guarded by a bare
+`if [[ -f "${CLAUDE_AUTO}" ]]` with no else, so the bridge silently mirrored
+nothing while still printing a tick for the stale file it left in place.
+
+Two failures, and the second is the worse one:
+  1. the path no longer resolves after a workspace move;
+  2. an unresolvable path is INDISTINGUISHABLE FROM SUCCESS.
+
+The helper takes repo root and home as PARAMETERS rather than reading script
+globals, matching the precedent set for bridge_commit_and_push (r1/r2 finding on
+#3384), so it is drivable from a temp fixture.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB = REPO_ROOT / "scripts" / "memory" / "resolve-auto-memory.sh"
+BRIDGE = REPO_ROOT / "scripts" / "memory" / "bridge-hermes-claude.sh"
+
+
+def _resolve(repo_root: Path, home: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c",
+         f'source "{LIB}"; resolve_claude_memory_dir "{repo_root}" "{home}"'],
+        capture_output=True, text=True,
+    )
+
+
+def _seed(home: Path, slug: str, *, with_index: bool = True) -> Path:
+    d = home / ".claude" / "projects" / slug / "memory"
+    d.mkdir(parents=True)
+    if with_index:
+        (d / "MEMORY.md").write_text("# index\n", encoding="utf-8")
+    return d
+
+
+def test_resolves_the_exact_slug_when_it_exists(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    want = _seed(home, str(repo).replace("/", "-"))
+
+    r = _resolve(repo, home)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == str(want)
+
+
+def test_falls_back_to_the_pre_migration_slug(tmp_path: Path) -> None:
+    """The live defect: repo moved, Claude Code still writes to the old slug."""
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    legacy = _seed(home, str(tmp_path / "mnt" / "local-analysis" / "workspace-hub").replace("/", "-"))
+
+    r = _resolve(repo, home)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == str(legacy), "must fall back to the legacy slug"
+
+
+def test_prefers_the_exact_slug_over_a_legacy_one(tmp_path: Path) -> None:
+    """After a real migration completes, the current path must win."""
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    _seed(home, str(tmp_path / "mnt" / "local-analysis" / "workspace-hub").replace("/", "-"))
+    exact = _seed(home, str(repo).replace("/", "-"))
+
+    r = _resolve(repo, home)
+    assert r.stdout.strip() == str(exact)
+
+
+def test_ignores_a_candidate_with_no_memory_index(tmp_path: Path) -> None:
+    """An empty directory is not a memory store; falling into it would mirror nothing."""
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    _seed(home, str(repo).replace("/", "-"), with_index=False)
+    legacy = _seed(home, str(tmp_path / "mnt" / "local-analysis" / "workspace-hub").replace("/", "-"))
+
+    r = _resolve(repo, home)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == str(legacy)
+
+
+def test_fails_loudly_when_nothing_resolves(tmp_path: Path) -> None:
+    """The core fix: unresolvable must NOT look like success.
+
+    The old code's bare `if [[ -f ... ]]` with no else made a missing source
+    indistinguishable from a completed mirror.
+    """
+    home = tmp_path / "home"
+    (home / ".claude" / "projects").mkdir(parents=True)
+    repo = tmp_path / "nowhere"
+    repo.mkdir()
+
+    r = _resolve(repo, home)
+    assert r.returncode != 0, "must exit non-zero when no memory dir resolves"
+    assert not r.stdout.strip(), "must not emit a path it could not verify"
+    assert "auto-memory" in r.stderr.lower() or "memory" in r.stderr.lower(), r.stderr
+
+
+def test_bridge_uses_the_resolver_and_warns_instead_of_skipping_silently() -> None:
+    """Wiring guard: the bridge must consume the helper and not re-derive the slug inline."""
+    text = BRIDGE.read_text(encoding="utf-8")
+
+    assert "resolve-auto-memory.sh" in text, "bridge must source the resolver"
+    assert "resolve_claude_memory_dir" in text, "bridge must call the resolver"
+    assert 'pwd | tr \'/\' \'-\'' not in text, (
+        "bridge must not still derive the slug inline -- that is the defect"
+    )
+    # The silent-skip shape: a bare existence test on the snapshot source with no warning.
+    assert "WARN" in text or "warning" in text.lower(), (
+        "bridge must warn when auto-memory cannot be resolved, not skip silently"
+    )
+
+
+def test_ambiguous_basename_collision_is_fatal(tmp_path: Path) -> None:
+    """Codex r1 MAJOR: '-workspace-hub' also suffix-matches '-my-workspace-hub'.
+
+    Slugification maps '/' and '-' to the same character, so the two are
+    genuinely indistinguishable by shape. Picking the newest MEMORY.md -- the
+    original tiebreak -- let an unrelated repo's store win. Ambiguity must be
+    fatal, not resolved by a guess.
+    """
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    _seed(home, str(tmp_path / "elsewhere" / "my-workspace-hub").replace("/", "-"))
+    _seed(home, str(tmp_path / "other" / "workspace-hub").replace("/", "-"))
+
+    r = _resolve(repo, home)
+    assert r.returncode != 0, "two suffix candidates must be fatal, not a guess"
+    assert not r.stdout.strip()
+    assert "candidate" in r.stderr.lower()
+
+
+def test_a_colliding_repo_does_not_win_on_mtime(tmp_path: Path) -> None:
+    """The specific wrong-store selection Codex demonstrated."""
+    home = tmp_path / "home"
+    repo = tmp_path / "mnt" / "ace" / "ws" / "workspace-hub"
+    repo.mkdir(parents=True)
+    intruder = _seed(home, str(tmp_path / "x" / "my-workspace-hub").replace("/", "-"))
+
+    r = _resolve(repo, home)
+    # Sole candidate, so it resolves -- but it must announce the guess on stderr
+    # so a wrong pick is visible rather than silent.
+    if r.returncode == 0:
+        assert r.stdout.strip() == str(intruder)
+        assert "verify" in r.stderr.lower(), "a fallback guess must be announced"
+
+
+def test_alias_rewrite_is_anchored_to_a_leading_prefix(tmp_path: Path) -> None:
+    """Codex r1 MINOR: substring replacement rewrote paths that merely CONTAIN the prefix."""
+    home = tmp_path / "home"
+    (home / ".claude" / "projects").mkdir(parents=True)
+    # A path containing '/mnt/ace/ws/' in the middle, not at the root.
+    repo = tmp_path / "srv" / "mnt" / "ace" / "ws" / "thing"
+    repo.mkdir(parents=True)
+    # Seed the store that a naive substring rewrite would wrongly reach for.
+    _seed(home, str(tmp_path / "srv" / "mnt" / "local-analysis" / "thing").replace("/", "-"))
+
+    r = _resolve(repo, home)
+    # The alias must not fire. It shares a basename with the repo, so the
+    # last-resort search can still reach it -- the discriminator is HOW: an
+    # alias hit returns silently, a fallback hit must announce itself.
+    if r.returncode == 0:
+        assert "falling back" in r.stderr.lower(), (
+            "resolved silently, so the mid-path prefix wrongly triggered the alias rewrite"
+        )
+
+
+def test_repo_outside_any_known_prefix_fails_cleanly(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".claude" / "projects").mkdir(parents=True)
+    repo = tmp_path / "opt" / "somewhere" / "proj"
+    repo.mkdir(parents=True)
+
+    r = _resolve(repo, home)
+    assert r.returncode != 0
+    assert not r.stdout.strip()
+
+
+def test_helper_name_is_namespaced(tmp_path: Path) -> None:
+    """Codex r1 MINOR: a generic `_has_memory` defined in-function leaks globally."""
+    text = LIB.read_text(encoding="utf-8")
+    assert "_auto_memory_has_index" in text
+    assert "_has_memory()" not in text, "generic helper name would leak into the caller's shell"


### PR DESCRIPTION
The memory bridge has mirrored **nothing** since the ecosystem moved to `/mnt/ace/ws`, and reported success the whole time.

## Evidence

Topic snapshots on disk are stamped `Captured: 2026-07-31` — four days before the 2026-08-03 migration. Their own `Source:` lines still point at `/mnt-local-analysis-workspace-hub`.

## Root cause

The bridge derived Claude Code's auto-memory directory by slugifying the **current** repo root:

```bash
_project_slug="$(cd "${REPO_ROOT}" && pwd | tr '/' '-')"
CLAUDE_MEM_DIR="${HOME}/.claude/projects/${_project_slug}/memory"
```

Claude Code pins that slug at **session start**. After the move it kept writing to `-mnt-local-analysis-workspace-hub` while the bridge looked for `-mnt-ace-ws-workspace-hub`. Verified on this machine: the derived path does not exist; the legacy path holds 5,808 files updated today.

**The second defect is worse than the first.** The snapshot was guarded by a bare `if [[ -f "${CLAUDE_AUTO}" ]]` with no `else`, so an unreachable source and a completed mirror were *indistinguishable* — and the run summary still printed a ✅ for the stale file it left in place.

That is `feedback_absence_of_signal_reads_as_success`, occurring inside the very script whose job is to mirror that lesson into the repo.

## Fix

`scripts/memory/resolve-auto-memory.sh :: resolve_claude_memory_dir()` tries the exact slug, then known workspace aliases (`/mnt/local-analysis` is a compatibility symlink to the `/mnt/ace/ws` surface), then any project slug ending in the repo's basename. A candidate counts only if it actually holds `MEMORY.md` — an empty directory is not a memory store, and selecting one would mirror nothing while reporting success.

Failing to resolve is now a **loud non-zero exit that emits no path**, and the bridge warns that the snapshot is STALE rather than skipping in silence.

Takes repo root and home as **parameters** rather than reading script globals, matching the precedent set for `bridge_commit_and_push` (r1/r2 finding on #3384), so it is drivable from a temp fixture.

## Adversarial review found a real defect — and proved it

Codex returned **MAJOR**, and did not merely reason about it: it built a fixture and demonstrated that the fallback could select the **wrong repository's** memory store.

With `base=workspace-hub`, `grep -- "-workspace-hub/memory$"` also matches `-tmp-x-my-workspace-hub/memory`, and the original "newest `MEMORY.md` wins" tiebreak then let that unrelated store win — mirroring the wrong project while reporting success. The same class of defect this change exists to eliminate.

Its closing question answered itself. Slugification maps `/` and `-` to the same character, so `/tmp/x/my-workspace-hub` and `/mnt/ace/ws/workspace-hub` are genuinely indistinguishable by shape. Choosing between them is a guess, and mtime is not an identity signal — an editor, backup, or unrelated session can flip it.

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | MAJOR | Suffix grep selects a colliding repo's store | **Fixed** — >1 candidate is now fatal, listing them |
| 2 | MAJOR | "newest wins" is not an identity signal | **Fixed** — tiebreak removed entirely |
| 3 | MINOR | Unanchored substring alias rewrite | **Fixed** — requires a leading prefix |
| 4 | MINOR | `_has_memory` defined in-function leaks globally | **Fixed** — top-level, renamed `_auto_memory_has_index` |
| 5 | MINOR | Redundant `elif` obscures the central guard | **Fixed** — reduced to `else` |

A sole fallback candidate still resolves — refusing would break the legitimate post-migration case this exists to fix — but it now **announces the guess on stderr**, so a wrong pick is visible rather than silent.

Codex also confirmed what was already right: the stdout-path / stderr-diagnostics contract is safe for command substitution, and `|| CLAUDE_MEM_DIR=""` behaves under `set -euo pipefail` because the failing assignment is guarded.

## Tests

Six written first (five red), eleven after review. Added at review: collision is fatal; a colliding repo does not win on mtime; the alias is anchored to a leading prefix; a repo outside any known prefix fails cleanly; the helper name is namespaced.

One of my own review-round tests asserted the wrong discriminator — it expected a mid-path prefix case to fail outright, when the correct property is that the *alias* must not fire while the announced fallback legitimately may. Corrected to test **how** it resolved, not merely whether.

```
uv run python -m pytest scripts/memory/tests/test_resolve_auto_memory.py   11 passed
bash -n on both scripts                                                    clean
live bridge run: snapshot 121 -> 149 lines, carrying both memories written today
```

Review evidence at `scripts/review/results/2026-09-03-memory-resolver-codex-r1.md` (gitignored, so local gate evidence rather than part of this diff).

## Note on how this was pushed

Branched off `origin/main` through a temporary index, so none of the ~200 unrelated local commits or the dirty working tree on this machine came along. The diff is exactly the three intended files.

The **content** refresh this unblocks — ~244 files under `.claude/memory/`, mostly `Captured:` header updates from 2026-07-31 to today — is deliberately **not** in this PR. That is the bridge's own data output and belongs on its normal commit path, not buried under a code fix.
