### PR TITLE
chore(preserve): six files that existed only on one disk, including an approval-gate marker

### DIFF
--- a/.planning/plan-approved/3787.md
+++ b/.planning/plan-approved/3787.md
@@ -1,0 +1,41 @@
+# Plan approval — workspace-hub#3787
+
+**Plan:** `docs/plans/2026-08-03-issue-3787-startup-tax.md`
+**Approved by:** repository owner (vamsee), in session chat, 2026-08-03.
+**Marker written by:** Claude, at the owner's explicit instruction ("apply labels per my chat").
+  Recorded this way deliberately: the approval decision is the owner's; only the
+  keystroke was delegated. An agent-manufactured approval would record nothing.
+
+**Restored 2026-08-03 after loss.** The original marker was written untracked and was
+removed along with the plan files — auto-sync cleans untracked files, not only commits
+them. Committed this time. See #3791.
+
+## Review state at approval
+
+- r1 Codex **MAJOR** (7 findings); r1 Claude **MAJOR**
+- r2 applied inline by the main session
+- Artifacts: `scripts/review/results/2026-08-03-plan-3787-{claude,codex,disagreement}.md`
+
+## What review changed before approval
+
+1. **Wrong function targeted.** The DB opens at `pytest_configure`
+   (`worldenergydata/tests/conftest.py:256-262`), not session finish — gating session
+   finish would leave the 59 MB DB opened on every collect-only run, and the plan's own
+   test would have failed against the plan's own fix. Replaced with a lazy tracker.
+2. **Test seam absent.** `Path(".test_performance.db")` hardcoded at `conftest.py:261`;
+   the planned temp-DB test was unimplementable. Adding the seam is scoped work.
+3. **Coverage guard blind to its target.** `digitalmodel/pytest.ini:34` is global
+   `addopts` and wins outright, so `-p no:benchmark` there disables the plugin for the
+   nightly sweep — and a plugin that stops loading does NOT change the collected count,
+   so `test_collected_count_unchanged` would have passed while order-randomisation was
+   silently lost. Moved to fast-lane invocation; full-lane plugin presence now asserted.
+
+## Governing constraint
+
+Remove the tax from the fast path; do NOT remove the capability. `pytest-randomly` still
+runs on the lane that catches order-dependence (digitalmodel demonstrably has such tests).
+Anything reducing coverage to buy speed is out of scope and must be reported, not done.
+
+## Out of scope
+
+The 487 suppressed test files — now #3790.

