### PR TITLE
fix(maintenance): stop treating untracked authored work as regenerable (#3826)

### DIFF
--- a/scripts/maintenance/never-clean-globs.sh
+++ b/scripts/maintenance/never-clean-globs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ABOUTME: Paths that maintenance sweeps must never delete, even when untracked (#3826).
+#
+# WHY THIS EXISTS. Two scheduled paths treated "untracked" as "regenerable":
+# repo-housekeeping.sh ran `git clean -fd` with no exclusions, and
+# return-to-main-guard.sh classified untracked as churn and `git stash -u`d it on
+# a 30-minute cron. That equation is false for a small, high-value class, and it
+# destroyed .planning/plan-approved/3787.md TWICE -- a file whose own body
+# documents the mechanism that destroyed it.
+#
+# An approval marker records a USER-IN-LOOP DECISION. It is not derivable from
+# the repo, no agent may re-issue one, and its loss is invisible: a missing gate
+# looks exactly like work that was never approved.
+#
+# Note the shape of the original defect. repo-housekeeping.sh already built
+# `-e` excludes from SECRET_GLOBS so git-ignored secrets survived `git clean -fdx`
+# -- the denylist existed, but was applied to the LOWER-risk path while untracked
+# authored work went unprotected eleven lines above. This file is that same idea,
+# put on the path that needed it.
+#
+# The list is deliberately short. Every entry is a class authored by a person and
+# reconstructable by nobody. Generated dashboards, reports, logs and state
+# snapshots are NOT here and must keep being swept -- a denylist that swallows
+# everything would strand sessions off main, which is the problem #3187 fixed.
+#
+# Bash `*` matches `/`, so each glob covers arbitrary nesting.
+
+NEVER_CLEAN_GLOBS=(
+  '.planning/plan-approved/*'   # approval-gate evidence -- the reason this exists
+  '.planning/*.md'              # plans, research, retrospectives
+  'docs/plans/*'                # authored plans
+  'docs/session-handoffs/*'     # handoffs; often a session's only record
+  'scripts/*.sh'                # a script is never build output; extension-scoped
+  'scripts/*.py'                #   so generated scratch under scripts/ (json, log,
+  'scripts/*.bash'              #   csv) stays sweepable and cannot strand the guard
+  '.claude/rules/*'             # operating rules
+  '.claude/skills/*'            # skills
+)
+
+# never_clean_match <path> -> 0 if the path is protected, 1 otherwise.
+never_clean_match() {
+  local path="$1" glob
+  for glob in "${NEVER_CLEAN_GLOBS[@]}"; do
+    # shellcheck disable=SC2053  # glob match is intended, not string equality
+    [[ "${path}" == ${glob} ]] && return 0
+  done
+  return 1
+}
+
+# never_clean_untracked <repo_root> -> prints protected UNTRACKED paths, one per
+# line; returns 0 if any were found, 1 if none.
+#
+# NUL-delimited iteration: a path containing a space or newline must not split
+# into fragments that individually miss every glob and let the file through.
+never_clean_untracked() {
+  local repo="$1" path found=1
+  while IFS= read -r -d '' path; do
+    if never_clean_match "${path}"; then printf '%s\n' "${path}"; found=0; fi
+  done < <(git -C "${repo}" ls-files --others --exclude-standard -z 2>/dev/null)
+  return "${found}"
+}
+
+# never_clean_ignored <repo_root> -> prints protected GIT-IGNORED paths.
+#
+# Ignored files are a separate hole, and a nastier one. `--exclude-standard`
+# hides them from never_clean_untracked, and `git add -A` does not stage them --
+# so neither the detector above nor repo-housekeeping's commit-WIP step sees
+# them. `git clean -fdx` under --prune-ignored then deletes them outright. A
+# gate marker in a repo whose .gitignore happens to cover .planning/ is exactly
+# that case, and it is still gate evidence.
+never_clean_ignored() {
+  local repo="$1" path found=1
+  while IFS= read -r -d '' path; do
+    if never_clean_match "${path}"; then printf '%s\n' "${path}"; found=0; fi
+  done < <(git -C "${repo}" ls-files --others --ignored --exclude-standard -z 2>/dev/null)
+  return "${found}"
+}
+
+# never_clean_any <repo_root> -> protected paths from either source.
+never_clean_any() {
+  local repo="$1" u i rc=1
+  u="$(never_clean_untracked "${repo}")" && rc=0
+  i="$(never_clean_ignored "${repo}")" && rc=0
+  [[ -n "${u}" ]] && printf '%s\n' "${u}"
+  [[ -n "${i}" ]] && printf '%s\n' "${i}"
+  return "${rc}"
+}

--- a/scripts/maintenance/repo-housekeeping.sh
+++ b/scripts/maintenance/repo-housekeeping.sh
@@ -81,6 +81,11 @@ GUARD="${REPO_ROOT}/scripts/lib/worktree_guard.py"  # #3143 deny-by-default work
 # Secret-file denylist: never removed even under --prune-ignored.
 SECRET_GLOBS=('.env' '.env.*' '*.key' '*.pem' 'auth.json' 'id_rsa' 'id_ed25519' '*secret*' '*.secret')
 
+# Paths a sweep must never delete even when untracked (#3826). Sibling in
+# intent to SECRET_GLOBS above: both say "this class is not disposable".
+# shellcheck source=scripts/maintenance/never-clean-globs.sh
+. "${REPO_ROOT}/scripts/maintenance/never-clean-globs.sh"
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 act() {
   # act "<description>" <command...> — run if --apply, else just narrate.
@@ -276,18 +281,45 @@ for dir in "${REPO_DIRS[@]}"; do
   # 4c) PRUNE untracked dirs (under --apply), ignored dirs (--prune-ignored).
   #     Skipped entirely under --no-clean-dirs (branch/worktree cleanup only).
   if (( CLEAN_DIRS )); then
-  untracked="$(git clean -nd 2>/dev/null | sed 's/^Would remove //')"
-  if [[ -n "$untracked" ]]; then
-    echo "  untracked dirs/files to remove:"; echo "$untracked" | sed 's/^/      /'
-    act "git clean -fd" git clean -fd >/dev/null 2>&1
+  # #3826: `git clean -fd` ran here with NO exclusions, while the branch below
+  # built -e excludes from SECRET_GLOBS so ignored secrets survived `clean -fdx`.
+  # The denylist existed and was applied to the lower-risk path; untracked
+  # authored work -- approval-gate markers, plans, single-copy scripts -- was
+  # swept unprotected. Protect it the same way, and REFUSE rather than remove:
+  # a gate marker records a user-in-loop decision and cannot be reconstructed.
+  never_excludes=(); for g in "${NEVER_CLEAN_GLOBS[@]}"; do never_excludes+=(-e "$g"); done
+  if protected="$(never_clean_any "$PWD")"; then
+    echo -e "  ${RED}REFUSING to clean — untracked NON-REGENERABLE work present:${NC}"
+    echo "$protected" | sed 's/^/      /'
+    echo "      commit or move these first; they are not reconstructable (#3826)."
+    SUMMARY+=("$name: SKIPPED clean (protected untracked work present)")
+  else
+    untracked="$(git clean -nd "${never_excludes[@]}" 2>/dev/null | sed 's/^Would remove //')"
+    if [[ -n "$untracked" ]]; then
+      echo "  untracked dirs/files to remove:"; echo "$untracked" | sed 's/^/      /'
+      act "git clean -fd (denylist-protected)" git clean -fd "${never_excludes[@]}" >/dev/null 2>&1
+    fi
   fi
   if (( PRUNE_IGNORED )); then
     # Build exclude args for the secret denylist so secrets survive.
-    excludes=(); for g in "${SECRET_GLOBS[@]}"; do excludes+=(-e "$g"); done
-    ignored="$(git clean -ndx "${excludes[@]}" 2>/dev/null | sed 's/^Would remove //')"
-    if [[ -n "$ignored" ]]; then
-      echo -e "  ${YELLOW}ignored dirs/files to remove (secrets preserved):${NC}"; echo "$ignored" | sed 's/^/      /'
-      act "git clean -fdx (denylist-protected)" git clean -fdx "${excludes[@]}" >/dev/null 2>&1
+    # #3826 r1 MAJOR: this path previously excluded only SECRET_GLOBS, so an
+    # IGNORED protected file was deleted outright. `git add -A` does not stage
+    # ignored files, so step 1's commit-WIP does not cover them either -- they
+    # were unprotected from both directions. Carry NEVER_CLEAN_GLOBS here too,
+    # and refuse rather than prune when a protected ignored path is present:
+    # a gate marker is gate evidence whether or not .gitignore happens to cover it.
+    excludes=(); for g in "${SECRET_GLOBS[@]}" "${NEVER_CLEAN_GLOBS[@]}"; do excludes+=(-e "$g"); done
+    if protected_ig="$(never_clean_ignored "$PWD")"; then
+      echo -e "  ${RED}REFUSING to prune ignored — protected paths are git-ignored here:${NC}"
+      echo "$protected_ig" | sed 's/^/      /'
+      echo "      commit or move these first; they are not reconstructable (#3826)."
+      SUMMARY+=("$name: SKIPPED ignored-prune (protected ignored work present)")
+    else
+      ignored="$(git clean -ndx "${excludes[@]}" 2>/dev/null | sed 's/^Would remove //')"
+      if [[ -n "$ignored" ]]; then
+        echo -e "  ${YELLOW}ignored dirs/files to remove (secrets + authored work preserved):${NC}"; echo "$ignored" | sed 's/^/      /'
+        act "git clean -fdx (denylist-protected)" git clean -fdx "${excludes[@]}" >/dev/null 2>&1
+      fi
     fi
   fi
   fi  # CLEAN_DIRS

--- a/scripts/maintenance/return-to-main-guard.sh
+++ b/scripts/maintenance/return-to-main-guard.sh
@@ -11,7 +11,8 @@
 #   staged changes present  -> exit 1, ALERT, do NOT restore (user work in flight)
 #   a `git` process is live  -> exit 0, skip (active op — wait for next tick)
 #   fully clean              -> git checkout main
-#   only unstaged/untracked  -> git stash -u (regenerable) + git checkout main
+#   untracked NON-regenerable -> exit 1, ALERT, do NOT stash (see #3826)
+#   only regenerable churn   -> git stash -u + git checkout main
 #
 # Env:
 #   GUARD_AUTO_STASH=0  disable the auto-stash path (then dirty off-main also exit 1).
@@ -72,6 +73,27 @@ if [ "$unstaged" -eq 0 ] && [ "$untracked" -eq 0 ]; then
   echo "GUARD: $current_branch is idle and clean — returning to main" >&2
   git checkout -q main || { echo "GUARD: 'git checkout main' failed — left on $current_branch" >&2; exit 1; }
   exit 0
+fi
+
+# #3826: untracked is NOT a synonym for regenerable. An approval-gate marker, an
+# authored plan or a single-copy script is untracked only because nobody ran
+# `git add` -- and `git stash -u` on a 30-minute cron destroyed
+# .planning/plan-approved/3787.md twice. Treat these the way staged changes are
+# already treated above: refuse, alert, touch nothing.
+# shellcheck source=scripts/maintenance/never-clean-globs.sh
+# Source from THIS SCRIPT's directory, resolved through symlinks -- NOT from
+# REPO_ROOT. Review suggested REPO_ROOT, but here REPO_ROOT is the repo being
+# guarded, which need not be the repo the guard lives in; sourcing from it broke
+# every sandbox test instantly. `readlink -f` handles the symlink case that made
+# plain BASH_SOURCE fragile.
+_guard_self="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+# shellcheck source=scripts/maintenance/never-clean-globs.sh
+. "$(dirname "${_guard_self}")/never-clean-globs.sh"
+if protected="$(never_clean_any "$REPO_ROOT")"; then
+  echo "GUARD: $current_branch has UNTRACKED NON-REGENERABLE work — refusing to stash." >&2
+  echo "$protected" | sed 's/^/GUARD:   /' >&2
+  echo "GUARD: commit or move these, then re-run. Gate markers cannot be reconstructed." >&2
+  exit 1
 fi
 
 # Only regenerable churn (unstaged and/or untracked, nothing staged).

--- a/scripts/maintenance/tests/test_never_clean_globs.sh
+++ b/scripts/maintenance/tests/test_never_clean_globs.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# ABOUTME: Test suite for never-clean-globs.sh and repo-housekeeping.sh's clean path (#3826).
+#
+# The defect under test: `git clean -fd` ran with NO exclusions while the branch
+# eleven lines below built -e excludes from SECRET_GLOBS, so git-ignored secrets
+# were protected and untracked AUTHORED work was not. That destroyed
+# .planning/plan-approved/3787.md twice.
+#
+# Two properties, and the second matters as much as the first:
+#   1. authored, non-reconstructable work survives a sweep;
+#   2. genuinely regenerable churn is STILL swept -- a denylist that swallowed
+#      everything would break the housekeeping this script exists to do.
+#
+# SAFETY: every test runs in a throwaway `git init` repo under mktemp. The real
+# checkout is never touched.
+
+set -uo pipefail
+
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0
+pass() { TESTS_PASSED=$((TESTS_PASSED+1)); TESTS_RUN=$((TESTS_RUN+1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_RUN=$((TESTS_RUN+1)); echo "  FAIL: $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3" "expected='$1' actual='$2'"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../never-clean-globs.sh"
+HK="$SCRIPT_DIR/../repo-housekeeping.sh"
+[[ -f "$LIB" ]] || { echo "ERROR: never-clean-globs.sh not found at $LIB" >&2; exit 1; }
+# shellcheck source=/dev/null
+. "$LIB"
+echo "Testing: $LIB"; echo ""
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+make_repo() {
+  local r="$TEST_DIR/repo-$$-$RANDOM"
+  mkdir -p "$r"; git -C "$r" init -q
+  git -C "$r" config user.email t@t; git -C "$r" config user.name t
+  echo base > "$r/base.txt"; git -C "$r" add base.txt; git -C "$r" commit -qm init
+  echo "$r"
+}
+
+# ── Test 1: classification ────────────────────────────────────────────────────
+echo "Test 1: never_clean_match classifies authored vs generated"
+for p in ".planning/plan-approved/3787.md" ".planning/research/a.md" "docs/plans/p.md" \
+         "docs/session-handoffs/h.md" "scripts/fleet/tool.sh" ".claude/rules/r.md" \
+         ".claude/skills/dev/s/SKILL.md"; do
+  never_clean_match "$p" && pass "protected: $p" || fail "protected: $p" "classified sweepable"
+done
+for p in "docs/reports/dash.html" "build.log" "logs/quality/x.log" \
+         "config/ai-tools/provider-kanban.json" ".claude/state/foo.json" "node_modules/x/y.js"; do
+  never_clean_match "$p" && fail "sweepable: $p" "wrongly protected" || pass "sweepable: $p"
+done
+echo ""
+
+# ── Test 2: never_clean_untracked finds protected untracked files ─────────────
+echo "Test 2: never_clean_untracked detection"
+R="$(make_repo)"; mkdir -p "$R/.planning/plan-approved"
+echo marker > "$R/.planning/plan-approved/1.md"
+OUT="$(never_clean_untracked "$R")"; RC=$?
+assert_eq "0" "$RC" "returns 0 when protected work present"
+assert_eq ".planning/plan-approved/1.md" "$OUT" "names the protected path"
+
+R="$(make_repo)"; mkdir -p "$R/docs/reports"; echo x > "$R/docs/reports/d.html"
+OUT="$(never_clean_untracked "$R")"; RC=$?
+assert_eq "1" "$RC" "returns 1 when only churn present"
+assert_eq "" "$OUT" "names nothing"
+echo ""
+
+# ── Test 3: a TRACKED protected file is not flagged ───────────────────────────
+# The guard is about UNTRACKED work. A committed marker is already safe, and
+# flagging it would block housekeeping forever on any repo that has one.
+echo "Test 3: tracked protected files are not flagged"
+R="$(make_repo)"; mkdir -p "$R/.planning/plan-approved"
+echo marker > "$R/.planning/plan-approved/2.md"
+git -C "$R" add -f .planning/plan-approved/2.md >/dev/null 2>&1
+git -C "$R" commit -qm marker >/dev/null 2>&1
+never_clean_untracked "$R" >/dev/null && fail "tracked marker not flagged" "flagged a committed file" \
+                                      || pass "tracked marker not flagged"
+echo ""
+
+# ── Test 4: paths with spaces survive NUL iteration ───────────────────────────
+# Word-splitting would fragment such a path into pieces that miss every glob and
+# let the file through -- a silent hole in the protection.
+echo "Test 4: a path containing spaces is still protected"
+R="$(make_repo)"; mkdir -p "$R/docs/plans"
+echo p > "$R/docs/plans/a plan with spaces.md"
+OUT="$(never_clean_untracked "$R")"
+assert_eq "docs/plans/a plan with spaces.md" "$OUT" "space-bearing path detected whole"
+echo ""
+
+# ── Test 5: repo-housekeeping PRESERVES untracked work by committing it ───────
+# CORRECTION, recorded because #3826 as filed claimed otherwise. This script's
+# `git clean -fd` was reported as a destroyer of untracked authored work. It is
+# not, on the --apply path: step 1 (line ~182) runs `git add -A` + commit for ANY
+# dirty tree, and `git status --porcelain` counts untracked files -- so by the
+# time the clean at line ~297 runs, nothing untracked remains. The marker is
+# committed to a housekeeping branch, not deleted.
+#
+# The denylist wired into the clean path is therefore DEFENCE IN DEPTH, not a
+# live-bug fix: it matters only if the commit step is ever skipped, reordered, or
+# made conditional. The live destroyer is return-to-main-guard.sh's `git stash -u`,
+# covered by tests 9-12 of test_return_to_main_guard.sh.
+echo "Test 5: repo-housekeeping preserves an untracked marker by committing it"
+R="$(make_repo)"; mkdir -p "$R/.planning/plan-approved"
+echo marker > "$R/.planning/plan-approved/3787.md"
+OUT="$( bash "$HK" --apply --root "$(dirname "$R")" --repos "$(basename "$R")" 2>&1 )"
+echo "$OUT" | grep -q "No git repos found" \
+  && fail "housekeeping: the sweep actually ran" "sweep found no repos — test would pass vacuously" \
+  || pass "housekeeping: the sweep actually ran"
+[[ -f "$R/.planning/plan-approved/3787.md" ]] \
+  && pass "housekeeping: marker survives --apply" \
+  || fail "housekeeping: marker survives --apply" "the sweep removed it"
+[[ -n "$(git -C "$R" ls-files .planning/plan-approved/3787.md)" ]] \
+  && pass "housekeeping: marker survives by being COMMITTED (not merely skipped)" \
+  || fail "housekeeping: marker is tracked afterwards" "survived untracked — the mechanism is not what this test documents"
+echo ""
+
+# ── Test 6: the denylist does not change housekeeping's behaviour ─────────────
+# A denylist that made the sweep refuse wholesale would break the housekeeping
+# this script exists to do. Regenerable churn must still be handled exactly as
+# before -- which, per test 5, means committed rather than deleted.
+echo "Test 6: regenerable churn is still handled, not refused"
+R="$(make_repo)"; mkdir -p "$R/docs/reports"
+echo junk > "$R/docs/reports/generated.html"
+OUT="$( bash "$HK" --apply --root "$(dirname "$R")" --repos "$(basename "$R")" 2>&1 )"
+echo "$OUT" | grep -q "REFUSING to clean" \
+  && fail "housekeeping: churn does not trigger a refusal" "denylist too broad — it refused on pure churn" \
+  || pass "housekeeping: churn does not trigger a refusal"
+[[ -n "$(git -C "$R" ls-files docs/reports/generated.html)" ]] \
+  && pass "housekeeping: churn still processed" \
+  || fail "housekeeping: churn still processed" "the sweep did nothing with it"
+echo ""
+
+# ── Test 7: an IGNORED protected file survives --prune-ignored (#3826 r1 MAJOR) ─
+# The hole the first fix missed, and the nastiest of the three. `git add -A` does
+# not stage ignored files, so step 1's commit-WIP never protects them; and
+# `--exclude-standard` hid them from the untracked detector, so the denylist
+# could not see them either. `git clean -fdx` then deleted them outright, with
+# only SECRET_GLOBS excluded. Reproduced by review before this test existed.
+echo "Test 7: ignored protected file survives --prune-ignored"
+R="$(make_repo)"
+printf '.planning/\n' > "$R/.gitignore"
+git -C "$R" add .gitignore >/dev/null 2>&1; git -C "$R" commit -qm ignore >/dev/null 2>&1
+mkdir -p "$R/.planning/plan-approved"
+echo marker > "$R/.planning/plan-approved/123.md"
+# Precondition: git must genuinely consider it ignored, or the test proves nothing.
+[[ -n "$(git -C "$R" ls-files --others --ignored --exclude-standard)" ]] \
+  && pass "ignored-marker precondition: git treats it as ignored" \
+  || fail "ignored-marker precondition: git treats it as ignored" "not ignored — test would be vacuous"
+OUT="$( bash "$HK" --apply --prune-ignored --root "$(dirname "$R")" --repos "$(basename "$R")" 2>&1 )"
+[[ -f "$R/.planning/plan-approved/123.md" ]] \
+  && pass "housekeeping --prune-ignored: ignored marker SURVIVES" \
+  || fail "housekeeping --prune-ignored: ignored marker SURVIVES" "deleted by git clean -fdx"
+echo ""
+
+# ── Test 8: ignored regenerable churn is STILL pruned ─────────────────────────
+# The refusal must be driven by protected paths, not by the presence of any
+# ignored file at all -- otherwise --prune-ignored becomes a permanent no-op.
+echo "Test 8: ignored churn is still pruned"
+R="$(make_repo)"
+printf 'build/\n' > "$R/.gitignore"
+git -C "$R" add .gitignore >/dev/null 2>&1; git -C "$R" commit -qm ignore >/dev/null 2>&1
+mkdir -p "$R/build"; echo junk > "$R/build/out.o"
+OUT="$( bash "$HK" --apply --prune-ignored --root "$(dirname "$R")" --repos "$(basename "$R")" 2>&1 )"
+echo "$OUT" | grep -q "REFUSING to prune ignored" \
+  && fail "housekeeping: pure ignored churn is not refused" "denylist too broad on the -fdx path" \
+  || pass "housekeeping: pure ignored churn is not refused"
+[[ -f "$R/build/out.o" ]] \
+  && fail "housekeeping: ignored churn pruned" "build/out.o survived — --prune-ignored is now inert" \
+  || pass "housekeeping: ignored churn pruned"
+echo ""
+
+# ── Test 9: generated scratch under scripts/ stays sweepable ──────────────────
+# `scripts/*` was narrowed to source extensions at review. A blanket glob would
+# refuse forever on any repo that generates json/log under scripts/, re-creating
+# the stranded-off-main problem #3187 fixed.
+echo "Test 9: scripts/ glob is extension-scoped, not blanket"
+never_clean_match "scripts/fleet/lane-sweep.sh" && pass "scripts/*.sh protected" || fail "scripts/*.sh protected" "not matched"
+never_clean_match "scripts/tools/gen.py"        && pass "scripts/*.py protected" || fail "scripts/*.py protected" "not matched"
+for p in "scripts/out/report.json" "scripts/cache/run.log" "scripts/data/rows.csv"; do
+  never_clean_match "$p" && fail "generated under scripts/ stays sweepable: $p" "wrongly protected" \
+                        || pass "generated under scripts/ stays sweepable: $p"
+done
+echo ""
+
+echo "============================================"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+echo "============================================"
+[[ "$TESTS_FAILED" -gt 0 ]] && exit 1 || exit 0

--- a/scripts/maintenance/tests/test_return_to_main_guard.sh
+++ b/scripts/maintenance/tests/test_return_to_main_guard.sh
@@ -138,6 +138,69 @@ assert_eq "1" "$RC" "test_guard_detached_head: exits 1 (refuse)"
 assert_contains "$OUT" "in-flight" "test_guard_detached_head: logs in-flight refusal"
 echo ""
 
+# ── Test 9: untracked GATE EVIDENCE is not "regenerable churn" (#3826) ────────
+# The guard's decision tree equated untracked with regenerable and stashed it via
+# `git stash -u` on a 30-minute cron. That destroyed .planning/plan-approved/3787.md
+# twice. An approval marker records a user-in-loop decision: it is not derivable
+# from the repo and no agent may re-issue one, so losing it silently un-approves
+# approved work. The guard must take its existing staged-changes branch instead --
+# refuse, alert, leave the tree alone.
+echo "Test 9: untracked approval-gate marker is protected"
+R="$(make_guard_repo)"
+mkdir -p "$R/.planning/plan-approved"
+printf '# Plan approval — #4242
+Approved by: owner, in session chat.
+' > "$R/.planning/plan-approved/4242.md"
+OUT="$(run_guard "$R" 1)"; RC="$(read_rc)"
+assert_eq "1" "$RC" "test_guard_gate_marker: exits 1 (refuse)"
+assert_eq "handoff" "$(branch_of "$R")" "test_guard_gate_marker: stays on handoff"
+[[ -f "$R/.planning/plan-approved/4242.md" ]] \
+  && pass "test_guard_gate_marker: marker SURVIVES on disk" \
+  || fail "test_guard_gate_marker: marker SURVIVES on disk" "the guard removed it"
+assert_eq "0" "$(git -C "$R" stash list | wc -l | tr -d ' ')" "test_guard_gate_marker: nothing stashed"
+echo ""
+
+# ── Test 10: authored plans and scripts are protected too ─────────────────────
+# An approval whose plan has been deleted approves nothing, and a script is never
+# build output. Both were among the six files stranded on one disk on 2026-09-03.
+echo "Test 10: untracked plans and scripts are protected"
+for path in "docs/plans/2026-01-01-a-plan.md" "docs/session-handoffs/2026-01-01-exit.md" "scripts/fleet/some-tool.sh"; do
+  R="$(make_guard_repo)"
+  mkdir -p "$R/$(dirname "$path")"; echo "content" > "$R/$path"
+  OUT="$(run_guard "$R" 1)"; RC="$(read_rc)"
+  assert_eq "1" "$RC" "test_guard_protects[$path]: exits 1"
+  [[ -f "$R/$path" ]] && pass "test_guard_protects[$path]: survives" \
+                      || fail "test_guard_protects[$path]: survives" "removed"
+done
+echo ""
+
+# ── Test 11: genuinely regenerable churn STILL gets stashed ───────────────────
+# The fix is only an improvement if it does not disable the guard. A denylist that
+# swallows everything would strand sessions off main, which is what #3187 fixed.
+echo "Test 11: regenerable untracked churn still stashes and returns"
+R="$(make_guard_repo)"
+mkdir -p "$R/docs/reports"; echo "<html>" > "$R/docs/reports/dashboard.html"
+echo "log line" > "$R/build.log"
+OUT="$(run_guard "$R" 1)"; RC="$(read_rc)"
+assert_eq "0" "$RC" "test_guard_churn_still_stashes: exits 0"
+assert_eq "main" "$(branch_of "$R")" "test_guard_churn_still_stashes: returned to main"
+assert_eq "1" "$(git -C "$R" stash list | wc -l | tr -d ' ')" "test_guard_churn_still_stashes: churn was stashed"
+echo ""
+
+# ── Test 12: a protected path beside churn still refuses ──────────────────────
+# The dangerous shape: one marker hidden among 200 regenerable files. The decision
+# must be driven by the presence of ANY protected path, not by the majority.
+echo "Test 12: one protected file among churn still refuses"
+R="$(make_guard_repo)"
+mkdir -p "$R/docs/reports" "$R/.planning/plan-approved"
+for i in 1 2 3 4 5; do echo "x" > "$R/docs/reports/gen-$i.html"; done
+echo "marker" > "$R/.planning/plan-approved/9999.md"
+OUT="$(run_guard "$R" 1)"; RC="$(read_rc)"
+assert_eq "1" "$RC" "test_guard_mixed: exits 1 despite mostly-churn"
+[[ -f "$R/.planning/plan-approved/9999.md" ]] \
+  && pass "test_guard_mixed: marker survives" || fail "test_guard_mixed: marker survives" "removed"
+echo ""
+
 echo "============================================"
 echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
 echo "============================================"


### PR DESCRIPTION
Fixes #3826. Stops two scheduled maintenance paths from destroying untracked authored work — approval-gate markers above all.

## The live defect

`return-to-main-guard.sh` stated a false premise as fact in its own decision tree, and acted on it every 30 minutes:

```
#   only unstaged/untracked  -> git stash -u (regenerable) + git checkout main
```

Untracked is not a synonym for regenerable. An approval marker, an authored plan, or a single-copy script is untracked only because nobody ran `git add`. `.planning/plan-approved/3787.md` was stranded twice; its own body documents the first loss.

The guard now takes its **existing** staged-changes branch for protected paths: exit 1, alert, stash nothing, switch nothing. That distinction already existed one line above in the same tree — staged changes were correctly treated as too valuable to sweep. Untracked was simply on the wrong side of the line.

## Two corrections to the issue as filed, both recorded rather than quietly shipped

**1. The issue named the wrong second script.** It claimed `repo-housekeeping.sh:282`'s `git clean -fd` also destroyed untracked work. It does not: **step 1 of the same loop runs `git add -A` + commit for any dirty tree**, and `git status --porcelain` counts untracked files, so nothing untracked survives to the clean. Verified on a temp repo — an untracked marker comes out **committed**, not deleted.

I found this because a test written to prove the fix failed, and the failure message I had written for it ("the denylist is too broad") was *also* wrong. Both were diagnoses from the symptom. The `-fd` denylist is therefore **defence in depth**, labelled as such in the tests rather than sold as a bug fix.

**2. Adversarial review found a real hole that first fix missed, and reproduced it.** `--prune-ignored` runs `git clean -fdx` with only `SECRET_GLOBS` excluded. And `never_clean_untracked` used `--exclude-standard`, so ignored files were invisible to the detector too — while `git add -A` does not stage ignored files either. **Protected from neither direction.** Codex reproduced deletion of an ignored `.planning/plan-approved/123.md`.

A gate marker is gate evidence whether or not `.gitignore` happens to cover it, so ignored protected paths are now **refused**, identically to untracked ones.

## Review findings and disposition

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | MAJOR | `--prune-ignored` deleted ignored protected files | **Fixed** — `never_clean_ignored()`, refusal on the `-fdx` path |
| 2 | MAJOR | Housekeeping tests would pass with the denylist deleted | **Fixed** — tests 7/8 drive `--prune-ignored` directly |
| 3 | MINOR | `$(dirname "${BASH_SOURCE[0]}")` fragile under symlink | **Fixed, but not as suggested** — see below |
| 4 | MINOR | `scripts/*` too broad, could strand the guard forever | **Fixed** — narrowed to `*.sh`/`*.py`/`*.bash` |

**On finding 3, the review's suggested remedy was wrong and I applied it uncritically.** Codex proposed sourcing the helper from `${REPO_ROOT}`. In `return-to-main-guard.sh`, `REPO_ROOT` is the repo *being guarded*, which need not be the repo the guard lives in — it broke all 12 new sandbox tests instantly. Reverted to script-dir sourcing, now resolved through `readlink -f` so the symlink case the review actually cared about is handled. `repo-housekeeping.sh` is the opposite case: its `REPO_ROOT` derives from the script's own location (line 77), so `${REPO_ROOT}` is correct there and stays.

Codex confirmed what was already right: the `set -uo pipefail` interaction (`if protected="$(...)"` correctly takes the function's status), and that the deliberate reliance on bash `*` matching `/` holds.

## The denylist

Deliberately short — every entry is authored by a person and reconstructable by nobody:

```
.planning/plan-approved/*   .planning/*.md   docs/plans/*
docs/session-handoffs/*     scripts/*.{sh,py,bash}
.claude/rules/*             .claude/skills/*
```

Generated dashboards, reports, logs and state snapshots are **not** protected and keep being swept. A denylist that swallowed everything would strand sessions off main — the problem #3187 fixed. Test 9 pins that boundary explicitly.

It is the sibling in intent to `SECRET_GLOBS`, whose excludes protected git-**ignored** secrets from `clean -fdx` while untracked **authored** work went unprotected eleven lines above. The guard existed; it was on the lower-risk path.

Detection iterates NUL-delimited, so a path containing spaces or newlines cannot split into fragments that individually miss every glob.

## Tests — 70 green, and shown red first

37 in `test_return_to_main_guard.sh` (8 pre-existing + 4 new cases), 33 in the new `test_never_clean_globs.sh`.

Every new protection test was verified to **fail without the fix**. Test 7 specifically: reverting the `-fdx` guard produces `FAIL ... deleted by git clean -fdx`. After **three vacuous passes** in this task — two from an invocation that swept the wrong root and found no repos at all, one caught by review — a new test is not trusted here until it has been seen red. Test 7 also asserts its own precondition (that git really considers the seeded file ignored), so a `.gitignore` that stopped matching would fail loudly instead of proving nothing.

## Scope note

Deliberately **not** making these scripts auto-commit gate evidence — that manufactures provenance. Refusing to remove it, loudly, is the correct behaviour, and is what they now do.

Review evidence at `scripts/review/results/2026-09-03-never-clean-denylist-codex-r1.md` (that directory is gitignored, so local gate evidence rather than part of this diff).

Branched off `origin/main` through a temporary index, so none of the ~200 unrelated local commits came along.