--- a/docs/plans/2026-08-03-ci-tiering-and-domain-routing.md
+++ b/docs/plans/2026-08-03-ci-tiering-and-domain-routing.md
@@ -1,0 +1,137 @@
+# Plan: tier the test lanes and give every tier-1 repo a domain axis
+
+**Status:** plan-review *(label not applied; `status:plan-approved` is the owner's)*
+**Lane:** `lane:claude` · **Complexity:** **T3** (cross-repo; changes what gates every push and PR) · **Client:** N/A
+**Issues:** to be filed on approval — one per repo plus the workspace-hub harness change.
+
+> Rewritten 2026-08-03. An earlier draft was lost — written untracked on a repo whose
+> auto-sync deletes untracked files (#3791). Committed this time.
+
+## Why
+
+The push gate is **broader and slower than CI**, which is backwards:
+
+| Lane | Scope today | Cost |
+|---|---|---|
+| PR CI (digitalmodel) | touched shards only | minutes |
+| **pre-push** | **entire repo suite** | **~32 min** |
+
+`scripts/testing/run-all-tests.sh` accepts `--repo`, `--coverage` and a `live_data`
+exclusion — **no domain scoping, no shallow/deep split**. The cheapest stage carries the
+heaviest gate. That is why `--no-verify` is routine, and it is the same inversion #3780
+fixed inside the pre-push hook itself.
+
+## What already exists — do not rebuild
+
+digitalmodel has the architecture, and it is well designed:
+
+- `tests/DOMAINS.md` — reviewable table, roots backtick-wrapped, **exactly one owning domain per root**
+- `scripts/ci/detect_touched_domains.py` — `--mode full|touched`, `--base`, `--head`, `--domains-file`
+- `quality-gates-by-domain.yml` — gated PR lane that **reports its own scope** ("the shards we ran passed", not "all shards passed")
+- `full-matrix-sweep.yml` — every shard nightly, under **distinct check names**, so a full-sweep failure never posts under the gated lane's names
+
+That last detail is what most teams get wrong. Extend this pattern; do not invent one.
+
+## Measured gap
+
+| Repo | `DOMAINS.md` | detector | test roots |
+|---|---|---|---|
+| digitalmodel | **yes** | **yes** | reference implementation |
+| assetutilities | no | no | 18 |
+| worldenergydata | no | no | 58 |
+| assethold | no | no | 25 |
+
+Domain routing is **1 of 4**. A shallow tier can be universal from day one.
+
+## Owner decisions (2026-08-02/03)
+
+1. The domain machinery is for **every** repo.
+2. The axis is **per-repo** and follows that repo's natural partition — do not copy digitalmodel's engineering-module axis.
+3. **worldenergydata partitions by DATA SOURCE, expressed as modules**: rows are sources, roots are the module paths serving them.
+4. Unifying principle — **the jurisdiction that publishes the data**: offshore by regulator (BSEE, HSE/UK, Sodir/Norway); onshore wells by country then region/state (US-TX RRC, US-NM OCD).
+
+### worldenergydata — corrected by measurement
+
+An earlier draft called this the largest item, reasoning that the tree mixed axes and needed
+reconciling. **Measurement refuted that** — the tree is already organised by jurisdiction:
+
+| Source | files | | Source | files |
+|---|---:|---|---|---:|
+| `bsee` | **92** | | `sodir` (Norway) | 28 |
+| `texas_rrc` | **62** | | `hse` (UK) | 21 |
+| `marine_safety` | 50 | | `canada` | 14 |
+| `vessel_fleet` | 47 | | `brazil_anp`·`spain`·`ukcs`·`eia_us`·`west_africa` | 7 each |
+| `safety_analysis` | 38 | | `kansas_kgs` | 6 |
+| `metocean` | 34 | | `mexico_cnh` | 4 |
+
+So item 4 is **write the manifest over existing structure**. Only the subject-shaped roots
+(`drilling`, `marine`, `reservoir`) need an owning domain assigned.
+
+## Lane budgets — the design rule
+
+| Stage | Budget | Runs |
+|---|---|---|
+| pre-commit | **< 2s** | format, syntax, secrets — staged files only |
+| pre-push | **< 30s** | shallow tier, touched domains only |
+| PR CI | < 10 min | deep tier, touched domains *(exists in digitalmodel)* |
+| main + nightly | unbounded | full sweep, integration, solvers *(exists in digitalmodel)* |
+
+## The two rules that make or break this
+
+Both are the failure this codebase keeps hitting: **absence of signal reading as success.**
+
+- **R-A. An unmarked test must fail collection.** Never default into a tier. Unmarked→shallow silently empties the deep tier; unmarked→deep silently empties pre-push. Enforce at collection time, not by convention.
+- **R-B. An unmapped path must fail loudly.** Never map to zero domains. Totality must be **proven by a test**, not asserted in review. `DOMAINS.md` already records this happening: 221 cathodic-protection tests "gated by nothing" (#1923).
+
+## Preconditions — both block the acceptance criteria
+
+1. **#3790 — 487 suppressed test files** (240 WED + 165 assetutilities + 82 digitalmodel).
+   A totality proof compares *collected* tests against domain roots, so **a suppressed file
+   passes trivially** — never collected, therefore never uncovered. The proof would certify a
+   tree with 487 invisible files and report green. Must be resolved first.
+2. **#3787 — the pytest startup tax.** A 30s shallow tier is unreachable while a fixed
+   multi-second-to-multi-minute cost precedes every invocation. Approved and in progress.
+3. **The red baseline** (digitalmodel ~193 failures). Tiering a suite where red is normal only
+   redistributes noise. Either green it (dm#1850) or pin a per-domain allowed-failure set so
+   *new* red is distinguishable.
+
+## Work breakdown
+
+| # | Item | Repo | Depends on |
+|---|---|---|---|
+| 1 | Per-domain allowed-failure baseline format + tooling | workspace-hub | — |
+| 2 | Baseline populated | digitalmodel | 1 |
+| 3 | `DOMAINS.md` + detector | assetutilities | #3790 |
+| 4 | `DOMAINS.md` + detector (manifest over existing structure) | worldenergydata | #3790 |
+| 5 | `DOMAINS.md` + detector | assethold | #3790 |
+| 6 | Shallow-tier marker + enforcement (R-A) | each repo | — |
+| 7 | `run-all-tests.sh`: `--shallow`, `--touched` | workspace-hub | 3,4,5,6 |
+| 8 | pre-push calls `--shallow --touched` | workspace-hub | 7, 2, #3787 |
+| 9 | Totality test (R-B) | each repo | 3,4,5 |
+
+Items 3–5 are independent and parallelisable.
+
+## Acceptance criteria
+
+1. `pytest` collection **fails** on an unmarked test in every tier-1 repo (R-A), demonstrated.
+2. A path absent from `DOMAINS.md` **fails** the totality test, demonstrated with a decoy path (R-B).
+3. Measured pre-push wall-clock **< 30s** on a representative single-domain change, per repo.
+4. A **new** failure not in the baseline breaks the build even when the total count went **down**.
+5. Baseline entries are removable only by fixing the test — no auto-refresh path exists.
+6. The gated lane still reports its own scope; the full sweep keeps distinct check names.
+
+## Risks and closed questions
+
+- **R1** — Tiering can become a way to run fewer tests and feel faster. Everything rests on R-A and R-B being enforced *by tests*. Reviewers should attack these first.
+- **R2** — Timing measurements are worthless on a loaded box; measure serially, and gate on *pre-existing* load (the measurement itself raises it).
+- **OQ1 — CLOSED.** I claimed `run-all-tests.sh` fails to resolve siblings. Refuted: `resolve_tier1_repo_path` probes `TIER1_REPOS_BASE`, nested, then flat-sibling (`tier1-repos.sh:33`), qualifying on `.git/` or `pyproject.toml` (`:51`); all three resolve, and a failure emits `skipped`, not `repo_missing` (`run-all-tests.sh:67`). That message came from `check-all.sh`. Item 7 unblocked.
+- **OQ2 — CLOSED.** uv speed features were largely off (11 setup-uv steps, 1 cached; zero `--frozen`). Fixed and merged independently: wh#3785 (11/11 + frozen), dm#1957 (9/9).
+- **OQ3** — worldenergydata and digitalmodel remain unclassified beyond 180s. Forward progress demonstrated, completion within 900s not proven. Their "before" figures are **censored values, not durations**.
+
+## Adversarial review
+
+*T3 (Claude + Codex + Agy) on approval. Default to non-APPROVE.* Attack first:
+1. Can R-A or R-B be satisfied in name only? Show an unmarked test or unmapped path that still goes green.
+2. Is "last unconditional exit" / "unmarked" decidable by the proposed parsers, or will they fail valid inputs and pass the defect?
+3. Does the plan under-state the blast radius of turning four new hard blocks on at push time?
+4. Are the preconditions genuinely blocking, or is that an excuse to defer the hard part?

--- a/docs/plans/2026-08-03-issue-3787-startup-tax.md
+++ b/docs/plans/2026-08-03-issue-3787-startup-tax.md
@@ -1,0 +1,101 @@
+# Plan for #3787: stop paying the pytest startup tax on lanes that cannot use it
+
+**Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3787
+**Status:** **plan-approved** (owner, 2026-08-03; marker `.planning/plan-approved/3787.md`)
+**Lane:** `lane:claude` · **Complexity:** T2 · **Client:** N/A
+**Review:** r1 Codex **MAJOR** + Claude **MAJOR**; r2 applied inline.
+Artifacts: `scripts/review/results/2026-08-03-plan-3787-{claude,codex,disagreement}.md`
+
+> **Restored 2026-08-03 after loss.** Originally written untracked and removed by the
+> auto-sync clean. Committed this time — see #3791.
+
+## Resource Intelligence Summary
+
+| Path | Role |
+|---|---|
+| `worldenergydata/tests/conftest.py:256-262` | constructs the tracker at `pytest_configure`; DB path hardcoded at :261 |
+| `worldenergydata/src/.../performance/database.py:44-60` | `__init__` calls `_init_database()` — construction *is* DB access |
+| `worldenergydata/tests/conftest.py:302` | `detect_regressions(lookback_days=7)`, unconditional |
+| `digitalmodel/pytest.ini:34-39` | global `addopts`; `pyproject.toml:263-268` confirms it wins outright |
+| `pytest_benchmark/utils.py:149` | `subprocess_output` — git metadata at plugin init |
+
+**Reproduction, measured on this box**
+
+```
+git describe --dirty --always --long   (digitalmodel)  = 38,158 ms
+worldenergydata/.test_performance.db                   = 59 MB, 105,348 execution rows
+
+pytest --collect-only:  assetutilities  7.56s (1,352 tests)
+                        worldenergydata >180s
+                        digitalmodel    >180s
+trivial single file:    digitalmodel 1.50s · assetutilities 4.38s
+```
+
+**Gap:** the two slow repos are unclassified beyond 180s — forward progress demonstrated,
+completion within 900s not proven. Their "before" figures are **censored values, not
+durations**, and must not be reported as measurements.
+
+## Governing constraint
+
+**Remove the tax from the fast path. Do not remove the capability.**
+`pytest-randomly` surfaces order-dependent tests and digitalmodel **has them**
+(cathodic-protection and `workflow_api` pass alone, fail in-suite). Benchmark git metadata
+is waste on collect-only and legitimate on a benchmark run. The regression analysis is
+legitimate after a real session. The nightly/full sweep keeps all of it.
+
+Anything reducing coverage to buy speed is out of scope and must be reported, not done.
+
+## Deliverable
+
+`--collect-only` completes well inside the 30s pre-push budget in both repos, with
+**identical collected-test counts** on the full lane.
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `worldenergydata/tests/conftest.py` | lazy tracker (`pytest_configure`, not just session finish); **add a DB-path seam** |
+| `worldenergydata/src/.../performance/database.py` | possibly, if laziness is cleaner at construction |
+| `digitalmodel/` **fast-lane invocation only** | `-p no:...`. **NOT `pytest.ini`** — its `addopts` is global and would disable plugins for the nightly sweep too |
+
+## Pseudocode
+
+```python
+def pytest_configure(config):
+    _performance_tracker = LazyTracker(db_path_provider)   # construct nothing yet
+
+# session finish
+if not _performance_tracker.was_used():
+    return      # nothing executed; nothing to analyse
+```
+
+Laziness subsumes `collectonly` rather than special-casing it, and also covers a session
+where every test is deselected — settling OQ1 with no second predicate to remember.
+
+## TDD Test List
+
+1. `test_collect_only_does_not_touch_the_performance_db` — asserts the property (no DB
+   access), not a wall-clock number, so a faster machine cannot satisfy it.
+2. `test_real_session_still_runs_regression_analysis` — **guard against "fixing" the tax
+   by deleting the feature.**
+3. `test_full_lane_still_loads_every_disabled_plugin` — randomly, benchmark, faker. Widened
+   from randomly-only per r1 finding 6.
+4. `test_collected_count_unchanged` — necessary and **NOT sufficient**: a plugin that stops
+   loading does not change the count, so this is blind to the r1 finding-5 leak. Test 3 closes it.
+5. `test_db_path_is_injectable` — the seam exists and is honoured; without it test 1 is unwritable.
+
+## Acceptance Criteria
+
+1. Tests 1–5 pass; 1 demonstrated failing beforehand.
+2. **Measured** before/after `--collect-only` wall-clock per repo on an idle box, with
+   `timeout 900` so "before" is a duration and not a censored `>180s`.
+3. Full-lane collected count **identical**, stated as a number both sides.
+4. Each disabled plugin named with the lane where it still runs.
+5. `check-no-abs-paths.sh` adds no new violations (baseline mode; bare run is rc 1 / 459 pre-existing).
+
+## Risks
+
+- **R1** The fastest route to a green number is a coverage regression. AC3 + test 3 close it.
+- **R2** Timing on a loaded box is worthless — already invalidated one round. Measure serially.
+  Note the threshold must gate *pre-existing* load; the measurement itself raises load.
+- **Out of scope:** the 487 suppressed files — #3790.

--- a/docs/plans/2026-08-03-issue-3790-hidden-test-files.md
+++ b/docs/plans/2026-08-03-issue-3790-hidden-test-files.md
@@ -1,0 +1,89 @@
+# Plan for #3790: resolve the 487 test files excluded from collection
+
+**Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3790
+**Status:** plan-review *(label not applied; `status:plan-approved` is the owner's)*
+**Lane:** `lane:claude` · **Complexity:** **T3** — three repos, and re-enabling tests changes what CI reports · **Client:** N/A
+**Blocks:** the CI-tiering plan (`docs/plans/2026-08-03-ci-tiering-and-domain-routing.md`), which names this a precondition.
+
+## Why this blocks the domain work
+
+The domain-routing totality proof checks that every **collected** test belongs to a domain root. **A suppressed file passes that check trivially** — never collected, therefore never uncoverable. Run against today's tree the proof would certify a codebase with 487 invisible test files and report green.
+
+The proof isn't wrong; it answers a question that excludes the problem. So this is a precondition, not parallel work.
+
+## Measured scope
+
+| repo | suppressed | mechanism |
+|---|---:|---|
+| `worldenergydata` | **240** min | `pyproject.toml:334` — 16 `testpaths`, 204 `norecursedirs`, 20 `--ignore`; plus hooks from `tests/conftest.py:316`. 1,031 pytest-shaped files, 807 eligible after config. |
+| `assetutilities` | **165** | `pytest.ini:3` hides 135 outside `tests/`; platform hook `tests/conftest.py:65` hides 30 more |
+| `digitalmodel` | **82** min | `pytest.ini:3`/`:4`; plus 14 `collect_ignore` at `tests/conftest.py:9` |
+
+Counts are **minima** — hook-based exclusions were not exhaustively enumerated. Establishing the true set is step 1, not an assumption.
+
+## Precedent
+
+`digitalmodel/tests/DOMAINS.md` records this happening once already: **221 cathodic-protection tests** "gated by nothing until #1923 — the gate pointed only at `tests/cathodic_protection/`, and `pytest.ini` `norecursedirs` hid the subtree from every shard." That was one directory. This is roughly twice that, across three repos.
+
+A prior audit in this ecosystem also found `collect_ignore` reasons that were each individually plausible and each individually false — "deleted service files" (the files existed), "data files not in git" (generated in memory), "fails with random ordering" (three seeds, all green) — concealing 139 tests of which 113 passed and 2 covered live production crashes.
+
+**So: a suppression's stated reason is a claim, not evidence.**
+
+## Deliverable
+
+Every pytest-shaped file in the three repos is either **collected**, or **excluded for a verified, recorded reason enforced by a marker rather than a path glob** — and a test prevents the next silent hiding.
+
+## Work breakdown
+
+| # | Item | Output |
+|---|---|---|
+| 1 | **Enumerate exhaustively**, per repo, across all five mechanisms: `testpaths`, `norecursedirs`, `--ignore`, `collect_ignore`, conftest hooks | the actual file set, not a count |
+| 2 | **Re-run each candidate** in isolation before judging it | pass / fail / error, measured |
+| 3 | **Triage** each into exactly one bucket | obsolete → delete · wrongly hidden → re-enable · legitimately conditional → marker |
+| 4 | **Convert legitimate exclusions from path globs to markers** | `-m "not solver"` etc., so the condition is named and checkable |
+| 5 | **Recurrence guard** (R-A below) | a test |
+
+Items 1–3 are per-repo and parallelisable; item 5 is shared.
+
+## The rule that makes this durable
+
+**R-A. Every pytest-shaped file must be either collected or explicitly excluded by a marker with a recorded reason.** A path-glob exclusion is invisible at collection time and produces no signal — that is precisely how 487 files accumulated. The guard is a test that enumerates pytest-shaped files, subtracts collected node IDs, and fails on any remainder not carrying a registered exclusion marker.
+
+Without item 5, items 1–4 clear today's debt and the next hidden subtree arrives the same silent way.
+
+## TDD Test List
+
+1. **`test_every_pytest_file_is_collected_or_explicitly_excluded`** — the R-A guard. Must be demonstrated failing against today's tree (it should report ~487), then pass once triage completes.
+2. **`test_a_new_hidden_file_fails_the_guard`** — add a decoy test file under a `norecursedirs` path; the guard must fail. **Without this, the guard could silently become a no-op** — the same defect class as the loosened matcher in #3787.
+3. **`test_exclusion_markers_carry_a_reason`** — a registered marker without a recorded reason fails.
+4. **Per-repo:** re-enabled tests actually run in the lane they were assigned to.
+
+## Acceptance Criteria
+
+1. Tests 1–4 pass; 1 and 2 demonstrated failing beforehand.
+2. The enumerated set is **published per repo** (a committed list), so the number is auditable rather than asserted.
+3. Every file in that set is dispositioned with a reason that was **verified by re-running it**, not copied from an existing comment.
+4. Collected-test count **increases** by the number re-enabled, stated as a number per repo. A flat count means nothing was actually re-enabled.
+5. Newly re-enabled failures are **filed, not suppressed** — see R2.
+
+## Risks and Open Questions
+
+### R1 — The obvious shortcut is to broaden the exclusion
+If a file is hard to re-enable, the cheap resolution is widening a glob and calling it triaged. **That is the defect, not the fix.** Any case resolved by broadening an exclusion must be reported as such and reviewed. AC3 exists to make the reason checkable.
+
+### R2 — Re-enabling will surface real failures, and that is success
+Some of these 487 will fail when re-enabled. Expect the count to go up before it goes down. They must be **filed as defects**, not re-suppressed, and they must not be added to the #3787-adjacent allowed-failure baseline without an owner and an issue. Otherwise this converts invisible tests into invisible failures — the same problem with better bookkeeping.
+
+### R3 — This interacts with the red baseline
+digitalmodel is already ~193-red. Re-enabling tests into that noise makes attribution harder. Sequence per repo: enumerate → triage → re-enable → *immediately* file what breaks, before moving to the next repo.
+
+### OQ1 — Is `pytest-shaped` the right universe?
+The counts use filename-pattern matching (`test_*.py` / `*_test.py`). A file that defines tests but doesn't match, or matches but defines none, is mis-counted in opposite directions. The enumeration should report both the pattern set **and** the collected set, and reconcile — rather than trusting the pattern alone.
+
+## Adversarial Review
+
+*T3 on approval. Default to non-APPROVE.* Attack first:
+1. **Can the R-A guard be satisfied while files stay hidden?** Find the loophole — that is the whole plan.
+2. **Is test 2 strong enough** to stop the guard decaying into a no-op?
+3. **Does AC4 (count increases) create pressure to re-enable trivial files** and leave hard ones excluded?
+4. **Is OQ1 handled, or does the plan trust a filename pattern to define the universe it audits?**

--- a/scripts/fleet/lane-sweep.sh
+++ b/scripts/fleet/lane-sweep.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# lane-sweep.sh -- reconcile what is ACTUALLY running on the fleet against
+# what the control surface thinks is running.
+#
+# WHY THIS EXISTS. On 2026-08-15 a poll loop launched on gpu-claw ran for
+# 13.5 hours after its job finished, because it waited on `pgrep -f
+# "stage45_driver"` -- a pattern that matches the ssh command carrying it.
+# Nothing reported an error. It was found only by sweeping by hand.
+#
+# ace-linux-1 is the CONTROL SURFACE: it should show orchestration and git,
+# never solver or provider-CLI compute. This script flags it if it does.
+#
+# Usage: lane-sweep.sh [--registry <file>]
+set -eo pipefail
+
+REGISTRY="${2:-$HOME/.claude/fleet-lanes.tsv}"
+COMPUTE='[i]nterFoam|[s]impleFoam|[s]nappyHexMesh|[p]otentialFoam|[c]odex exec|[a]gy -p|[b]ench_run'
+# A waiter that polls by process name can match its own ssh command line and
+# never exit. Any `until ! pgrep` on a remote host is suspect by construction.
+ZOMBIE='until . pgrep|while pgrep'
+
+hosts=(gpu-claw-ts ace-linux-2)
+
+# Match the EXECUTABLE name, not the command line. An `ssh host '...bench_run...'`
+# has the pattern in its argv and is orchestration, not compute -- the first
+# version of this check flagged its own dispatch commands as violations, which
+# is the same self-match class it exists to detect.
+COMPUTE_EXE='^(interFoam|simpleFoam|potentialFoam|snappyHexMesh|blockMesh|mpirun)$'
+# Provider CLIs count as compute only in one-shot mode. `codex app-server` /
+# `app-server-broker.mjs` / `codex-update-manager daemon` are long-lived MCP
+# and update daemons -- flagging those as policy violations is crying wolf,
+# and a detector that cries wolf gets ignored exactly when it is right.
+PROVIDER_RUN='[c]odex exec|[a]gy -p'
+PROVIDER_SKIP='app-server|broker|update-manager|daemon'
+
+echo "=== ace-linux-1 (CONTROL SURFACE -- compute here is a policy violation)"
+hits_local=$( { ps -eo comm=,etime= | awk -v re="$COMPUTE_EXE" '$1 ~ re {print}'
+                ps -eo comm=,etime=,args= \
+                  | grep -E "$PROVIDER_RUN" \
+                  | grep -vE "$PROVIDER_SKIP" \
+                  | awk '$1=="node"||$1=="codex"||$1=="agy" {print $1, $2}'
+              } || true)
+if [ -n "$hits_local" ]; then
+  echo "  !! COMPUTE RUNNING ON THE CONTROL SURFACE:"
+  printf '%s\n' "$hits_local" | sed 's/^/     /'
+else
+  echo "  clean (orchestration and git only)"
+fi
+
+for h in "${hosts[@]}"; do
+  echo "=== $h"
+  out=$(ssh -o ConnectTimeout=10 -o BatchMode=yes "$h" \
+        "ps -eo etime=,args= 2>/dev/null" 2>/dev/null) || {
+    echo "  UNREACHABLE"; continue; }
+
+  # Summarise rather than dump: 8 identical solver ranks is one lane, not eight.
+  live=$(printf '%s\n' "$out" | grep -E "$COMPUTE" | grep -v " grep " || true)
+  if [ -n "$live" ]; then
+    echo "  live work:"
+    printf '%s\n' "$live" | awk '{
+        et=$1; $1=""; cmd=substr($0,2,70);
+        gsub(/^[ \t]+/,"",cmd); key=cmd; n[key]++; if (!(key in first)) first[key]=et
+      } END { for (k in n) printf "     %-10s x%-3d %s\n", first[k], n[k], k }' \
+      | sort -k2 -r
+  else
+    echo "  no live work"
+  fi
+
+  # Long-lived pollers are the failure mode this script was written for.
+  zomb=$(printf '%s\n' "$out" | grep -E "$ZOMBIE" | grep -v " grep " | cut -c1-100 || true)
+  if [ -n "$zomb" ]; then
+    echo "  !! SUSPECTED ZOMBIE WAITER (poll-by-process-name can self-match):"
+    printf '%s\n' "$zomb" | sed 's/^/     /'
+    echo "     -> kill by PID; do NOT pkill -f with the same pattern, it kills your own ssh"
+  fi
+done
+
+if [ -f "$REGISTRY" ]; then
+  echo "=== registry ($REGISTRY)"
+  column -t -s $'\t' "$REGISTRY" 2>/dev/null || cat "$REGISTRY"
+  echo "  Reconcile by hand: a registry row with no live process is either"
+  echo "  finished (check its marker file) or died silently."
+else
+  echo "=== no registry at $REGISTRY"
+fi

--- a/tests/hooks/test_install_hooks_extension_point.py
+++ b/tests/hooks/test_install_hooks_extension_point.py
@@ -1,0 +1,207 @@
+"""Tests for the pre-push installer extension point — workspace-hub#3781.
+
+TDD: written before implementation.
+
+Background: `install-hooks.sh` wired enforcement blocks with `cat >> pre-push`,
+but the hook ends in an unconditional `exit`, so every appended block was
+unreachable. Its idempotence check greps for a *string* rather than checking
+*reachability*, so the installer reported "already wired" forever and could
+never repair the damage it caused.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "pre-push.sh"
+INSTALLER = REPO_ROOT / "scripts" / "enforcement" / "install-hooks.sh"
+SENTINEL = "<<INSTALL_HOOKS_EXTENSION_POINT>>"
+
+# Directories whose scripts are enforcement gates. Matching on these rather than
+# on a `require-*` filename prefix is deliberate: the two gates that were dead
+# for months -- check-state-file-size-prepush.sh and sync-cadence-helper.sh --
+# carry neither that prefix nor that directory, so a prefix-based guard would
+# have missed the exact defect it exists to catch.
+GATE_DIRS = ("scripts/enforcement/", "scripts/sync/", ".claude/hooks/")
+
+
+def _body_after_final_exit(text: str) -> str:
+    """Return everything after the last top-level unconditional `exit`.
+
+    "Top-level" means column zero: an `exit` indented inside an if/case/function
+    is conditional and is not the script terminator.
+    """
+    matches = list(re.finditer(r"(?m)^exit\b.*$", text))
+    if not matches:
+        return ""
+    return text[matches[-1].end():]
+
+
+class TestReachability:
+    """No enforcement may live below the hook's terminal exit."""
+
+    def test_no_enforcement_block_below_final_exit(self):
+        text = HOOK_SCRIPT.read_text()
+        tail = _body_after_final_exit(text)
+
+        offenders = []
+        for line in tail.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            if any(d in line for d in GATE_DIRS) or "enforcement-env" in line:
+                offenders.append(stripped)
+
+        assert not offenders, (
+            "enforcement below the terminal exit never runs (#3781):\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_hook_declares_an_extension_point(self):
+        assert SENTINEL in HOOK_SCRIPT.read_text(), (
+            "the hook must carry an explicit insertion marker so the installer "
+            "never has to append blindly"
+        )
+
+    def test_extension_point_precedes_the_final_exit(self):
+        text = HOOK_SCRIPT.read_text()
+        assert SENTINEL not in _body_after_final_exit(text), (
+            "the extension point itself sits below the exit — anything inserted "
+            "at it would be unreachable"
+        )
+
+
+class TestOrdering:
+    """enforcement-env must precede the gates whose behaviour it sets."""
+
+    def test_enforcement_env_precedes_review_gate(self):
+        text = HOOK_SCRIPT.read_text()
+        env_at = text.find("enforcement-env")
+        review_at = text.find("require-review-on-push.sh")
+        assert env_at != -1, "enforcement-env is not wired into the hook"
+        assert review_at != -1, "review gate is not wired into the hook"
+        assert env_at < review_at, (
+            "enforcement-env exports REVIEW_GATE_STRICT=1; the review wrapper "
+            "defaults it to 0. Sourcing it after the wrapper leaves the review "
+            "gate advisory — the #3781 defect."
+        )
+
+
+class TestStdinReplay:
+    """Gates that read git's pre-push stdin must actually receive it."""
+
+    def test_state_size_guard_receives_the_pushed_refs(self):
+        """The hook consumes stdin into PUSH_LINES before any gate runs.
+
+        `check-state-file-size-prepush.sh` reads ref lines from its own stdin and
+        silently falls back to an inferred ref when none arrive — so a gate that
+        merely *executes* can still be scanning the wrong commit range. The
+        buffered lines must be replayed into it.
+        """
+        text = HOOK_SCRIPT.read_text()
+        idx = text.find("check-state-file-size-prepush.sh")
+        assert idx != -1, "state-size guard is not wired into the hook"
+
+        block = text[max(0, idx - 400): idx + 400]
+        assert "PUSH_LINES" in block, (
+            "state-size guard invoked without replaying ${PUSH_LINES[@]} into "
+            "its stdin — it will scan an inferred ref, not the pushed range"
+        )
+
+
+def _make_repo(tmp_path: Path, sentinel: bool, stale_block: bool = False) -> Path:
+    """Build a throwaway repo with a pre-push hook in a chosen state."""
+    repo = tmp_path / "repo"
+    hooks = repo / ".git" / "hooks"
+    scripts = repo / "scripts" / "enforcement"
+    hooks.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    for name in (
+        "enforcement-env.sh",
+        "require-stage-prompt-drift.sh",
+        "require-review-on-push.sh",
+    ):
+        src = REPO_ROOT / "scripts" / "enforcement" / name
+        if src.exists():
+            shutil.copy2(src, scripts / name)
+
+    body = "#!/usr/bin/env bash\nset -euo pipefail\nOVERALL_EXIT=0\n"
+    if sentinel:
+        body += f"# {SENTINEL}\n\nexit 0\n"
+    else:
+        body += "exit 0\n"
+    if stale_block:
+        # Reproduce the real #3781 state: the hook DOES carry an extension point
+        # (post-#3782), and a block sits below the terminal exit anyway. An
+        # earlier version of this fixture omitted the sentinel, which tested the
+        # refusal path instead of the repair path.
+        body += (
+            "\n# ── Enforcement environment ──\n"
+            'ENFORCEMENT_ENV="${REPO_ROOT}/.git/hooks/enforcement-env"\n'
+            'if [[ -f "${ENFORCEMENT_ENV}" ]]; then source "${ENFORCEMENT_ENV}"; fi\n'
+        )
+
+    (hooks / "pre-push").write_text(body)
+    (hooks / "pre-commit").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (hooks / "post-commit").write_text("#!/usr/bin/env bash\nexit 0\n")
+    return repo
+
+
+def _run_installer(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(INSTALLER)], cwd=repo, capture_output=True, text=True
+    )
+
+
+class TestInstaller:
+    """The installer must insert at the marker, never append past the end."""
+
+    def test_refuses_without_sentinel(self, tmp_path):
+        repo = _make_repo(tmp_path, sentinel=False)
+        hook = repo / ".git" / "hooks" / "pre-push"
+        before = hook.read_text()
+
+        result = _run_installer(repo)
+
+        assert result.returncode != 0, (
+            "installing into a hook with no extension point must fail loudly — "
+            "appending blindly is what created #3781"
+        )
+        assert hook.read_text() == before, "hook must be left untouched on refusal"
+
+    def test_idempotent_when_already_reachable(self, tmp_path):
+        repo = _make_repo(tmp_path, sentinel=True)
+        hook = repo / ".git" / "hooks" / "pre-push"
+
+        assert _run_installer(repo).returncode == 0
+        once = hook.read_text()
+        assert _run_installer(repo).returncode == 0
+        twice = hook.read_text()
+
+        assert once == twice, "second install must be a no-op"
+        assert once.count("ENFORCEMENT_ENV=") <= 1, "block inserted twice"
+
+    def test_rewires_an_unreachable_block(self, tmp_path):
+        """Given the #3781 state, the installer must repair it — not report OK.
+
+        A string-presence idempotence check reports 'already wired' here, which
+        is why the broken state was permanent.
+        """
+        repo = _make_repo(tmp_path, sentinel=True, stale_block=True)
+        hook = repo / ".git" / "hooks" / "pre-push"
+
+        result = _run_installer(repo)
+        assert result.returncode == 0, result.stderr
+
+        text = hook.read_text()
+        tail = _body_after_final_exit(text)
+        assert "enforcement-env" not in tail, (
+            "the unreachable block was left below the exit — the installer "
+            "detected a string, not a reachable block"
+        )


### PR DESCRIPTION
Preservation only. **No content is modified** — these six files existed on one machine's disk and on no remote ref.

## Why this is urgent rather than tidy

`workspace-hub` runs an auto-sync process that **deletes untracked files**. An audit for stranded work found these outside git in a repo where that process was observed running during the scan.

The highest-value item is not a plan. It is a **gate marker**:

```
.planning/plan-approved/3787.md
```

Approval evidence is not reconstructable. It records a user-in-loop decision, and no agent may re-issue one. Losing it silently un-approves work that was approved.

**It has already been lost once.** The marker's own text says so:

> **Restored 2026-08-03 after loss.** The original marker was written untracked and was removed along with the plan files — auto-sync cleans untracked files, not only commits them. Committed this time. See #3791.

It was not committed that time — or was committed and later reverted to untracked. Either way the same file was stranded a second time by the same mechanism, with a note in its own body explaining the mechanism. That is worth more attention than this PR: a one-off restore did not hold.

## Verified legitimate, not manufactured

[#3787](https://github.com/vamseeachanta/workspace-hub/issues/3787) carries `status:plan-approved` on GitHub right now, and the marker names the approver, the date, and the fact that only the keystroke was delegated. This PR **preserves an existing approval record**; it does not create gate state.

## Contents

| File | What | Why single-copy matters |
|---|---|---|
| `.planning/plan-approved/3787.md` | Approval-gate marker | Not reconstructable; already lost once |
| `docs/plans/2026-08-03-issue-3787-startup-tax.md` | The plan that marker approves | Approval without its plan is meaningless |
| `docs/plans/2026-08-03-ci-tiering-and-domain-routing.md` | Authored plan | Nowhere else |
| `docs/plans/2026-08-03-issue-3790-hidden-test-files.md` | Authored plan | Nowhere else |
| `scripts/fleet/lane-sweep.sh` | Fleet lane control surface | The operating memory index names this script as the way to track fleet lanes rather than from memory — a documented operational dependency existing in exactly one place |
| `tests/hooks/test_install_hooks_extension_point.py` | Hook test | Nowhere else |

`git add -f` was needed for paths under ignored prefixes.

## Worth a follow-on

The audit also found ~50 further untracked authored files in this repo, including 18 memory-topic mirrors and 27 `.planning/research/*.md` artifacts. They are lower value individually but sit in the same deletion path. Separately, `.planning/plan-approved/` being ignore-adjacent is arguably the root defect — gate evidence should not live where a cleaner can reach it.

## Note on how this was pushed

Branched off `origin/main` through a temporary index, so none of the ~200 unrelated local commits or the dirty working tree came along. The diff is exactly the six intended files.
